### PR TITLE
feat: tab bar menus, packaging entitlements, and recipe PATH fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ log/*
 llm/
 training/__pycache__/validate_training_data.cpython-313.pyc
 resources/browserTabPreload.js.map
+logs/background-web-requests.log

--- a/background.ts
+++ b/background.ts
@@ -1202,7 +1202,7 @@ ipcMainProxy.handle('capture-studio:get-sources', async() => {
       thumbnailDataUrl: s.thumbnail.toDataURL(),
     }));
   } catch (e: any) {
-    console.warn('[capture-studio:get-sources] Failed:', e.message);
+    console.warn('[capture-studio:get-sources] Failed:', e?.message || e?.name || String(e));
     return [];
   }
 });

--- a/build/signing-config-mac.yaml
+++ b/build/signing-config-mac.yaml
@@ -36,9 +36,16 @@ entitlements:
     - com.apple.security.cs.allow-unsigned-executable-memory
   - paths:
     - Contents/Frameworks/Sulla Desktop Helper (GPU).app
+    entitlements:
+    - com.apple.security.cs.allow-jit
+  - paths:
     - Contents/Frameworks/Sulla Desktop Helper (Renderer).app
     entitlements:
     - com.apple.security.cs.allow-jit
+    - com.apple.security.cs.allow-unsigned-executable-memory
+    - com.apple.security.cs.disable-library-validation
+    - com.apple.security.device.audio-input
+    - com.apple.security.device.camera
   - paths:
     - Contents/Frameworks/Sulla Desktop Helper (Plugin).app
     entitlements:

--- a/justfile
+++ b/justfile
@@ -109,6 +109,17 @@ install-mac:
     # Copy using ditto (preserves symlinks, resource forks, HFS metadata)
     ditto "dist/mac-arm64/Sulla Desktop.app" "/Applications/Sulla Desktop.app"
     xattr -rd com.apple.quarantine "/Applications/Sulla Desktop.app" 2>/dev/null || true
+    # Ad-hoc sign with entitlements (required for screen capture, mic, camera with hardened runtime)
+    ENT="packaging/entitlements.mac.plist"
+    if [ -f "$ENT" ]; then
+        echo "Signing helpers with entitlements..."
+        codesign --force --sign - --entitlements "$ENT" "/Applications/Sulla Desktop.app/Contents/Frameworks/Sulla Desktop Helper.app" 2>/dev/null || true
+        codesign --force --sign - --entitlements "$ENT" "/Applications/Sulla Desktop.app/Contents/Frameworks/Sulla Desktop Helper (Renderer).app" 2>/dev/null || true
+        codesign --force --sign - --entitlements "$ENT" "/Applications/Sulla Desktop.app/Contents/Frameworks/Sulla Desktop Helper (Plugin).app" 2>/dev/null || true
+        codesign --force --sign - --entitlements "$ENT" "/Applications/Sulla Desktop.app/Contents/Frameworks/Sulla Desktop Helper (GPU).app" 2>/dev/null || true
+        codesign --force --sign - --entitlements "$ENT" "/Applications/Sulla Desktop.app"
+        echo "Signed with entitlements"
+    fi
     echo "Installed to /Applications/Sulla Desktop.app"
 
 # Stop Sulla Desktop, remove from Applications, and eject the DMG

--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -30,6 +30,8 @@ mac:
   icon: ./resources/icons/sulla-app-icon.png
   target: [ dmg, zip ]
   identity: ~ # We sign in a separate step
+  entitlements: ./packaging/entitlements.mac.plist
+  entitlementsInherit: ./packaging/entitlements.mac.plist
   artifactName: Sulla-Desktop-${version}-mac.${ext}
   extendInfo:
     NSMicrophoneUsageDescription: "Sulla Desktop needs microphone access for voice features including chat, transcription, and capture studio."

--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -25,7 +25,7 @@ files:
   - '!**/node_modules/*/prebuilds/!(${platform}*)/*.node'
 mac:
   darkModeSupport: true
-  hardenedRuntime: true
+  hardenedRuntime: false  # Re-enable when we have an Apple Developer certificate for notarization
   gatekeeperAssess: false
   icon: ./resources/icons/sulla-app-icon.png
   target: [ dmg, zip ]

--- a/packaging/entitlements.mac.plist
+++ b/packaging/entitlements.mac.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/pkg/rancher-desktop/main/extensions/recipeExtension.ts
+++ b/pkg/rancher-desktop/main/extensions/recipeExtension.ts
@@ -471,6 +471,7 @@ export class RecipeExtensionImpl implements Extension {
         const { stdout, stderr } = await spawnFile('/bin/sh', ['-c', resolvedCommand], {
           stdio: 'pipe',
           cwd:   resolvedCwd,
+          env:   this.spawnEnv,
         });
 
         if (stdout?.trim()) {
@@ -840,6 +841,24 @@ export class RecipeExtensionImpl implements Extension {
   }
 
   /**
+   * Build a spawn environment with PATH augmented to include directories where
+   * the docker CLI is likely to live.  On macOS, Electron apps launched from
+   * the Dock inherit a minimal PATH that often lacks /usr/local/bin and
+   * ~/.rd/bin, causing "command not found" (exit 127) for docker commands.
+   */
+  protected get spawnEnv(): Record<string, string> {
+    const extraDirs = [
+      paths.integration,                                  // ~/.rd/bin
+      path.join(paths.resources, process.platform, 'bin'), // bundled binaries
+      '/usr/local/bin',                                   // common on macOS
+    ];
+    const existing = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean);
+    const combined = [...new Set([...existing, ...extraDirs])];
+
+    return { ...process.env as Record<string, string>, PATH: combined.join(path.delimiter) };
+  }
+
+  /**
    * Collapse repetitive command output into a compact, readable summary.
    */
   protected summarizeCommandOutput(output: string, maxLines = 30): string {
@@ -888,7 +907,7 @@ export class RecipeExtensionImpl implements Extension {
     sullaLog({ topic: 'extensions', level: 'info', message: `Starting ${ this.id }`, data: { command: resolved, cwd: this.dir } });
 
     try {
-      const { stdout, stderr } = await spawnFile('/bin/sh', ['-c', resolved], { stdio: 'pipe', cwd: this.dir });
+      const { stdout, stderr } = await spawnFile('/bin/sh', ['-c', resolved], { stdio: 'pipe', cwd: this.dir, env: this.spawnEnv });
 
       if (stdout) {
         const summarizedStdout = this.summarizeCommandOutput(stdout);
@@ -928,17 +947,27 @@ export class RecipeExtensionImpl implements Extension {
     const resolved = this.resolveCommand(cmd);
 
     sullaLog({ topic: 'extensions', level: 'info', message: `Stopping ${ this.id }`, data: { command: resolved, cwd: this.dir } });
-    const { stdout, stderr } = await spawnFile('/bin/sh', ['-c', resolved], { stdio: 'pipe', cwd: this.dir });
 
-    if (stdout) {
-      sullaLog({ topic: 'extensions', level: 'debug', message: `[${ this.id } stop stdout] ${ stdout.trim() }` });
-    }
-    if (stderr) {
-      sullaLog({ topic: 'extensions', level: 'debug', message: `[${ this.id } stop stderr] ${ stderr.trim() }` });
-    }
-    sullaLog({ topic: 'extensions', level: 'info', message: `Stopped ${ this.id } successfully` });
+    try {
+      const { stdout, stderr } = await spawnFile('/bin/sh', ['-c', resolved], { stdio: 'pipe', cwd: this.dir, env: this.spawnEnv });
 
-    // Persist stopped state so we don't auto-start on app restart
+      if (stdout) {
+        sullaLog({ topic: 'extensions', level: 'debug', message: `[${ this.id } stop stdout] ${ stdout.trim() }` });
+      }
+      if (stderr) {
+        sullaLog({ topic: 'extensions', level: 'debug', message: `[${ this.id } stop stderr] ${ stderr.trim() }` });
+      }
+      sullaLog({ topic: 'extensions', level: 'info', message: `Stopped ${ this.id } successfully` });
+    } catch (err: any) {
+      const stderr = err?.stderr || '';
+
+      sullaLog({ topic: 'extensions', level: 'warn', message: `Stop command for ${ this.id } failed (exit code ${ err?.code ?? '?' }): ${ err.message || err }${ stderr ? `\n${ stderr }` : '' }` });
+    }
+
+    // Persist stopped state so we don't auto-start on app restart.
+    // This runs even if the stop command failed — the user's intent was to
+    // stop, and a missing docker CLI (code 127) means the container engine
+    // isn't running anyway.
     await this.saveRunningState('stopped');
   }
 
@@ -956,7 +985,7 @@ export class RecipeExtensionImpl implements Extension {
     const resolved = this.resolveCommand(cmd);
 
     sullaLog({ topic: 'extensions', level: 'info', message: `Restarting ${ this.id }`, data: { command: resolved, cwd: this.dir } });
-    const { stdout, stderr } = await spawnFile('/bin/sh', ['-c', resolved], { stdio: 'pipe', cwd: this.dir });
+    const { stdout, stderr } = await spawnFile('/bin/sh', ['-c', resolved], { stdio: 'pipe', cwd: this.dir, env: this.spawnEnv });
 
     if (stdout) {
       sullaLog({ topic: 'extensions', level: 'debug', message: `[${ this.id } restart stdout] ${ stdout.trim() }` });
@@ -978,7 +1007,7 @@ export class RecipeExtensionImpl implements Extension {
     const resolved = this.resolveCommand(cmd);
 
     try {
-      const result = await spawnFile('/bin/sh', ['-c', resolved], { stdio: 'pipe', cwd: this.dir });
+      const result = await spawnFile('/bin/sh', ['-c', resolved], { stdio: 'pipe', cwd: this.dir, env: this.spawnEnv });
 
       return (result as any).stdout?.toString?.() ?? 'running';
     } catch {
@@ -1010,7 +1039,7 @@ export class RecipeExtensionImpl implements Extension {
       const composePath = path.join(this.dir, composeFile);
       const removeImagesCmd = `docker compose -f ${ this.shellQuote(composePath) } down --rmi all --remove-orphans`;
 
-      const { stdout, stderr } = await spawnFile('/bin/sh', ['-c', removeImagesCmd], { stdio: 'pipe', cwd: this.dir });
+      const { stdout, stderr } = await spawnFile('/bin/sh', ['-c', removeImagesCmd], { stdio: 'pipe', cwd: this.dir, env: this.spawnEnv });
 
       if (stdout?.trim()) {
         sullaLog({ topic: 'extensions', level: 'debug', message: `[${ this.id } uninstall image cleanup stdout] ${ stdout.trim() }` });
@@ -1029,7 +1058,7 @@ export class RecipeExtensionImpl implements Extension {
         const composeFile = this._manifest?.compose?.composeFile || 'docker-compose.yml';
         const composePath = path.join(this.dir, composeFile);
 
-        await spawnFile('/bin/sh', ['-c', `docker compose -f ${ this.shellQuote(composePath) } down -v`], { stdio: 'pipe' });
+        await spawnFile('/bin/sh', ['-c', `docker compose -f ${ this.shellQuote(composePath) } down -v`], { stdio: 'pipe', env: this.spawnEnv });
         sullaLog({ topic: 'extensions', level: 'info', message: `Removed docker volumes for ${ this.id }` });
       } catch (ex) {
         sullaLog({ topic: 'extensions', level: 'warn', message: `Failed to remove docker volumes for ${ this.id }`, error: ex });

--- a/pkg/rancher-desktop/main/moreMenuWindow.ts
+++ b/pkg/rancher-desktop/main/moreMenuWindow.ts
@@ -19,6 +19,7 @@ import { getWindow } from '@pkg/window';
 const console = Logging.background;
 
 let win: BrowserWindow | null = null;
+let showGuard = false;  // prevents spurious blur during initial show
 
 const MENU_WIDTH = 200;
 const MENU_HEIGHT = 210;  // main view with 5 items + separator
@@ -37,17 +38,25 @@ export function registerMoreMenuIpc(): void {
 
 // ─── IPC handlers ───────────────────────────────────────────────
 
+function _showAndFocus(): void {
+  if (!win || win.isDestroyed()) return;
+  showGuard = true;
+  win.show();        // show + focus in one step (avoids macOS blur race)
+  win.focus();       // ensure focus even if show() didn't grant it
+  setTimeout(() => { showGuard = false; }, 200);
+}
+
 function onShow(
   _event: Electron.IpcMainEvent,
   payload: { screenX: number; screenY: number },
 ): void {
   const { screenX, screenY } = payload;
+  console.log('[MoreMenu] onShow', { screenX, screenY, existingWindow: !!win });
 
   if (win && !win.isDestroyed()) {
     win.setBounds({ x: screenX, y: screenY, width: MENU_WIDTH, height: MENU_HEIGHT });
     win.webContents.send('more-menu:show');
-    win.showInactive();
-    setTimeout(() => { if (win && !win.isDestroyed()) win.focus(); }, 50);
+    _showAndFocus();
     return;
   }
 
@@ -78,18 +87,22 @@ function onShow(
   win.loadFile(htmlPath);
 
   win.once('ready-to-show', () => {
-    if (!win || win.isDestroyed()) return;
-    win.showInactive();
-    setTimeout(() => { if (win && !win.isDestroyed()) win.focus(); }, 50);
+    _showAndFocus();
   });
 
-  win.on('blur', () => _close());
+  win.webContents.on('did-fail-load', (_event, errorCode, errorDescription) => {
+    console.error('[MoreMenu] Failed to load HTML:', errorCode, errorDescription, htmlPath);
+  });
+
+  win.on('blur', () => {
+    if (!showGuard) _close();
+  });
 
   win.on('closed', () => {
     win = null;
   });
 
-  console.log('[MoreMenu] Opened popup');
+  console.log('[MoreMenu] Created popup window, loading:', htmlPath);
 }
 
 function onAction(

--- a/pkg/rancher-desktop/pages/BrowserTab.vue
+++ b/pkg/rancher-desktop/pages/BrowserTab.vue
@@ -99,6 +99,7 @@
         <AgentIntegrations
           embedded
           @switch-to-vault="onSetMode('vault')"
+          @create-account="onIntegrationsCreateAccount"
         />
       </div>
     </template>
@@ -347,6 +348,12 @@ function onUseGeneratedPassword(password: string) {
   } else {
     returnToVaultList();
   }
+}
+
+/** Handle "Connect Now" from the standalone Integrations tab — switch to vault flow */
+function onIntegrationsCreateAccount(data: { integrationId: string }) {
+  onSetMode('vault');
+  showNewAccountEditor(data);
 }
 
 function onHistoryNavigate(entry: { id: string; type: string; url?: string }) {


### PR DESCRIPTION
## Summary
- Add tab context menu and more-menu popup windows for the tab bar
- Add macOS entitlements for screen capture and ad-hoc signing support
- Augment spawn PATH in recipe extensions so docker CLI is found when app is launched from Dock
- Disable hardenedRuntime until Apple Developer certificate is available for notarization
- Wire up integrations create-account event in BrowserTab

## Test plan
- [ ] Verify tab context menu appears on right-click
- [ ] Verify more-menu popup opens correctly
- [ ] Confirm recipe extensions can find docker CLI when launched from Dock
- [ ] Confirm DMG builds successfully with ad-hoc signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)