### PR TITLE
Mobile chat through agent loop + relay hardening

### DIFF
--- a/pkg/rancher-desktop/agent/services/BackendGraphWebSocketService.ts
+++ b/pkg/rancher-desktop/agent/services/BackendGraphWebSocketService.ts
@@ -15,6 +15,14 @@ const SULLA_DESKTOP_CHANNEL_ID = 'sulla-desktop';
 const WORKBENCH_CHANNEL_ID = 'workbench';
 const HEARTBEAT_CHANNEL_ID = 'heartbeat';
 const CALENDAR_CHANNEL_ID = 'calendar_event';
+// Dedicated channel for chats routed from a paired mobile device via the
+// Cloudflare relay. Mobile messages arrive through `DesktopRelayClient`,
+// which publishes them here as plain `user_message` frames. The agent
+// loop picks them up the same way it picks up desktop UI messages —
+// same AgentNode/BaseNode pipeline, same XML strip, same tool execution.
+// Responses emitted by the agent land back on this channel; the relay
+// client subscribes and forwards them up to Cloudflare → mobile.
+const MOBILE_RELAY_CHANNEL_ID = 'mobile-relay';
 
 let backendGraphWebSocketServiceInstance: BackendGraphWebSocketService | null = null;
 
@@ -76,6 +84,16 @@ export class BackendGraphWebSocketService {
     });
     if (heartbeatUnsub) this.unsubscribes.push(heartbeatUnsub);
 
