### PR TITLE
fix(release): stamp version into package.json + per-arch mac filenames

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -32,8 +32,21 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
-        # Needed to run `git describe` to get full version info
+        # Full history so the non-tag fallback can find the most recent tag.
         fetch-depth: 0
+    # Stamp the build version into package.json before packaging so
+    # electron-builder bakes it into the app. Tag pushes get a clean
+    # semver; non-tag builds get `<last-tag>-dev.<short-sha>`.
+    - name: Stamp version
+      run: |
+        if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+          VERSION="${GITHUB_REF_NAME#v}"
+        else
+          BASE=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.0)
+          VERSION="${BASE#v}-dev.$(git rev-parse --short HEAD)"
+        fi
+        echo "Stamping version: $VERSION"
+        V="$VERSION" node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.version=process.env.V; fs.writeFileSync('package.json', JSON.stringify(p,null,2)+'\n')"
     # timeout-minutes lives on the workflow step (composite actions
     # reject it). Caps a silent "Building fresh packages…" hang so we
     # fail fast instead of burning the full 30-minute job default.

--- a/packaging/electron-builder.yml
+++ b/packaging/electron-builder.yml
@@ -43,7 +43,7 @@ mac:
   entitlements: ./packaging/entitlements.mac.plist
   entitlementsInherit: ./packaging/entitlements.mac.plist
   notarize: true
-  artifactName: Sulla-Desktop-${version}-mac.${ext}
+  artifactName: Sulla-Desktop-${version}-${arch}-mac.${ext}
   extendInfo:
     NSMicrophoneUsageDescription: "Sulla Desktop needs microphone access for voice features including chat, transcription, and capture studio."
     NSCameraUsageDescription: "Sulla Desktop uses your camera for the capture studio face-cam overlay."

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -5,7 +5,6 @@
 
 'use strict';
 
-import childProcess from 'child_process';
 import fs from 'fs';
 import * as path from 'path';
 
@@ -155,16 +154,15 @@ class Builder {
   async package(): Promise<CliOptions> {
     log.info('Packaging...');
 
-    // Build the electron builder configuration to include the version data
+    // Build the electron builder configuration to include the version data.
+    // The version is sourced from package.json, which the CI workflow stamps
+    // before packaging (tag pushes → clean semver; non-tag builds →
+    // `<last-tag>-dev.<short-sha>`). Local dev builds use whatever is
+    // committed in package.json.
     const config: ReadWrite<Configuration> = yaml.parse(await fs.promises.readFile('packaging/electron-builder.yml', 'utf-8'));
     const configPath = path.join(buildUtils.distDir, 'electron-builder.yaml');
-    let fullBuildVersion: string;
-    try {
-      fullBuildVersion = childProcess.execFileSync('git', ['describe', '--tags']).toString().trim();
-    } catch {
-      fullBuildVersion = 'unknown';
-    }
-    const finalBuildVersion = fullBuildVersion.replace(/^v/, '');
+    const pkgJson = JSON.parse(await fs.promises.readFile('package.json', 'utf-8'));
+    const finalBuildVersion: string = pkgJson.version;
     const distDir = path.join(process.cwd(), 'dist');
     const electronPlatform = ({
       darwin: 'mac',


### PR DESCRIPTION
## Summary
- Mac `artifactName` had no `${arch}` token, so both Intel and Apple Silicon builds wrote `Sulla-Desktop-<v>-mac.zip` and the release job's final `cp` overwrote one with the other — Intel users downloading v1.3.4 got the arm64 binary.
- In-app version came from `git describe --tags` at package time, surfacing ugly `v1.3.3-23-gSHA` strings on non-tag workflow_dispatch builds.

## Changes
- New `Stamp version` workflow step writes `package.json` before `yarn package`: tag pushes → clean `1.3.5`; non-tag builds → `1.3.3-dev.<short-sha>`.
- `scripts/package.ts` reads version from `package.json` instead of shelling out to git.
- `packaging/electron-builder.yml` mac artifactName → `Sulla-Desktop-${version}-${arch}-mac.${ext}`.

## Verification
Workflow run [24842940441](https://github.com/merchantprotocol/sulla-desktop/actions/runs/24842940441) on this branch produced:
- `Stamping version: 1.3.4-dev.a19e4e4e6` on all 4 jobs.
- Distinct mac zips: `Sulla-Desktop-1.3.4-dev.a19e4e4e6-arm64-mac.zip` and `…-x64-mac.zip`.

## Test plan
- [ ] Tag `v1.3.5` after merge → confirm release shows two arch-specific Mac zips and app reports `1.3.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)