### PR TITLE
Restructure application menu for clarity and discoverability

### DIFF
--- a/pkg/rancher-desktop/main/mainmenu.ts
+++ b/pkg/rancher-desktop/main/mainmenu.ts
@@ -1,14 +1,11 @@
-import path from 'path';
-
 import Electron, { Menu, MenuItem, MenuItemConstructorOptions, shell } from 'electron';
 
 import { VMBackend } from '@pkg/backend/backend';
 import { State } from '@pkg/backend/k8s';
-import { Settings } from '@pkg/config/settings';
 import mainEvents from '@pkg/main/mainEvents';
-import paths from '@pkg/utils/paths';
 import Logging from '@pkg/utils/logging';
-import { openDockerDashboard, openLanguageModelSettings, openAudioSettings, openMain, openEditor } from '@pkg/window';
+import setupUpdate from '@pkg/main/update';
+import { openDockerDashboard, openLanguageModelSettings, openAudioSettings, openMain, openEditor, getWindow } from '@pkg/window';
 import { openDashboard } from '@pkg/window/dashboard';
 import { openPreferences } from '@pkg/window/preferences';
 
@@ -16,8 +13,6 @@ const console = Logging.mainmenu;
 
 // State for dynamic menu updates
 let kubernetesState: State = State.STOPPED;
-let networkStatus = 'checking';
-let containerEngine = 'moby';
 
 export default function buildApplicationMenu(): void {
   const menuItems: MenuItem[] = getApplicationMenu();
@@ -31,15 +26,9 @@ export default function buildApplicationMenu(): void {
     rebuildMenu();
   });
 
