### PR TITLE
feat: business onboarding, identity-based card visibility, async sub-agents

### DIFF
--- a/pkg/rancher-desktop/agent/tools/agents/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/manifests.ts
@@ -26,7 +26,7 @@ export const agentToolManifests: ToolManifest[] = [
       async: {
         type:        'boolean',
         optional:    true,
-        description: 'When true, launches agents in the background and returns immediately with a jobId. Use check_agent_jobs to poll for results. Default: false (synchronous — blocks until all agents complete).',
+        description: 'When true (default), launches agents in the background and returns immediately with a jobId. Use check_agent_jobs to poll for results. Set to false to block until all agents complete.',
       },
     },
     operationTypes: ['execute'],

--- a/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
@@ -44,7 +44,7 @@ export class SpawnAgentWorker extends BaseTool {
 
     // ── Options ───────────────────────────────────────────────────
     const parallel: boolean = input.parallel !== false; // default true
-    const async_: boolean = input.async === true;       // default false
+    const async_: boolean = input.async !== false;       // default true
 
     // ── Depth guard ─────────────────────────────────────────────
     const parentDepth: number = (this.state as any)?.metadata?.subAgentDepth ?? 0;

--- a/pkg/rancher-desktop/pages/BrowserTabChat.vue
+++ b/pkg/rancher-desktop/pages/BrowserTabChat.vue
@@ -273,6 +273,8 @@
           :voice-configured="isVoiceConfigured"
           :model-selector="modelSelector"
           :is-first-chat="isFirstChat"
+          :show-goals-onboarding="showGoalsOnboarding"
+          :show-business-onboarding="showBusinessOnboarding"
           @send="send"
           @stop="stop"
           @primary-action="handlePrimaryAction"
@@ -280,6 +282,7 @@
           @stop-tts="voice.stopTTS()"
           @pick="(mode: string) => emit('set-mode', mode as BrowserTabMode)"
           @start-onboarding="startOnboarding"
+          @start-business-onboarding="startBusinessOnboarding"
         />
       </div>
     </div>
@@ -466,20 +469,34 @@ const modelSelector = new AgentModelSelectorController({
   isRunning,
 });
 
-// First-chat detection — show onboarding card when user has never chatted
-const isFirstChat = ref(false);
+// Onboarding card visibility — each card hides once its identity file exists
+const showGoalsOnboarding = ref(false);
+const showBusinessOnboarding = ref(false);
+const isFirstChat = computed(() => showGoalsOnboarding.value || showBusinessOnboarding.value);
+
 async function checkFirstChat(): Promise<void> {
   try {
-    isFirstChat.value = await ipcRenderer.invoke('check-first-chat');
+    const [goals, business] = await Promise.all([
+      ipcRenderer.invoke('check-goals-onboarding'),
+      ipcRenderer.invoke('check-business-onboarding'),
+    ]);
+    showGoalsOnboarding.value = goals;
+    showBusinessOnboarding.value = business;
   } catch {
-    isFirstChat.value = false;
+    showGoalsOnboarding.value = false;
+    showBusinessOnboarding.value = false;
   }
 }
 
 function startOnboarding(): void {
-  isFirstChat.value = false;
-  ipcRenderer.invoke('mark-first-chat-complete');
+  showGoalsOnboarding.value = false;
   query.value = 'I\'m new here — help me set my goals and get to know how I work best.';
+  nextTick(() => send());
+}
+
+function startBusinessOnboarding(): void {
+  showBusinessOnboarding.value = false;
+  query.value = 'I want to put Sulla to work on my business.';
   nextTick(() => send());
 }
 
@@ -602,8 +619,8 @@ const send = (metadata?: Record<string, unknown>) => {
     return;
   }
   if (isFirstChat.value) {
-    isFirstChat.value = false;
-    ipcRenderer.invoke('mark-first-chat-complete');
+    showGoalsOnboarding.value = false;
+    showBusinessOnboarding.value = false;
   }
   chatController.send(metadata);
 };
@@ -616,8 +633,8 @@ const sendWithAttachments = () => {
     return;
   }
   if (isFirstChat.value) {
-    isFirstChat.value = false;
-    ipcRenderer.invoke('mark-first-chat-complete');
+    showGoalsOnboarding.value = false;
+    showBusinessOnboarding.value = false;
   }
   const attachments = composerRef.value?.consumeAttachments?.() || [];
   chatController.send(undefined, attachments.length > 0 ? attachments : undefined);

--- a/pkg/rancher-desktop/pages/chat-options/ChatOptionsVariantB.vue
+++ b/pkg/rancher-desktop/pages/chat-options/ChatOptionsVariantB.vue
@@ -90,9 +90,9 @@
       </button>
     </div>
 
-    <!-- Onboarding card — shown only on user's very first chat -->
+    <!-- Goals onboarding card — hidden once human identity file exists -->
     <div
-      v-if="isFirstChat"
+      v-if="showGoalsOnboarding"
       class="vb-onboarding"
     >
       <button
@@ -102,8 +102,27 @@
       >
         <div class="vb-onboarding-accent" />
         <div class="vb-onboarding-body">
