### PR TITLE
fix: bundle signing config into macOS app for yarn sign

### DIFF
--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -38,6 +38,9 @@ mac:
     NSCameraUsageDescription: "Sulla Desktop uses your camera for the capture studio face-cam overlay."
     NSScreenCaptureUsageDescription: "Sulla Desktop needs screen recording access for the capture studio to record your screen."
     NSAppleEventsUsageDescription: "Sulla uses automation to interact with apps on your Mac — like managing your calendar, creating reminders, or controlling music playback. You choose which apps to enable."
+  extraFiles:
+    - build/signing-config-mac.yaml
+    - { from: dist/electron-builder.yaml, to: electron-builder.yml }
 win:
   icon: ./pkg/rancher-desktop/pages/agent/sulla-icon.ico
   target: [ zip ]


### PR DESCRIPTION
## Summary
- Add `electron-builder.yml` and `signing-config-mac.yaml` as `extraFiles` in the mac section of electron-builder config
- Without these, `yarn sign` fails with ENOENT because it expects them inside the app bundle
- Both files are removed after signing (per `signing-config-mac.yaml` remove section) and don't ship to users

## Test plan
- [x] `yarn sign` completes successfully with these files present

🤖 Generated with [Claude Code](https://claude.com/claude-code)