### PR TITLE
fix(lima): use ~/.rd/lima consistently to avoid UNIX_PATH_MAX errors

### DIFF
--- a/pkg/rancher-desktop/agent/tools/util/CommandRunner.ts
+++ b/pkg/rancher-desktop/agent/tools/util/CommandRunner.ts
@@ -32,7 +32,7 @@ export function shouldFallbackFromLimaShell(result: { stdout?: string; stderr?: 
 export function resolveLimaHome(options: CommandRunnerOptions): string {
   return options.limaHome ||
     process.env.LIMA_HOME ||
-    path.join(os.homedir(), 'Library/Application Support/rancher-desktop/lima');
+    path.join(os.homedir(), '.rd', 'lima');
 }
 
 export function resolveLimactlPath(options: CommandRunnerOptions): string {

--- a/pkg/rancher-desktop/sulla.ts
+++ b/pkg/rancher-desktop/sulla.ts
@@ -68,7 +68,7 @@ const checkDockerMode = async() => {
       resourcesPath = process.resourcesPath;
     }
     const limactlPath = path.join(resourcesPath, 'darwin/lima/bin/limactl');
-    const output = execSync(`LIMA_HOME=~/Library/Application\\ Support/rancher-desktop/lima "${ limactlPath }" list --json`, { encoding: 'utf8' });
+    const output = execSync(`LIMA_HOME=~/.rd/lima "${ limactlPath }" list --json`, { encoding: 'utf8' });
     const instances = JSON.parse(output);
     const instance = instances.find((i: any) => i.name === '0');
     const vmRunning = instance?.status === 'Running';

--- a/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
+++ b/pkg/rancher-desktop/utils/__tests__/paths.spec.ts
@@ -61,7 +61,7 @@ describe('paths', () => {
     lima: {
       win32:  new Error('lima'),
       linux:  '%HOME%/.local/share/rancher-desktop/lima/',
-      darwin: '%HOME%/Library/Application Support/rancher-desktop/lima/',
+      darwin: '%HOME%/.rd/lima/',
     },
     integration: {
       win32:  new Error('integration'),


### PR DESCRIPTION
## Summary
- Fixes UNIX_PATH_MAX socket path errors for users with long usernames
- Previous fix updated paths.ts but missed two hardcoded fallbacks
- Updates CommandRunner.ts and sulla.ts to use ~/.rd/lima consistently

## Customer Impact
Customer alexanderteissonniere hitting 105-char socket path (exceeds 104 limit) on v1.3.10.

## Changes
- CommandRunner.ts:35: fallback now uses ~/.rd/lima
- sulla.ts:71: hardcoded path now uses ~/.rd/lima
- paths.spec.ts:64: updated test expectation