### PR TITLE
chore: release v1.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sulla-desktop",
   "productName": "Sulla Desktop",
   "license": "Apache-2.0 WITH Commons-Clause",
-  "version": "1.3.0",
+  "version": "1.3.6",
   "author": {
     "name": "Jonathon Byrdziak",
     "email": "jonathonbyrd@gmail.com"


### PR DESCRIPTION
## Summary
- Bump version to 1.3.6
- Bundles merged PRs #417 (browser tab runtime fixes + marketplace integration manifest + deep link handler) and #418 (Cohere LLM integration) into a release

## Release
Once merged, tag `v1.3.6` will be pushed to trigger the multi-platform CI build (macOS Intel, macOS ARM, Windows, Linux).

## Test plan
- [ ] CI build succeeds on all four runners
- [ ] Installers published as release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)