### PR TITLE
chore: bump version to 1.3.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sulla-desktop",
-  "version": "1.3.10",
+  "version": "1.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sulla-desktop",
-      "version": "1.3.10",
+      "version": "1.3.12",
       "hasInstallScript": true,
       "license": "Apache-2.0 WITH Commons-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sulla-desktop",
   "productName": "Sulla Desktop",
   "license": "Apache-2.0 WITH Commons-Clause",
-  "version": "1.3.10",
+  "version": "1.3.12",
   "author": {
     "name": "Jonathon Byrdziak",
     "email": "jonathonbyrd@gmail.com"


### PR DESCRIPTION
## Summary

Bumps `package.json` + `package-lock.json` to 1.3.12 to match the freshly cut `v1.3.12` tag (which already triggered the release build).

`v1.3.11` was previously tagged at the lima fix commit (#436), so this release rolls forward to 1.3.12 on top of the SSOT path refactor, hardened Claude CLI install, and subconscious run-state fix from #438.

## Test plan

- [ ] Tag `v1.3.12` produces a valid release build via CI
- [ ] `package.json` reads 1.3.12 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)