-          <span class="vb-onboarding-title">Start Onboarding for Maximum Effectiveness</span>
-          <span class="vb-onboarding-desc">Tell Sulla about your goals and working style so it can deliver the best results from day one.</span>
+          <span class="vb-onboarding-title">Tell Sulla About Your Goals</span>
+          <span class="vb-onboarding-desc">Sulla will align herself with your goals to help you better accomplish them.</span>
+        </div>
+        <span class="vb-card-arrow">&rarr;</span>
+      </button>
+    </div>
+
+    <!-- Business onboarding card — hidden once business identity file exists -->
+    <div
+      v-if="showBusinessOnboarding"
+      class="vb-onboarding"
+    >
+      <button
+        type="button"
+        class="vb-onboarding-btn vb-onboarding-btn--business"
+        @click="$emit('start-business-onboarding')"
+      >
+        <div class="vb-onboarding-accent vb-onboarding-accent--business" />
+        <div class="vb-onboarding-body">
+          <span class="vb-onboarding-title">Put Sulla to Work on Your Business</span>
+          <span class="vb-onboarding-desc">Whether you're starting fresh or already running, Sulla can help you build, grow, and automate your business from day one.</span>
         </div>
         <span class="vb-card-arrow">&rarr;</span>
       </button>
@@ -127,6 +146,8 @@ const props = defineProps<{
   voiceConfigured?: boolean;
   modelSelector: any;
   isFirstChat?: boolean;
+  showGoalsOnboarding?: boolean;
+  showBusinessOnboarding?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -138,6 +159,7 @@ const emit = defineEmits<{
   'stop-tts': [];
   pick: [mode: string];
   'start-onboarding': [];
+  'start-business-onboarding': [];
 }>();
 
 const localQuery = computed({
@@ -205,6 +227,10 @@ const localQuery = computed({
 }
 
 /* ── Onboarding card ── */
+.vb-onboarding:first-of-type {
+  margin-top: 1.5rem;
+}
+
 .vb-onboarding {
   width: 100%;
   margin-bottom: 1.25rem;
@@ -263,6 +289,15 @@ const localQuery = computed({
   font-size: 0.75rem;
   font-weight: 400;
   color: var(--text-dim);
+}
+
+.vb-onboarding-accent--business {
+  background: var(--text-success, #4ade80);
+}
+
+.vb-onboarding-btn--business:hover {
+  border-color: var(--text-success, #4ade80);
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(74, 222, 128, 0.2);
 }
 
 /* ── Card grid ── */

--- a/pkg/rancher-desktop/sulla.ts
+++ b/pkg/rancher-desktop/sulla.ts
@@ -20,6 +20,7 @@ import * as path from 'path';
 import { app, webContents } from 'electron';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
+import * as os from 'os';
 import { submitErrorReport } from '@pkg/main/errorReporter';
 import { getServiceLifecycleManager } from '@pkg/agent/services/ServiceLifecycleManager';
 import Logging from '@pkg/utils/logging';
@@ -414,7 +415,21 @@ export async function onMainProxyLoad(ipcMainProxy: any) {
     return app.getPath('userData');
   });
 
-  // First-chat detection — returns true if the user has never chatted before
+  // Onboarding card visibility — each card hides only when its specific
+  // onboarding-created file exists (NOT the general identity files that
+  // daily workflows create independently).
+  const sullaHome = path.join(os.homedir(), 'sulla');
+  const goalsOnboardingPath = path.join(sullaHome, 'identity', 'onboarding.md');
+  const businessOnboardingPath = path.join(sullaHome, 'identity', 'business', 'onboarding.md');
+
+  ipcMainProxy.handle('check-goals-onboarding', async() => {
+    return !fs.existsSync(goalsOnboardingPath);
+  });
+  ipcMainProxy.handle('check-business-onboarding', async() => {
+    return !fs.existsSync(businessOnboardingPath);
+  });
+
+  // Legacy — still used by some code paths to mark first chat complete
   const firstChatLockPath = path.join(app.getPath('userData'), 'first-chat.lock');
   ipcMainProxy.handle('check-first-chat', async() => {
     return !fs.existsSync(firstChatLockPath);


### PR DESCRIPTION
## Summary
- Add "Put Sulla to Work on Your Business" onboarding card with green accent on the welcome view
- Onboarding card visibility now driven by identity files (`~/sulla/identity/onboarding.md` and `~/sulla/identity/business/onboarding.md`) instead of a lock file — daily backend workflows won't accidentally hide cards
- Goals card updated: "Tell Sulla About Your Goals" / "Sulla will align herself with your goals..."
- `spawn_agent` now defaults to async (non-blocking) — sub-agents run in the background
- New IPC handlers: `check-goals-onboarding`, `check-business-onboarding`

## Skills created (in ~/sulla/resources/)
- `onboarding/goals-onboarding.md` — personal goals interview
- `onboarding/business-onboarding.md` — new vs existing router
- `skills/onboarding/business-onboarding-existing.md` — empathy map interview + async research
- `skills/onboarding/business-onboarding-new.md` — placeholder
- `skills/onboarding/business-website-research.md` — async website crawl
- `skills/onboarding/empathy-map-questions.md` — shared question set
- `skills/onboarding/empathy-map-customer-perspective.md` — async customer POV research

## Test plan
- [ ] Fresh install (no identity files) — both onboarding cards visible
- [ ] Click goals card — starts goals interview, card hides after `~/sulla/identity/onboarding.md` written
- [ ] Click business card — starts business onboarding, card hides after `~/sulla/identity/business/onboarding.md` written
- [ ] Cards show independently — completing one doesn't hide the other
- [ ] `spawn_agent` defaults to async — sub-agents return jobId immediately
- [ ] Margin between pill buttons and onboarding cards looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)