### PR TITLE
fix(article_create): robust error serialization to avoid [object Object]

### DIFF
--- a/pkg/rancher-desktop/agent/tools/memory/article_create.ts
+++ b/pkg/rancher-desktop/agent/tools/memory/article_create.ts
@@ -2,6 +2,32 @@ import { BaseTool, ToolResponse } from "../base";
 import { Article } from "../../database/models/Article";
 
 /**
+ * Helper to safely extract error message from any error type
+ */
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object') {
+    // Handle Neo4j errors and other complex error objects
+    if ('message' in error) {
+      const msg = (error as any).message;
+      return typeof msg === 'string' ? msg : JSON.stringify(msg);
+    }
+    // Last resort: stringify the whole object
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return 'Unknown error (could not serialize)';
+    }
+  }
+  return 'Unknown error';
+}
+
+/**
  * Article Create Tool - Worker class for execution
  */
 export class ArticleCreateWorker extends BaseTool {
@@ -62,17 +88,11 @@ Order: ${order}`;
         responseString
       };
     } catch (error) {
-      if (error instanceof Error) {
-        return {
-          successBoolean: false,
-          responseString: `Error creating article: ${error.message}`
-        };
-      } else {
-        return {
-          successBoolean: false,
-          responseString: 'Error creating article: Unknown error'
-        };
-      }
+      const errorMessage = getErrorMessage(error);
+      return {
+        successBoolean: false,
+        responseString: `Error creating article: ${errorMessage}`
+      };
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes #88 - article_create was showing '[object Object]' when errors occurred because complex error objects (like Neo4j errors) were being concatenated to strings without proper serialization.

## Changes
Added `getErrorMessage()` helper that:
- Handles standard Error instances via `.message`
- Handles string errors directly  
- Handles objects with `.message` property (Neo4j errors)
- Falls back to `JSON.stringify` for other objects
- Handles circular reference errors in JSON.stringify

## Testing
- Error objects now serialize properly to readable messages
- Neo4j connection errors show actual error details instead of `[object Object]`