### PR TITLE
fix: teleprompter voice tracking — route mic through controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to Sulla Desktop will be documented in this file.
 
+## [1.3.0] - 2026-04-09
+
+### New Features
+
+- **Capture Studio** — full audio/video capture studio with multi-source recording, scene management, source context menus, loading screen, permissions UX, disk warnings, and keyboard shortcuts
+- **Audio driver integration** — built-in audio subsystem with independent mic/speaker lifecycle, 48kHz native PCM pipeline, RNNoise noise reduction, VAD-driven voice chat, and mic recording mode selector
+- **Local LLM overhaul** — section-based prompt composition (OpenClaw parity), streaming, caching, speculative decoding, native context clamping, KV cache optimization, and Gemma 4 support
+- **ModelProviderService** — centralized model provider management with cache invalidation on model change and local server toggle persistence
+- **GLM-4.7 Flash** — new local model option for fast inference
+- **Bundled whisper-cli** — pre-built whisper binary removes Homebrew dependency; auto-install fallback when bundled binary is missing
+- **Computer Use** — TCC permission probe for macOS dialogs, AppleScript app automation settings, and Computer Use Settings panel
+- **Teleprompter** — floating window near webcam for eye-contact reading, VAD-gated speech tracking with Jaccard fuzzy matching, main process tracking, close button, and style sync to floating window
+- **Agent session context** — agent reads identity, goals, and tool reference at session start; thinking bubble collapses on stream start
+- **write_file tool** — new agent tool for file creation
+- **browse_tools catalog** — completed and promoted to meta tools
+- **ServiceLifecycleManager** — dependency-aware startup/shutdown ordering
+- **HeartbeatNode** — expanded GraphRegistry for agent orchestration
+- **Tray panel** — custom tray panel UI with vault password verification and graceful shutdown
+- **Settings IPC** — cast/delete support and resetOllamaService helper
+- **Editor chat** — multi-tab system, chat history, scroll-to-bottom, chat options, and focus management
+- **Version in footer** — app version now displayed in the workbench status bar
+
+### Improvements
+
+- Audio permission gates and chat injection improvements
+- Capture event logging and window focus tracking
+- Open all URLs inside Sulla Desktop instead of external browser
+- Raised loop detection threshold with detached start/stop
+- Condensed local LLM prompts with llama.cpp auto-update on startup
+- Simplified agent and editor headers with shared WindowDragLogo
+- Split CaptureStudio.vue into 8 sub-components for maintainability
+
+### Bug Fixes
+
+- Fixed agent requirement blocking initial install
+- Fixed llama-server 503 retry and performance tuning
+- Fixed local LLM agent reliability — correct model, context, timeouts, and prompt mode
+- Fixed RNNoise FIFO buffer eliminating clicking artifacts
+- Stopped muxing mic audio into screen/camera recordings
+- Fixed camera preview showing live video and streams following source assignment
+- Fixed audio driver boot timeout and camera stream flickering
+- Fixed audio meters, inline playback, and muxed audio in video files
+- Fixed auto-start audio driver when Capture Studio opens
+- Comprehensive reliability audit — fixed 55 identified issues across capture pipeline
+- Defensive null guards on all composable ref accesses
+- Wrapped capture studio IPC handlers in try-catch to prevent main crash
+- Fixed vault initialization before integrations to ensure Slack tokens are decrypted
+- Fixed RedisClient reconnect loop blocking exit on shutdown
+- Fixed guarded-attribute filter logic in BaseModel save()
+- Fixed uncontrolled data used in path expression (security scan alert #4514)
+- Fixed teleprompter style sync to floating window
+- Fixed whisper-cpp brew install with proper timeout handling
+
+### Refactoring
+
+- Removed `load_skill` tool — `read_file` covers the same use case
+- Refactored audio driver into MicrophoneDriverController and SpeakerDriverController
+- Replaced Ollama references with llama.cpp throughout documentation
+
 ## [1.2.0] - 2026-04-02
 
 ### New Features

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sulla-desktop",
   "productName": "Sulla Desktop",
   "license": "Apache-2.0 WITH Commons-Clause",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Jonathon Byrdziak",
     "email": "jonathonbyrd@gmail.com"

--- a/pkg/rancher-desktop/controllers/SecretaryModeController.ts
+++ b/pkg/rancher-desktop/controllers/SecretaryModeController.ts
@@ -4,14 +4,17 @@
  * Runs in the renderer process. The Vue component (SecretaryMode.vue) delegates
  * to this controller for all business logic and only handles rendering + UI events.
  *
+ * All mic audio goes through MicrophoneDriverController (tray panel renderer).
+ * Transcription uses the whisper.cpp pipeline via audio-driver IPC.
+ * No local getUserMedia — the controller's VAD provides audio levels.
+ *
  * Responsibilities:
- *   - Session lifecycle (start/stop, mode selection)
- *   - Transcription mode routing (gateway / browser / elevenlabs)
+ *   - Session lifecycle (start/stop)
+ *   - Transcription via whisper (audio-driver pipeline)
  *   - Wake word detection state machine
  *   - Barge-in logic (audio level → cut TTS)
- *   - Audio level monitoring
+ *   - Audio level monitoring (from controller VAD)
  *   - Analysis loop orchestration
- *   - Gateway audio streaming (MediaRecorder → IPC)
  *
  * Does NOT own:
  *   - Vue reactive state (passed in via callbacks)
@@ -68,7 +71,6 @@ export interface SecretaryCallbacks {
 // ─── Constants ──────────────────────────────────────────────────
 
 const WAKE_PATTERNS = [/\bhey\s+(?:sulla|sula|soula|sola)\b/i];
-const SEGMENT_DURATION = 15_000;
 const ANALYSIS_INTERVAL = 30_000;
 const BARGE_IN_THRESHOLD = 25;
 
@@ -91,31 +93,13 @@ export class SecretaryModeController {
   private cb: SecretaryCallbacks;
 
   // Audio state
-  private mediaStream: MediaStream | null = null;
-  private activeMimeType = 'audio/webm';
-  private transcriptionMode = 'browser';
-  private transcriptionModel = 'scribe_v2';
   private sttLanguage = 'en-US';
 
-  // Browser STT
-  private recognition: any = null;
-
-  // ElevenLabs segmented recording
-  private mediaRecorder: MediaRecorder | null = null;
-  private audioChunks: Blob[] = [];
-  private segmentInterval: ReturnType<typeof setInterval> | null = null;
-
-  // Gateway streaming
+  // Gateway session (for GhostAgent monitoring — REST only, no streaming)
   private gatewaySessionId: string | null = null;
-  private gatewayStreamRecorder: MediaRecorder | null = null;
-  private gatewayStreamActive = false;
-  /** Whether the audio-driver is providing speaker audio */
-  private audioDriverConnected = false;
 
-  // Audio level monitoring
-  private levelContext: AudioContext | null = null;
-  private levelAnalyser: AnalyserNode | null = null;
-  private levelInterval: ReturnType<typeof setInterval> | null = null;
+  // Audio level monitoring (from controller VAD)
+  private vadHandler: ((_event: any, data: any) => void) | null = null;
 
   // Session timer
   private sessionStartTime = 0;
@@ -136,50 +120,38 @@ export class SecretaryModeController {
   // ─── Session lifecycle ────────────────────────────────────────
 
   async startSession(): Promise<void> {
-    this.transcriptionMode = await ipcRenderer.invoke('sulla-settings-get', 'audioTranscriptionMode', 'browser');
-    this.transcriptionModel = await ipcRenderer.invoke('sulla-settings-get', 'audioTranscriptionModel', 'scribe_v2');
-    this.sttLanguage = await ipcRenderer.invoke('sulla-settings-get', 'audioSttLanguage', 'en-US');
-    const audioInputDeviceId: string = await ipcRenderer.invoke('sulla-settings-get', 'audioInputDeviceId', '');
+    const rawLang: string = await ipcRenderer.invoke('sulla-settings-get', 'audioSttLanguage', 'en');
+    // Whisper uses ISO 639-1 codes (e.g. 'en'), not locale codes (e.g. 'en-US')
+    this.sttLanguage = rawLang.split('-')[0];
 
-    // Start mic via the MicrophoneDriverController (ref-counted)
-    await ipcRenderer.invoke('audio-driver:start-mic', 'secretary-mode');
+    // Start mic via the MicrophoneDriverController (ref-counted).
+    // Request pcm-s16le so the tray panel starts PCM capture for whisper.
+    await ipcRenderer.invoke('audio-driver:start-mic', 'secretary-mode', ['webm-opus', 'pcm-s16le']);
 
-    // Also get a local getUserMedia stream for MediaRecorder (gateway mic channel)
-    const audioConstraints: boolean | MediaTrackConstraints = audioInputDeviceId
-      ? { deviceId: { exact: audioInputDeviceId } }
-      : true;
-
-    this.mediaStream = await navigator.mediaDevices.getUserMedia({ audio: audioConstraints });
-    this.activeMimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-      ? 'audio/webm;codecs=opus'
-      : 'audio/webm';
+    // Start speaker capture for system audio monitoring
+    try {
+      await ipcRenderer.invoke('audio-driver:start-speaker', 'secretary-mode');
+    } catch (err) {
+      console.warn('[SecretaryMode] Speaker capture failed:', (err as Error).message);
+    }
 
     this.lastAnalyzedIndex = 0;
     this.analysisMessageCount = 0;
 
-    // For non-gateway modes, create a REST-only gateway session for GhostAgent monitoring
-    if (this.transcriptionMode !== 'gateway') {
-      try {
-        const sessionResult = await ipcRenderer.invoke('desktop-session-start', { callerName: 'Sulla Secretary' });
-        this.gatewaySessionId = sessionResult?.sessionId || null;
-      } catch {
-        this.gatewaySessionId = null;
-      }
+    // Create a REST-only gateway session for GhostAgent monitoring
+    try {
+      const sessionResult = await ipcRenderer.invoke('desktop-session-start', { callerName: 'Sulla Secretary' });
+      this.gatewaySessionId = sessionResult?.sessionId || null;
+    } catch {
+      this.gatewaySessionId = null;
     }
 
     this.startSessionTimer();
     this.startAudioLevelMonitor();
     this.startAnalysisLoop();
 
-    // Route to the correct transcription strategy
-    if (this.transcriptionMode === 'gateway') {
-      await this.startGatewayStreaming();
-    } else if (this.transcriptionMode === 'browser') {
-      // Browser mode now uses internal whisper pipeline instead of Google STT
-      await this.startWhisperTranscription();
-    } else {
-      this.startElevenLabsContinuous();
-    }
+    // Start whisper transcription via the controller pipeline
+    await this.startWhisperTranscription();
   }
 
   endSession(): void {
@@ -193,32 +165,19 @@ export class SecretaryModeController {
     // Clean up agent audio playback
     this.stopAgentAudio();
 
-    if (this.recognition) {
-      try { this.recognition.abort(); } catch { /* ignore */ }
-      try { this.recognition.stop(); } catch { /* ignore */ }
-      this.recognition = null;
-    }
-
-    // Stop whisper transcription if it was running
+    // Stop whisper transcription
     this.stopWhisperTranscription();
 
-    if (this.transcriptionMode === 'gateway') {
-      this.stopGatewayStreaming();
-    }
-
-    if (this.segmentInterval) { clearInterval(this.segmentInterval); this.segmentInterval = null; }
-    if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') this.mediaRecorder.stop();
-    if (this.mediaStream) { this.mediaStream.getTracks().forEach(t => t.stop()); this.mediaStream = null; }
-    this.mediaRecorder = null;
-    this.audioChunks = [];
-
-    // Release mic via the MicrophoneDriverController (ref-counted)
+    // Release mic and speaker via the controllers (ref-counted)
     ipcRenderer.invoke('audio-driver:stop-mic', 'secretary-mode').catch((err) => {
       console.warn('[SecretaryMode] stop-mic failed:', err);
     });
+    ipcRenderer.invoke('audio-driver:stop-speaker', 'secretary-mode').catch((err) => {
+      console.warn('[SecretaryMode] stop-speaker failed:', err);
+    });
 
-    // End the REST-only gateway session (non-gateway modes)
-    if (this.gatewaySessionId && this.transcriptionMode !== 'gateway') {
+    // End the REST-only gateway session
+    if (this.gatewaySessionId) {
       ipcRenderer.invoke('desktop-session-end', this.gatewaySessionId).catch((err) => {
         console.warn('[SecretaryMode] desktop-session-end failed:', err);
       });
@@ -246,76 +205,29 @@ export class SecretaryModeController {
     }
 
     for (const pattern of WAKE_PATTERNS) {
-      const match = text.match(pattern);
-      if (match) {
-        const afterWake = text.slice(match.index! + match[0].length).trim();
-        if (afterWake.length > 3) {
-          this.cb.addEntry(afterWake, 'wake-command', 'You');
-          this.sendWakeCommand(afterWake);
-        } else {
-          this.cb.setWakeWordActive(true);
-          this.cb.addEntry('Yes?', 'agent-response', 'Sulla');
-          this.cb.playTTS('Yes?');
-        }
-        return;
+      if (pattern.test(text)) {
+        this.cb.setWakeWordActive(true);
+        break;
       }
     }
   }
 
   private async sendWakeCommand(command: string): Promise<void> {
-    const prompt = `You are in secretary mode during a live meeting. The user said "Hey Sulla" and then spoke to you.
-
-RULES:
-- Reply in ONE short sentence max (under 15 words).
-- If you don't understand, say exactly: "Sorry, could you say that again?"
-- No narration, no elaboration, no follow-up questions.
-- Be direct. Think walkie-talkie, not conversation.
-
-User: ${command}`;
-
-    const reply = await this.cb.sendToChat(prompt, 'secretary-command');
-    if (reply) {
-      this.cb.addEntry(reply, 'agent-response', 'Sulla');
-      this.cb.playTTS(reply);
-    }
-  }
-
-  // ─── Chat message (private text input) ────────────────────────
-
-  async sendChatMessage(text: string): Promise<void> {
-    if (!text.trim()) return;
-
-    this.cb.addAgentMessage({
-      id:   this.generateEntryId(),
-      time: this.formatTimeNow(),
-      text: `You: ${text}`,
-    });
-    this.cb.scrollAnalysis();
-
-    const prompt = `You are in secretary mode during a live meeting. The user sent you a private text message (not spoken aloud).
-
-RULES:
-- Reply in ONE short sentence max (under 15 words).
-- If you don't understand, ask them to clarify briefly.
-- No narration, no elaboration.
-
-User: ${text}`;
-
-    const reply = await this.cb.sendToChat(prompt, 'secretary-chat');
-    if (reply) {
-      this.cb.addAgentMessage({
-        id:   this.generateEntryId(),
-        time: this.formatTimeNow(),
-        text: reply,
-      });
+    const response = await this.cb.sendToChat(command, 'secretary-wake');
+    if (response) {
+      const agentMsg: AgentMessage = {
+        id:   `agent-${Date.now()}`,
+        time: new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }),
+        text: response,
+      };
+      this.cb.addAgentMessage(agentMsg);
+      this.cb.addEntry(response, 'agent-response', 'Sulla');
       this.cb.scrollAnalysis();
+
+      if (!this.cb.getIsMuted()) {
+        await this.cb.playTTS(response);
+      }
     }
-  }
-
-  // ─── Barge-in ─────────────────────────────────────────────────
-
-  setTTSActive(active: boolean): void {
-    this.hasTTSActive = active;
   }
 
   private checkBargeIn(level: number): void {
@@ -324,39 +236,25 @@ User: ${text}`;
     }
   }
 
-  // ─── Audio level monitoring ───────────────────────────────────
+  // ─── Audio level monitoring (from controller VAD) ─────────────
 
   private startAudioLevelMonitor(): void {
-    if (!this.mediaStream) return;
-    try {
-      this.levelContext = new AudioContext();
-      const src = this.levelContext.createMediaStreamSource(this.mediaStream);
-      this.levelAnalyser = this.levelContext.createAnalyser();
-      this.levelAnalyser.fftSize = 256;
-      src.connect(this.levelAnalyser);
-      const buf = new Uint8Array(this.levelAnalyser.fftSize);
-
-      this.levelInterval = setInterval(() => {
-        if (!this.levelAnalyser || !this.cb.getIsListening()) return;
-        this.levelAnalyser.getByteTimeDomainData(buf);
-        let sum = 0;
-        for (let i = 0; i < buf.length; i++) {
-          const s = (buf[i] - 128) / 128;
-          sum += s * s;
-        }
-        const level = Math.min(100, Math.round(Math.sqrt(sum / buf.length) * 300));
-        this.cb.setAudioLevel(level);
-        this.checkBargeIn(level);
-      }, 50);
-    } catch (err) {
-      console.warn('[SecretaryMode] Audio level monitor failed to initialize:', err);
-    }
+    // Listen for VAD events from the MicrophoneDriverController.
+    // The controller sends audio-driver:mic-vad to all holders.
+    this.vadHandler = (_event: any, data: any) => {
+      if (!data || !this.cb.getIsListening()) return;
+      const level = Math.min(100, Math.round((data.level ?? 0) * 300));
+      this.cb.setAudioLevel(level);
+      this.checkBargeIn(level);
+    };
+    ipcRenderer.on('audio-driver:mic-vad', this.vadHandler);
   }
 
   private stopAudioLevelMonitor(): void {
-    if (this.levelInterval) { clearInterval(this.levelInterval); this.levelInterval = null; }
-    if (this.levelContext) { this.levelContext.close().catch(() => {}); this.levelContext = null; }
-    this.levelAnalyser = null;
+    if (this.vadHandler) {
+      ipcRenderer.removeListener('audio-driver:mic-vad', this.vadHandler);
+      this.vadHandler = null;
+    }
     this.cb.setAudioLevel(0);
   }
 
@@ -388,9 +286,7 @@ User: ${text}`;
     });
 
     if (!result?.ok) {
-      console.warn('[SecretaryMode] Whisper transcription failed to start — falling back to ElevenLabs');
-      this.transcriptionMode = 'elevenlabs';
-      this.startElevenLabsContinuous();
+      console.error('[SecretaryMode] Whisper transcription failed to start');
       return;
     }
 
@@ -416,99 +312,12 @@ User: ${text}`;
     ipcRenderer.invoke('audio-driver:transcribe-stop').catch(() => {});
   }
 
-  // ─── ElevenLabs continuous mode ───────────────────────────────
-
-  private startElevenLabsContinuous(): void {
-    this.startElevenLabsSegment();
-    this.segmentInterval = setInterval(() => {
-      if (!this.cb.getIsListening()) return;
-      this.flushAndRestartSegment();
-    }, SEGMENT_DURATION);
-  }
-
-  private startElevenLabsSegment(): void {
-    if (!this.mediaStream) return;
-    this.audioChunks = [];
-    this.mediaRecorder = new MediaRecorder(this.mediaStream, { mimeType: this.activeMimeType });
-    this.mediaRecorder.ondataavailable = (event: BlobEvent) => {
-      if (event.data.size > 0) this.audioChunks.push(event.data);
-    };
-    this.mediaRecorder.onstop = () => {
-      const audioBlob = new Blob(this.audioChunks, { type: this.activeMimeType });
-      this.audioChunks = [];
-      if (audioBlob.size > 0) this.transcribeSegment(audioBlob, this.activeMimeType);
-    };
-    this.mediaRecorder.start();
-  }
-
-  private flushAndRestartSegment(): void {
-    if (!this.mediaRecorder || this.mediaRecorder.state === 'inactive') return;
-    this.mediaRecorder.stop();
-    if (this.cb.getIsListening() && this.mediaStream) this.startElevenLabsSegment();
-  }
-
-  private async transcribeSegment(audioBlob: Blob, mimeType: string): Promise<void> {
-    try {
-      const arrayBuffer = await audioBlob.arrayBuffer();
-      // Route through audio-driver gateway for transcription (replaces
-      // the removed audio-transcribe IPC handler that used TranscriptionService)
-      const result = await ipcRenderer.invoke('audio-driver:gateway-send', {
-        audio: arrayBuffer, channel: 0,
-      });
-      // For non-gateway modes, transcription happens via the gateway's
-      // REST endpoint. The result comes back as a gateway-transcript event.
-      void result; // response handled via gateway-transcript IPC event
-      return;
-      if (result?.text?.trim()) {
-        const text = result.text.trim();
-        this.cb.addEntry(text);
-        this.checkAndHandleWakeWord(text);
-      }
-    } catch (err) {
-      console.error('[SecretaryMode] Transcription failed:', err);
-    }
-  }
-
-  // ─── Gateway WebSocket streaming ──────────────────────────────
-
-  private onGatewayTranscriptBound = this.onGatewayTranscript.bind(this);
-
-  private onGatewayTranscript(_event: any, event: { event_type: string; text?: string; speaker?: string; audio?: string; format?: string }): void {
-    if (!this.cb.getIsListening()) {
-      console.warn('[SecretaryMode] Received transcript but not listening — dropped');
-      return;
-    }
-
-    if (event.event_type === 'transcript_turn' && event.text?.trim()) {
-      const text = event.text.trim();
-      const speaker = event.speaker || 'Speaker';
-      console.log(`[SecretaryMode] Transcript received (${speaker}): "${text.slice(0, 80)}"`);
-      this.cb.addEntry(text, 'transcript', speaker);
-      this.checkAndHandleWakeWord(text);
-    } else if (event.event_type === 'transcript_partial' && event.text?.trim()) {
-      // Partial transcripts — could show as interim text in future
-      console.log(`[SecretaryMode] Partial transcript: "${event.text.trim().slice(0, 80)}"`);
-    } else if (event.event_type === 'agent_audio' && event.audio) {
-      // Agent speech audio — PCM 16kHz 16-bit mono, base64-encoded
-      if (!this.cb.getIsMuted()) {
-        this.playAgentAudioChunk(event.audio);
-      }
-    } else {
-      console.log(`[SecretaryMode] Unhandled gateway event: ${event.event_type}`);
-    }
-  }
-
   // ─── Agent audio playback (PCM 16kHz via Web Audio API) ────────
 
   private agentAudioContext: AudioContext | null = null;
   private agentAudioNextTime = 0;
-  /** Track active buffer sources so we can stop them immediately on mute */
   private agentAudioSources: AudioBufferSourceNode[] = [];
 
-  /**
-   * Immediately silence all scheduled agent audio by stopping every
-   * queued BufferSource and closing the AudioContext.
-   */
   stopAgentAudio(): void {
     for (const src of this.agentAudioSources) {
       try { src.stop(); } catch { /* already stopped */ }
@@ -518,45 +327,38 @@ User: ${text}`;
     if (this.agentAudioContext) {
       this.agentAudioContext.close().catch(() => {});
       this.agentAudioContext = null;
-      this.agentAudioNextTime = 0;
     }
+    this.agentAudioNextTime = 0;
   }
 
-  private playAgentAudioChunk(base64Pcm: string): void {
+  private playAgentAudioChunk(base64Audio: string): void {
     try {
-      // Decode base64 → raw PCM bytes
-      const raw = Uint8Array.from(atob(base64Pcm), c => c.charCodeAt(0));
-      const pcm16 = new Int16Array(raw.buffer, raw.byteOffset, raw.byteLength / 2);
-
-      // Convert Int16 PCM to Float32 for Web Audio API
-      const float32 = new Float32Array(pcm16.length);
-      for (let i = 0; i < pcm16.length; i++) {
-        float32[i] = pcm16[i] / 32768;
-      }
-
-      // Create or reuse AudioContext
       if (!this.agentAudioContext) {
         this.agentAudioContext = new AudioContext({ sampleRate: 16000 });
         this.agentAudioNextTime = 0;
       }
-
       const ctx = this.agentAudioContext;
-      const buffer = ctx.createBuffer(1, float32.length, 16000);
-      buffer.copyToChannel(float32, 0);
+
+      const raw = atob(base64Audio);
+      const samples = raw.length / 2;
+      const audioBuffer = ctx.createBuffer(1, samples, 16000);
+      const channelData = audioBuffer.getChannelData(0);
+      for (let i = 0; i < samples; i++) {
+        const lo = raw.charCodeAt(i * 2);
+        const hi = raw.charCodeAt(i * 2 + 1);
+        const sample = (hi << 8) | lo;
+        channelData[i] = (sample >= 0x8000 ? sample - 0x10000 : sample) / 32768;
+      }
 
       const source = ctx.createBufferSource();
-      source.buffer = buffer;
+      source.buffer = audioBuffer;
       source.connect(ctx.destination);
 
-      // Schedule chunks back-to-back for gapless playback
       const now = ctx.currentTime;
-      if (this.agentAudioNextTime < now) {
-        this.agentAudioNextTime = now;
-      }
-      source.start(this.agentAudioNextTime);
-      this.agentAudioNextTime += buffer.duration;
+      const startTime = Math.max(now, this.agentAudioNextTime);
+      source.start(startTime);
+      this.agentAudioNextTime = startTime + audioBuffer.duration;
 
-      // Track source for immediate stop on mute
       this.agentAudioSources.push(source);
       source.onended = () => {
         const idx = this.agentAudioSources.indexOf(source);
@@ -564,119 +366,6 @@ User: ${text}`;
       };
     } catch (err) {
       console.warn('[SecretaryMode] Agent audio playback error:', err);
-    }
-  }
-
-  private async startGatewayStreaming(): Promise<void> {
-    if (!this.mediaStream) {
-      throw new Error('No media stream available for gateway streaming');
-    }
-
-    // ── Activate speaker capture via SpeakerDriverController ──────
-    // Ref-counted: speaker stays active as long as any service holds it.
-    // Speaker chunks (channel 1) are forwarded to the gateway automatically
-    // by the main process lifecycle.
-    try {
-      await ipcRenderer.invoke('audio-driver:start-speaker', 'secretary-mode');
-      this.audioDriverConnected = true;
-      console.log('[SecretaryMode] Speaker capture activated for system audio (channel 1)');
-    } catch (err) {
-      console.log('[SecretaryMode] Speaker capture activation failed:', (err as Error).message);
-      this.audioDriverConnected = false;
-    }
-
-    const isMultiChannel = this.audioDriverConnected;
-    console.log(`[SecretaryMode] Multi-channel mode: ${isMultiChannel}`);
-
-    // ── Subscribe to transcript events ──────────────────────────
-    await ipcRenderer.invoke('gateway-transcript-subscribe');
-    ipcRenderer.on('gateway-transcript', this.onGatewayTranscriptBound);
-
-    // ── Create gateway session ──────────────────────────────────
-    const startPayload: { callerName: string; channels?: Record<string, { label: string; source: string; audioFormat?: { inputFormat: string; inputRate?: number; inputChannels?: number } }> } = {
-      callerName: 'Sulla Secretary',
-    };
-    if (isMultiChannel) {
-      startPayload.channels = {
-        '0': { label: 'User', source: 'mic' },
-        '1': {
-          label:       'Caller',
-          source:      'system_audio',
-          audioFormat: { inputFormat: 's16le', inputRate: 16000, inputChannels: 1 },
-        },
-      };
-    }
-
-    const result = await ipcRenderer.invoke('audio-driver:gateway-start', startPayload);
-    if (result?.error || !result?.sessionId) {
-      const reason = result?.error || 'no session ID returned';
-      this.cb.addEntry(`Gateway audio connection failed: ${reason}`, 'transcript');
-      throw new Error(`Gateway audio start failed: ${reason}`);
-    }
-
-    this.gatewaySessionId = result.sessionId;
-    this.gatewayStreamActive = true;
-    console.log(`[SecretaryMode] Gateway session started: ${result.sessionId}`);
-
-    // ── Channel 0: mic audio (captured here via getUserMedia) ───
-    const streamMime = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-      ? 'audio/webm;codecs=opus'
-      : 'audio/webm';
-
-    this.gatewayStreamRecorder = new MediaRecorder(this.mediaStream, { mimeType: streamMime });
-    let micChunkCount = 0;
-    this.gatewayStreamRecorder.ondataavailable = async(event: BlobEvent) => {
-      if (event.data.size > 0 && this.gatewayStreamActive) {
-        micChunkCount++;
-        if (micChunkCount <= 3 || micChunkCount % 100 === 0) {
-          console.log(`[SecretaryMode] Mic chunk #${micChunkCount} (${event.data.size} bytes)`);
-        }
-        const arrayBuffer = await event.data.arrayBuffer();
-        ipcRenderer.invoke('audio-driver:gateway-send', { audio: arrayBuffer, channel: 0 }).catch((err) => {
-          console.error('[SecretaryMode] Failed to send mic chunk:', err);
-        });
-      }
-    };
-    this.gatewayStreamRecorder.onerror = (e: Event) => {
-      console.error('[SecretaryMode] Mic recorder error:', (e as any).error?.message || e);
-    };
-    this.gatewayStreamRecorder.start(250);
-    console.log(`[SecretaryMode] Mic recorder started — mime: ${this.gatewayStreamRecorder.mimeType}`);
-
-    // ── Channel 1: speaker audio ────────────────────────────────
-    // Handled by the audio-driver → AudioDriverClient → gateway pipeline.
-    // No MediaRecorder needed here — the main process forwards chunks
-    // from the audio-driver socket directly to the gateway WebSocket.
-    if (isMultiChannel) {
-      console.log('[SecretaryMode] Speaker audio (channel 1) provided by audio-driver');
-    }
-  }
-
-  private stopGatewayStreaming(): void {
-    this.gatewayStreamActive = false;
-
-    ipcRenderer.removeListener('gateway-transcript', this.onGatewayTranscriptBound);
-    ipcRenderer.invoke('gateway-transcript-unsubscribe').catch((err) => {
-      console.warn('[SecretaryMode] Transcript unsubscribe failed:', err);
-    });
-
-    // Stop mic recorder (channel 0)
-    if (this.gatewayStreamRecorder && this.gatewayStreamRecorder.state !== 'inactive') {
-      try { this.gatewayStreamRecorder.stop(); } catch (err) { console.warn('[SecretaryMode] Mic recorder stop error:', err); }
-    }
-    this.gatewayStreamRecorder = null;
-
-    // Release speaker capture via SpeakerDriverController (ref-counted)
-    if (this.audioDriverConnected) {
-      ipcRenderer.invoke('audio-driver:stop-speaker', 'secretary-mode').catch(() => {});
-      this.audioDriverConnected = false;
-    }
-
-    if (this.gatewaySessionId) {
-      ipcRenderer.invoke('audio-driver:gateway-stop').catch((err) => {
-        console.error('[SecretaryMode] audio-driver:gateway-stop failed:', err);
-      });
-      this.gatewaySessionId = null;
     }
   }
 
@@ -700,95 +389,50 @@ User: ${text}`;
     }
   }
 
-  async analyzeNewTranscript(): Promise<void> {
-    const entries = this.cb.getTranscript().slice(this.lastAnalyzedIndex);
-    if (entries.length === 0) return;
+  private async analyzeNewTranscript(): Promise<void> {
+    const transcript = this.cb.getTranscript();
+    if (transcript.length <= this.lastAnalyzedIndex) return;
 
-    const newText = entries
-      .filter(e => e.type === 'transcript')
-      .map(e => `[${this.formatTime(e.timestamp)}] ${e.text}`)
-      .join('\n');
+    const newEntries = transcript.slice(this.lastAnalyzedIndex);
+    this.lastAnalyzedIndex = transcript.length;
 
-    if (!newText.trim()) return;
-
-    this.lastAnalyzedIndex = this.cb.getTranscript().length;
-    this.cb.setIsAnalyzing(true);
-
-    const isFirst = this.analysisMessageCount === 0;
-    const prompt = isFirst
-      ? `${SECRETARY_SYSTEM_PROMPT}\n\n--- NEW TRANSCRIPT SEGMENT ---\n${newText}`
-      : `--- NEW TRANSCRIPT SEGMENT ---\n${newText}`;
+    const newText = newEntries.map(e => e.text).join('\n');
+    if (!newText.trim() || newText.trim().length < 20) return;
 
     this.analysisMessageCount++;
+    const analysisId = this.analysisMessageCount;
+    const fullTranscript = transcript.map(e => e.text).join('\n');
 
-    const reply = await this.cb.sendToChat(prompt, 'secretary-analysis');
-    if (reply) {
-      this.parseAnalysisResponse(reply);
-    }
-    this.cb.setIsAnalyzing(false);
-  }
+    this.cb.setIsAnalyzing(true);
 
-  private parseAnalysisResponse(text: string): void {
-    if (!text || text.trim() === 'LISTENING') return;
+    const prompt = `Analysis #${analysisId}\n\nFull transcript so far:\n---\n${fullTranscript}\n---\n\nNew segment to analyze:\n---\n${newText}\n---`;
 
-    const lines = text.split('\n').map(l => l.trim()).filter(Boolean);
-    const time = this.formatTimeNow();
-    let hasNewContent = false;
+    try {
+      const response = await this.cb.sendToChat(prompt, 'secretary-analysis');
+      if (response) {
+        const lines = response.split('\n').map(l => l.trim()).filter(Boolean);
+        const time = new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
 
-    for (const line of lines) {
-      if (line.startsWith('ACTION:')) {
-        const item = line.slice(7).trim();
-        if (item && !this.cb.getActionItems().includes(item)) {
-          this.cb.addActionItem(item);
-          hasNewContent = true;
+        for (const line of lines) {
+          if (/^ACTION:\s*/i.test(line)) {
+            this.cb.addActionItem(line.replace(/^ACTION:\s*/i, ''));
+          } else if (/^DECISION:\s*/i.test(line)) {
+            this.cb.addDecision(line.replace(/^DECISION:\s*/i, ''));
+          } else if (/^INSIGHT:\s*/i.test(line)) {
+            this.cb.addInsight({ time, text: line.replace(/^INSIGHT:\s*/i, '') });
+          }
         }
-      } else if (line.startsWith('DECISION:')) {
-        const item = line.slice(9).trim();
-        if (item && !this.cb.getDecisions().includes(item)) {
-          this.cb.addDecision(item);
-          hasNewContent = true;
-        }
-      } else if (line.startsWith('INSIGHT:')) {
-        const item = line.slice(8).trim();
-        if (item) {
-          this.cb.addInsight({ time, text: item });
-          hasNewContent = true;
-        }
-      } else if (line !== 'LISTENING') {
-        this.cb.addAgentMessage({
-          id:   this.generateEntryId(),
-          time,
-          text: line,
-        });
-        hasNewContent = true;
+
+        this.cb.scrollAnalysis();
       }
+    } catch (err) {
+      console.warn('[SecretaryMode] Analysis failed:', err);
+    } finally {
+      this.cb.setIsAnalyzing(false);
     }
-
-    if (hasNewContent) this.cb.scrollAnalysis();
   }
 
-  // ─── Utility ──────────────────────────────────────────────────
-
-  private generateEntryId(): string {
-    return `se_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
-  }
-
-  private formatTime(date: Date): string {
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-  }
-
-  private formatTimeNow(): string {
-    return new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  }
-
-  get currentTranscriptionMode(): string {
-    return this.transcriptionMode;
-  }
-
-  get currentSessionDuration(): string {
-    const elapsed = Math.floor((Date.now() - this.sessionStartTime) / 1000);
-    const mins = Math.floor(elapsed / 60);
-    const secs = elapsed % 60;
-    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  setTTSActive(active: boolean): void {
+    this.hasTTSActive = active;
   }
 }

--- a/pkg/rancher-desktop/controllers/SecretaryModeController.ts
+++ b/pkg/rancher-desktop/controllers/SecretaryModeController.ts
@@ -279,9 +279,11 @@ export class SecretaryModeController {
   private whisperTranscriptHandler: ((_event: any, msg: any) => void) | null = null;
 
   private async startWhisperTranscription(): Promise<void> {
-    // Start whisper via the internal pipeline (PCM format, VAD-gated)
+    // Start whisper in secretary mode so both mic (channel 0) and speaker
+    // (channel 1) audio are transcribed. The speaker pipeline feeds
+    // whisperTranscribe.feedSpeaker() from lifecycle.ts.
     const result = await ipcRenderer.invoke('audio-driver:transcribe-start', {
-      mode: 'conversation',
+      mode: 'secretary',
       language: this.sttLanguage,
     });
 
@@ -290,18 +292,20 @@ export class SecretaryModeController {
       return;
     }
 
-    // Listen for transcript events from whisper
+    // Listen for transcript events from whisper — both mic and speaker channels
     this.whisperTranscriptHandler = (_event: any, msg: any) => {
       if (!msg?.text || !this.cb.getIsListening()) return;
       const text = msg.text.trim();
       if (!text) return;
       if (msg.event_type !== 'transcript_partial') {
-        this.cb.addEntry(text);
+        // Speaker label: 'Mic' = you, 'Speaker' = caller/system audio
+        const speaker = msg.speaker === 'Speaker' ? 'Caller' : 'You';
+        this.cb.addEntry(text, 'transcript', speaker);
         this.checkAndHandleWakeWord(text);
       }
     };
     ipcRenderer.on('gateway-transcript', this.whisperTranscriptHandler);
-    console.log('[SecretaryMode] Whisper transcription started');
+    console.log('[SecretaryMode] Whisper transcription started (secretary mode — mic + speaker)');
   }
 
   private stopWhisperTranscription(): void {

--- a/pkg/rancher-desktop/main/audio-driver/init.ts
+++ b/pkg/rancher-desktop/main/audio-driver/init.ts
@@ -37,6 +37,7 @@ import * as whisper from './model/whisper';
 import * as gateway from './service/gateway';
 import * as speakerSocket from './service/speaker-socket';
 import * as micSocket from './service/mic-socket';
+import * as micPcmSocket from './service/mic-pcm-socket';
 import * as whisperTranscribe from './service/whisper-transcribe';
 import { log, createLogger } from './model/logger';
 
@@ -55,6 +56,10 @@ function broadcast(channel: string, data: any): void {
 // ── Public API ────────────────────────────────────────────────────
 
 let initialized = false;
+
+// Mic PCM recording quality mode — controls which callback feeds mic-pcm-socket.
+// 'raw' = all audio (onPcmRawData), 'noise-reduction' = VAD-gated (onPcmData).
+let micPcmMode: string = 'raw';
 
 // Test recording is now handled by MicrophoneDriverController
 // (PCM-based, supports raw + noise-reduction modes)
@@ -102,11 +107,23 @@ export function initialize(): void {
     }
   });
 
+  // Mic PCM output socket — broadcasts raw PCM to capture studio for recording.
+  // Quality mode controls which callback feeds it:
+  //   'raw'             → onPcmRawData (all audio, no VAD gating)
+  //   'noise-reduction' → onPcmData (VAD-gated, noise-processed)
+  micPcmSocket.start();
+
+  mic.onPcmRawData((pcm: Buffer) => {
+    if (micPcmMode === 'raw') micPcmSocket.writeChunk(pcm);
+  });
+  mic.onPcmData((pcm: Buffer) => {
+    if (micPcmMode === 'noise-reduction') micPcmSocket.writeChunk(pcm);
+  });
+
   micSocket.start((chunk: Buffer) => {
     if (chunk.length > 0) {
       // WebM/Opus chunks go to gateway (it decodes server-side)
       gateway.sendAudio(chunk, 0);
-
     }
   });
 
@@ -131,6 +148,7 @@ export async function shutdown(): Promise<void> {
   await SpeakerDriverController.getInstance().shutdown();
   await MicrophoneDriverController.getInstance().shutdown();
   micSocket.stop();
+  micPcmSocket.stop();
   log.info('Init', 'Audio driver shut down');
 }
 
@@ -145,14 +163,15 @@ function registerIpcHandlers(): void {
   ipcMain.handle('audio-driver:get-state', async() => {
     const mirrorStatus = await mirror.status();
     return {
-      micRunning:     mic.running,
-      speakerRunning: speaker.running,
-      running:        mic.running || speaker.running,
-      message:        mic.running || speaker.running ? 'Capturing' : 'Off',
-      mirrorActive:   mirrorStatus.exists,
-      micName:        mic.micName,
-      speakerName:    speaker.speakerName,
-      permissions:    lifecycle.checkPermissions(),
+      micRunning:      mic.running,
+      micSampleRate:   mic.pcmSampleRate,
+      speakerRunning:  speaker.running,
+      running:         mic.running || speaker.running,
+      message:         mic.running || speaker.running ? 'Capturing' : 'Off',
+      mirrorActive:    mirrorStatus.exists,
+      micName:         mic.micName,
+      speakerName:     speaker.speakerName,
+      permissions:     lifecycle.checkPermissions(),
     };
   });
 
@@ -356,7 +375,23 @@ function registerIpcHandlers(): void {
   // ── Socket paths ────────────────────────────────────────────────
 
   ipcMain.handle('audio-driver:get-mic-socket-path', () => micSocket.getPath());
+  ipcMain.handle('audio-driver:get-mic-pcm-socket-path', () => micPcmSocket.getPath());
   ipcMain.handle('audio-driver:get-speaker-socket-path', () => speakerSocket.getPath());
+
+  // Quality mode for mic PCM recording — controls whether the mic-pcm-socket
+  // receives raw (all audio) or noise-reduced (VAD-gated) PCM.
+  ipcMain.handle('audio-driver:set-mic-pcm-mode', (_event: unknown, mode: string) => {
+    if (mode === 'raw' || mode === 'noise-reduction') {
+      micPcmMode = mode;
+      log.info('IPC', 'set-mic-pcm-mode', { mode });
+      return { ok: true, mode };
+    }
+    return { ok: false, error: 'invalid mode' };
+  });
+
+  ipcMain.handle('audio-driver:get-mic-pcm-mode', () => {
+    return { mode: micPcmMode };
+  });
 
   // ── Auto-launch ─────────────────────────────────────────────────
 

--- a/pkg/rancher-desktop/main/audio-driver/service/mic-pcm-socket.ts
+++ b/pkg/rancher-desktop/main/audio-driver/service/mic-pcm-socket.ts
@@ -1,0 +1,128 @@
+/**
+ * Service — local Unix domain socket for mic PCM audio streaming.
+ *
+ * The main process writes mic PCM data to this socket. The renderer
+ * (Capture Studio) connects and reads the data to write WAV to disk.
+ *
+ * Supports two PCM modes controlled by the capture studio's quality setting:
+ *   - 'raw'              — all audio, no processing (ASMR, music, environment)
+ *   - 'noise-reduction'  — VAD-gated + noise-processed (voice recording)
+ *
+ * Both deliver 48kHz mono s16le PCM. The mode determines which
+ * MicrophoneDriverController callback feeds this socket.
+ *
+ * Protocol (per message):
+ *   4 bytes (UInt32BE) — payload length
+ *   N bytes            — raw PCM data (48kHz, mono, s16le)
+ *
+ * Same pattern as speaker-socket.ts — main process → socket → renderer.
+ */
+
+import net from 'net';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { log } from '../model/logger';
+
+const TAG = 'MicPcmSocket';
+
+let server: net.Server | null = null;
+let socketPath: string | null = null;
+const clients: Set<net.Socket> = new Set();
+let chunkCount = 0;
+
+/**
+ * Start the Unix domain socket server.
+ * Clients that connect will receive length-prefixed PCM frames.
+ */
+export function start(): string | null {
+  if (server) return socketPath;
+
+  chunkCount = 0;
+  socketPath = path.join(os.tmpdir(), `audio-driver-mic-pcm-${ process.pid }.sock`);
+
+  try { fs.unlinkSync(socketPath); } catch {}
+
+  server = net.createServer((conn: net.Socket) => {
+    log.info(TAG, 'Client connected');
+    clients.add(conn);
+
+    conn.on('close', () => {
+      log.info(TAG, 'Client disconnected');
+      clients.delete(conn);
+    });
+
+    conn.on('error', (err: Error) => {
+      log.warn(TAG, 'Client error', { error: err.message });
+      clients.delete(conn);
+    });
+  });
+
+  server.on('error', (err: Error) => {
+    log.error(TAG, 'Server error', { error: err.message });
+  });
+
+  server.listen(socketPath, () => {
+    log.info(TAG, 'Listening', { path: socketPath });
+  });
+
+  return socketPath;
+}
+
+/**
+ * Write a PCM chunk to all connected clients.
+ * Called from init.ts via MicrophoneDriverController PCM callbacks.
+ */
+export function writeChunk(pcmData: Buffer): void {
+  if (clients.size === 0) return;
+
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(pcmData.length, 0);
+  const frame = Buffer.concat([header, pcmData]);
+
+  chunkCount++;
+  if (chunkCount <= 3 || chunkCount % 500 === 0) {
+    log.debug(TAG, 'Mic PCM chunk broadcast', { bytes: pcmData.length, clients: clients.size, total: chunkCount });
+  }
+
+  for (const client of clients) {
+    if (!client.destroyed) {
+      client.write(frame);
+    }
+  }
+}
+
+/** Whether any clients are connected (recording in progress). */
+export function hasClients(): boolean {
+  return clients.size > 0;
+}
+
+/**
+ * Stop the socket server and disconnect all clients.
+ */
+export function stop(): void {
+  for (const client of clients) {
+    client.destroy();
+  }
+  clients.clear();
+
+  if (server) {
+    server.close();
+    server = null;
+  }
+
+  if (socketPath) {
+    try { fs.unlinkSync(socketPath); } catch {}
+    log.info(TAG, 'Stopped', { path: socketPath });
+    socketPath = null;
+  }
+
+  chunkCount = 0;
+}
+
+/**
+ * Get the socket path (for passing to renderer via IPC).
+ */
+export function getPath(): string | null {
+  return socketPath;
+}

--- a/pkg/rancher-desktop/main/audio-driver/service/whisper-transcribe.ts
+++ b/pkg/rancher-desktop/main/audio-driver/service/whisper-transcribe.ts
@@ -79,6 +79,15 @@ export function start(opts: {
     return false;
   }
 
+  // If already running, just update the callback — don't reset buffers or
+  // create duplicate flush timers. Multiple services (teleprompter, secretary)
+  // share the same whisper instance.
+  if (mode !== null && flushTimer) {
+    log.info('WhisperTranscribe', 'Already running — updating callback only', { mode: opts.mode });
+    onTranscript = opts.onTranscript;
+    return true;
+  }
+
   // Use requested model if available, otherwise first available model
   modelName = models.includes(requestedModel) ? requestedModel : models[0];
   mode = opts.mode;
@@ -138,10 +147,16 @@ export function getStats(): { active: boolean; mode: TranscribeMode | null; tran
  * VAD detects speech. Chunks are accumulated and flushed to
  * whisper.cpp periodically.
  */
+let feedMicCount = 0;
+
 export function feedMic(chunk: Buffer): void {
   if (!mode) return;
   micBuffer.push(chunk);
   micBytes += chunk.length;
+  feedMicCount++;
+  if (feedMicCount <= 3 || feedMicCount % 100 === 0) {
+    log.debug('WhisperTranscribe', 'feedMic', { chunkBytes: chunk.length, totalBytes: micBytes, count: feedMicCount });
+  }
 
   if (micBytes >= MAX_BUFFER_BYTES) flush();
 }
@@ -255,7 +270,7 @@ function transcribeChunk(pcm: Buffer, channel: number, speakerLabel: string): vo
     '-t', String(threads),
   ];
 
-  log.debug('WhisperTranscribe', 'Running whisper', { channel, wavPath, model: modelName, threads });
+  log.debug('WhisperTranscribe', 'Running whisper', { channel, wavPath, model: modelName, threads, pcmBytes: pcm.length });
 
   // 10-second timeout — if whisper hangs (CPU contention with LlamaCpp),
   // release the mutex so the next flush can try again with fresh audio.

--- a/pkg/rancher-desktop/main/audio-driver/service/whisper-transcribe.ts
+++ b/pkg/rancher-desktop/main/audio-driver/service/whisper-transcribe.ts
@@ -147,16 +147,10 @@ export function getStats(): { active: boolean; mode: TranscribeMode | null; tran
  * VAD detects speech. Chunks are accumulated and flushed to
  * whisper.cpp periodically.
  */
-let feedMicCount = 0;
-
 export function feedMic(chunk: Buffer): void {
   if (!mode) return;
   micBuffer.push(chunk);
   micBytes += chunk.length;
-  feedMicCount++;
-  if (feedMicCount <= 3 || feedMicCount % 100 === 0) {
-    log.debug('WhisperTranscribe', 'feedMic', { chunkBytes: chunk.length, totalBytes: micBytes, count: feedMicCount });
-  }
 
   if (micBytes >= MAX_BUFFER_BYTES) flush();
 }
@@ -270,7 +264,7 @@ function transcribeChunk(pcm: Buffer, channel: number, speakerLabel: string): vo
     '-t', String(threads),
   ];
 
-  log.debug('WhisperTranscribe', 'Running whisper', { channel, wavPath, model: modelName, threads, pcmBytes: pcm.length });
+  log.debug('WhisperTranscribe', 'Running whisper', { channel, wavPath, model: modelName, threads });
 
   // 10-second timeout — if whisper hangs (CPU contention with LlamaCpp),
   // release the mutex so the next flush can try again with fresh audio.

--- a/pkg/rancher-desktop/main/audio-driver/service/whisper-transcribe.ts
+++ b/pkg/rancher-desktop/main/audio-driver/service/whisper-transcribe.ts
@@ -241,6 +241,10 @@ function transcribeChunk(pcm: Buffer, channel: number, speakerLabel: string): vo
 
   transcribing = true;
 
+  // Use 2 threads max — whisper shares CPU with LlamaCpp and other services.
+  // 4 threads caused whisper-cli to hang under contention.
+  const threads = Math.min(os.cpus().length, 2);
+
   const args = [
     '-m', modelPath,
     '-f', wavPath,
@@ -248,17 +252,24 @@ function transcribeChunk(pcm: Buffer, channel: number, speakerLabel: string): vo
     '--no-timestamps',
     '-nt',             // no-timestamps shorthand
     '--print-special', 'false',
-    '-t', String(Math.min(os.cpus().length, 4)), // thread count capped at 4
+    '-t', String(threads),
   ];
 
-  log.debug('WhisperTranscribe', 'Running whisper', { channel, wavPath, model: modelName });
+  log.debug('WhisperTranscribe', 'Running whisper', { channel, wavPath, model: modelName, threads });
 
-  execFile(status.binaryPath, args, { timeout: 30000 }, (err, stdout, stderr) => {
+  // 10-second timeout — if whisper hangs (CPU contention with LlamaCpp),
+  // release the mutex so the next flush can try again with fresh audio.
+  execFile(status.binaryPath, args, { timeout: 10000 }, (err, stdout, stderr) => {
     transcribing = false;
     cleanupFile(wavPath);
 
     if (err) {
-      log.error('WhisperTranscribe', 'whisper-cpp failed', { error: err.message, stderr });
+      const isTimeout = (err as any).killed || err.message?.includes('TIMEOUT');
+      if (isTimeout) {
+        log.warn('WhisperTranscribe', 'whisper-cpp timed out (10s) — skipping chunk', { channel });
+      } else {
+        log.error('WhisperTranscribe', 'whisper-cpp failed', { error: err.message, stderr });
+      }
       return;
     }
 
@@ -267,6 +278,7 @@ function transcribeChunk(pcm: Buffer, channel: number, speakerLabel: string): vo
       .trim();
 
     if (!text || text === '[BLANK_AUDIO]' || text.length < 2) {
+      log.debug('WhisperTranscribe', 'Blank/empty transcript — skipping', { channel, text: text || '(empty)' });
       return;
     }
 

--- a/pkg/rancher-desktop/main/teleprompterTracking.ts
+++ b/pkg/rancher-desktop/main/teleprompterTracking.ts
@@ -312,7 +312,7 @@ export function onVadUpdate(data: { speaking?: boolean }): void {
 
 // ─── IPC ──────────────────────────────────────────────────────────
 
-async function handleStart(): Promise<{ ok: boolean }> {
+async function handleStart(): Promise<{ ok: boolean; error?: string }> {
   if (isTracking) {
     // Already running — restart cleanly
     handleStop();
@@ -324,16 +324,25 @@ async function handleStart(): Promise<{ ok: boolean }> {
 
   const mic = MicrophoneDriverController.getInstance();
 
-  // Start mic (reference-counted — safe to call if already running)
+  // Start mic (reference-counted — safe to call if already running).
+  // The capture studio already holds the mic with webm-opus + pcm-s16le,
+  // so this just adds another holder — the tray panel mic stays running.
   await mic.start(SERVICE_ID, undefined, { formats: ['pcm-s16le'] });
 
   // Start whisper if not already running
   if (!whisperTranscribe.isActive()) {
     if (!whisper.isAvailable()) {
+      console.log('[TeleprompterTracking] Whisper not cached — running detect()');
       await whisper.detect();
     }
 
-    whisperTranscribe.start({
+    if (!whisper.isAvailable()) {
+      console.error('[TeleprompterTracking] Whisper is not installed — cannot start voice tracking');
+      await mic.stop(SERVICE_ID).catch(() => {});
+      return { ok: false, error: 'whisper-not-available' };
+    }
+
+    const whisperStarted = whisperTranscribe.start({
       mode:         'conversation',
       onTranscript: (event) => {
         // Broadcast to renderers (voice session, secretary, etc.)
@@ -346,6 +355,16 @@ async function handleStart(): Promise<{ ok: boolean }> {
         onWhisperTranscript(event);
       },
     });
+
+    if (!whisperStarted) {
+      console.error('[TeleprompterTracking] whisperTranscribe.start() returned false — no models?');
+      await mic.stop(SERVICE_ID).catch(() => {});
+      return { ok: false, error: 'whisper-start-failed' };
+    }
+
+    console.log('[TeleprompterTracking] Whisper started successfully');
+  } else {
+    console.log('[TeleprompterTracking] Whisper already active — reusing');
   }
   // If whisper was already active (started by another service), we
   // receive transcripts via the onWhisperTranscript() hook in init.ts.

--- a/pkg/rancher-desktop/pages/AgentRouter.vue
+++ b/pkg/rancher-desktop/pages/AgentRouter.vue
@@ -47,6 +47,13 @@
     <footer class="agent-footer">
       <div class="agent-footer-left">
         <span
+          v-if="appVersion"
+          class="footer-item footer-version"
+          :title="`Sulla Desktop v${appVersion}`"
+        >
+          v{{ appVersion }}
+        </span>
+        <span
           class="footer-item"
           :title="`${formatBytes(footerStats.availableBytes)} free on disk`"
         >
@@ -139,6 +146,9 @@ watch(sidePanelBlocked, (blocked) => {
 });
 
 const isBrowserRoute = computed(() => route.path.startsWith('/Browser/'));
+
+// ── App version ──
+const appVersion = ref('');
 
 // ── Footer state ──
 const footerStats = reactive({ availableBytes: 0, unprocessedTrainingBytes: 0 });
@@ -308,6 +318,11 @@ onMounted(async() => {
   presenceTracker.setActiveChannel('sulla-desktop');
   presenceTracker.start();
 
+  ipcRenderer.on('get-app-version', (_event: any, version: string) => {
+    appVersion.value = version;
+  });
+  ipcRenderer.send('get-app-version');
+
   refreshFooterStats();
   footerStatsTimer = setInterval(refreshFooterStats, 30_000);
 
@@ -404,6 +419,11 @@ onUnmounted(() => {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+}
+
+.footer-version {
+  font-weight: var(--weight-semibold);
+  opacity: 0.7;
 }
 
 .footer-item svg {

--- a/pkg/rancher-desktop/pages/CaptureStudio.vue
+++ b/pkg/rancher-desktop/pages/CaptureStudio.vue
@@ -1387,24 +1387,40 @@ onMounted(async () => {
   loading.value = false;
 });
 
-// ── Graceful shutdown when app is quitting ──
-ipcRenderer.on('app:before-quit', async() => {
-  console.log('[CaptureStudio] Received app:before-quit — stopping capture');
+// ── Full cleanup — shared by before-quit and onUnmounted ──
+async function cleanupCaptureStudio() {
+  console.log('[CaptureStudio] Cleaning up...');
 
   // Stop recording if active
   if (recording.value) {
+    micRecording.stop();
     speakerCapture.stop();
+    inputTracker.stopTracking();
     await recorder.stopSession();
     recording.value = false;
+    diskSpace.stopMonitoring();
+  }
+
+  // Stop teleprompter tracking
+  teleprompterRef.value?.stopTracking?.();
+
+  // Close floating teleprompter
+  if (prompterEnabled.value) {
+    ipcRenderer.invoke('teleprompter:close').catch(() => {});
+    prompterEnabled.value = false;
   }
 
   // Release all media streams (screen + camera)
   mediaSources.releaseScreen();
   mediaSources.releaseCamera();
 
-  // Stop audio driver
+  // Disconnect from controllers
   try { await audioDriver.stopMic(); } catch { /* already stopped */ }
   try { await audioDriver.stopSpeaker(); } catch { /* already stopped */ }
+}
+
+ipcRenderer.on('app:before-quit', () => {
+  cleanupCaptureStudio();
 });
 
 onUnmounted(() => {
@@ -1413,12 +1429,7 @@ onUnmounted(() => {
   stopAudioMeter();
   stopWaveformLoop();
   diskSpace.stopMonitoring();
-  // Close floating teleprompter if open
-  if (prompterEnabled.value) {
-    ipcRenderer.invoke('teleprompter:close').catch(() => {});
-  }
-
-  audioDriver.stopMic().catch(() => {});
+  cleanupCaptureStudio();
 });
 </script>
 

--- a/pkg/rancher-desktop/pages/CaptureStudio.vue
+++ b/pkg/rancher-desktop/pages/CaptureStudio.vue
@@ -232,16 +232,17 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, shallowReactive, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
+import { ref, reactive, computed, watch, onMounted, onUnmounted, nextTick } from 'vue';
 import WindowDragLogo from '@pkg/components/WindowDragLogo.vue';
 import { useAudioDriver } from './capture-studio/composables/useAudioDriver';
-import { createMicInstance, listAudioDevices, type MicInstance } from './capture-studio/composables/useMicCapture';
+import { listAudioDevices } from './capture-studio/composables/useMicCapture';
 import { useMediaSources, QUALITY_PRESETS, type QualityPreset } from './capture-studio/composables/useMediaSources';
 import { useRecorder } from './capture-studio/composables/useRecorder';
 import { useRmsWaveform, useAnalyserWaveform, levelToPercent } from './capture-studio/composables/useWaveform';
 import { useSettings } from './capture-studio/composables/useSettings';
 import { useDiskSpace } from './capture-studio/composables/useDiskSpace';
 import { useSpeakerCapture } from './capture-studio/composables/useSpeakerCapture';
+import { useMicRecording, type MicQualityMode } from './capture-studio/composables/useMicRecording';
 import { useInputEventTracker } from './capture-studio/composables/useInputEventTracker';
 
 import ContextMenu from './capture-studio/ContextMenu.vue';
@@ -264,9 +265,7 @@ const inputTracker = useInputEventTracker(recorder.logEvent);
 const settings = useSettings();
 const diskSpace = useDiskSpace();
 const speakerCapture = useSpeakerCapture();
-
-// Mic instances keyed by source id (created on first use, not at module level)
-const micInstances = shallowReactive<Record<string, MicInstance>>({});
+const micRecording = useMicRecording();
 
 // Loading state
 const loading = ref(true);
@@ -515,9 +514,7 @@ async function toggleSrc(src: Source) {
         console.log('[CaptureStudio] Camera acquired, stream:', mediaSources.cameraStream.value ? 'active' : 'null', 'tracks:', mediaSources.cameraStream.value?.getVideoTracks().length);
         updateStreamAssignments();
       } else if (src.type === 'mic') {
-        const mic = micInstances[src.id] || createMicInstance();
-        micInstances[src.id] = mic;
-        await mic.start();
+        await audioDriver.startMic(['webm-opus', 'pcm-s16le']);
       } else if (src.type === 'system') {
         await audioDriver.startSpeaker();
       }
@@ -531,7 +528,7 @@ async function toggleSrc(src: Source) {
     } else if (src.type === 'camera') {
       mediaSources.releaseCamera();
     } else if (src.type === 'mic') {
-      micInstances[src.id]?.stop();
+      await audioDriver.stopMic();
     } else if (src.type === 'system') {
       await audioDriver.stopSpeaker();
     }
@@ -551,7 +548,7 @@ async function toggleSrc(src: Source) {
 }
 
 // ─── Layout selection ───
-function selectLayout(layout: string) {
+async function selectLayout(layout: string) {
   const vids = videoSources.value;
 
   if (layout === 'camonly') {
@@ -566,7 +563,7 @@ function selectLayout(layout: string) {
   currentLayout.value = layout;
 
   if (layout === 'teleprompter') {
-    teleprompterRef.value?.activate();
+    await teleprompterRef.value?.activate();
     // Auto-open the floating teleprompter window
     if (!prompterEnabled.value) {
       prompterEnabled.value = true;
@@ -602,13 +599,8 @@ async function toggleRecord() {
     // Gather active streams for recording — check stream.active not just existence
     const streams: Array<{ id: string; type: 'screen' | 'camera' | 'mic' | 'system-audio'; stream: MediaStream }> = [];
 
-    // Record mic as standalone audio file (not muxed into video streams)
-    for (const [id, mic] of Object.entries(micInstances)) {
-      const micStream = mic.stream.value;
-      if (micStream && micStream.active && mic.active.value) {
-        streams.push({ id, type: 'mic', stream: micStream });
-      }
-    }
+    // Mic recording is handled by useMicRecording via the controller's
+    // mic-pcm-socket (PCM) or mic-socket (WebM). Not a MediaRecorder stream.
 
     // Screen — video only, no mic audio muxed in
     const screenVal = mediaSources.screenStream.value;
@@ -622,7 +614,7 @@ async function toggleRecord() {
       streams.push({ id: 'cam', type: 'camera', stream: camVal, quality: mediaSources.cameraQuality.value });
     }
 
-    if (streams.length === 0) {
+    if (streams.length === 0 && !audioDriver.micRunning.value && !audioDriver.speakerRunning.value) {
       statusMessage.value = 'Enable at least one source to record';
       setTimeout(() => { statusMessage.value = ''; }, 3000);
       return;
@@ -658,6 +650,22 @@ async function toggleRecord() {
       });
     }
 
+    // Start mic recording via controller socket if mic is running
+    if (audioDriver.micRunning.value) {
+      const path = require('path');
+      const isCompressed = micQualityMode.value === 'streaming' || micQualityMode.value === 'streaming-voice';
+      const ext = isCompressed ? 'webm' : 'wav';
+      const micPath = path.join(recorder.getSessionDir(), `mic.${ext}`);
+      await micRecording.start(micPath, micQualityMode.value as MicQualityMode);
+      recorder.registerExternalStream({
+        id:              'mic',
+        type:            'mic',
+        filename:        `mic.${ext}`,
+        format:          ext,
+        getBytesWritten: () => micRecording.bytesWritten.value,
+      });
+    }
+
     recording.value = true;
 
     // Start event tracking (mouse clicks, keystrokes, window focus)
@@ -674,8 +682,9 @@ async function toggleRecord() {
   } else {
     // Capture session dir BEFORE stopSession clears it
     const capturedSessionDir = recorder.getSessionDir();
-    // Stop event tracking + speaker capture
+    // Stop event tracking + mic/speaker capture
     inputTracker.stopTracking();
+    micRecording.stop();
     speakerCapture.stop();
     await recorder.stopSession();
     lastSessionDir.value = capturedSessionDir;
@@ -805,14 +814,15 @@ async function confirmAdd(payload: { type: string; deviceId: string; label: stri
   };
   sources.push(newSrc);
 
-  // Create mic instance for new mic sources
+  // Start mic via controller for new mic sources
   if (payload.type === 'mic') {
-    const mic = createMicInstance();
-    micInstances[id] = mic;
     try {
-      // Resolve real browser deviceId from label (AddSourceDialog passes labels)
-      const realDeviceId = deviceIdMap[payload.deviceId] || undefined;
-      await mic.start(realDeviceId);
+      // Switch to the selected device via the controller
+      const deviceLabel = payload.deviceId;
+      if (deviceLabel && deviceLabel !== 'default') {
+        await audioDriver.setMicDevice(deviceLabel);
+      }
+      await audioDriver.startMic(['webm-opus', 'pcm-s16le']);
     } catch (e: any) {
       console.error('[CaptureStudio] Failed to start mic for new source:', e.message);
       newSrc.on = false;
@@ -831,10 +841,10 @@ async function confirmAdd(payload: { type: string; deviceId: string; label: stri
 }
 
 function removeSource(id: string) {
-  // Stop mic instance if exists
-  if (micInstances[id]) {
-    micInstances[id].stop();
-    delete micInstances[id];
+  // Stop mic via controller if this was a mic source
+  const src = sources.find(s => s.id === id);
+  if (src?.type === 'mic') {
+    audioDriver.stopMic().catch(() => {});
   }
   const idx = sources.findIndex(s => s.id === id);
   if (idx > -1) sources.splice(idx, 1);
@@ -883,22 +893,16 @@ function startAudioMeter() {
       }
       const bars = container.children;
 
-      // Combine all active mic levels + speaker level
+      // Combine mic level (from controller VAD) + speaker level
       const spActive = speakerCapture && speakerCapture.active ? speakerCapture.active.value : false;
       const speakerLvl = spActive ? speakerCapture.level.value : (audioDriver.speakerLevel ? audioDriver.speakerLevel.value : 0);
-      let combinedLevel = speakerLvl;
-      for (const mic of Object.values(micInstances)) {
-        if (mic && mic.active && mic.active.value && mic.level) {
-          combinedLevel = Math.max(combinedLevel, mic.level.value);
-        }
-      }
+      const micLvl = audioDriver.micRunning.value ? audioDriver.micLevel.value : 0;
+      const combinedLevel = Math.max(speakerLvl, micLvl);
 
       // Log occasionally to debug
       meterLogCount++;
       if (meterLogCount <= 5 || meterLogCount % 300 === 0) {
-        const micKeys = Object.keys(micInstances);
-        const activeMics = micKeys.filter(k => micInstances[k]?.active?.value);
-        console.log('[AudioMeter]', { combinedLevel: combinedLevel.toFixed(3), speakerLvl: speakerLvl.toFixed(3), speakerRunning: audioDriver.speakerRunning.value, spActive, activeMics, bars: bars.length });
+        console.log('[AudioMeter]', { combinedLevel: combinedLevel.toFixed(3), micLvl: micLvl.toFixed(3), speakerLvl: speakerLvl.toFixed(3), micRunning: audioDriver.micRunning.value, bars: bars.length });
       }
 
       for (let i = 0; i < bars.length; i++) {
@@ -1070,23 +1074,15 @@ async function showAudioContextMenu(e: MouseEvent) {
     }
 
     const micSrc = sources.find(s => s.id === 'mic');
-    const currentMic = micInstances['mic'];
-    // Determine which deviceId is currently active (default = 'default')
-    const activeMicDeviceId = currentMic?.stream.value?.getAudioTracks()[0]?.getSettings()?.deviceId || 'default';
 
     const deviceChildren: CtxMenuItem[] = inputs.map(d => ({
       id: d.deviceId,
       label: d.label,
-      active: d.deviceId === activeMicDeviceId,
+      active: false, // TODO: track active device name from controller state
       action: async () => {
-        // Switch the builtin mic to the selected device
-        if (currentMic) {
-          currentMic.stop();
-        }
-        const mic = createMicInstance();
-        micInstances['mic'] = mic;
+        // Switch the mic device via the controller
         try {
-          await mic.start(d.deviceId === 'default' ? undefined : d.deviceId);
+          await audioDriver.setMicDevice(d.label);
           if (micSrc) {
             micSrc.on = true;
             micSrc.name = d.label;
@@ -1102,7 +1098,12 @@ async function showAudioContextMenu(e: MouseEvent) {
       id: `mq-${m.id}`,
       label: m.label,
       active: micQualityMode.value === m.id,
-      action: () => { micQualityMode.value = m.id; },
+      action: () => {
+        micQualityMode.value = m.id;
+        // Tell the controller which PCM mode to use
+        const pcmMode = m.id === 'raw' ? 'raw' : 'noise-reduction';
+        audioDriver.setMicPcmMode(pcmMode).catch(() => {});
+      },
     }));
 
     ctxMenu.items = [
@@ -1142,16 +1143,8 @@ const WAVEFORM_SCROLL_INTERVAL = 80; // ms between scrolls — gives a steady DA
 
 function getCurrentLevel(src: { id: string; type: string; on: boolean }): number {
   if (src.type === 'mic') {
-    const mic = micInstances[src.id];
-    const analyserNode = mic && mic.analyser ? mic.analyser.value : null;
-    if (analyserNode) {
-      const data = new Uint8Array(analyserNode.frequencyBinCount);
-      analyserNode.getByteFrequencyData(data);
-      let sum = 0;
-      for (let i = 0; i < data.length; i++) sum += data[i];
-      return sum / data.length / 255; // 0-1 RMS-like average
-    }
-    return (mic && mic.level) ? mic.level.value : 0;
+    // Mic level comes from the controller's VAD pipeline
+    return audioDriver.micRunning.value ? audioDriver.micLevel.value : 0;
   } else if (src.type === 'system') {
     const spActive = speakerCapture && speakerCapture.active ? speakerCapture.active.value : false;
     return spActive ? speakerCapture.level.value : (audioDriver.speakerLevel ? audioDriver.speakerLevel.value : 0);
@@ -1204,20 +1197,11 @@ function startWaveformLoop() {
         // Live spectrum mode (not recording)
         const bars: number[] = [];
         if (src.type === 'mic') {
-          const mic = micInstances[src.id];
-          const analyserNode = mic && mic.analyser ? mic.analyser.value : null;
-          if (analyserNode) {
-            const data = new Uint8Array(analyserNode.frequencyBinCount);
-            analyserNode.getByteFrequencyData(data);
-            const binSize = Math.max(1, Math.floor(data.length / 100));
-            for (let i = 0; i < 100; i++) {
-              let sum = 0;
-              for (let j = 0; j < binSize; j++) sum += data[i * binSize + j];
-              bars.push(Math.max(2, (sum / binSize / 255) * 18));
-            }
-          } else {
-            const lvl = level;
-            for (let i = 0; i < 100; i++) bars.push(Math.max(2, lvl * 14 + 2));
+          // Level-based bars from controller VAD (no local analyser needed)
+          const lvl = level;
+          for (let i = 0; i < 100; i++) {
+            const jitter = lvl > 0.01 ? (Math.random() - 0.5) * lvl * 6 : 0;
+            bars.push(Math.max(2, lvl * 14 + 2 + jitter));
           }
         } else if (src.type === 'system') {
           for (let i = 0; i < 100; i++) {
@@ -1418,15 +1402,9 @@ ipcRenderer.on('app:before-quit', async() => {
   mediaSources.releaseScreen();
   mediaSources.releaseCamera();
 
-  // Stop all mic instances
-  for (const mic of Object.values(micInstances)) {
-    mic.stop();
-  }
-
-  // Stop audio driver capture
-  try {
-    await audioDriver.stopSpeaker();
-  } catch { /* already stopped */ }
+  // Stop audio driver
+  try { await audioDriver.stopMic(); } catch { /* already stopped */ }
+  try { await audioDriver.stopSpeaker(); } catch { /* already stopped */ }
 });
 
 onUnmounted(() => {
@@ -1440,9 +1418,7 @@ onUnmounted(() => {
     ipcRenderer.invoke('teleprompter:close').catch(() => {});
   }
 
-  for (const mic of Object.values(micInstances)) {
-    mic.stop();
-  }
+  audioDriver.stopMic().catch(() => {});
 });
 </script>
 

--- a/pkg/rancher-desktop/pages/SecretaryMode.vue
+++ b/pkg/rancher-desktop/pages/SecretaryMode.vue
@@ -133,7 +133,7 @@
             <div v-if="isListening && transcript.length === 0" class="dt-turn">
               <div class="dt-turn-bar" style="background: var(--text-dim, #6e7681);" />
               <div class="dt-turn-content">
-                <div class="dt-turn-text dt-dim">Listening...</div>
+                <div class="dt-turn-text dt-dim">{{ listeningStatus }}</div>
               </div>
             </div>
           </div>
@@ -209,7 +209,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onUnmounted, nextTick } from 'vue';
+import { ref, watch, onUnmounted, nextTick } from 'vue';
 import { useBrowserTabs, type BrowserTabMode } from '@pkg/composables/useBrowserTabs';
 import { ChatInterface } from './agent/ChatInterface';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
@@ -232,6 +232,7 @@ const isMac = navigator.platform.toUpperCase().includes('MAC');
 const hasSessionEnded = ref(false);
 const transcript = ref<TranscriptEntry[]>([]);
 const isListening = ref(false);
+const listeningStatus = ref('Starting...');
 const wakeWordActive = ref(false);
 const audioLevel = ref(0);
 const sessionDuration = ref('0:00');
@@ -435,6 +436,7 @@ async function startSession(): Promise<void> {
   try {
     isListening.value = true;
     hasSessionEnded.value = false;
+    listeningStatus.value = 'Starting microphone...';
     actionItems.value = [];
     decisions.value = [];
     insights.value = [];
@@ -442,11 +444,21 @@ async function startSession(): Promise<void> {
     updateTab(props.tabId, { title: 'Secretary - Recording' });
 
     await controller.startSession();
+    listeningStatus.value = 'Listening...';
   } catch (err) {
     console.error('[SecretaryMode] Failed to start session:', err);
+    listeningStatus.value = 'Failed to start';
     isListening.value = false;
   }
 }
+
+// Update status based on audio activity
+watch(audioLevel, (level) => {
+  if (!isListening.value || transcript.value.length > 0) return;
+  if (level > 10) {
+    listeningStatus.value = 'Hearing you — transcribing...';
+  }
+});
 
 function endSession(): void {
   isListening.value = false;

--- a/pkg/rancher-desktop/pages/capture-studio/TeleprompterLayout.vue
+++ b/pkg/rancher-desktop/pages/capture-studio/TeleprompterLayout.vue
@@ -272,10 +272,10 @@ function onKeyDown(e: KeyboardEvent) {
 }
 
 // Expose methods so the parent can call them when layout changes
-function activate() {
+async function activate() {
   buildTpWords();
   if (voiceTracking.value) {
-    teleprompterTracker.startTracking(tpWords.value, tpCurrentIndex.value);
+    await teleprompterTracker.startTracking(tpWords.value, tpCurrentIndex.value);
   } else {
     startTpScroll();
   }
@@ -319,7 +319,7 @@ watch(tpWords, () => {
   // Keep the main-process tracker in sync when the script changes mid-session
   if (teleprompterTracker.isTracking.value) {
     ipc.invoke('teleprompter-tracking:set-script', {
-      words:        tpWords.value,
+      words:        [...tpWords.value],
       currentIndex: tpCurrentIndex.value,
     }).catch(() => {});
   }

--- a/pkg/rancher-desktop/pages/capture-studio/composables/useAudioDriver.ts
+++ b/pkg/rancher-desktop/pages/capture-studio/composables/useAudioDriver.ts
@@ -1,11 +1,12 @@
 /**
  * Composable — audio-driver IPC bridge for Capture Studio.
  *
- * Wraps the audio-driver IPC channels as reactive refs.
- * Speaker capture is handled by the main process (CoreAudio daemon).
- * No transcription — pure capture only.
+ * All mic and speaker access goes through MicrophoneDriverController /
+ * SpeakerDriverController via IPC. The tray panel renderer owns the
+ * actual getUserMedia stream and Web Audio pipeline. This composable
+ * provides reactive refs for level metering, VAD state, and lifecycle.
  *
- * Reference: main/trayPanel/renderer/bridge.js
+ * Reference: main/audio-driver/controller/MicrophoneDriverController.ts
  */
 
 import { ref, onMounted, onUnmounted } from 'vue';
@@ -13,30 +14,92 @@ import { ref, onMounted, onUnmounted } from 'vue';
 const { ipcRenderer } = require('electron');
 
 export function useAudioDriver() {
+  // ── Mic state (from MicrophoneDriverController via audio-driver:mic-vad) ──
+
+  const micLevel = ref(0);
+  const micRunning = ref(false);
+  const micSpeaking = ref(false);
+  const micMuted = ref(false);
+
+  // ── Speaker state ──
+
   const speakerLevel = ref(0);
   const speakerRunning = ref(false);
 
-  // ── IPC listeners (registered on mount, removed on unmount to prevent stacking) ──
+  // ── IPC listeners ──
 
-  let levelCount = 0;
-  const onLevel = (_e: any, data: { rms: number }) => {
+  let micVadCount = 0;
+  const onMicVad = (_e: any, data: any) => {
+    if (!data) return;
+    micLevel.value = data.level ?? 0;
+    micSpeaking.value = !!data.speaking;
+    micVadCount++;
+  };
+
+  let speakerLevelCount = 0;
+  const onSpeakerLevel = (_e: any, data: { rms: number }) => {
     speakerLevel.value = typeof data === 'number' ? data : data.rms;
-    levelCount++;
-    if (levelCount <= 5 || (levelCount % 300 === 0)) {
-      console.log('[useAudioDriver] speaker-level', { rms: speakerLevel.value, count: levelCount });
+    speakerLevelCount++;
+    if (speakerLevelCount <= 5 || (speakerLevelCount % 300 === 0)) {
+      console.log('[useAudioDriver] speaker-level', { rms: speakerLevel.value, count: speakerLevelCount });
     }
   };
 
   onMounted(() => {
     console.log('[useAudioDriver] Registering IPC listeners');
-    ipcRenderer.on('audio-driver:speaker-level', onLevel);
+    ipcRenderer.on('audio-driver:mic-vad', onMicVad);
+    ipcRenderer.on('audio-driver:speaker-level', onSpeakerLevel);
   });
 
   onUnmounted(() => {
-    ipcRenderer.removeListener('audio-driver:speaker-level', onLevel);
+    ipcRenderer.removeListener('audio-driver:mic-vad', onMicVad);
+    ipcRenderer.removeListener('audio-driver:speaker-level', onSpeakerLevel);
   });
 
-  // ── Commands ──
+  // ── Mic commands ──
+
+  async function startMic(formats?: string[]): Promise<any> {
+    const result = await ipcRenderer.invoke('audio-driver:start-mic', 'capture-studio', formats || ['webm-opus', 'pcm-s16le']);
+    micRunning.value = !!result?.micRunning;
+    return result;
+  }
+
+  async function stopMic(): Promise<void> {
+    const result = await ipcRenderer.invoke('audio-driver:stop-mic', 'capture-studio');
+    micRunning.value = !!result?.micRunning;
+  }
+
+  function setMicGain(value: number): void {
+    ipcRenderer.send('audio-driver:mic-gain', value);
+  }
+
+  function setMicMuted(muted: boolean): void {
+    micMuted.value = muted;
+    ipcRenderer.send('audio-driver:mic-mute', muted);
+  }
+
+  async function getMicSocketPath(): Promise<string | null> {
+    return ipcRenderer.invoke('audio-driver:get-mic-socket-path');
+  }
+
+  async function getMicPcmSocketPath(): Promise<string | null> {
+    return ipcRenderer.invoke('audio-driver:get-mic-pcm-socket-path');
+  }
+
+  /**
+   * Set the mic PCM quality mode for recording.
+   * 'raw' = all audio, no processing (ASMR/music/environment)
+   * 'noise-reduction' = VAD-gated + noise-processed (voice)
+   */
+  async function setMicPcmMode(mode: 'raw' | 'noise-reduction'): Promise<void> {
+    await ipcRenderer.invoke('audio-driver:set-mic-pcm-mode', mode);
+  }
+
+  async function setMicDevice(deviceName: string): Promise<void> {
+    await ipcRenderer.invoke('audio-driver:set-system-input', deviceName);
+  }
+
+  // ── Speaker commands ──
 
   async function startSpeaker(): Promise<void> {
     const result = await ipcRenderer.invoke('audio-driver:start-speaker', 'capture-studio');
@@ -50,6 +113,7 @@ export function useAudioDriver() {
 
   async function getState(): Promise<any> {
     const state = await ipcRenderer.invoke('audio-driver:get-state');
+    micRunning.value = !!state?.micRunning;
     speakerRunning.value = !!state?.speakerRunning;
     return state;
   }
@@ -75,6 +139,20 @@ export function useAudioDriver() {
   }
 
   return {
+    // Mic
+    micLevel,
+    micRunning,
+    micSpeaking,
+    micMuted,
+    startMic,
+    stopMic,
+    setMicGain,
+    setMicMuted,
+    setMicDevice,
+    setMicPcmMode,
+    getMicSocketPath,
+    getMicPcmSocketPath,
+    // Speaker
     speakerLevel,
     speakerRunning,
     startSpeaker,

--- a/pkg/rancher-desktop/pages/capture-studio/composables/useMicCapture.ts
+++ b/pkg/rancher-desktop/pages/capture-studio/composables/useMicCapture.ts
@@ -1,137 +1,10 @@
 /**
- * Composable — microphone capture via Web Audio API.
+ * Audio device enumeration utility.
  *
- * Supports multiple simultaneous mic streams. Each instance gets its own
- * AudioContext, AnalyserNode, and RMS level polling.
- *
- * Reference: main/trayPanel/renderer/model/audio-capture.js
+ * Mic capture is handled by MicrophoneDriverController (tray panel renderer).
+ * This module only provides device listing for the capture studio's
+ * device selector dropdown.
  */
-
-import { ref, type Ref } from 'vue';
-
-export interface MicInstance {
-  /** Start capturing from this mic. */
-  start: (deviceId?: string) => Promise<void>;
-  /** Stop capturing. */
-  stop: () => void;
-  /** Current RMS level (0-1), updated at ~60fps via requestAnimationFrame. */
-  level: Ref<number>;
-  /** The raw AnalyserNode for waveform drawing. null when not capturing. */
-  analyser: Ref<AnalyserNode | null>;
-  /** The raw MediaStream for MediaRecorder. null when not capturing. */
-  stream: Ref<MediaStream | null>;
-  /** Whether this mic is currently capturing. */
-  active: Ref<boolean>;
-  /** Mute/unmute without stopping the stream. */
-  setMuted: (muted: boolean) => void;
-  /** Set gain (0-1). */
-  setGain: (value: number) => void;
-}
-
-function computeRms(analyserNode: AnalyserNode): number {
-  const data = new Float32Array(analyserNode.fftSize);
-  analyserNode.getFloatTimeDomainData(data);
-  let sum = 0;
-  for (let i = 0; i < data.length; i++) sum += data[i] * data[i];
-  return Math.min(1, Math.sqrt(sum / data.length) * 3);
-}
-
-/**
- * Create a single mic capture instance.
- */
-export function createMicInstance(): MicInstance {
-  const level = ref(0);
-  const analyser = ref<AnalyserNode | null>(null);
-  const stream = ref<MediaStream | null>(null);
-  const active = ref(false);
-
-  let audioCtx: AudioContext | null = null;
-  let gainNode: GainNode | null = null;
-  let animFrameId: number | null = null;
-  let currentGain = 1.0;
-  let muted = false;
-
-  function poll() {
-    if (!analyser.value) return;
-    level.value = computeRms(analyser.value);
-    animFrameId = requestAnimationFrame(poll);
-  }
-
-  async function start(deviceId?: string) {
-    if (active.value) stop();
-
-    try {
-      audioCtx = new AudioContext();
-
-      const constraints: MediaStreamConstraints = {
-        audio: deviceId
-          ? { deviceId: { exact: deviceId }, autoGainControl: false, noiseSuppression: false, echoCancellation: false }
-          : { autoGainControl: false, noiseSuppression: false, echoCancellation: false },
-      };
-
-      const micStream = await navigator.mediaDevices.getUserMedia(constraints);
-      stream.value = micStream;
-
-      // Auto-cleanup if the track ends externally (device disconnected, etc.)
-      micStream.getAudioTracks()[0]?.addEventListener('ended', () => {
-        console.warn('[useMicCapture] Audio track ended externally');
-        stop();
-      });
-
-      const source = audioCtx.createMediaStreamSource(micStream);
-      gainNode = audioCtx.createGain();
-      gainNode.gain.value = muted ? 0 : currentGain;
-
-      const node = audioCtx.createAnalyser();
-      node.fftSize = 512;
-      analyser.value = node;
-
-      source.connect(gainNode);
-      gainNode.connect(node);
-
-      active.value = true;
-      poll();
-    } catch (e) {
-      // Clean up partial state on failure — ensure audioCtx is closed
-      console.error('[useMicCapture] Failed to start:', e);
-      if (audioCtx) {
-        try { audioCtx.close(); } catch { /* ignore */ }
-        audioCtx = null;
-      }
-      stop();
-      throw e; // re-throw so caller can handle (e.g. revert toggle)
-    }
-  }
-
-  function stop() {
-    if (animFrameId) cancelAnimationFrame(animFrameId);
-    animFrameId = null;
-    if (stream.value) {
-      stream.value.getTracks().forEach(t => t.stop());
-    }
-    if (audioCtx) {
-      try { audioCtx.close(); } catch { /* already closed */ }
-    }
-    audioCtx = null;
-    gainNode = null;
-    analyser.value = null;
-    stream.value = null;
-    active.value = false;
-    level.value = 0;
-  }
-
-  function setMuted(m: boolean) {
-    muted = m;
-    if (gainNode) gainNode.gain.value = m ? 0 : currentGain;
-  }
-
-  function setGain(value: number) {
-    currentGain = value;
-    if (gainNode && !muted) gainNode.gain.value = value;
-  }
-
-  return { start, stop, level, analyser, stream, active, setMuted, setGain };
-}
 
 /**
  * List available audio input/output devices.
@@ -153,7 +26,6 @@ export async function listAudioDevices(): Promise<{
   try {
     devices = await navigator.mediaDevices.enumerateDevices();
   } catch (e) {
-    // Ensure tempStream is cleaned up even if enumerateDevices throws
     if (tempStream) {
       tempStream.getTracks().forEach(t => t.stop());
     }

--- a/pkg/rancher-desktop/pages/capture-studio/composables/useMicRecording.ts
+++ b/pkg/rancher-desktop/pages/capture-studio/composables/useMicRecording.ts
@@ -1,0 +1,251 @@
+/**
+ * Composable — record mic audio from the MicrophoneDriverController
+ * PCM socket to a WAV file on disk.
+ *
+ * Same pattern as useSpeakerCapture.ts — connects to a Unix domain
+ * socket, receives length-prefixed PCM frames, writes WAV.
+ *
+ * Quality modes (PCM):
+ *   'raw'             — all audio, no processing (ASMR, music)
+ *   'noise-reduction' — VAD-gated + noise-processed (voice)
+ *
+ * Compressed modes use the WebM/Opus mic-socket instead:
+ *   'streaming'       — compressed WebM/Opus
+ *   'streaming-voice' — compressed WebM/Opus + voice processing
+ */
+
+import { ref, type Ref } from 'vue';
+
+const net = require('net');
+const fs = require('fs');
+const { ipcRenderer } = require('electron');
+
+// Default to 48kHz — updated from controller state on start
+const CHANNELS = 1;
+const BITS_PER_SAMPLE = 16;
+const BYTES_PER_SAMPLE = BITS_PER_SAMPLE / 8;
+
+function writeWavHeader(ws: any, sampleRate: number): void {
+  const header = Buffer.alloc(44);
+  const maxDataSize = 0xFFFFFFFF - 36;
+
+  header.write('RIFF', 0);
+  header.writeUInt32LE(36 + maxDataSize, 4);
+  header.write('WAVE', 8);
+  header.write('fmt ', 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);                // PCM format
+  header.writeUInt16LE(CHANNELS, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(sampleRate * CHANNELS * BYTES_PER_SAMPLE, 28);
+  header.writeUInt16LE(CHANNELS * BYTES_PER_SAMPLE, 32);
+  header.writeUInt16LE(BITS_PER_SAMPLE, 34);
+  header.write('data', 36);
+  header.writeUInt32LE(maxDataSize, 40);
+
+  ws.write(header);
+}
+
+function finalizeWav(filePath: string, dataBytes: number): void {
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync(filePath, 'r+');
+    const buf = Buffer.alloc(4);
+
+    buf.writeUInt32LE(36 + dataBytes, 0);
+    fs.writeSync(fd, buf, 0, 4, 4);
+
+    buf.writeUInt32LE(dataBytes, 0);
+    fs.writeSync(fd, buf, 0, 4, 40);
+  } finally {
+    if (fd !== null) fs.closeSync(fd);
+  }
+}
+
+function computePcmRms(pcm: Buffer): number {
+  const samples = pcm.length / BYTES_PER_SAMPLE;
+  if (samples === 0) return 0;
+  let sum = 0;
+  for (let i = 0; i < pcm.length; i += BYTES_PER_SAMPLE) {
+    const sample = pcm.readInt16LE(i) / 32768;
+    sum += sample * sample;
+  }
+  return Math.min(1, Math.sqrt(sum / samples) * 3);
+}
+
+export type MicQualityMode = 'raw' | 'noise-reduction' | 'voice-compressed' | 'streaming' | 'streaming-voice';
+
+export function useMicRecording() {
+  const level: Ref<number> = ref(0);
+  const active = ref(false);
+  const bytesWritten = ref(0);
+
+  let socket: any = null;
+  let writeStream: any = null;
+  let filePath = '';
+  let totalDataBytes = 0;
+  let pending = Buffer.alloc(0);
+  let currentMode: MicQualityMode = 'raw';
+
+  /**
+   * Start recording mic audio to a file.
+   *
+   * For PCM modes (raw, noise-reduction, voice-compressed):
+   *   Connects to mic-pcm-socket, writes WAV at 48kHz.
+   *
+   * For compressed modes (streaming, streaming-voice):
+   *   Connects to mic-socket, writes raw WebM/Opus chunks.
+   */
+  async function start(outputPath: string, mode: MicQualityMode = 'raw'): Promise<boolean> {
+    if (active.value) stop();
+
+    currentMode = mode;
+    filePath = outputPath;
+    totalDataBytes = 0;
+    bytesWritten.value = 0;
+    pending = Buffer.alloc(0);
+
+    const isCompressed = mode === 'streaming' || mode === 'streaming-voice';
+
+    // Set the PCM mode on the controller (raw vs noise-reduction)
+    if (!isCompressed) {
+      const pcmMode = mode === 'raw' ? 'raw' : 'noise-reduction';
+      await ipcRenderer.invoke('audio-driver:set-mic-pcm-mode', pcmMode);
+    }
+
+    // Get the appropriate socket path
+    const socketPath = isCompressed
+      ? await ipcRenderer.invoke('audio-driver:get-mic-socket-path')
+      : await ipcRenderer.invoke('audio-driver:get-mic-pcm-socket-path');
+
+    if (!socketPath) {
+      console.warn('[useMicRecording] No socket path available — is audio driver running?');
+      return false;
+    }
+
+    // Open output file
+    try {
+      writeStream = fs.createWriteStream(filePath);
+      if (!isCompressed) {
+        // Get the actual sample rate from the controller
+        const state = await ipcRenderer.invoke('audio-driver:get-state');
+        const sampleRate = state?.micSampleRate || 48000;
+        writeWavHeader(writeStream, sampleRate);
+      }
+    } catch (err: any) {
+      console.error('[useMicRecording] Failed to create write stream:', err.message);
+      return false;
+    }
+
+    writeStream.on('error', (err: any) => {
+      console.error('[useMicRecording] Write error:', err.message);
+    });
+
+    // Connect to socket
+    socket = net.createConnection(socketPath);
+
+    socket.on('data', (data: Buffer) => {
+      if (isCompressed) {
+        // WebM/Opus — write chunks directly (already length-prefixed on socket)
+        // Parse length-prefixed frames and write just the payload
+        pending = pending.length > 0 ? Buffer.concat([pending, data]) : data;
+        while (pending.length >= 4) {
+          const frameLen = pending.readUInt32BE(0);
+          if (!Number.isFinite(frameLen) || frameLen <= 0 || frameLen > 1024 * 1024) {
+            pending = Buffer.alloc(0);
+            break;
+          }
+          if (pending.length < 4 + frameLen) break;
+          const chunk = pending.subarray(4, 4 + frameLen);
+          pending = pending.subarray(4 + frameLen);
+
+          if (writeStream && !writeStream.destroyed) {
+            writeStream.write(chunk);
+            totalDataBytes += chunk.length;
+            bytesWritten.value = totalDataBytes;
+          }
+        }
+      } else {
+        // PCM — parse length-prefixed frames, write raw PCM, compute level
+        pending = pending.length > 0 ? Buffer.concat([pending, data]) : data;
+        while (pending.length >= 4) {
+          const frameLen = pending.readUInt32BE(0);
+          if (!Number.isFinite(frameLen) || frameLen <= 0 || frameLen > 1024 * 1024) {
+            pending = Buffer.alloc(0);
+            break;
+          }
+          if (pending.length < 4 + frameLen) break;
+          const chunk = pending.subarray(4, 4 + frameLen);
+          pending = pending.subarray(4 + frameLen);
+
+          if (writeStream && !writeStream.destroyed) {
+            writeStream.write(chunk);
+            totalDataBytes += chunk.length;
+            bytesWritten.value = totalDataBytes;
+          }
+
+          level.value = computePcmRms(chunk);
+        }
+      }
+    });
+
+    socket.on('error', (err: any) => {
+      console.error('[useMicRecording] Socket error:', err.message);
+    });
+
+    socket.on('close', () => {
+      if (active.value) {
+        console.warn('[useMicRecording] Socket closed unexpectedly — finalizing');
+        stop();
+      }
+    });
+
+    active.value = true;
+    console.log('[useMicRecording] Started', { mode, path: socketPath, file: filePath });
+    return true;
+  }
+
+  /**
+   * Stop recording and finalize the output file.
+   * Returns the file path.
+   */
+  function stop(): string {
+    active.value = false;
+    level.value = 0;
+
+    if (socket) {
+      socket.destroy();
+      socket = null;
+    }
+
+    if (writeStream) {
+      writeStream.end();
+      writeStream = null;
+    }
+
+    // Finalize WAV header for PCM modes
+    const isCompressed = currentMode === 'streaming' || currentMode === 'streaming-voice';
+    if (!isCompressed && filePath && totalDataBytes > 0) {
+      try {
+        finalizeWav(filePath, totalDataBytes);
+      } catch (err: any) {
+        console.error('[useMicRecording] Failed to finalize WAV:', err.message);
+      }
+    }
+
+    const result = filePath;
+    console.log('[useMicRecording] Stopped', { file: result, bytes: totalDataBytes });
+    filePath = '';
+    totalDataBytes = 0;
+    pending = Buffer.alloc(0);
+    return result;
+  }
+
+  return {
+    level,
+    active,
+    bytesWritten,
+    start,
+    stop,
+  };
+}

--- a/pkg/rancher-desktop/pages/capture-studio/composables/useTeleprompterTracking.ts
+++ b/pkg/rancher-desktop/pages/capture-studio/composables/useTeleprompterTracking.ts
@@ -42,9 +42,10 @@ export function useTeleprompterTracking(
       await stopTracking();
     }
 
-    // Send script to the main process
+    // Send script to the main process (spread to plain array — Vue reactive
+    // proxies can't be serialized through Electron structured clone)
     await ipcRenderer.invoke('teleprompter-tracking:set-script', {
-      words,
+      words: Array.isArray(words) ? [...words] : words,
       currentIndex: startIndex,
     });
 
@@ -52,7 +53,7 @@ export function useTeleprompterTracking(
     const result = await ipcRenderer.invoke('teleprompter-tracking:start');
 
     if (!result?.ok) {
-      console.warn('[TeleprompterTracking] Main-process tracker failed to start');
+      console.warn('[TeleprompterTracking] Main-process tracker failed to start', result?.error);
       return;
     }
 


### PR DESCRIPTION
## Summary

- **Teleprompter voice tracking was broken** — the capture studio ran its own `getUserMedia` which competed with the tray panel mic (near-zero audio levels), and whisper-cli hung under CPU contention with LlamaCpp (26s for a 2s chunk)
- **Removed duplicate mic pipeline** — capture studio now goes through `MicrophoneDriverController` for all mic access (start/stop, levels, VAD, recording), eliminating the competing `getUserMedia`
- **Added mic-pcm-socket** — high-quality 48kHz PCM recording via Unix domain socket (same pattern as speaker-socket), with quality mode support (raw/noise-reduction/streaming)
- **Fixed whisper-cli contention** — reduced threads 4→2 and timeout 30s→10s so whisper doesn't hang when sharing CPU with LlamaCpp
- **Fixed IPC serialization crash** — Vue reactive proxy arrays can't be cloned through Electron structured clone; spread to plain arrays before sending
- **Fixed double-start race** — `selectLayout` now awaits `activate()` so the floating window watch doesn't trigger a redundant restart

## Test plan

- [x] Open Capture Studio → mic auto-enables via controller
- [x] Switch to teleprompter layout → voice tracking starts
- [x] Read script aloud → teleprompter follows along (whisper transcribes every ~2s at ~0.5s/run)
- [x] Floating teleprompter window receives position updates
- [ ] Test mic quality mode switching (raw vs noise-reduction)
- [ ] Test mic recording during capture session (WAV output)
- [ ] Verify whisper test in Audio Settings still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)