### PR TITLE
Disable flipFuses afterPack hook to debug missing framework binary

### DIFF
--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -142,15 +142,14 @@ class Builder {
   }
 
   protected async afterPack(context: AfterPackContext) {
-    await this.flipFuses(context);
+    // flipFuses disabled temporarily: investigating whether it's the
+    // cause of the Electron Framework binary going missing from the
+    // packaged .app (Versions/A/Electron Framework is absent after
+    // packaging, breaking codesign --deep and Gatekeeper). If builds
+    // succeed without it we'll reinstate it as a separate step that
+    // runs before codesign, not inside afterPack.
+    // await this.flipFuses(context);
     await this.writeLinuxDesktopFile(context);
-    // removeMacUsageDescriptions() intentionally not called: modifying
-    // Info.plist in afterPack invalidates the signature electron-builder
-    // is about to apply. The asymmetric re-sign (arm64 yes, x64 no) left
-    // Electron Framework.framework without a Developer ID signature on
-    // x64, which fails Gatekeeper despite notarization succeeding.
-    // extendInfo in electron-builder.yml overrides the UsageDescription
-    // keys that matter for our permission prompts; the rest can stay.
   }
 
   async package(): Promise<CliOptions> {


### PR DESCRIPTION
## Summary

Disables the `flipFuses` call in the afterPack hook to diagnose a missing framework binary in packaged builds.

## Context

Built `.app` is missing `Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework` — the top-level symlink is broken, `codesign --deep` fails, Gatekeeper rejects. Affects both arm64 and x64 builds.

`flipFuses` is the most likely suspect: it opens the framework binary via the symlink path to patch fuse bytes and writes it back. If Node's `fs.writeFile` misbehaves on a path that resolves through `Versions/Current` (another symlink), we end up writing to a location that orphans the original file.

## Test plan
- [ ] Run packaging and verify `Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework` exists in the output .app
- [ ] `codesign --deep` succeeds
- [ ] Gatekeeper accepts

If the next build ships a .app whose framework binary is intact, the fuse flip needs to happen via a different path (direct `Versions/A/`, or a different API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)