### PR TITLE
chore: disable automatic workflow triggers; run only on release or dispatch

### DIFF
--- a/.github/workflows/bats.yaml
+++ b/.github/workflows/bats.yaml
@@ -39,8 +39,6 @@ on:
         description: Run with experimental settings (WSL)
         default: false
         type: boolean
-  schedule:
-  - cron: '0 8 * * 1-5' # 8AM UTC weekdays as a baseline
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,12 +1,8 @@
 name: "CodeQL Advanced"
 
 on:
-  push:
-    branches: ["main", "release*"]
-  pull_request:
-    branches: ["main", "release*"]
-  schedule:
-  - cron: '33 19 * * 5'
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-cli-monitor.yaml
+++ b/.github/workflows/docker-cli-monitor.yaml
@@ -1,7 +1,5 @@
 name: Check for new releases of docker/cli
 on:
-  schedule:
-    - cron: '55 8 * * *'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/go-work-sync.yaml
+++ b/.github/workflows/go-work-sync.yaml
@@ -4,12 +4,7 @@
 
 name: Sync go.work
 on:
-  pull_request_target:
-    types: [ opened, reopened, synchronize ]
-    paths:
-    - '**/go.mod'
-    - '**/go.sum'
-    - 'go.work'
+  workflow_dispatch:
 permissions:
   contents: write
 concurrency:

--- a/.github/workflows/k3s-versions.yaml
+++ b/.github/workflows/k3s-versions.yaml
@@ -1,7 +1,5 @@
 name: Update k3s-versions.json
 on:
-  schedule:
-  - cron: '43 8 * * *'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/linux-e2e.yaml
+++ b/.github/workflows/linux-e2e.yaml
@@ -1,11 +1,9 @@
 name: e2e tests on Linux
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
-  push:
-    branches-ignore:
-    - 'dependabot/**'
-  pull_request: {}
 
 jobs:
   check-paths:

--- a/.github/workflows/macM1-e2e.yaml
+++ b/.github/workflows/macM1-e2e.yaml
@@ -1,9 +1,9 @@
 name: e2e tests on Mac M1
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
-  schedule:
-  - cron: '15 8 * * 1-5'
 
 jobs:
 

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,15 +1,8 @@
 name: Package
 
 on:
-  pull_request:
-    paths-ignore:
-    - '.github/actions/spelling/**'
-    - 'docs/**'
-    - '**.md'
-  push:
-    branches:
-    - main
-    - release-*
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       sign:

--- a/.github/workflows/rddepman.yaml
+++ b/.github/workflows/rddepman.yaml
@@ -1,7 +1,5 @@
 name: Update external dependencies
 on:
-  schedule:
-    - cron: '23 8 * * *'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/rdx-host-api-tests.yaml
+++ b/.github/workflows/rdx-host-api-tests.yaml
@@ -3,9 +3,6 @@
 
 name: RDX Host APIs Testing image
 on:
-  push:
-    branches: [ main ]
-    paths: [ 'bats/tests/extensions/testdata/**' ]
   workflow_dispatch: {}
 permissions:
   packages: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,15 +1,5 @@
 name: Scorecard supply-chain security
 on:
-  # For Branch-Protection check. Only the default branch is supported. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
-  branch_protection_rule:
-  # To guarantee Maintained check is occasionally updated. See
-  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
-  schedule:
-  - cron: '23 13 * * 4'
-  push:
-    branches:
-    - master
   workflow_dispatch:
 
 # Declare default permissions as read only.

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -59,18 +59,7 @@ name: Check Spelling
 # on.pull_request(_target).edited is only needed for with.check_commit_messages: title | description
 
 on:
-  push:
-    branches:
-    - "**"
-    tags-ignore:
-    - "**"
-  pull_request:
-    branches:
-    - "**"
-    types:
-    - 'opened'
-    - 'reopened'
-    - 'synchronize'
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,8 +1,9 @@
 name: Test
 
 on:
-  push: {}
-  pull_request: {}
+  release:
+    types: [published]
+  workflow_dispatch: {}
 
 permissions: {}
 

--- a/.github/workflows/ucmonitor.yaml
+++ b/.github/workflows/ucmonitor.yaml
@@ -1,7 +1,5 @@
 name: Check for unreleased changes
 on:
-  schedule:
-    - cron: '48 8 * * *'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/windows-e2e.yaml
+++ b/.github/workflows/windows-e2e.yaml
@@ -1,11 +1,9 @@
 name: e2e tests on Windows
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
-  push:
-    branches-ignore:
-    - 'dependabot/**'
-  pull_request: {}
 
 defaults:
   run:


### PR DESCRIPTION
## Summary

- Every GitHub Actions workflow was firing on push, pull_request, or cron — wasted minutes and noise on every commit.
- All 21 workflows now trigger only on `release.published`, `workflow_dispatch`, or `workflow_call` (reusable).
- Release-only workflows (`linux-release.yaml`, `release-merge-to-main.yaml`) untouched.

## What was removed

- `push:`, `pull_request:`, `pull_request_target:`, `schedule:`, `branch_protection_rule:` across `bats`, `codeql`, `docker-cli-monitor`, `go-work-sync`, `k3s-versions`, `linux-e2e`, `macM1-e2e`, `package`, `rddepman`, `rdx-host-api-tests`, `scorecard`, `spelling`, `test`, `ucmonitor`, `windows-e2e`.

## Test plan

- [ ] Push this PR — nothing should run automatically (verifies the change itself takes effect).
- [ ] Cut a tag / publish a release — the release-relevant workflows (`package`, `test`, `linux-e2e`, `windows-e2e`, `macM1-e2e`, `codeql`, `linux-release`, `release-merge-to-main`) fire.
- [ ] Confirm `workflow_dispatch` still works from the Actions tab for any workflow you want to run manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)