### PR TITLE
fix: auto-update llama.cpp on startup when newer release available

### DIFF
--- a/pkg/rancher-desktop/agent/services/LlamaCppService.ts
+++ b/pkg/rancher-desktop/agent/services/LlamaCppService.ts
@@ -1238,6 +1238,10 @@ export class LlamaCppService {
       _isGpuBuild = detectGpuCapability();
       this._installedTag = currentTag;
       this._ready = true;
+
+      // Check for newer release in the background — update without blocking startup
+      this.checkForUpdate(currentTag).catch(err =>
+        console.warn(`${ LOG_PREFIX } Background update check failed:`, err));
       return;
     }
 
@@ -1262,6 +1266,40 @@ export class LlamaCppService {
     } catch (err) {
       console.error(`${ LOG_PREFIX } Failed to install llama.cpp:`, err);
       this._ready = false;
+    }
+  }
+
+  /**
+     * Background update check — fetches latest tag and upgrades if newer.
+     * Restarts llama-server automatically if it was running.
+     */
+  private async checkForUpdate(currentTag: string): Promise<void> {
+    const latestTag = await fetchLatestTag();
+    if (latestTag === currentTag) {
+      console.log(`${ LOG_PREFIX } Already at latest version ${ currentTag }`);
+      return;
+    }
+
+    console.log(`${ LOG_PREFIX } Update available: ${ currentTag } → ${ latestTag }. Downloading...`);
+
+    const wasRunning = this._serverRunning;
+    const activeModel = this._activeModel;
+
+    // Stop server before replacing binaries
+    if (wasRunning) {
+      await this.stopServer();
+    }
+
+    await downloadAndExtract(latestTag);
+    this._installedTag = latestTag;
+    this._ready = !!findBinary('llama-server');
+
+    console.log(`${ LOG_PREFIX } Updated to ${ latestTag }`);
+
+    // Restart server with the same model if it was running
+    if (wasRunning && activeModel && this._ready) {
+      console.log(`${ LOG_PREFIX } Restarting llama-server with model ${ activeModel }...`);
+      await this.startServer(activeModel);
     }
   }
 


### PR DESCRIPTION
## Summary
- `ensure()` previously short-circuited when any build was installed, never checking for updates — this left `b8606` pinned even though Gemma 4 arch support landed in later releases
- Adds a non-blocking `checkForUpdate()` that runs after the fast-path return: fetches latest GitHub tag, downloads if newer, stops/restarts llama-server with the same model
- Fixes `unknown model architecture: 'gemma4'` crash when loading Gemma 4 E2B/E4B/26B GGUF models

## Test plan
- [ ] Start Sulla Desktop with an older llama.cpp build installed (e.g. b8606)
- [ ] Verify startup is not blocked — app boots immediately with existing build
- [ ] Confirm background update downloads newer release (check `[LlamaCppService] Update available:` log)
- [ ] Verify llama-server restarts automatically if it was running
- [ ] Load a Gemma 4 model and confirm it no longer fails with architecture error

🤖 Generated with [Claude Code](https://claude.com/claude-code)