+    // Mobile relay channel — messages forwarded from a paired mobile device
+    // via DesktopRelayClient. Agent processing is identical to the desktop
+    // UI channel (same trigger type, same AgentNode pipeline) so the XML
+    // wrappers, tool execution, memory recall, etc. all apply uniformly.
+    this.wsService.connect(MOBILE_RELAY_CHANNEL_ID);
+    const mobileRelayUnsub = this.wsService.onMessage(MOBILE_RELAY_CHANNEL_ID, (msg) => {
+      this.handleChannelMessage(MOBILE_RELAY_CHANNEL_ID, 'sulla-desktop', msg);
+    });
+    if (mobileRelayUnsub) this.unsubscribes.push(mobileRelayUnsub);
+
     // Initialize calendar event channel
     this.wsService.connect(CALENDAR_CHANNEL_ID);
     const calendarUnsub = this.wsService.onMessage(CALENDAR_CHANNEL_ID, (msg) => {
@@ -87,6 +105,7 @@ export class BackendGraphWebSocketService {
     this.subscribedChannels.add(SULLA_DESKTOP_CHANNEL_ID);
     this.subscribedChannels.add(WORKBENCH_CHANNEL_ID);
     this.subscribedChannels.add(HEARTBEAT_CHANNEL_ID);
+    this.subscribedChannels.add(MOBILE_RELAY_CHANNEL_ID);
     this.subscribedChannels.add(CALENDAR_CHANNEL_ID);
 
     // Register agents in the active agents registry
@@ -96,6 +115,8 @@ export class BackendGraphWebSocketService {
       console.warn('[BackendGraphWS] Failed to register workbench agent:', err));
     this.registerAgent(HEARTBEAT_CHANNEL_ID, 'Heartbeat', 'Autonomous heartbeat agent').catch(err =>
       console.warn('[BackendGraphWS] Failed to register heartbeat agent:', err));
+    this.registerAgent(MOBILE_RELAY_CHANNEL_ID, 'Sulla (Mobile)', 'Chat routed from paired mobile device').catch(err =>
+      console.warn('[BackendGraphWS] Failed to register mobile-relay agent:', err));
 
     // Subscribe to any custom agent channels from ~/sulla/agents/
     this.subscribeToAgentChannels().catch(err =>
@@ -258,6 +279,19 @@ export class BackendGraphWebSocketService {
           data:      { threadId },
           timestamp: Date.now(),
         });
+      }
+
+      // Abort any prior run still in flight on this channel before starting
+      // a new one. Without this, rapid user sends (e.g. mobile PTT firing
+      // twice before the first reply lands) spawn two concurrent graph
+      // executions on the same state object and corrupt per-thread stream
+      // buffers downstream (the mobile-relay bridge keys its streamed-text
+      // and final-text maps by thread id, so two active runs on the same
+      // thread race through each other's state).
+      const prior = this.activeAborts.get(channelId);
+      if (prior) {
+        try { prior.abort(); } catch { /* already aborted */ }
+        this.activeAborts.delete(channelId);
       }
 
       // Create abort service for this run.

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -723,20 +723,46 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
 
     // Install Claude Code CLI.
     //
-    // Idempotent: skips if claude is already on PATH. Before running npm
-    // (which spawns Node), block until the kernel's CRNG is initialized —
-    // reading one byte from /dev/random achieves this on Linux. Without
-    // this wait, provision scripts that run at ~3s into boot hit Node's
-    // `PlatformInit` assertion when getrandom() returns EAGAIN on a not-
-    // yet-seeded CRNG, and the install silently fails leaving the VM
-    // without the claude CLI.
+    // Two hard problems this script has to survive:
+    //
+    // 1. /usr/local is tmpfs in this Alpine Lima VM — it's wiped on every
+    //    reboot. A plain `npm install -g ...` puts the binary in a place
+    //    that vanishes, so every boot the CLI disappears until re-install,
+    //    and the app logs `sh: exec: line 0: claude: not found`. We pin the
+    //    install to /mnt/data/npm-global (on the persistent data volume)
+    //    and re-symlink into /usr/local/bin on every boot. The install
+    //    itself then becomes a one-time cost instead of a per-boot cost.
+    //
+    // 2. The `npm install` step invokes Node, and Node's early-boot
+    //    PlatformInit aborts when the kernel CRNG isn't seeded yet. That
+    //    assertion killed script 00000010 on every fresh boot. We don't
+    //    hit it after the persistent install already exists because the
+    //    fast path exits before ever calling Node — and on the first boot
+    //    we block briefly on /dev/random to let the CRNG seed before npm
+    //    runs.
+    //
+    // Net effect: a freshly-provisioned VM installs claude once to
+    // /mnt/data/npm-global; every subsequent reboot just recreates the
+    // /usr/local/bin symlink (cheap, doesn't touch Node) even if the
+    // provision script previously died mid-install.
     const claudeCodeScript = [
       '#!/bin/sh',
       'set -o errexit',
-      'command -v claude >/dev/null 2>&1 && exit 0',
-      '# Block until kernel CRNG is seeded (avoids Node PlatformInit abort)',
+      'PREFIX=/mnt/data/npm-global',
+      'LINK=/usr/local/bin/claude',
+      '# Fast path: persistent install already exists — just recreate the',
+      '# symlink that tmpfs wiped on reboot. No Node invocation, no CRNG',
+      '# race, can\'t fail due to script 00000010 crashing.',
+      'if [ -x "$PREFIX/bin/claude" ]; then',
+      '  ln -sf "$PREFIX/bin/claude" "$LINK"',
+      '  exit 0',
+      'fi',
+      '# First boot (or after a persistent-prefix wipe): real install.',
+      'mkdir -p "$PREFIX"',
+      '# Block until kernel CRNG is seeded (avoids Node PlatformInit abort).',
       'dd if=/dev/random of=/dev/null bs=1 count=1 2>/dev/null',
-      'npm install -g @anthropic-ai/claude-code',
+      'npm install --prefix "$PREFIX" -g @anthropic-ai/claude-code',
+      'ln -sf "$PREFIX/bin/claude" "$LINK"',
     ].join('\n');
     config.provision = config.provision.filter((p: { script?: string }) => {
       return !(p.script ?? '').includes('@anthropic-ai/claude-code');

--- a/pkg/rancher-desktop/main/desktopRelay.ts
+++ b/pkg/rancher-desktop/main/desktopRelay.ts
@@ -13,16 +13,32 @@
  */
 
 import { SullaSettingsModel } from '@pkg/agent/database/models/SullaSettingsModel';
+import { getWebSocketClientService, type WebSocketMessage } from '@pkg/agent/services/WebSocketClientService';
 import { getIpcMainProxy } from '@pkg/main/ipcMain';
 import { getCurrentAccessToken } from '@pkg/main/sullaCloudAuth';
 import { getDesktopDeviceId } from '@pkg/main/deviceIdentity';
+import { stripProtocolTags } from '@pkg/agent/utils/stripProtocolTags';
 import Logging from '@pkg/utils/logging';
 
 const console = Logging.background;
 
 const RELAY_URL = 'wss://sulla-workers.jonathon-44b.workers.dev';
+// Local WebSocket channel that BackendGraphWebSocketService watches for
+// mobile-originated chats. Must match the constant in that file.
+const MOBILE_RELAY_CHANNEL = 'mobile-relay';
 const RECONNECT_BASE_MS = 1_000;
 const RECONNECT_MAX_MS  = 30_000;
+// Heartbeat + watchdog tuned for Cloudflare Workers: the DO auto-responds to
+// "ping" with "pong" via setWebSocketAutoResponse without waking from
+// hibernation. A 20s ping interval + 45s silence watchdog keeps the pipe
+// warm through NAT/proxy idle timeouts and surfaces silently-dead sockets
+// (where TCP never FINs) well before Cloudflare's ~10min hibernation cutoff.
+const PING_INTERVAL_MS = 20_000;
+const STALE_SOCKET_MS  = 45_000;
+// If a freshly-opened socket doesn't fire `open` in this window, we assume
+// it's stuck and tear it down. Prevents a wedged connect from pinning the
+// client in "connecting" forever.
+const CONNECT_TIMEOUT_MS = 15_000;
 
 type Role = 'desktop' | 'mobile';
 
@@ -56,11 +72,24 @@ class DesktopRelayClient {
   private connected = false;
   private lastError = '';
   private statusListeners: Array<(s: Status) => void> = [];
-  // conversationId → AbortController for in-flight chat requests. Mobile can
-  // send a `{type:'cancel', conversationId}` frame to stop a run; we call
-  // .abort() on the matching controller which propagates through ClaudeCodeService
-  // to the limactl process and the in-VM claude CLI.
-  private inFlightAborts = new Map<string, AbortController>();
+  // Stop requests from mobile go out to the agent via stop_run on the
+  // mobile-relay channel (see handleMessage). No local in-process
+  // AbortController state is needed anymore — the agent owns aborts now.
+  // Subscription guard so we only hook the mobile-relay channel once.
+  private mobileChannelBridged = false;
+
+  // ── Liveness tracking ──────────────────────────────────────
+  // The DO auto-responds to application-level "ping" frames with "pong",
+  // without waking from hibernation. We send a ping on a timer and watch
+  // for any inbound message (pong, chat, anything) to prove the pipe is
+  // still alive. If the socket goes silent for STALE_SOCKET_MS we force a
+  // reconnect — the `close` event alone is unreliable when intermediaries
+  // drop the connection without sending a TCP FIN.
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private watchdogTimer: ReturnType<typeof setInterval> | null = null;
+  private lastInboundAt = 0;
+  // Guards against a stuck `new WebSocket()` that never resolves to `open`.
+  private connectTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
 
   async start(): Promise<void> {
     const paired = (await SullaSettingsModel.get('pairedMobileUserId', '')) ?? '';
@@ -112,6 +141,7 @@ class DesktopRelayClient {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+    this.teardownLiveness();
     if (this.ws) {
       try { this.ws.close(); } catch { /* ignore */ }
       this.ws = null;
@@ -119,6 +149,31 @@ class DesktopRelayClient {
     this.currentRoom = null;
     this.connected = false;
     this.broadcastStatus();
+  }
+
+  /** Stop all heartbeat/watchdog/connect timers. Idempotent. */
+  private teardownLiveness() {
+    if (this.pingTimer) { clearInterval(this.pingTimer); this.pingTimer = null; }
+    if (this.watchdogTimer) { clearInterval(this.watchdogTimer); this.watchdogTimer = null; }
+    if (this.connectTimeoutTimer) { clearTimeout(this.connectTimeoutTimer); this.connectTimeoutTimer = null; }
+  }
+
+  /**
+   * Tear down the current socket and schedule a reconnect. Called on error
+   * events, stale-socket watchdog trips, and connect-timeout expiry — every
+   * failure path funnels here so we can't leak sockets or timers.
+   */
+  private forceReconnect(reason: string) {
+    if (this.intentionallyClosed) return;
+    console.warn(`[DesktopRelay] Forcing reconnect — ${ reason }`);
+    this.teardownLiveness();
+    if (this.ws) {
+      try { this.ws.close(); } catch { /* already closed */ }
+      this.ws = null;
+    }
+    this.connected = false;
+    this.broadcastStatus();
+    this.scheduleReconnect();
   }
 
   private async openSocket() {
@@ -143,20 +198,49 @@ class DesktopRelayClient {
     const ws = new WebSocket(url);
     this.ws = ws;
 
+    // If the socket doesn't open in time, give up and reconnect. Without
+    // this a stuck TCP handshake can park us in "connecting" indefinitely.
+    this.connectTimeoutTimer = setTimeout(() => {
+      this.connectTimeoutTimer = null;
+      if (this.ws === ws && !this.connected) {
+        this.forceReconnect(`connect timeout after ${ CONNECT_TIMEOUT_MS }ms`);
+      }
+    }, CONNECT_TIMEOUT_MS);
+
     ws.addEventListener('open', () => {
+      if (this.connectTimeoutTimer) { clearTimeout(this.connectTimeoutTimer); this.connectTimeoutTimer = null; }
       this.connected = true;
       this.lastError = '';
       this.reconnectDelay = RECONNECT_BASE_MS;
+      this.lastInboundAt = Date.now();
       console.log(`[DesktopRelay] Connected — room=${ room }`);
       this.broadcastStatus();
+
+      // Start heartbeat: send a ping every PING_INTERVAL_MS. The DO
+      // auto-replies without waking, so this is cheap on the server.
+      this.pingTimer = setInterval(() => {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+        try { this.ws.send(JSON.stringify({ type: 'ping' })); } catch { /* socket in bad state; watchdog will handle */ }
+      }, PING_INTERVAL_MS);
+
+      // Watchdog: any silent period >STALE_SOCKET_MS means the pipe is
+      // dead even if the browser hasn't fired `close` yet. Force-reconnect.
+      this.watchdogTimer = setInterval(() => {
+        const silentMs = Date.now() - this.lastInboundAt;
+        if (silentMs > STALE_SOCKET_MS) {
+          this.forceReconnect(`no inbound traffic for ${ silentMs }ms`);
+        }
+      }, Math.floor(STALE_SOCKET_MS / 3));
     });
 
     ws.addEventListener('message', (event) => {
+      this.lastInboundAt = Date.now();
       this.handleMessage(event.data as string);
     });
 
     ws.addEventListener('close', () => {
       this.connected = false;
+      this.teardownLiveness();
       console.log('[DesktopRelay] Socket closed');
       this.broadcastStatus();
       if (!this.intentionallyClosed) this.scheduleReconnect();
@@ -166,6 +250,10 @@ class DesktopRelayClient {
       this.lastError = e?.message || 'WebSocket error';
       console.warn('[DesktopRelay] Error:', this.lastError);
       this.broadcastStatus();
+      // Some runtimes don't fire `close` after `error`, especially on
+      // half-open sockets. Force the reconnect path so we never sit idle
+      // waiting for a `close` that may never arrive.
+      this.forceReconnect(`socket error: ${ this.lastError }`);
     });
   }
 
@@ -196,6 +284,12 @@ class DesktopRelayClient {
       return;
     }
 
+    if (msg.type === 'pong') {
+      // Keepalive reply from the DO's auto-response. Watchdog already
+      // reset lastInboundAt on the message event above; nothing else to do.
+      return;
+    }
+
     if (msg.type === 'error') {
       console.warn(`[DesktopRelay] Relay error: ${ msg.reason }`);
       return;
@@ -221,86 +315,200 @@ class DesktopRelayClient {
     }
 
     if (msg.type === 'cancel') {
-      // Mobile hit the stop button. Abort any in-flight chatStream for this
-      // conversation — propagates to ClaudeCodeService → limactl kill + VM pkill.
-      const key = msg.conversationId ?? this.currentRoom ?? '__default__';
-      const ctrl = this.inFlightAborts.get(key);
-      if (ctrl) {
-        console.log(`[DesktopRelay] Cancel received for conversationId=${ key }`);
-        try { ctrl.abort() } catch { /* already aborted */ }
-        this.inFlightAborts.delete(key);
-      } else {
-        console.log(`[DesktopRelay] Cancel received for conversationId=${ key } — no in-flight request`);
-      }
+      // Mobile hit the stop button. Publish stop_run on the mobile-relay
+      // channel — BackendGraphWebSocketService.handleChannelMessage handles
+      // stop_run by aborting the active agent run (which propagates through
+      // ClaudeCodeService → limactl kill + in-VM claude pkill).
+      const conversationId = msg.conversationId ?? this.currentRoom ?? '__default__';
+      console.log(`[DesktopRelay] Cancel received for conversationId=${ conversationId }`);
+      const wsService = getWebSocketClientService();
+      wsService.send(MOBILE_RELAY_CHANNEL, {
+        type:      'stop_run',
+        data:      { threadId: conversationId },
+        timestamp: Date.now(),
+      });
       return;
     }
 
     console.log(`[DesktopRelay] Unknown message type: ${ msg.type }`);
   }
 
+  /**
+   * Bridge a mobile chat request onto the local agent channel.
+   *
+   * Previously this method called ClaudeCodeService.chatStream directly,
+   * bypassing the entire AgentNode/BaseNode pipeline — which meant the
+   * `<AGENT_DONE>` / `<AGENT_CONTINUE>` protocol wrappers, tool execution,
+   * memory recall, and subconscious middleware all got skipped. Mobile saw
+   * raw XML-tagged responses and the desktop's full agent capabilities
+   * never applied to mobile-originated chats.
+   *
+   * The relay is now a pure bridge: it translates the mobile `chat` frame
+   * into a `user_message` on the local `mobile-relay` WebSocket channel
+   * and lets BackendGraphWebSocketService route it through the normal
+   * agent loop (same AgentNode, same strip, same tools). Responses
+   * emitted by the agent arrive as `assistant_message`/streaming frames
+   * on the same channel, which our subscription picks up and forwards
+   * back up to Cloudflare as `chunk`/`done` frames mobile already
+   * understands.
+   */
   private async handleChatRequest(msg: IncomingMessage) {
     const messages = msg.messages ?? [];
-    // Prefer the per-thread conversation id from mobile; fall back to the room
-    // (= user id) so older mobile clients still work, but sessions collide.
     const conversationId = msg.conversationId ?? this.currentRoom ?? undefined;
-    const abortKey = conversationId ?? '__default__';
     console.log(`[DesktopRelay] Chat request — ${ messages.length } messages, conversationId=${ conversationId ?? '(none)' }`);
 
-    // If a prior chat for this conversation is still running (user tapped
-    // send twice without stop), abort it so we don't fan out two parallel
-    // claude processes for the same thread.
-    const prior = this.inFlightAborts.get(abortKey);
-    if (prior) {
-      try { prior.abort() } catch { /* already aborted */ }
-      this.inFlightAborts.delete(abortKey);
+    // Extract the user prompt from the incoming frame. The agent maintains
+    // its own conversation state keyed by threadId; we only need the fresh
+    // user turn each request. If the mobile client sends a multi-message
+    // payload, pick the last user turn — older messages are already in the
+    // thread on the desktop side.
+    const lastUser = [...messages].reverse().find(m => m.role === 'user');
+    const content = (lastUser?.content ?? '').trim();
+    if (!content) {
+      console.warn('[DesktopRelay] Chat request had no user content; ignoring');
+      this.send({ type: 'error', reason: 'empty_user_message' });
+      return;
     }
 
-    const abortController = new AbortController();
-    this.inFlightAborts.set(abortKey, abortController);
+    this.ensureMobileChannelBridge();
 
-    try {
-      const { getClaudeCodeService } = await import('@pkg/agent/languagemodels/ClaudeCodeService');
-      const svc = getClaudeCodeService();
-
-      // Stream each text delta to mobile as it arrives, then emit a final
-      // `done` with the full content so clients that missed chunks still get
-      // the whole reply. De-dupe consecutive activity messages so "Using
-      // Bash…" then "$ ls /etc" doesn't spam the mobile thinking bubble.
-      let lastActivity = '';
-      const result = await svc.chatStream(
-        messages as any,
-        {
-          onToken: (delta: string) => {
-            if (delta) this.send({ type: 'chunk', delta });
-          },
-          onActivity: (message: string) => {
-            if (!message || message === lastActivity) return;
-            lastActivity = message;
-            this.send({ type: 'activity', message });
-          },
+    const wsService = getWebSocketClientService();
+    wsService.send(MOBILE_RELAY_CHANNEL, {
+      type: 'user_message',
+      data: {
+        content,
+        threadId: conversationId,
+        metadata: {
+          source:         'mobile-relay',
+          inputSource:    'keyboard',
+          conversationId,
         },
-        { conversationId, signal: abortController.signal },
-      );
+      },
+      timestamp: Date.now(),
+    });
+  }
 
-      const content = result?.content ?? '';
-      this.send({ type: 'done', content });
-    } catch (err: any) {
-      const message = err?.message || 'Claude Code failed';
-      // Treat AbortError as a clean cancel, not a chat failure.
-      if (abortController.signal.aborted || /abort/i.test(message)) {
-        console.log(`[DesktopRelay] Chat aborted for conversationId=${ conversationId ?? '(none)' }`);
-        this.send({ type: 'cancelled' });
-      } else {
-        console.warn('[DesktopRelay] Chat handler failed:', message);
-        this.send({ type: 'error', reason: message });
+  /**
+   * Install the one-time subscription to the mobile-relay channel. Messages
+   * the agent emits during execution (streaming tokens, activity, final
+   * assistant_message, graph completion) arrive here; we translate each
+   * into the frame shape mobile already understands and forward it up to
+   * Cloudflare.
+   *
+   * Idempotent — runs once on first use. The subscription lives for the
+   * lifetime of the relay client; no need to tear down on reconnect since
+   * it's local, not over the wire to Cloudflare.
+   *
+   * Protocol translation notes:
+   *
+   *   - `assistant_message kind=streaming` carries the AGENT's accumulated
+   *     buffer each tick, but mobile expects *incremental deltas* (it
+   *     concatenates them into its own streamBuffer). We compute the delta
+   *     by comparing the new buffer to what we last sent.
+   *
+   *   - `assistant_message kind=thinking` is activity indication (tool use,
+   *     reasoning) — forward as `activity`.
+   *
+   *   - `assistant_message kind=progress` (the default) is the agent's
+   *     authoritative text for one iteration of the loop. It duplicates
+   *     what streaming already sent, so we record it as the "final text
+   *     so far" but don't forward it as a chunk.
+   *
+   *   - `transfer_data content='graph_execution_complete'` is the real
+   *     end-of-run signal. THIS is when we emit `done` to mobile so it
+   *     closes the socket and resolves its pending promise. Emitting
+   *     `done` any earlier (e.g. on the first progress message) closes
+   *     the mobile socket mid-turn and everything after is lost.
+   */
+  private ensureMobileChannelBridge() {
+    if (this.mobileChannelBridged) return;
+    this.mobileChannelBridged = true;
+
+    const wsService = getWebSocketClientService();
+    wsService.connect(MOBILE_RELAY_CHANNEL);
+
+    // Per-thread state: the last-sent streaming buffer (for delta math)
+    // and the latest known "final text" (for when we emit done).
+    // Keyed by thread_id so two simultaneous mobile conversations don't
+    // corrupt each other's delta computation.
+    const streamedByThread = new Map<string, string>();
+    const finalTextByThread = new Map<string, string>();
+    let lastActivity = '';
+
+    wsService.onMessage(MOBILE_RELAY_CHANNEL, (msg: WebSocketMessage) => {
+      if (msg.type === 'assistant_message') {
+        const data = (msg.data && typeof msg.data === 'object') ? (msg.data as any) : {};
+        const kind = typeof data.kind === 'string' ? data.kind : '';
+        const threadId = typeof data.thread_id === 'string' ? data.thread_id : '';
+        const raw = typeof data.content === 'string' ? data.content : '';
+        if (!raw) return;
+        // Defense-in-depth: agent already strips wrappers, but a final strip
+        // here guarantees nothing slips through if a new message kind is
+        // added that doesn't pass through the normal strip path.
+        const stripped = stripProtocolTags(raw);
+        if (!stripped) return;
+
+        if (kind === 'thinking') {
+          // Tool-use / reasoning indicator. De-dup consecutive duplicates.
+          if (stripped === lastActivity) return;
+          lastActivity = stripped;
+          this.send({ type: 'activity', message: stripped });
+          return;
+        }
+
+        if (kind === 'streaming') {
+          // Agent re-sends the accumulated buffer each tick. Mobile
+          // replaces its local streamBuffer on each chunk (see the
+          // `streamBuffer = delta` line in sulla-mobile/desktop-relay.ts),
+          // so we ship the full buffer in `delta` rather than computing
+          // incremental slices. Mobile gets the authoritative snapshot
+          // every tick and can render it without concatenation drift.
+          const prev = streamedByThread.get(threadId) ?? '';
+          if (stripped === prev) return; // no-op tick
+          streamedByThread.set(threadId, stripped);
+          this.send({ type: 'chunk', delta: stripped });
+          return;
+        }
+
+        if (kind === 'progress' || kind === '') {
+          // Agent's authoritative final text for this iteration. Record it
+          // so we can ship it via `done` at graph_execution_complete. Don't
+          // forward as chunk — it duplicates the streaming content mobile
+          // has already been building, and emitting a chunk here with the
+          // full text would double up the mobile's streamBuffer.
+          finalTextByThread.set(threadId, stripped);
+          return;
+        }
+
+        // Any other kind (e.g. thinking_complete) — intentionally ignored.
+        return;
       }
-    } finally {
-      // Only remove the controller if it's still ours — a later chat request
-      // or a cancel frame may have already replaced/removed it.
-      if (this.inFlightAborts.get(abortKey) === abortController) {
-        this.inFlightAborts.delete(abortKey);
+
+      if (msg.type === 'transfer_data') {
+        // Graph.execute emits { role: 'system', content: 'graph_execution_complete' }
+        // on the channel when the agent run is fully done. THIS is the only
+        // place we emit `done` to mobile — any earlier and the mobile socket
+        // closes mid-stream.
+        const data = (msg.data && typeof msg.data === 'object') ? (msg.data as any) : {};
+        const content = typeof data.content === 'string' ? data.content : '';
+        if (content !== 'graph_execution_complete') return;
+        const threadId = typeof data.thread_id === 'string' ? data.thread_id : '';
+        // Prefer the agent's authoritative final text; fall back to whatever
+        // we streamed if no progress message arrived (non-streaming-only run).
+        const finalText = finalTextByThread.get(threadId) ?? streamedByThread.get(threadId) ?? '';
+        streamedByThread.delete(threadId);
+        finalTextByThread.delete(threadId);
+        lastActivity = '';
+        this.send({ type: 'done', content: finalText });
+        return;
       }
-    }
+
+      if (msg.type === 'thread_created') {
+        // Agent created a new threadId for this conversation. Mobile uses
+        // its own conversationId scheme; we don't need to plumb this back.
+        return;
+      }
+    });
   }
 
   private send(payload: unknown) {

--- a/pkg/rancher-desktop/main/sullaCloudAuth.ts
+++ b/pkg/rancher-desktop/main/sullaCloudAuth.ts
@@ -556,27 +556,68 @@ export function initSullaCloudAuthEvents(): void {
     return buildStatus();
   });
 
-  // Auto-pair relay on startup if we have a signed-in session
+  // Auto-pair relay on startup if we have a signed-in session.
+  //
+  // This needs to be resilient to a DB that isn't ready yet. On a fresh app
+  // launch the Sulla Postgres container can take 30-60s to come up while
+  // Lima provisions the VM and docker compose brings up the service, so
+  // loadSession() — which reads from integration_values — throws
+  // ECONNREFUSED if we fire it too early. Previously the IIFE ran once,
+  // caught the error, and gave up. That left the relay permanently
+  // disconnected for the entire app session even though the user was
+  // signed in, which surfaced as mobile peer-offline errors until the
+  // user manually re-signed-in.
+  //
+  // Retry strategy: backoff 2s → 60s cap, up to ~10 minutes total. Only
+  // retries on transient connection errors (ECONNREFUSED, ETIMEDOUT, etc.
+  // plus generic network failures). Stops on the first successful
+  // loadSession() call — whether that returns a session (pair + start
+  // services) or null (no signed-in user — nothing to do).
   (async() => {
-    try {
-      const session = await loadSession();
-      if (session) {
-        await getDesktopRelayClient().setPairedUserId(session.userId);
-        // Resume device registration + heartbeat so this desktop shows online
-        // for any mobile looking at the AI Assistant settings screen.
-        void DevicesCloudApi.register().then(() => DevicesCloudApi.startHeartbeat());
-        // Resume the offline-friendly sync loop so pulled claude_messages
-        // can be dispatched to Claude even without the WS relay.
-        try {
-          const { SullaSync } = await import('./sync/SullaSyncService');
-          SullaSync.start();
-        } catch (err) {
-          console.warn('[SullaCloudAuth] Failed to start SullaSync on restore:', err);
+    const RETRY_BASE_MS  = 2_000;
+    const RETRY_MAX_MS   = 60_000;
+    const RETRY_GIVEUP_MS = 10 * 60_000;
+    const startedAt = Date.now();
+    let delay = RETRY_BASE_MS;
+
+    const isTransient = (err: any): boolean => {
+      const code = err?.code ?? err?.cause?.code;
+      if (code === 'ECONNREFUSED' || code === 'ETIMEDOUT' || code === 'ENOTFOUND' || code === 'ECONNRESET') return true;
+      const msg = String(err?.message || err || '').toLowerCase();
+      return /econnrefused|etimedout|enotfound|econnreset|connect.*failed|pool.*shutting down|database.*not ready/.test(msg);
+    };
+
+    while (true) {
+      try {
+        const session = await loadSession();
+        if (session) {
+          await getDesktopRelayClient().setPairedUserId(session.userId);
+          // Resume device registration + heartbeat so this desktop shows online
+          // for any mobile looking at the AI Assistant settings screen.
+          void DevicesCloudApi.register().then(() => DevicesCloudApi.startHeartbeat());
+          // Resume the offline-friendly sync loop so pulled claude_messages
+          // can be dispatched to Claude even without the WS relay.
+          try {
+            const { SullaSync } = await import('./sync/SullaSyncService');
+            SullaSync.start();
+          } catch (err) {
+            console.warn('[SullaCloudAuth] Failed to start SullaSync on restore:', err);
+          }
+          console.log(`[SullaCloudAuth] Restored session: user=${ session.userId }`);
+        } else {
+          console.log('[SullaCloudAuth] Startup restore: no signed-in session');
         }
-        console.log(`[SullaCloudAuth] Restored session: user=${ session.userId }`);
+        // Success (either a session was restored or none exists) — stop retrying.
+        return;
+      } catch (err) {
+        if (!isTransient(err) || (Date.now() - startedAt) >= RETRY_GIVEUP_MS) {
+          console.warn('[SullaCloudAuth] Startup restore failed (giving up):', err);
+          return;
+        }
+        console.log(`[SullaCloudAuth] Startup restore not ready yet (${ (err as Error)?.message || err }); retrying in ${ delay }ms`);
+        await new Promise(resolve => setTimeout(resolve, delay));
+        delay = Math.min(delay * 2, RETRY_MAX_MS);
       }
-    } catch (err) {
-      console.warn('[SullaCloudAuth] Startup restore failed:', err);
     }
   })();
 }


### PR DESCRIPTION
## Summary

- Mobile chats now route through the full Agent/Base node pipeline on a dedicated `mobile-relay` WS channel (was bypassing the agent entirely and leaking `<AGENT_DONE>` wrappers raw to mobile).
- Desktop↔Cloud WS keepalive: ping/pong via CF DO auto-response, stale-socket watchdog, connect timeout, forced reconnect on error.
- Startup restore retries `loadSession` with backoff so the relay auto-pairs even if Postgres is slow to come up after a reboot.
- Persistent Claude Code CLI install (`/mnt/data/npm-global` + symlink into `/usr/local/bin`) so `claude: not found` stops recurring on every VM reboot.
- `dispatchToAgent` aborts the prior in-flight run before starting a new one — concurrent user sends on the same channel no longer race through each other's state.

## Test plan

- [ ] From mobile, send a multi-turn chat with a tool call (e.g. "what branch am I on"); verify wrappers never appear and the full reply streams in.
- [ ] Leave desktop idle 15+ minutes then send from mobile; should still arrive (keepalive proven).
- [ ] Reboot desktop; confirm `claude: not found` doesn't appear and relay auto-pairs without manual sign-out/sign-in.
- [ ] PTT twice in rapid succession; verify only the second reply streams (first cleanly aborted, no interleave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)