-  mainEvents.on('settings-update', (cfg: Settings) => {
-    containerEngine = cfg.containerEngine.name;
-    rebuildMenu();
-  });
-
-  mainEvents.on('update-network-status', (connected: boolean) => {
-    networkStatus = connected ? 'online' : 'offline';
-    rebuildMenu();
-  });
+  // Refresh extensions list for the menu
+  refreshExtensions();
+  mainEvents.on('extensions/changed' as any, () => refreshExtensions());
 }
 
 function rebuildMenu(): void {
@@ -70,74 +59,207 @@ function restartApplication(): void {
   Electron.app.quit();
 }
 
-function getNeuralNetworkMenu(): MenuItem {
-  const k8sLabels: Record<State, string> = {
-    [State.STOPPED]:  'Kubernetes is stopped',
-    [State.STARTING]: 'Kubernetes is starting',
-    [State.STARTED]:  'Kubernetes is running',
-    [State.STOPPING]: 'Kubernetes is shutting down',
-    [State.ERROR]:    'Kubernetes has encountered an error',
-    [State.DISABLED]: 'Kubernetes is disabled',
-  };
+/**
+ * Navigate the main Agent window to a given route path.
+ * Opens the main window first if it isn't already visible.
+ */
+function navigateAgent(routePath: string): void {
+  openMain();
+  const existing = getWindow('main-agent');
 
-  const k8sIcon = (kubernetesState === State.STARTED || kubernetesState === State.DISABLED)
-    ? path.join(paths.resources, 'icons', 'kubernetes-icon-color.png')
-    : path.join(paths.resources, 'icons', 'kubernetes-icon-black.png');
+  if (existing) {
+    sendWhenReady(existing, 'route', { path: routePath });
+  } else {
+    const poll = setInterval(() => {
+      const window = getWindow('main-agent');
 
-  const containerEngineLabel = containerEngine === 'containerd'
-    ? 'containerd'
-    : `dockerd (${ containerEngine })`;
+      if (window) {
+        clearInterval(poll);
+        sendWhenReady(window, 'route', { path: routePath });
+      }
+    }, 50);
+    setTimeout(() => clearInterval(poll), 5000);
+  }
+}
 
+/**
+ * Send a message to a window, waiting for load if necessary.
+ */
+function sendWhenReady(window: Electron.BrowserWindow, channel: string, data: unknown): void {
+  if (!window.webContents.isLoading()) {
+    window.webContents.send(channel, data);
+  } else {
+    window.webContents.once('did-finish-load', () => {
+      window.webContents.send(channel, data);
+    });
+  }
+}
+
+/**
+ * Send a command to the Agent window renderer (e.g. to create tabs).
+ */
+function sendAgentCommand(command: string, payload?: Record<string, unknown>): void {
+  openMain();
+  const existing = getWindow('main-agent');
+
+  if (existing) {
+    sendWhenReady(existing, 'agent-command', { command, ...payload });
+  } else {
+    const poll = setInterval(() => {
+      const window = getWindow('main-agent');
+
+      if (window) {
+        clearInterval(poll);
+        sendWhenReady(window, 'agent-command', { command, ...payload });
+      }
+    }, 50);
+    setTimeout(() => clearInterval(poll), 5000);
+  }
+}
+
+// ── Dynamic extension data for menu ──
+
+interface ExtensionData {
+  version:    string;
+  metadata:   any;
+  labels:     Record<string, string>;
+  extraUrls?: { label: string; url: string }[];
+}
+
+let installedExtensions: Record<string, ExtensionData> = {};
+
+async function refreshExtensions(): Promise<void> {
+  try {
+    const credentials = await mainEvents.invoke('api-get-credentials');
+
+    if (!credentials) {
+      return;
+    }
+
+    const authHeader = `Basic ${ Buffer.from(`${ credentials.user }:${ credentials.password }`).toString('base64') }`;
+    const response = await fetch('http://127.0.0.1:6107/v1/extensions', {
+      headers: { Authorization: authHeader },
+    });
+
+    if (!response.ok) {
+      return;
+    }
+
+    installedExtensions = await response.json();
+    rebuildMenu();
+  } catch {
+    // Extensions API may not be available yet
+  }
+}
+
+function getExtensionsSubmenu(): MenuItemConstructorOptions[] {
+  const entries = Object.entries(installedExtensions);
+
+  if (entries.length === 0) {
+    return [{ label: 'No extensions installed', enabled: false }];
+  }
+
+  return entries.map(([id, ext]) => {
+    const title = ext.labels?.['org.opencontainers.image.title'] || id;
+    const urls = ext.extraUrls ?? [];
+
+    if (urls.length === 0) {
+      return { label: title, enabled: false };
+    }
+
+    return {
+      label:   title,
+      submenu: urls.map(link => ({
+        label: link.label,
+        click: () => {
+          void shell.openExternal(link.url);
+        },
+      })),
+    };
+  });
+}
+
+/**
+ * Navigate the Docker Dashboard window to a given route path.
+ * Opens the Docker Dashboard first if it isn't already visible.
+ */
+function navigateDockerDashboard(routePath: string): void {
+  const existing = getWindow('docker-dashboard');
+
+  if (existing) {
+    sendWhenReady(existing, 'route', { path: routePath });
+    existing.show();
+  } else {
+    openDockerDashboard();
+    const poll = setInterval(() => {
+      const window = getWindow('docker-dashboard');
+
+      if (window) {
+        clearInterval(poll);
+        sendWhenReady(window, 'route', { path: routePath });
+      }
+    }, 50);
+    setTimeout(() => clearInterval(poll), 5000);
+  }
+}
+
+// ── Menu builders ──
+
+function getFileMenu(): MenuItem {
   return new MenuItem({
-    label:   'Neural Network',
+    label:   '&File',
     submenu: [
       {
-        label:       'Language Model Settings…',
-        accelerator: 'CmdOrCtrl+L',
-        click:       openLanguageModelSettings,
+        label:       'New Chat Tab',
+        accelerator: 'CmdOrCtrl+N',
+        click:       () => sendAgentCommand('new-chat-tab'),
       },
       {
-        label:       'Audio Settings…',
-        accelerator: 'CmdOrCtrl+Shift+A',
-        click:       openAudioSettings,
-      },
-      {
-        label: 'Preferences…',
-        click: openPreferences,
+        label:       'New Browser Tab',
+        accelerator: 'CmdOrCtrl+T',
+        click:       () => sendAgentCommand('new-browser-tab'),
       },
       { type: 'separator' },
       {
-        id:      'k8s-state',
-        label:   k8sLabels[kubernetesState] || 'Kubernetes status unknown',
-        enabled: false,
-        icon:    k8sIcon,
+        label:       'Open Sulla Agent',
+        accelerator: 'CmdOrCtrl+O',
+        click:       openMain,
       },
       {
-        id:      'network-status',
-        label:   `Network status: ${ networkStatus }`,
-        enabled: false,
+        label:       'Open Agent Workbench',
+        accelerator: 'CmdOrCtrl+Shift+E',
+        click:       openEditor,
       },
       {
-        id:      'container-engine',
-        label:   containerEngineLabel,
-        enabled: false,
-      },
-      { type: 'separator' },
-      {
-        label: 'Docker Dashboard',
+        label: 'Open Docker Dashboard',
         click: openDockerDashboard,
       },
       {
-        label:   'Cluster Dashboard',
+        label:   'Open Cluster Dashboard',
         click:   openDashboard,
         enabled: kubernetesState === State.STARTED,
       },
+      { type: 'separator' },
       {
-        id:      'k8s-contexts',
-        label:   'Kubernetes Contexts',
-        submenu: [],
-        visible: false,
+        label: 'Calendar',
+        click: () => sendAgentCommand('open-tab', { mode: 'calendar' }),
       },
+      {
+        label: 'Integrations',
+        click: () => sendAgentCommand('open-tab', { mode: 'integrations' }),
+      },
+      {
+        label: 'Extensions',
+        click: () => sendAgentCommand('open-tab', { mode: 'extensions' }),
+      },
+      { type: 'separator' },
+      {
+        id:      'extensions-list',
+        label:   'Installed Extensions',
+        submenu: getExtensionsSubmenu(),
+      },
+      { type: 'separator' },
+      { role: 'close', label: 'Close Window' },
     ],
   });
 }
@@ -160,17 +282,15 @@ function getEditMenu(isMac: boolean): MenuItem {
 }
 
 function getViewMenu(): MenuItem {
+  const devToolsSubmenu: MenuItemConstructorOptions[] = [
+    { role: 'reload', label: '&Reload' },
+    { role: 'forceReload', label: '&Force Reload' },
+    { role: 'toggleDevTools', label: 'Toggle &Developer Tools' },
+  ];
+
   return new MenuItem({
     label:   '&View',
     submenu: [
-      ...(Electron.app.isPackaged
-        ? []
-        : [
-          { role: 'reload', label: '&Reload' },
-          { role: 'forceReload', label: '&Force Reload' },
-          { role: 'toggleDevTools', label: 'Toggle &Developer Tools' },
-          { type: 'separator' },
-        ] as const),
       {
         label:       '&Actual Size',
         accelerator: 'CmdOrCtrl+0',
@@ -194,6 +314,68 @@ function getViewMenu(): MenuItem {
       },
       { type: 'separator' },
       { role: 'togglefullscreen', label: 'Toggle Full &Screen' },
+      ...(!Electron.app.isPackaged
+        ? [
+          { type: 'separator' } as MenuItemConstructorOptions,
+          {
+            label:   'Developer Tools',
+            submenu: devToolsSubmenu,
+          } as MenuItemConstructorOptions,
+        ]
+        : []),
+    ],
+  });
+}
+
+function getGoMenu(): MenuItem {
+  return new MenuItem({
+    label:   '&Go',
+    submenu: [
+      {
+        label:       '&Agent',
+        accelerator: 'CmdOrCtrl+1',
+        click:       () => navigateAgent('/Chat'),
+      },
+      {
+        label:       '&Calendar',
+        accelerator: 'CmdOrCtrl+2',
+        click:       () => sendAgentCommand('open-tab', { mode: 'calendar' }),
+      },
+      {
+        label:       'A&utomations',
+        accelerator: 'CmdOrCtrl+3',
+        click:       () => navigateAgent('/Automations'),
+      },
+      {
+        label:       '&Integrations',
+        accelerator: 'CmdOrCtrl+4',
+        click:       () => sendAgentCommand('open-tab', { mode: 'integrations' }),
+      },
+      {
+        label:       'E&xtensions',
+        accelerator: 'CmdOrCtrl+5',
+        click:       () => sendAgentCommand('open-tab', { mode: 'extensions' }),
+      },
+      { type: 'separator' },
+      {
+        label:       '&Language Model Settings…',
+        accelerator: 'CmdOrCtrl+L',
+        click:       openLanguageModelSettings,
+      },
+      {
+        label:       'A&udio Settings…',
+        accelerator: 'CmdOrCtrl+Shift+U',
+        click:       openAudioSettings,
+      },
+      { type: 'separator' },
+      {
+        label: '&Diagnostics',
+        click: () => navigateDockerDashboard('/Diagnostics'),
+      },
+      {
+        label: '&Troubleshooting',
+        click: () => navigateDockerDashboard('/Troubleshooting'),
+      },
     ],
   });
 }
@@ -213,27 +395,35 @@ function getHelpMenu(isMac: boolean): MenuItem {
       ]
       : []),
     {
-      label: isMac ? 'Sulla Desktop &Help' : 'Get &Help',
-      click: async() => {
-        shell.openExternal('https://sulladesktop.com/support');
+      label: '&Documentation',
+      click() {
+        shell.openExternal('https://docs.sulladesktop.com');
       },
     },
     {
-      label: 'File a &Bug',
+      label: '&Release Notes',
+      click() {
+        shell.openExternal('https://sulladesktop.com/release-notes');
+      },
+    },
+    { type: 'separator' },
+    {
+      label: 'Report an &Issue…',
       click() {
         shell.openExternal('https://sulladesktop.com/support');
       },
     },
     {
-      label: '&Project Page',
-      click() {
-        shell.openExternal('https://sulladesktop.com');
-      },
-    },
-    {
-      label: '&Discuss',
+      label: '&Premium Support',
       click() {
         shell.openExternal('https://www.skool.com/book-more-appointments-8103');
+      },
+    },
+    { type: 'separator' },
+    {
+      label: 'P&roject Page',
+      click() {
+        shell.openExternal('https://sulladesktop.com');
       },
     },
   ];
@@ -245,6 +435,8 @@ function getHelpMenu(isMac: boolean): MenuItem {
   });
 }
 
+// ── Platform-specific menus ──
+
 function getMacApplicationMenu(): MenuItem[] {
   return [
     new MenuItem({
@@ -252,10 +444,17 @@ function getMacApplicationMenu(): MenuItem[] {
       submenu: [
         { role: 'about' },
         { type: 'separator' },
-        ...getPreferencesMenuItem(),
         {
-          label: 'Open Agent Workbench',
-          click: openEditor,
+          label: 'Check for Updates…',
+          async click() {
+            await setupUpdate(true, false);
+          },
+        },
+        { type: 'separator' },
+        {
+          label:       'Preferences…',
+          accelerator: 'CmdOrCtrl+,',
+          click:       openPreferences,
         },
         { type: 'separator' },
         { role: 'services' },
@@ -264,36 +463,18 @@ function getMacApplicationMenu(): MenuItem[] {
         { role: 'hideOthers' },
         { role: 'unhide' },
         { type: 'separator' },
-        { role: 'quit' },
-      ],
-    }),
-    new MenuItem({
-      label:   'File',
-      submenu: [
         {
-          label:       'Open Sulla',
-          accelerator: 'CmdOrCtrl+Shift+A',
-          icon:        path.join(paths.resources, 'icons', 'logo-tray-Template@2x.png'),
-          click:       openMain,
-        },
-        {
-          label: 'Open Agent Workbench',
-          click: openEditor,
-        },
-        { type: 'separator' },
-        { role: 'close' },
-        { type: 'separator' },
-        {
-          label:       'Restart',
+          label:       'Restart Sulla Desktop',
           accelerator: 'CmdOrCtrl+Shift+R',
           click:       restartApplication,
         },
         { role: 'quit' },
       ],
     }),
+    getFileMenu(),
     getEditMenu(true),
     getViewMenu(),
-    getNeuralNetworkMenu(),
+    getGoMenu(),
     new MenuItem({
       label: '&Window',
       role:  'windowMenu',
@@ -308,17 +489,61 @@ function getWindowsApplicationMenu(): MenuItem[] {
       label:   '&File',
       submenu: [
         {
-          label:       '&Open Sulla',
-          accelerator: 'CmdOrCtrl+Shift+A',
-          icon:        path.join(paths.resources, 'icons', 'logo-tray-Template@2x.png'),
+          label:       'New &Chat Tab',
+          accelerator: 'CmdOrCtrl+N',
+          click:       () => sendAgentCommand('new-chat-tab'),
+        },
+        {
+          label:       'New &Browser Tab',
+          accelerator: 'CmdOrCtrl+T',
+          click:       () => sendAgentCommand('new-browser-tab'),
+        },
+        { type: 'separator' },
+        {
+          label:       '&Open Sulla Agent',
+          accelerator: 'CmdOrCtrl+O',
           click:       openMain,
         },
         {
-          label: '&Open Agent Workbench',
-          click: openEditor,
+          label:       'Open Agent &Workbench',
+          accelerator: 'CmdOrCtrl+Shift+E',
+          click:       openEditor,
+        },
+        {
+          label: 'Open &Docker Dashboard',
+          click: openDockerDashboard,
+        },
+        {
+          label:   'Open C&luster Dashboard',
+          click:   openDashboard,
+          enabled: kubernetesState === State.STARTED,
         },
         { type: 'separator' },
-        ...getPreferencesMenuItem(),
+        {
+          label: 'Ca&lendar',
+          click: () => sendAgentCommand('open-tab', { mode: 'calendar' }),
+        },
+        {
+          label: '&Integrations',
+          click: () => sendAgentCommand('open-tab', { mode: 'integrations' }),
+        },
+        {
+          label: 'E&xtensions',
+          click: () => sendAgentCommand('open-tab', { mode: 'extensions' }),
+        },
+        { type: 'separator' },
+        {
+          id:      'extensions-list',
+          label:   'Installed Extensions',
+          submenu: getExtensionsSubmenu(),
+        },
+        { type: 'separator' },
+        {
+          label:       '&Preferences…',
+          accelerator: 'CmdOrCtrl+,',
+          click:       openPreferences,
+        },
+        { type: 'separator' },
         {
           label:       '&Restart',
           accelerator: 'CmdOrCtrl+Shift+R',
@@ -332,26 +557,8 @@ function getWindowsApplicationMenu(): MenuItem[] {
     }),
     getEditMenu(false),
     getViewMenu(),
-    getNeuralNetworkMenu(),
+    getGoMenu(),
     getHelpMenu(false),
-  ];
-}
-
-/**
- * Gets the preferences menu item for all supported platforms
- * @returns MenuItemConstructorOptions: The preferences menu item object
- */
-function getPreferencesMenuItem(): MenuItemConstructorOptions[] {
-  return [
-    {
-      label:               'Preferences…',
-      id:                  'preferences',
-      visible:             true,
-      registerAccelerator: true,
-      accelerator:         'CmdOrCtrl+Shift+,',
-      click:               openPreferences,
-    },
-    { type: 'separator' },
   ];
 }
 
@@ -359,8 +566,6 @@ function getPreferencesMenuItem(): MenuItemConstructorOptions[] {
  * Adjusts the zoom level for the focused window by the desired increment.
  * Also emits an IPC request to the webContents to trigger a resize of the
  * extensions view.
- * @param focusedWindow The window that has focus
- * @param zoomLevelAdjustment The desired increment to adjust the zoom level by
  */
 function adjustZoomLevel(focusedWindow: Electron.BaseWindow | undefined, zoomLevelAdjustment: number) {
   if (!focusedWindow || !(focusedWindow instanceof Electron.BrowserWindow)) {

--- a/pkg/rancher-desktop/main/tray.ts
+++ b/pkg/rancher-desktop/main/tray.ts
@@ -79,7 +79,7 @@ export class Tray {
     },
     {
       id:      'dashboard',
-      label:   'Kubernetes Dashboard',
+      label:   'Cluster Dashboard',
       icon:    path.join(paths.resources, 'icons', 'kubernetes-icon-color.png'),
       type:    'normal',
       enabled: false,

--- a/pkg/rancher-desktop/pages/AgentRouter.vue
+++ b/pkg/rancher-desktop/pages/AgentRouter.vue
@@ -108,7 +108,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref, onMounted, onUnmounted } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 
 import BrowserTab from './BrowserTab.vue';
 import StartupOverlay from './agent/StartupOverlay.vue';
@@ -117,7 +117,8 @@ import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import { getHumanPresenceTracker } from '@pkg/agent/services/HumanPresenceTracker';
 
 const route = useRoute();
-const { tabs: browserTabs } = useBrowserTabs();
+const router = useRouter();
+const { tabs: browserTabs, createTab } = useBrowserTabs();
 
 const isBrowserRoute = computed(() => route.path.startsWith('/Browser/'));
 
@@ -203,6 +204,37 @@ async function refreshFooterStats() {
   } catch { /* ignore */ }
 }
 
+function onRoute(_event: any, args: any) {
+  if (args?.path) {
+    router.push(args.path);
+  }
+}
+
+function onAgentCommand(_event: any, args: any) {
+  if (!args?.command) return;
+
+  switch (args.command) {
+  case 'new-chat-tab': {
+    const tab = createTab('about:blank', { mode: 'chat' });
+
+    router.push(`/Browser/${ tab.id }`);
+    break;
+  }
+  case 'new-browser-tab': {
+    const tab = createTab('about:blank');
+
+    router.push(`/Browser/${ tab.id }`);
+    break;
+  }
+  case 'open-tab': {
+    const tab = createTab('about:blank', { mode: args.mode || 'welcome' });
+
+    router.push(`/Browser/${ tab.id }`);
+    break;
+  }
+  }
+}
+
 const presenceTracker = getHumanPresenceTracker();
 
 onMounted(() => {
@@ -215,6 +247,8 @@ onMounted(() => {
   refreshFooterStats();
   footerStatsTimer = setInterval(refreshFooterStats, 30_000);
 
+  ipcRenderer.on('route' as any, onRoute);
+  ipcRenderer.on('agent-command' as any, onAgentCommand);
   ipcRenderer.on('k8s-check-state' as any, onK8sCheckState);
   ipcRenderer.on('k8s-progress' as any, onK8sProgress);
   ipcRenderer.invoke('k8s-progress').then((p: any) => {
@@ -227,6 +261,8 @@ onUnmounted(() => {
   if (footerStatsTimer) {
     clearInterval(footerStatsTimer);
   }
+  ipcRenderer.removeListener('route' as any, onRoute);
+  ipcRenderer.removeListener('agent-command' as any, onAgentCommand);
   ipcRenderer.removeListener('k8s-check-state' as any, onK8sCheckState);
   ipcRenderer.removeListener('k8s-progress' as any, onK8sProgress);
 });

--- a/pkg/rancher-desktop/window/index.ts
+++ b/pkg/rancher-desktop/window/index.ts
@@ -11,7 +11,7 @@ import { IpcRendererEvents } from '@pkg/typings/electron-ipc';
 import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 import { CommandOrControl, Shortcuts } from '@pkg/utils/shortcuts';
-import { mainRoutes } from '@pkg/window/constants';
+
 import { openPreferences } from '@pkg/window/preferences';
 
 const console = Logging[`window_${ process.type || 'unknown' }`];
@@ -169,18 +169,6 @@ export function openMain() {
       () => openPreferences(),
       'open preferences',
     );
-
-    mainRoutes.forEach(({ route }, index) => {
-      Shortcuts.register(
-        window,
-        {
-          ...CommandOrControl,
-          key: index + 1,
-        },
-        () => window.webContents.send('route', { path: route }),
-        `switch main tabs ${ route }`,
-      );
-    });
 
     Shortcuts.register(
       window,


### PR DESCRIPTION
## Summary
- **Removed "Neural Network" menu** — redistributed items to File, Go, View, and Help menus where users would expect them
- **Added Go menu** with keyboard shortcuts (⌘1–⌘5) for navigating Agent pages (Chat, Calendar, Automations, Integrations, Extensions) plus LM/Audio settings and Diagnostics/Troubleshooting
- **Added File > New Chat Tab (⌘N) and New Browser Tab (⌘T)** with IPC-based tab creation in the Agent window
- **Added File > Calendar, Integrations, Extensions** — open as proper tabs in the Agent window
- **Added File > Installed Extensions** dynamic submenu (mirrors tray behavior, fetches from extensions API)
- **Added Check for Updates** to the macOS app menu
- **Moved Restart** to app menu (macOS convention)
- **Fixed accelerator conflict** — ⌘⇧A was assigned to both "Open Sulla" and "Audio Settings"
- **Fixed Preferences shortcut** to standard ⌘, (was ⌘⇧,), removed duplicate entries (was in 3 places)
- **Grouped dev tools** under View > Developer Tools submenu (dev builds only)
- **Help menu** now has Documentation (docs.sulladesktop.com), Release Notes, Report an Issue, Premium Support, Project Page
- **Tray**: Renamed "Kubernetes Dashboard" → "Cluster Dashboard"
- **Removed read-only status indicators** (K8s state, network, container engine) from menu bar — already visible in tray

### Files changed
- `pkg/rancher-desktop/main/mainmenu.ts` — full menu rewrite
- `pkg/rancher-desktop/main/tray.ts` — label rename
- `pkg/rancher-desktop/pages/AgentRouter.vue` — added `route` and `agent-command` IPC listeners for menu-driven navigation and tab creation
- `pkg/rancher-desktop/window/index.ts` — removed redundant `mainRoutes` shortcut registration (now handled by Go menu accelerators)

## Test plan
- [ ] Verify all Go menu items navigate correctly in the Agent window (⌘1–⌘5)
- [ ] Verify File > New Chat Tab and New Browser Tab create tabs
- [ ] Verify File > Calendar/Integrations/Extensions open as tabs
- [ ] Verify File > Installed Extensions submenu populates dynamically
- [ ] Verify File > Open Docker/Cluster Dashboard open correct windows
- [ ] Verify Go > Diagnostics/Troubleshooting open Docker Dashboard to correct tab
- [ ] Verify Check for Updates triggers update check
- [ ] Verify Preferences opens from ⌘,
- [ ] Verify View > Developer Tools submenu appears in dev builds only
- [ ] Verify tray shows "Cluster Dashboard" (disabled when K8s not running)
- [ ] Verify Windows/Linux menu structure matches (no app menu, Preferences/Restart in File)

🤖 Generated with [Claude Code](https://claude.com/claude-code)