### PR TITLE
feat: OpenAI and Claude Code OAuth integration with internal BrowserWindow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ llm/
 training/__pycache__/validate_training_data.cpython-313.pyc
 resources/browserTabPreload.js.map
 logs/background-web-requests.log
+.claude/

--- a/background.ts
+++ b/background.ts
@@ -179,19 +179,22 @@ Electron.protocol.registerSchemesAsPrivileged([
 ]);
 
 process.on('unhandledRejection', (reason: any, promise: any) => {
-  if (reason.code === 'ECONNREFUSED' && reason.port === cfg.kubernetes.port) {
-    // Do nothing: a connection to the kubernetes server was broken
-  } else {
-    console.error('UnhandledRejectionWarning:', reason);
-    const err = reason instanceof Error ? reason : new Error(String(reason));
-
-    submitErrorReport({
-      error_type:    err.name || 'unhandledRejection',
-      error_message: err.message,
-      stack_trace:   err.stack || '',
-      user_context:  'unhandledRejection in main process (background.ts)',
-    }).catch(() => {});
+  if (reason?.code === 'ECONNREFUSED' && reason.port === cfg.kubernetes.port) {
+    return;
   }
+  if (reason?.code === '57P01') {
+    console.warn('[Unhandled] Ignored Postgres admin termination');
+    return;
+  }
+  console.error('UnhandledRejectionWarning:', reason);
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+
+  submitErrorReport({
+    error_type:    err.name || 'unhandledRejection',
+    error_message: err.message,
+    stack_trace:   err.stack || '',
+    user_context:  'unhandledRejection in main process (background.ts)',
+  }).catch(() => {});
 });
 
 process.on('uncaughtException', (err: Error) => {

--- a/pkg/rancher-desktop/SullaWebRequestFixer.ts
+++ b/pkg/rancher-desktop/SullaWebRequestFixer.ts
@@ -137,7 +137,20 @@ export class SullaWebRequestFixer extends EventEmitter {
     });
 
     // ==================== onBeforeSendHeaders ====================
-    session.webRequest.onBeforeSendHeaders((details, callback) => {
+    // Electron's webRequest callback is a one-time native callback (gin_helper).
+    // The async IIFE below has both a success and a .catch() path that call it,
+    // and the success-path invocation can throw (e.g. session torn down, request
+    // cancelled). When it throws, the rejection lands in .catch() which would
+    // call the callback a second time — Electron then throws "One-time callback
+    // was called more than once". Wrap once at entry to enforce Electron's
+    // own contract.
+    session.webRequest.onBeforeSendHeaders((details, originalCallback) => {
+      let callbackInvoked = false;
+      const callback: typeof originalCallback = (response) => {
+        if (callbackInvoked) return;
+        callbackInvoked = true;
+        originalCallback(response);
+      };
       this.emit('beforeSendHeaders', details);
 
       if (details.url.startsWith('app://') || details.url.startsWith('x-rd-extension://')) {

--- a/pkg/rancher-desktop/agent/integrations/oauth/providers/OpenAIOAuth.ts
+++ b/pkg/rancher-desktop/agent/integrations/oauth/providers/OpenAIOAuth.ts
@@ -2,7 +2,7 @@
 // Uses the official Codex CLI OAuth app (no client_secret needed).
 // Grants unlimited API access via ChatGPT Plus/Pro subscription.
 
-import { OAuthProvider, type OAuthProviderConfig } from '../OAuthProvider';
+import { OAuthProvider, type OAuthProviderConfig, type OAuthTokenSet } from '../OAuthProvider';
 import { registerOAuthProvider } from '../registry';
 
 class OpenAIOAuthProvider extends OAuthProvider {
@@ -20,11 +20,67 @@ class OpenAIOAuthProvider extends OAuthProvider {
     fixedCallbackPath:    '/auth/callback',
     extraAuthorizeParams: {
       id_token_add_organizations:  'true',
-      codex_cli_simplified_flow:   'true',
-      originator:                  'codex_cli_rs',
+      originator:                  'pi',
     },
     refreshBufferSeconds: 300,
   };
+
+  override async onTokenReceived(tokens: OAuthTokenSet): Promise<void> {
+    const idToken = tokens.id_token as string | undefined;
+    if (!idToken) {
+      console.warn('[OpenAIOAuth] No id_token in response — skipping API key exchange');
+      return;
+    }
+
+    try {
+      const body = new URLSearchParams({
+        grant_type:         'urn:ietf:params:oauth:grant-type:token-exchange',
+        client_id:          'app_EMoamEEZ73f0CkXaXp7hrann',
+        requested_token:    'openai-api-key',
+        subject_token:      idToken,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+      });
+
+      const res = await fetch('https://auth.openai.com/oauth/token', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body:    body.toString(),
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        console.error('[OpenAIOAuth] API key exchange failed:', res.status, text);
+        return;
+      }
+
+      const data = await res.json() as Record<string, unknown>;
+      const apiKey = (data.access_token as string) || '';
+      if (!apiKey) {
+        console.warn('[OpenAIOAuth] No access_token in key exchange response');
+        return;
+      }
+
+      // Store API key in vault so OpenAIService.create() picks it up
+      const { getIntegrationService } = await import('../../../services/IntegrationService');
+      await getIntegrationService().setIntegrationValue({
+        integration_id: 'openai',
+        property:       'api_key',
+        value:          apiKey,
+      });
+
+      // Bust the LLM cache so the next agent call re-reads the new key
+      try {
+        const { LLMRegistry } = await import('../../../languagemodels/index');
+        LLMRegistry.invalidate('openai');
+        const { resetOpenAIService } = await import('../../../languagemodels/OpenAIService');
+        resetOpenAIService();
+      } catch { /* non-critical */ }
+
+      console.log('[OpenAIOAuth] OpenAI API key stored successfully');
+    } catch (err) {
+      console.error('[OpenAIOAuth] Failed to exchange id_token for API key:', err);
+    }
+  }
 }
 
 const instance = new OpenAIOAuthProvider();

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -177,19 +177,10 @@ async function runMemoryRecall(state: BaseThreadState, variant?: 'default' | 'he
       Array.isArray(m.content) && m.content.some((b: any) => b?.type === 'tool_use'),
     ).length;
 
-    // Extract the agent's accumulated response.
-    // Fallback: if response is empty (e.g. hit max_iterations), grab the
-    // last substantial assistant message from the subconscious conversation.
-    let response = agentMeta.response;
-    if (!response || !String(response).trim()) {
-      for (let i = subState.messages.length - 1; i >= 0; i--) {
-        const msg = subState.messages[i];
-        if (msg.role === 'assistant' && typeof msg.content === 'string' && msg.content.trim().length > 50) {
-          response = msg.content;
-          break;
-        }
-      }
-    }
+    // Extract only the structured contract from AGENT_DONE.
+    // Never fall back to raw assistant messages — those are narration for the
+    // thinking bubble, not a contract for the primary agent.
+    const response = agentMeta.response;
 
     if (response && typeof response === 'string' && response.trim()) {
       console.log(`[SubconsciousMiddleware:MemoryRecall] Returning ${ response.length } chars in ${ Date.now() - startTime }ms | iterations: ${ iterations }, tool_calls: ${ toolCalls }, status: ${ agentMeta.status }`);

--- a/pkg/rancher-desktop/agent/nodes/SubconsciousAgentNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/SubconsciousAgentNode.ts
@@ -112,14 +112,6 @@ export class SubconsciousAgentNode extends BaseNode {
   }
 
   async execute(state: BaseThreadState): Promise<NodeResult<BaseThreadState>> {
-    // Emit immediately so the parent chat UI shows a thinking bubble the
-    // instant this node starts — before any LLM call or subprocess spawn.
-    const agentLabel = (state.metadata as any).agentLabel || 'subconscious';
-    if (agentLabel !== 'observation') {
-      console.log(`[ThinkingTrace] SubconsciousAgent emit "Starting ${ agentLabel }…" (threadId=${ state.metadata.threadId }, parentChannel=${ (state.metadata as any).parentWsChannel }, parentTid=${ (state.metadata as any).parentConversationId })`);
-      await this.emitThinking(state, `Starting ${ agentLabel }…`);
-    }
-
     // Build system prompt: caller's prompt + completion wrappers
     const callerPrompt = (state.metadata as any).systemPrompt || '';
     const systemPrompt = callerPrompt + COMPLETION_WRAPPER_PROMPT;
@@ -246,6 +238,7 @@ export class SubconsciousAgentNode extends BaseNode {
       }
     }
 
+    const agentLabel = (state.metadata as any).agentLabel || 'subconscious';
     console.log(`[SubconsciousAgentNode:${ agentLabel }] Complete — status: ${ outcome.status }`);
 
     return { state, decision: { type: 'next' } };

--- a/pkg/rancher-desktop/agent/prompts/environment.ts
+++ b/pkg/rancher-desktop/agent/prompts/environment.ts
@@ -7,9 +7,9 @@ export const environmentPrompt = `
 
 For visual content (dashboards, charts, tables, widgets): wrap your entire response in \`<html>...</html>\` tags. The chat UI renders it in an isolated Shadow DOM with the Noir Terminal Editorial design system pre-loaded.
 
-Available CSS variables: \`--bg\`, \`--surface-1\` through \`--surface-3\`, \`--text\`, \`--text-muted\`, \`--text-dim\`, \`--green\`, \`--green-bright\`, \`--green-glow\`, \`--border\`, \`--border-muted\`, \`--info\`, \`--success\`, \`--warning\`, \`--danger\`.
+Available CSS variables: \`--bg\`, \`--surface-1\` through \`--surface-3\`, \`--text\`, \`--text-muted\`, \`--text-dim\`, \`--accent\` (steel blue #5096b3 — primary brand color), \`--accent-hover\`, \`--accent-dim\`, \`--accent-border\`, \`--border\`, \`--border-muted\`, \`--info\`, \`--success\`, \`--warning\`, \`--danger\`. Do NOT use \`--green\` or \`--green-bright\` as accent colors — green is reserved for success/status only.
 Fonts: \`var(--font-display)\` (Playfair Display for headlines), \`var(--font-mono)\` (JetBrains Mono for body/code), \`var(--font-body)\` (system sans for long text).
-Aesthetic: dark mode only, green-on-black, noir cinematic feel. Use CSS variables — don't hardcode colors.
+Aesthetic: dark mode only, steel blue accent on dark backgrounds, noir cinematic feel. Use CSS variables — don't hardcode colors. Primary accent is \`--accent\` (steel blue), not green.
 
 For notifications: use \`notify_user\` via the Tools API when the user is not looking at the chat.
 For simple text: use markdown.

--- a/pkg/rancher-desktop/agent/prompts/sections/environment.ts
+++ b/pkg/rancher-desktop/agent/prompts/sections/environment.ts
@@ -18,9 +18,9 @@ export function buildEnvironmentSection(ctx: PromptBuildContext): PromptSection 
 
 For visual content (reports, statistics, dashboards, charts, tables, widgets): wrap your entire response in \`<html>...</html>\` tags. The chat UI renders it as HTML.
 
-Available CSS variables: \`--bg\`, \`--surface-1\` through \`--surface-3\`, \`--text\`, \`--text-muted\`, \`--text-dim\`, \`--green\`, \`--green-bright\`, \`--green-glow\`, \`--border\`, \`--border-muted\`, \`--info\`, \`--success\`, \`--warning\`, \`--danger\`.
+Available CSS variables: \`--bg\`, \`--surface-1\` through \`--surface-3\`, \`--text\`, \`--text-muted\`, \`--text-dim\`, \`--accent\` (steel blue #5096b3 — primary brand color), \`--accent-hover\`, \`--accent-dim\`, \`--accent-border\`, \`--border\`, \`--border-muted\`, \`--info\`, \`--success\`, \`--warning\`, \`--danger\`. Do NOT use \`--green\` or \`--green-bright\` as accent colors — green is reserved for success/status only.
 Fonts: \`var(--font-display)\` (Playfair Display for headlines), \`var(--font-mono)\` (JetBrains Mono for body/code), \`var(--font-body)\` (system sans for long text).
-Aesthetic: dark mode only, green-on-black, noir cinematic feel. Use CSS variables — don't hardcode colors.
+Aesthetic: dark mode only, steel blue accent on dark backgrounds, noir cinematic feel. Use CSS variables — don't hardcode colors. Primary accent is \`--accent\` (steel blue), not green.
 
 For notifications: use \`notify_user\` via the Tools API when the user is not looking at the chat.
 For simple text: use markdown.`;

--- a/pkg/rancher-desktop/agent/prompts/sections/workspace.ts
+++ b/pkg/rancher-desktop/agent/prompts/sections/workspace.ts
@@ -22,16 +22,7 @@ Sulla Home: ${ sullaHome }/
 Key dirs: skills/, workflows/, agents/, integrations/, identity/ (human/business/agent goals), projects/, logs/
 
 **Agent + tool docs (canonical reference):** ${ sullaDocs }/
-Start with \`${ sullaDocs }/INDEX.md\` — it maps every subsystem and user-facing request to the right tool + doc.
-
-Use \`file_search\` / \`read_file\` to load specifics.
-
-Session start — read these before acting:
-1. \`${ sullaDocs }/INDEX.md\` — what's available, where to look
-2. \`${ sullaDocs }/tools/inventory.md\` — every tool by category (verified live)
-3. \`${ sullaDocs }/agent-patterns/user-stories.md\` — common request → action playbook
-4. \`${ sullaHome }/identity/human/identity.md\` — who you work for
-5. \`${ sullaHome }/projects/ACTIVE_PROJECTS.md\` — current projects`;
+Start by reading \`${ sullaDocs }/INDEX.md\` — it lists what to load next and maps every subsystem to the right doc.`;
 
     return {
       id:             'workspace',
@@ -69,9 +60,9 @@ ${ sullaHome }/
 
 ### Agent + tool docs — ${ sullaDocs }/
 
-This is the canonical reference for **every tool you can call, every subsystem you operate, and every common user request**. It ships with Sulla Desktop (bundled in the app; resolves to the packaged path at runtime or the dev checkout). Use \`read_file\` against the absolute paths below.
+The canonical reference for every tool, subsystem, and common user request. Ships with Sulla Desktop (bundled in the app; resolves to the packaged path at runtime or the dev checkout).
 
-**Always start here:** \`${ sullaDocs }/INDEX.md\`
+**Read \`${ sullaDocs }/INDEX.md\` first.** It lists what to load next on session start and maps every topic to the right doc.
 
 Core subdirectories:
 
@@ -112,6 +103,7 @@ ${ sullaDocs }/
 ├── agent-patterns/
 │   ├── user-stories.md                 # ⭐ Common request → step-by-step plan
 │   ├── known-gaps.md                   # What you CAN'T do today — don't fake it
+│   ├── writing-voice.md                # ✍️ Required reading before writing prose for a human
 │   ├── orchestrator.md                 # Completion wrappers, orchestratorInstructions
 │   ├── context-passing.md              # Template resolution, merge output
 │   └── channels.md                     # Inter-agent messaging
@@ -127,25 +119,7 @@ ${ sullaDocs }/
 └── verification-2026-04-23.md          # What was live-verified, what was wrong, what got fixed
 \`\`\`
 
-### Session start — load context before acting
-
-When you wake up on a non-trivial task, read these in order:
-
-1. \`read_file\` → \`${ sullaDocs }/INDEX.md\` — map what's available
-2. \`read_file\` → \`${ sullaDocs }/tools/inventory.md\` — every tool by category (saves tons of \`browse_tools\` round-trips)
-3. \`read_file\` → \`${ sullaDocs }/agent-patterns/user-stories.md\` — concrete plans for common requests
-4. \`read_file\` → \`${ sullaDocs }/agent-patterns/known-gaps.md\` — what you CAN'T do; don't fake it
-5. \`read_file\` → \`${ sullaHome }/identity/human/identity.md\` — who you work for, operating model
-6. \`read_file\` → \`${ sullaHome }/identity/business/identity.md\` — business model, active deadlines
-7. \`read_file\` → \`${ sullaHome }/identity/human/goals.md\` — current goals, financial targets, operating rules
-8. \`read_file\` → \`${ sullaHome }/projects/ACTIVE_PROJECTS.md\` — active projects and blockers
-
-For any user request, if you're not sure which subsystem is involved, grep sulla-docs:
-\`\`\`
-exec({ command: "grep -rli '<keyword>' ${ sullaDocs }/" })
-\`\`\`
-
-Do not guess tool names or make up documentation. If a doc says a tool or feature exists, trust it. If you see something not documented, verify with \`sulla meta/browse_tools '{"query":"..."}'\` before using it, and if confirmed, consider updating the doc.`;
+Do not guess tool names or invent documentation. If a doc says a tool or feature exists, trust it. If you see something not documented, verify with \`sulla meta/browse_tools '{"query":"..."}'\` before using it, and if confirmed, update the doc.`;
 
   return {
     id:             'workspace',

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -25,13 +25,11 @@ const registry = new Map<string, {
 /** Summarizer: no tools — pure text analysis and XML output */
 const SUMMARIZER_TOOLS: string[] = [];
 
-/** Memory Recall: targeted searches for resources, tabs, credentials, environment, tools */
+/** Memory Recall: read-only access to files and vault — nothing else */
 const MEMORY_RECALL_TOOLS: string[] = [
   'file_search',           // Search ~/sulla/resources/ for skills & workflows
   'read_file',             // Read SKILL.md, workflow YAML, environment docs
   'vault_list',            // List available integration service credentials
-  'get_human_presence',    // Check if user is available
-  'browse_tools',          // Search tool catalog by category or keyword
 ];
 
 /** Observation Agent: manage observational memory and update identity files */
@@ -109,10 +107,8 @@ the human is asking about. Never list all credentials unprompted.
 Search \`~/sulla/integrations/environment/\` for environment docs relevant
 to the conversation. Read and include key details from matching files.
 
-### 6. Tools & Connected Accounts
-Use \`browse_tools\` to search for tools relevant to this conversation.
-Only search when the human is asking about an integration or tool by name.
-For relevant tools, call \`vault_list\` to check for connected accounts.
+### 6. Connected Accounts
+Call \`vault_list\` to check for connected accounts when the human is asking about an integration or tool by name.
 
 ### 7. Identity & Goals
 Search \`~/sulla/identity/\` when the request involves business strategy, outreach,
@@ -128,7 +124,7 @@ Read only the files relevant to the request — don't load all of them by defaul
 ### 8. Platform Documentation
 Search \`~/Sites/sulla/sulla-desktop/resources/sulla-docs/\` when the request
 involves a specific Sulla subsystem (workflows, functions, browser, GitHub, etc.)
-and the agent needs procedural detail beyond what browse_tools returns.
+and the agent needs procedural detail.
 Start with \`INDEX.md\` to find the right doc, then read only the relevant file.
 Only search here when the human is asking HOW to do something with Sulla's internals.
 

--- a/pkg/rancher-desktop/agent/services/ModelProviderService.ts
+++ b/pkg/rancher-desktop/agent/services/ModelProviderService.ts
@@ -171,18 +171,10 @@ class ModelProviderService {
       if (EXCLUDED_PROVIDER_IDS.includes(integration.id)) continue;
 
       let connected = false;
-      if (integration.id === 'claude-code') {
-        // Claude Code is "connected" if the user has either credential type stored
-        try {
-          const oauth = await SullaSettingsModel.get('claudeOAuthToken', '');
-          const apiKey = await SullaSettingsModel.get('claudeApiKey', '');
-          connected = !!(oauth || apiKey);
-        } catch { /* DB not ready */ }
-      } else {
-        try {
-          connected = await integrationService.isAnyAccountConnected(integration.id);
-        } catch { /* not ready */ }
-      }
+      try {
+        // All providers (including Claude Code) check the vault for connected accounts
+        connected = await integrationService.isAnyAccountConnected(integration.id);
+      } catch { /* not ready */ }
 
       providers.push({ id: integration.id, name: integration.name, connected });
     }

--- a/pkg/rancher-desktop/agent/services/OAuthService.ts
+++ b/pkg/rancher-desktop/agent/services/OAuthService.ts
@@ -97,7 +97,7 @@ export class OAuthService {
     let codeVerifier: string | undefined;
     let codeChallenge: string | undefined;
     if (cfg.usePKCE) {
-      codeVerifier = crypto.randomBytes(32).toString('base64url');
+      codeVerifier = crypto.randomBytes(64).toString('base64url');
       codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
     }
 
@@ -202,6 +202,7 @@ export class OAuthService {
     const headers: Record<string, string> = {
       'Content-Type': 'application/x-www-form-urlencoded',
       Accept:         'application/json',
+      'User-Agent':   'Sulla-Desktop/1.0',
     };
 
     if (cfg.clientAuthMethod === 'header') {

--- a/pkg/rancher-desktop/assets/styles/themes.css
+++ b/pkg/rancher-desktop/assets/styles/themes.css
@@ -17,3 +17,11 @@
 @import "./themes/nord-dark.css";
 @import "./themes/protocol-dark.css";
 @import "./themes/protocol-light.css";
+
+/* Global accent aliases — themes can override, but these ensure --accent-dim,
+   --accent-border, and --accent-hover always resolve to something sensible. */
+:root {
+  --accent-dim: rgba(80, 150, 179, 0.12);
+  --accent-border: rgba(80, 150, 179, 0.45);
+  --accent-hover: rgba(80, 150, 179, 0.08);
+}

--- a/pkg/rancher-desktop/assets/styles/themes.css
+++ b/pkg/rancher-desktop/assets/styles/themes.css
@@ -16,3 +16,4 @@
 @import "./themes/nord-light.css";
 @import "./themes/nord-dark.css";
 @import "./themes/protocol-dark.css";
+@import "./themes/protocol-light.css";

--- a/pkg/rancher-desktop/assets/styles/themes/default-dark.css
+++ b/pkg/rancher-desktop/assets/styles/themes/default-dark.css
@@ -39,6 +39,7 @@
   /* Accent */
   --accent-primary: #38bdf8;
   --accent-primary-hover: #0ea5e9;
+  --accent: var(--accent-primary);
   --text-accent: #a78bfa;
 
   /* Semantic Borders */

--- a/pkg/rancher-desktop/assets/styles/themes/default-light.css
+++ b/pkg/rancher-desktop/assets/styles/themes/default-light.css
@@ -40,6 +40,7 @@
   /* Accent */
   --accent-primary: #0ea5e9;
   --accent-primary-hover: #0284c7;
+  --accent: var(--accent-primary);
   --text-accent: #7c3aed;
 
   /* Semantic Borders */

--- a/pkg/rancher-desktop/assets/styles/themes/nord-dark.css
+++ b/pkg/rancher-desktop/assets/styles/themes/nord-dark.css
@@ -39,6 +39,7 @@
   /* Accent */
   --accent-primary: #88c0d0;
   --accent-primary-hover: #81a1c1;
+  --accent: var(--accent-primary);
   --text-accent: #b48ead;
 
   /* Semantic Borders */

--- a/pkg/rancher-desktop/assets/styles/themes/nord-light.css
+++ b/pkg/rancher-desktop/assets/styles/themes/nord-light.css
@@ -39,6 +39,7 @@
   /* Accent */
   --accent-primary: #88c0d0;
   --accent-primary-hover: #81a1c1;
+  --accent: var(--accent-primary);
   --text-accent: #b48ead;
 
   /* Semantic Borders */

--- a/pkg/rancher-desktop/assets/styles/themes/ocean-dark.css
+++ b/pkg/rancher-desktop/assets/styles/themes/ocean-dark.css
@@ -39,6 +39,7 @@
   /* Accent */
   --accent-primary: #4fc3f7;
   --accent-primary-hover: #29b6f6;
+  --accent: var(--accent-primary);
   --text-accent: #a78bfa;
 
   /* Semantic Borders */

--- a/pkg/rancher-desktop/assets/styles/themes/ocean-light.css
+++ b/pkg/rancher-desktop/assets/styles/themes/ocean-light.css
@@ -39,6 +39,7 @@
   /* Accent */
   --accent-primary: #4fc3f7;
   --accent-primary-hover: #29b6f6;
+  --accent: var(--accent-primary);
   --text-accent: #7c3aed;
 
   /* Semantic Borders */

--- a/pkg/rancher-desktop/assets/styles/themes/protocol-dark.css
+++ b/pkg/rancher-desktop/assets/styles/themes/protocol-dark.css
@@ -53,6 +53,7 @@
   /* Accent — steel blue (buttons, links, indicators only) */
   --accent-primary: #5096b3;
   --accent-primary-hover: #6ab0cc;
+  --accent: var(--accent-primary);
   --text-accent: #bc8cff;
 
   /* Semantic Borders */
@@ -360,41 +361,6 @@
   color: #fff;
 }
 
-/* ── CRT Scanline Overlay — matches docs.sulladesktop.com ── */
-.theme-default-dark::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  z-index: 10000;
-  pointer-events: none;
-  background: repeating-linear-gradient(
-    0deg,
-    transparent,
-    transparent 2px,
-    rgba(0, 0, 0, 0.08) 2px,
-    rgba(0, 0, 0, 0.08) 4px
-  );
-}
-
-/* ── Vignette — corner darkening matching docs site CRT overlay ── */
-.theme-default-dark::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  pointer-events: none;
-  background:
-    /* Top-left corner */
-    radial-gradient(ellipse at top left, rgba(0, 0, 0, 0.3) 0%, transparent 50%),
-    /* Top-right corner */
-    radial-gradient(ellipse at top right, rgba(0, 0, 0, 0.3) 0%, transparent 50%),
-    /* Bottom-left corner */
-    radial-gradient(ellipse at bottom left, rgba(0, 0, 0, 0.2) 0%, transparent 45%),
-    /* Bottom-right corner */
-    radial-gradient(ellipse at bottom right, rgba(0, 0, 0, 0.2) 0%, transparent 45%),
-    /* Overall vignette */
-    radial-gradient(ellipse at center, transparent 55%, rgba(0, 0, 0, 0.2) 100%);
-}
 
 /* ── Global scrollbar ── */
 .theme-protocol-dark ::-webkit-scrollbar {
@@ -426,20 +392,6 @@
   -webkit-app-region: no-drag;
 }
 
-/* ── Ambient center glow (noir radial) ── */
-.theme-protocol-dark .page-root::before {
-  content: '';
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 800px;
-  height: 600px;
-  border-radius: 50%;
-  background: radial-gradient(ellipse, rgba(80, 150, 179, 0.06) 0%, transparent 60%);
-  pointer-events: none;
-  z-index: 0;
-}
 
 /* ── Header: noir nav with backdrop blur ── */
 .theme-protocol-dark header {
@@ -453,23 +405,10 @@
   text-transform: uppercase;
 }
 
-/* Hide light/dark toggle — protocol theme is dark-only */
-.theme-protocol-dark header .fill-sky-400 {
-  display: none !important;
-}
-
-.theme-protocol-dark header button[aria-label*="Switch to"] {
-  display: none !important;
-}
-
-/* ── Page background with subtle grid lines ── */
+/* ── Page background ── */
 .theme-protocol-dark .page-root {
-  background: #0d1117;           /* Level 0 — deepest, so cards at Level 100 stand out */
+  background: #0d1117;
   color: #e6edf3;
-  background-image:
-    linear-gradient(rgba(80, 150, 179, 0.02) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(80, 150, 179, 0.02) 1px, transparent 1px);
-  background-size: 80px 80px;
 }
 
 /* ── Composer input: Terminal look ── */

--- a/pkg/rancher-desktop/assets/styles/themes/protocol-light.css
+++ b/pkg/rancher-desktop/assets/styles/themes/protocol-light.css
@@ -1,0 +1,1784 @@
+/* ------------------------------------------------------------------ */
+/*  Protocol Light theme — Sulla Desktop steel-blue daylight          */
+/*  Brand color: Steel Blue #5096b3 (same as Protocol Dark)           */
+/*  Companion to protocol-dark; toggles cleanly via useTheme.         */
+/* ------------------------------------------------------------------ */
+
+.theme-protocol-light {
+  /* Typography tokens */
+  --fs-display:  30px;
+  --fs-heading:  18px;
+  --fs-body:     14px;
+  --fs-body-sm:  12px;
+  --fs-caption:  10px;
+  --fs-code:     13px;
+  --font-mono: 'SF Mono', 'JetBrains Mono', 'Fira Code', 'Roboto Mono', monospace;
+
+  /* Backgrounds — clean daylight palette, steel-blue tinted */
+  --body-bg: #f4f7fb;
+  --bg-page: #f4f7fb;
+  --bg-surface: #ffffff;
+  --bg-surface-alt: #eef2f8;
+  --bg-surface-hover: #e4eaf4;
+  --bg-elevated: #ffffff;
+  --bg-header: rgba(244, 247, 251, 0.92);
+  --bg-input: #ffffff;
+  --bg-overlay: rgba(0, 0, 0, 0.4);
+
+  /* Text — steel-blue tinted grays */
+  --text-primary: #1a2332;
+  --text-secondary: #3d4f63;
+  --text-muted: #6a7d94;
+  --text-dim: #94a8bc;
+  --text-link: #3a7fa0;
+  --text-on-accent: #ffffff;
+  --text-success: #16803c;
+  --text-error: #b91c1c;
+  --text-warning: #b45309;
+  --text-info: #1d70a8;
+
+  /* Borders */
+  --border-default: #c8d5e4;
+  --border-strong: #a8bccf;
+  --border-subtle: #dde6f0;
+  --border: #c8d5e4;
+  --subtle-border: #eef2f8;
+
+  /* Semantic Backgrounds */
+  --bg-primary: #f4f7fb;
+  --bg-hover: rgba(80, 150, 179, 0.07);
+  --bg-active: rgba(80, 150, 179, 0.12);
+  --bg-success: rgba(22, 128, 60, 0.1);
+  --bg-error: rgba(185, 28, 28, 0.1);
+  --bg-warning: rgba(180, 83, 9, 0.1);
+  --bg-info: rgba(29, 112, 168, 0.1);
+  --bg-accent: rgba(80, 150, 179, 0.1);
+
+  /* Accent — steel blue, same as Protocol Dark */
+  --accent-primary: #5096b3;
+  --accent-primary-hover: #3a7fa0;
+  --accent: var(--accent-primary);
+  --text-accent: #7c56c8;
+
+  /* Semantic Borders */
+  --border-success: rgba(22, 128, 60, 0.4);
+  --border-error: rgba(185, 28, 28, 0.35);
+  --border-warning: rgba(180, 83, 9, 0.35);
+  --border-info: rgba(29, 112, 168, 0.4);
+  --border-accent: rgba(80, 150, 179, 0.45);
+  --border-focus: rgba(80, 150, 179, 0.5);
+
+  /* Glow system */
+  --brand-glow: rgba(80, 150, 179, 0.3);
+  --brand-glow-soft: rgba(80, 150, 179, 0.1);
+  --brand-glow-strong: rgba(80, 150, 179, 0.5);
+
+  /* Status */
+  --status-success: #16803c;
+  --status-info: #1d70a8;
+  --status-warning: #b45309;
+  --status-error: #b91c1c;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 3px rgba(26, 35, 50, 0.08), 0 1px 2px rgba(26, 35, 50, 0.04);
+  --shadow-md: 0 4px 12px rgba(26, 35, 50, 0.1), 0 2px 6px rgba(26, 35, 50, 0.06);
+  --shadow-lg: 0 10px 32px rgba(26, 35, 50, 0.12), 0 4px 12px rgba(26, 35, 50, 0.08);
+  --ring-color: rgba(80, 150, 179, 0.5);
+  --shadow: rgba(26, 35, 50, 0.15);
+
+  /* Editor */
+  --editor-bg: #f4f7fb;
+  --editor-border: #c8d5e4;
+  --editor-btn-color: #3d4f63;
+  --editor-btn-hover: rgba(80, 150, 179, 0.1);
+  --editor-separator: #c8d5e4;
+
+  /* Terminal */
+  --terminal-bg: #f4f7fb;
+  --terminal-fg: #1a2332;
+  --terminal-cursor: #5096b3;
+  --terminal-selection-bg: rgba(80, 150, 179, 0.25);
+  --terminal-selection-fg: #1a2332;
+  --terminal-dot-red: #ff5f57;
+  --terminal-dot-yellow: #febc2e;
+  --terminal-dot-green: #28c840;
+
+  /* Default Colors */
+  --default: #eef2f8;
+  --default-text: #6a7d94;
+  --default-hover-bg: #e4eaf4;
+  --default-hover-text: #1a2332;
+  --default-active-bg: #d8e4f0;
+  --default-active-text: #1a2332;
+  --default-border: #eef2f8;
+  --default-banner-bg: rgba(238, 242, 248, 0.15);
+  --default-light-bg: rgba(238, 242, 248, 0.05);
+
+  /* Muted */
+  --muted: #6a7d94;
+
+  /* Body */
+  --body-text: #1a2332;
+
+  /* Scrollbar */
+  --scrollbar-thumb: #a8bccf;
+  --scrollbar-thumb-dropdown: #c8d5e4;
+  --scrollbar-track: transparent;
+
+  /* Header */
+  --header-bg: #f4f7fb;
+  --header-btn-bg: #ffffff;
+  --header-btn-text: #1a2332;
+  --header-input-text: #1a2332;
+  --header-height: 55px;
+  --header-border: #c8d5e4;
+  --header-border-size: 1px;
+
+  /* Nav */
+  --nav-width: 230px;
+  --nav-bg: #f4f7fb;
+  --nav-active: rgba(80, 150, 179, 0.12);
+  --nav-hover: #e4eaf4;
+  --nav-expander-hover: rgba(80, 150, 179, 0.07);
+  --nav-border: #c8d5e4;
+  --nav-border-size: 1px;
+
+  /* Footer */
+  --footer-bg: #f4f7fb;
+  --footer-border: #c8d5e4;
+
+  /* Top Menu */
+  --topmenu-bg: #f4f7fb;
+  --topmenu-text: #1a2332;
+  --topmost-border: #c8d5e4;
+  --topmost-shadow: #ffffff;
+  --topmost-light-hover: #dde6f0;
+
+  /* Accent Button */
+  --accent-btn: rgba(80, 150, 179, 0.1);
+  --accent-btn-hover: #5096b3;
+  --accent-btn-hover-text: #ffffff;
+
+  /* Modal */
+  --modal-bg: #ffffff;
+  --modal-border: #c8d5e4;
+  --overlay-bg: rgba(0, 0, 0, 0.4);
+
+  /* Checkbox */
+  --checkbox-tick: #ffffff;
+  --checkbox-border: #a8bccf;
+  --checkbox-tick-disabled: #94a8bc;
+  --checkbox-disabled-bg: #c8d5e4;
+  --checkbox-tick-locked: #f4f7fb;
+  --checkbox-locked-bg: #94a8bc;
+  --checkbox-ticked-bg: #5096b3;
+  --checkbox-locked-border: #94a8bc;
+  --checkbox-locked-shadow: #94a8bc;
+
+  /* Dropdown */
+  --dropdown-bg: #ffffff;
+  --dropdown-border: #a8bccf;
+  --dropdown-divider: #c8d5e4;
+  --dropdown-text: #5096b3;
+  --dropdown-active-text: #ffffff;
+  --dropdown-active-bg: #5096b3;
+  --dropdown-hover-text: #ffffff;
+  --dropdown-hover-bg: #5096b3;
+  --dropdown-disabled-bg: #eef2f8;
+  --dropdown-disabled-text: #94a8bc;
+  --dropdown-locked-text: #1a2332;
+
+  /* Input */
+  --input-text: #1a2332;
+  --input-label: #3d4f63;
+  --input-placeholder: #94a8bc;
+  --input-border: var(--border);
+  --input-bg: #ffffff;
+  --input-bg-accent: #eef2f8;
+  --input-hover-bg: #f4f7fb;
+  --input-focus-bg: #ffffff;
+  --input-disabled-text: #94a8bc;
+  --input-disabled-label: #a8bccf;
+  --input-disabled-bg: #eef2f8;
+  --input-disabled-border: #c8d5e4;
+  --input-disabled-placeholder: #c8d5e4;
+  --input-addon-bg: #eef2f8;
+  --input-locked-text: #1a2332;
+
+  /* Radio */
+  --radio-locked-bg: #f4f7fb;
+  --radio-locked-shadow: #f4f7fb;
+
+  /* Progress */
+  --progress-bg: #dde6f0;
+  --progress-divider: #1a2332;
+
+  /* Sortable Table */
+  --sortable-table-bg: #eef2f8;
+  --sortable-table-row-bg: #ffffff;
+  --sortable-table-header-bg: #f4f7fb;
+  --sortable-table-accent-bg: #ffffff;
+  --sortable-table-accent-alt: #f4f7fb;
+  --sortable-table-top-divider: var(--border);
+  --sortable-table-body-divider: #c8d5e4;
+  --sortable-table-hover-bg: #eef2f8;
+  --sortable-table-selected-bg: rgba(80, 150, 179, 0.12);
+  --sortable-table-group-label: #6a7d94;
+
+  /* Tag */
+  --tag-primary: #1a2332;
+  --tag-bg: #dde6f0;
+
+  /* Popover */
+  --popover-bg: #ffffff;
+  --popover-border: #c8d5e4;
+  --popover-text: #1a2332;
+  --popover-border-radius: 4px;
+
+  /* Tooltip */
+  --tooltip-bg: #1a2332;
+  --tooltip-border: #3d4f63;
+  --tooltip-text: #f4f7fb;
+  --tooltip-bg-warning: rgba(180, 83, 9, 0.8);
+  --tooltip-text-warning: #f4f7fb;
+
+  /* Icon */
+  --icon-circle: #dde6f0;
+
+  /* Tabbed */
+  --tabbed-border: #c8d5e4;
+  --tabbed-sidebar-bg: #f4f7fb;
+  --tabbed-container-bg: #ffffff;
+
+  /* YAML Editor */
+  --yaml-editor-bg: #f4f7fb;
+
+  /* Diff */
+  --diff-border: var(--border);
+  --diff-header-bg: var(--nav-bg);
+  --diff-header-border: var(--border);
+  --diff-header: rgba(244, 247, 251, 0.5);
+  --diff-linenum-bg: var(--nav-bg);
+  --diff-linenum: var(--muted);
+  --diff-linenum-border: var(--border);
+  --diff-line-ins-bg: var(--status-success);
+  --diff-line-del-bg: rgba(185, 28, 28, 0.6);
+  --diff-del-bg: rgba(185, 28, 28, 0.15);
+  --diff-del-border: #b91c1c;
+  --diff-ins-bg: rgba(22, 128, 60, 0.15);
+  --diff-ins-border: rgba(22, 128, 60, 0.4);
+  --diff-chg-ins: rgba(22, 128, 60, 0.12);
+  --diff-chg-del: rgba(180, 83, 9, 0.3);
+  --diff-empty-placeholder: #f4f7fb;
+
+  /* Window Manager */
+  --wm-tabs-bg: #dde6f0;
+  --wm-tab-bg: #f4f7fb;
+  --wm-closer-hover-bg: #c8d5e4;
+  --wm-tab-active-bg: #ffffff;
+  --wm-title-bg: #f4f7fb;
+  --wm-title-border: #c8d5e4;
+  --wm-body-bg: #f4f7fb;
+  --wm-border: #eef2f8;
+  --wm-tab-height: 29px;
+
+  /* Glance */
+  --glance-bg-rgb: 80, 150, 179;
+  --glance-divider: #c8d5e4;
+
+  /* Resource Gauge */
+  --resource-gauge-back-circle: 200, 213, 228, 0.5;
+
+  /* Simple Box */
+  --simple-box-bg: #f4f7fb;
+  --simple-box-border: #eef2f8;
+  --simple-box-divider: #c8d5e4;
+  --simple-box-shadow: rgba(26, 35, 50, 0.08);
+
+  /* Terminal (additional) */
+  --terminal-selection: rgba(80, 150, 179, 0.5);
+  --terminal-text: var(--body-text);
+
+  /* Logs */
+  --logs-bg: var(--wm-body-bg);
+  --logs-highlight: var(--wm-body-bg);
+  --logs-highlight-bg: var(--status-warning);
+  --logs-text: var(--body-text);
+
+  /* Gauge */
+  --gauge-divider: rgba(0, 0, 0, 0.15);
+  --gauge-zero: #dde6f0;
+  --gauge-success-primary: 22, 128, 60;
+  --gauge-success-secondary: 74, 222, 128;
+  --gauge-warning-primary: 180, 83, 9;
+  --gauge-warning-secondary: 251, 191, 36;
+  --gauge-error-primary: 185, 28, 28;
+  --gauge-error-secondary: 252, 165, 165;
+
+  /* Sizzle Colors */
+  --sizzle-0: 180, 210, 30;
+  --sizzle-1: 225, 45, 74;
+  --sizzle-2: 212, 66, 148;
+  --sizzle-3: 0, 169, 217;
+  --sizzle-4: 244, 136, 68;
+  --sizzle-5: 0, 147, 128;
+  --sizzle-6: 136, 81, 165;
+  --sizzle-7: 45, 47, 149;
+  --sizzle-8: 255, 235, 0;
+  --sizzle-success: 34, 197, 94;
+  --sizzle-info: 80, 150, 179;
+  --sizzle-warning: 180, 83, 9;
+  --sizzle-error: 185, 28, 28;
+  --sizzle-unknown: 200, 213, 228;
+
+  /* App Accents */
+  --app-rancher-accent: #5096b3;
+  --app-rancher-accent-text: #ffffff;
+  --app-partner-accent: #fea424;
+  --app-partner-accent-text: #000000;
+  --app-color1-accent: rgba(185, 28, 28, 1);
+  --app-color1-accent-text: #ffffff;
+  --app-color2-accent: rgba(124, 86, 200, 1);
+  --app-color2-accent-text: #ffffff;
+  --app-color3-accent: rgba(80, 150, 179, 1);
+  --app-color3-accent-text: #ffffff;
+  --app-color4-accent: rgba(180, 83, 9, 1);
+  --app-color4-accent-text: #ffffff;
+  --app-color5-accent: rgba(22, 128, 60, 1);
+  --app-color5-accent-text: #ffffff;
+  --app-color6-accent: rgba(29, 112, 168, 1);
+  --app-color6-accent-text: #ffffff;
+  --app-color7-accent: rgba(58, 127, 160, 1);
+  --app-color7-accent-text: #ffffff;
+  --app-color8-accent: rgba(255, 235, 0, 1);
+  --app-color8-accent-text: #1a2332;
+
+  /* Product */
+  --product-icon: #6a7d94;
+  --product-icon-active: #1a2332;
+
+  /* Button */
+  --button-icon: #dde6f0;
+  --button-icon-bg: #1a2332;
+
+  /* Border Utilities */
+  --border-width: 1px;
+  --border-radius: 4px;
+  --border-radius-md: 6px;
+  --border-radius-lg: 8px;
+  --outline: var(--accent-primary);
+  --outline-width: 1px;
+
+  /* Sulla component tokens */
+  --bg: #f4f7fb;
+  --surface-1: #ffffff;
+  --surface-2: #eef2f8;
+  --surface-3: #e4eaf4;
+  --text: #1a2332;
+  --border-muted: #dde6f0;
+  --green: #16803c;
+  --green-bright: #22c55e;
+  --green-glow: rgba(22, 128, 60, 0.3);
+  --info: #1d70a8;
+  --success: #16803c;
+  --warning: #b45309;
+  --danger: #b91c1c;
+
+  /* Disabled */
+  --disabled-bg: #c8d5e4;
+  --disabled-text: #6a7d94;
+
+  /* Box */
+  --box-bg: #f4f7fb;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Component Overrides for Light Theme — FORCE LIGHT MODE
+   These override any dark theme remnants with !important
+   ═════════════════════════════════════════════════════════════════ */
+
+/* Chat Canvas — force light background, hide dark elements */
+.theme-protocol-light .chat-canvas {
+  background: linear-gradient(135deg, #f4f7fb 0%, #eef2f8 50%, #e4eaf4 100%) !important;
+}
+
+.theme-protocol-light .chat-stars,
+.theme-protocol-light .stars {
+  display: none !important;
+}
+
+.theme-protocol-light .chat-glow.a,
+.theme-protocol-light .chat-glow.b {
+  opacity: 0.15 !important;
+}
+
+/* Page root backgrounds */
+.theme-protocol-light .chat-root,
+.theme-protocol-light .page-root,
+.theme-protocol-light [class*="page-root"] {
+  background: var(--bg-page, #f4f7fb) !important;
+  color: var(--text-primary, #1a2332) !important;
+}
+
+/* Empty State — High Contrast */
+.theme-protocol-light .empty h1,
+.theme-protocol-light h1:has(+ .lede) {
+  color: #1a2332 !important;
+  text-shadow: none !important;
+}
+
+.theme-protocol-light .lede,
+.theme-protocol-light .hero .dek,
+.theme-protocol-light .empty p[class*="lede"] {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .e-kicker,
+.theme-protocol-light .kicker {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .e-kicker::before,
+.theme-protocol-light .e-kicker::after,
+.theme-protocol-light .kicker::before {
+  background: #a8bccf !important;
+  opacity: 1 !important;
+}
+
+/* Suggestion buttons */
+.theme-protocol-light .sug,
+.theme-protocol-light .suggests button {
+  background: rgba(238, 242, 248, 0.9) !important;
+  border-color: rgba(168, 188, 207, 0.4) !important;
+  color: #3d4f63 !important;
+  box-shadow: 0 1px 3px rgba(26, 35, 50, 0.08) !important;
+}
+
+.theme-protocol-light .sug:hover,
+.theme-protocol-light .suggests button:hover {
+  background: rgba(80, 150, 179, 0.15) !important;
+  border-color: rgba(80, 150, 179, 0.5) !important;
+  color: #1a2332 !important;
+}
+
+/* Routines Home */
+.theme-protocol-light .routines-home {
+  background: linear-gradient(135deg, #f4f7fb 0%, #eef2f8 60%, #e4eaf4 100%) !important;
+  color: var(--text-primary, #1a2332) !important;
+}
+
+.theme-protocol-light .routines-home .canvas {
+  background: transparent !important;
+}
+
+.theme-protocol-light .bracket {
+  border-color: rgba(80, 150, 179, 0.25) !important;
+}
+
+/* Tabs */
+.theme-protocol-light .tab {
+  color: #6a7d94 !important;
+  background: transparent !important;
+}
+
+.theme-protocol-light .tab:hover {
+  color: #1a2332 !important;
+  background: rgba(80, 150, 179, 0.08) !important;
+}
+
+.theme-protocol-light .tab.on {
+  color: #5096b3 !important;
+  background: rgba(80, 150, 179, 0.12) !important;
+  border-color: rgba(80, 150, 179, 0.3) !important;
+}
+
+.theme-protocol-light .tab-num {
+  background: rgba(168, 188, 207, 0.15) !important;
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .tab.on .tab-num {
+  background: rgba(80, 150, 179, 0.2) !important;
+  color: #5096b3 !important;
+}
+
+/* Sub-tabs */
+.theme-protocol-light .subtab {
+  color: #6a7d94 !important;
+  background: transparent !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .subtab:hover {
+  color: #1a2332 !important;
+  border-color: #a8bccf !important;
+}
+
+.theme-protocol-light .subtab.on {
+  color: #5096b3 !important;
+  background: rgba(80, 150, 179, 0.12) !important;
+  border-color: rgba(80, 150, 179, 0.3) !important;
+}
+
+/* Browser Tabs */
+.theme-protocol-light .tab-bar,
+.theme-protocol-light [class*="tab-bar"] {
+  background: var(--bg-surface, #ffffff) !important;
+  border-bottom-color: var(--border-default, #c8d5e4) !important;
+}
+
+.theme-protocol-light .browser-tab,
+.theme-protocol-light .tab-item,
+.theme-protocol-light [class*="browser-tab"] {
+  background: transparent !important;
+  color: var(--text-secondary, #3d4f63) !important;
+}
+
+.theme-protocol-light .browser-tab.active,
+.theme-protocol-light .tab-item.active,
+.theme-protocol-light .tab-item.on,
+.theme-protocol-light [class*="browser-tab"][class*="active"] {
+  background: var(--bg-page, #f4f7fb) !important;
+  color: var(--text-primary, #1a2332) !important;
+  border-color: var(--border-default, #c8d5e4) !important;
+}
+
+/* Remove any dark overlays */
+.theme-protocol-light::after,
+.theme-protocol-light::before,
+.theme-protocol-light .page-root::before {
+  display: none !important;
+}
+
+/* Force body/html background for light theme */
+.theme-protocol-light,
+.theme-protocol-light html,
+.theme-protocol-light body {
+  background: var(--bg-page, #f4f7fb) !important;
+  color: var(--body-text, #1a2332) !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Ribbon Footer — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .ribbon {
+  background: rgba(238, 242, 248, 0.85) !important;
+  border-top: 1px solid rgba(168, 188, 207, 0.3) !important;
+  backdrop-filter: blur(8px) !important;
+}
+
+.theme-protocol-light .ribbon .l,
+.theme-protocol-light .ribbon .r {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .ribbon .l .tc,
+.theme-protocol-light .ribbon .r b {
+  color: #1a2332 !important;
+  font-weight: 600 !important;
+}
+
+.theme-protocol-light .ribbon .c .mark {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .ribbon .c .sig {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .ribbon .c .sig b {
+  color: #5096b3 !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Hero Section — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .hero h1 {
+  color: #1a2332 !important;
+  text-shadow: none !important;
+}
+
+.theme-protocol-light .hero .dek {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .hero .kicker,
+.theme-protocol-light .kicker {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .kicker .d,
+.theme-protocol-light .hero .kicker .d {
+  background: #a8bccf !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Form Inputs & Selected Items — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light input[type="text"],
+.theme-protocol-light input[type="password"],
+.theme-protocol-light input[type="email"],
+.theme-protocol-light input[type="number"],
+.theme-protocol-light input[type="search"],
+.theme-protocol-light input[type="url"],
+.theme-protocol-light textarea,
+.theme-protocol-light select,
+.theme-protocol-light .address-bar,
+.theme-protocol-light [class*="input"],
+.theme-protocol-light [class*="select"] {
+  background: var(--bg-input, #ffffff) !important;
+  color: var(--text-primary, #1a2332) !important;
+  border-color: var(--border-default, #c8d5e4) !important;
+}
+
+.theme-protocol-light .selected-item,
+.theme-protocol-light [class*="selected"],
+.theme-protocol-light .dropdown-item.active,
+.theme-protocol-light .dropdown-item.selected,
+.theme-protocol-light [class*="chip"],
+.theme-protocol-light [class*="tag"],
+.theme-protocol-light .multiselect__option--highlight,
+.theme-protocol-light .multiselect__option--selected {
+  background: rgba(80, 150, 179, 0.15) !important;
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .editor-field input,
+.theme-protocol-light .editor-field select,
+.theme-protocol-light .editor-badge-type,
+.theme-protocol-light .pwgen-display,
+.theme-protocol-light .pwgen-password,
+.theme-protocol-light .pwgen-mode-toggle,
+.theme-protocol-light .pwgen-options,
+.theme-protocol-light .pwgen-num-input,
+.theme-protocol-light .pwgen-select {
+  background: var(--bg-input, #ffffff) !important;
+  color: var(--text-primary, #1a2332) !important;
+  border-color: var(--border-default, #c8d5e4) !important;
+}
+
+.theme-protocol-light .pwgen-mode-toggle button.active,
+.theme-protocol-light [class*="mode-toggle"] button.active,
+.theme-protocol-light [class*="toggle"] button.active {
+  background: var(--accent-primary, #5096b3) !important;
+  color: #ffffff !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Brand Header — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .brand-name {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .brand-sub {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .brand-mark {
+  background: linear-gradient(135deg, #5096b3, #3a7fa0) !important;
+  color: #ffffff !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Sub-tabs (Active/Archive) — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .subtab {
+  color: #6a7d94 !important;
+  background: transparent !important;
+  border-color: rgba(168, 188, 207, 0.4) !important;
+}
+
+.theme-protocol-light .subtab:hover {
+  color: #1a2332 !important;
+  border-color: #a8bccf !important;
+}
+
+.theme-protocol-light .subtab.on {
+  color: #1a2332 !important;
+  background: rgba(80, 150, 179, 0.15) !important;
+  border-color: rgba(80, 150, 179, 0.4) !important;
+}
+
+.theme-protocol-light .subtab .subtab-num {
+  background: rgba(168, 188, 207, 0.2) !important;
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .subtab.on .subtab-num {
+  background: rgba(80, 150, 179, 0.25) !important;
+  color: #5096b3 !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Empty State Card — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .empty-state {
+  background: rgba(238, 242, 248, 0.85) !important;
+  border-color: rgba(168, 188, 207, 0.4) !important;
+  backdrop-filter: blur(8px) !important;
+}
+
+.theme-protocol-light .empty-state .kicker,
+.theme-protocol-light .empty-state-kicker {
+  color: #5096b3 !important;
+}
+
+.theme-protocol-light .empty-state .title,
+.theme-protocol-light .empty-state-title,
+.theme-protocol-light .empty-state h2 {
+  color: #1a2332 !important;
+  font-style: italic !important;
+}
+
+.theme-protocol-light .empty-state .message,
+.theme-protocol-light .empty-state-message,
+.theme-protocol-light .empty-state p {
+  color: #3d4f63 !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   ModeRail Sidebar — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .mode-rail {
+  background: rgba(238, 242, 248, 0.85) !important;
+  border-right-color: rgba(168, 188, 207, 0.2) !important;
+}
+
+.theme-protocol-light .mode-btn {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .mode-btn:hover {
+  color: #1a2332 !important;
+  background: rgba(80, 150, 179, 0.1) !important;
+}
+
+.theme-protocol-light .mode-btn.active {
+  color: #5096b3 !important;
+  background: rgba(80, 150, 179, 0.15) !important;
+}
+
+.theme-protocol-light .mode-btn.active::before {
+  background: #5096b3 !important;
+  box-shadow: 0 0 10px rgba(80, 150, 179, 0.5) !important;
+}
+
+.theme-protocol-light .mode-btn::after {
+  color: #1a2332 !important;
+  background: rgba(255, 255, 255, 0.96) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+  box-shadow: 0 6px 22px rgba(26, 35, 50, 0.15) !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Tab Mode Overrides (Routines/Marketplace) — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .tab-mode-routines,
+.theme-protocol-light .tab-mode-marketplace {
+  --tab-bg: var(--bg-surface, #ffffff) !important;
+  --tab-bg-hover: rgba(80, 150, 179, 0.12) !important;
+  --tab-accent: #5096b3 !important;
+}
+
+.theme-protocol-light .tab-mode-routines .tab-item.active,
+.theme-protocol-light .tab-mode-marketplace .tab-item.active,
+.theme-protocol-light .tab-mode-routines .tab.on,
+.theme-protocol-light .tab-mode-marketplace .tab.on {
+  background: var(--bg-page, #f4f7fb) !important;
+  color: var(--text-primary, #1a2332) !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Library Page — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .library .rail {
+  background: rgba(238, 242, 248, 0.85) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .library .rail-head {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .library .rail-item {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .library .rail-item:hover {
+  background: rgba(80, 150, 179, 0.1) !important;
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .library .rail-item.on {
+  background: rgba(80, 150, 179, 0.15) !important;
+  border-color: rgba(80, 150, 179, 0.4) !important;
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .library .rail-item .count {
+  color: #6a7d94 !important;
+  background: rgba(168, 188, 207, 0.2) !important;
+}
+
+.theme-protocol-light .library .rail-item.on .count {
+  color: #5096b3 !important;
+  background: rgba(80, 150, 179, 0.2) !important;
+}
+
+.theme-protocol-light .library .rail-divider {
+  background: rgba(168, 188, 207, 0.2) !important;
+}
+
+.theme-protocol-light .library .rail-footer p {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .library .content-head h3 {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .library .count-pill {
+  color: #6a7d94 !important;
+  background: rgba(168, 188, 207, 0.2) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .library .search-box {
+  background: rgba(238, 242, 248, 0.85) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .library .search-box input {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .library .search-box svg {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .library .status {
+  background: rgba(238, 242, 248, 0.6) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .library .status p strong {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .library .stat-tile {
+  background: rgba(255, 255, 255, 0.7) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .library .stat-tile:hover {
+  background: rgba(255, 255, 255, 0.9) !important;
+  border-color: rgba(80, 150, 179, 0.4) !important;
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .library .stat-tile .stat-value {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .library .stat-tile .stat-label {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .library .draft-row {
+  background: linear-gradient(90deg, rgba(238, 242, 248, 0.9), rgba(255, 255, 255, 0.7)) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .library .draft-row:hover {
+  background: linear-gradient(90deg, rgba(238, 242, 248, 1), rgba(255, 255, 255, 0.9)) !important;
+  border-color: rgba(80, 150, 179, 0.4) !important;
+}
+
+.theme-protocol-light .library .draft-row .title {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .library .draft-row .meta {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .library .chip {
+  color: #6a7d94 !important;
+  background: rgba(168, 188, 207, 0.15) !important;
+  border-color: rgba(168, 188, 207, 0.25) !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Secretary Mode — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .flex.h-full.flex-col[style*="--bg"] {
+  background: var(--bg-page, #f4f7fb) !important;
+}
+
+.theme-protocol-light [style*="background: var(--bg, #0d1117)"] {
+  background: var(--bg-page, #f4f7fb) !important;
+}
+
+.theme-protocol-light .welcome-title {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .welcome-subtitle {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .welcome-card {
+  background: var(--bg-surface, #ffffff) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .welcome-card:hover {
+  border-color: rgba(80, 150, 179, 0.5) !important;
+  box-shadow: 0 0 15px rgba(80, 150, 179, 0.15), 0 0 30px rgba(80, 150, 179, 0.1) !important;
+}
+
+.theme-protocol-light .welcome-card-cta {
+  color: #5096b3 !important;
+  background: rgba(80, 150, 179, 0.1) !important;
+  border-top-color: rgba(168, 188, 207, 0.2) !important;
+}
+
+.theme-protocol-light .dt-header {
+  background: rgba(238, 242, 248, 0.9) !important;
+  border-bottom-color: rgba(168, 188, 207, 0.2) !important;
+}
+
+.theme-protocol-light .dt-title {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .dt-pane-hdr {
+  background: rgba(238, 242, 248, 0.9) !important;
+  border-bottom-color: rgba(168, 188, 207, 0.2) !important;
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .dt-line {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .dt-ts {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .dt-bubble-caller {
+  background: rgba(168, 188, 207, 0.15) !important;
+}
+
+.theme-protocol-light .dt-bubble-you {
+  background: rgba(80, 150, 179, 0.15) !important;
+}
+
+.theme-protocol-light .dt-bubble-text {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .dt-bubble-speaker {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .dt-bubble-time {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .dt-section-hdr {
+  color: #6a7d94 !important;
+  border-bottom-color: rgba(168, 188, 207, 0.2) !important;
+}
+
+.theme-protocol-light .dt-item {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .dt-insight {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .dt-chat-input {
+  background: rgba(238, 242, 248, 0.9) !important;
+  border-top-color: rgba(168, 188, 207, 0.2) !important;
+}
+
+.theme-protocol-light .dt-chat-field {
+  color: #1a2332 !important;
+  background: #ffffff !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .dt-chat-field::placeholder {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .dt-kbd {
+  background: rgba(168, 188, 207, 0.2) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .dt-divider {
+  background: rgba(168, 188, 207, 0.2) !important;
+}
+
+.theme-protocol-light .dt-pane-scroll {
+  background: transparent !important;
+}
+
+.theme-protocol-light .dt-empty {
+  color: #a8bccf !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Chat Page Gradients — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .chat-root {
+  background: var(--bg-page, #f4f7fb) !important;
+}
+
+.theme-protocol-light .header-backdrop {
+  background: linear-gradient(
+    to bottom,
+    rgba(238, 242, 248, 0.95) 0%,
+    rgba(238, 242, 248, 0.85) 55%,
+    rgba(238, 242, 248, 0) 100%
+  ) !important;
+}
+
+.theme-protocol-light .composer-backdrop {
+  background: linear-gradient(
+    to top,
+    rgba(238, 242, 248, 0.95) 0%,
+    rgba(238, 242, 248, 0.85) 45%,
+    rgba(238, 242, 248, 0) 100%
+  ) !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Model Switcher Modal — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .modal-veil {
+  background: rgba(26, 35, 50, 0.4) !important;
+  backdrop-filter: blur(8px) !important;
+}
+
+.theme-protocol-light .modal {
+  background: rgba(255, 255, 255, 0.98) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+  box-shadow: 0 30px 60px rgba(26, 35, 50, 0.15), 0 0 0 1px rgba(168, 188, 207, 0.1) !important;
+}
+
+.theme-protocol-light .mhead {
+  color: #6a7d94 !important;
+  border-bottom-color: rgba(168, 188, 207, 0.2) !important;
+}
+
+.theme-protocol-light .mhead .x {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .msearch {
+  border-bottom-color: rgba(168, 188, 207, 0.15) !important;
+}
+
+.theme-protocol-light .msearch input {
+  color: #1a2332 !important;
+  caret-color: #5096b3 !important;
+}
+
+.theme-protocol-light .msearch input::placeholder {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .mgroup-head .provider {
+  color: #5096b3 !important;
+}
+
+.theme-protocol-light .mgroup-head .primary-pill {
+  color: #5096b3 !important;
+  background: rgba(80, 150, 179, 0.1) !important;
+  border-color: rgba(80, 150, 179, 0.25) !important;
+}
+
+.theme-protocol-light .mdivider {
+  background: rgba(168, 188, 207, 0.15) !important;
+}
+
+.theme-protocol-light .mempty {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .mitem:hover {
+  background: rgba(80, 150, 179, 0.08) !important;
+}
+
+.theme-protocol-light .mitem .name {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .mitem .tier {
+  color: #6a7d94 !important;
+  background: rgba(168, 188, 207, 0.15) !important;
+  border-color: rgba(168, 188, 207, 0.25) !important;
+}
+
+.theme-protocol-light .mitem .tier.active {
+  color: #16803c !important;
+  background: rgba(22, 128, 60, 0.1) !important;
+  border-color: rgba(22, 128, 60, 0.25) !important;
+}
+
+.theme-protocol-light .mitem.active {
+  background: rgba(80, 150, 179, 0.1) !important;
+}
+
+.theme-protocol-light .mitem.active::before {
+  color: #5096b3 !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Scrollbars — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light ::-webkit-scrollbar {
+  width: 8px !important;
+  height: 8px !important;
+}
+
+.theme-protocol-light ::-webkit-scrollbar-track {
+  background: rgba(168, 188, 207, 0.1) !important;
+}
+
+.theme-protocol-light ::-webkit-scrollbar-thumb {
+  background: rgba(168, 188, 207, 0.4) !important;
+  border-radius: 4px !important;
+}
+
+.theme-protocol-light ::-webkit-scrollbar-thumb:hover {
+  background: rgba(168, 188, 207, 0.6) !important;
+}
+
+.theme-protocol-light * {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(168, 188, 207, 0.4) rgba(168, 188, 207, 0.1) !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Empty State — Light Mode (high contrast fixes)
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .empty h1 {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .e-kicker {
+  color: #5096b3 !important;
+}
+
+.theme-protocol-light .e-kicker::before,
+.theme-protocol-light .e-kicker::after {
+  background: #5096b3 !important;
+}
+
+.theme-protocol-light .lede {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .sug {
+  background: rgba(255, 255, 255, 0.7) !important;
+  border-color: rgba(80, 150, 179, 0.3) !important;
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .sug:hover {
+  background: rgba(80, 150, 179, 0.15) !important;
+  border-color: #5096b3 !important;
+  color: #1a2332 !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Composer — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .composer {
+  border-bottom-color: rgba(80, 150, 179, 0.4) !important;
+}
+
+.theme-protocol-light .composer:focus-within {
+  border-bottom-color: #5096b3 !important;
+  box-shadow: 0 14px 20px -14px rgba(80, 150, 179, 0.25) !important;
+}
+
+.theme-protocol-light .input,
+.theme-protocol-light textarea.input {
+  color: #1a2332 !important;
+  caret-color: #5096b3 !important;
+  background: transparent !important;
+}
+
+.theme-protocol-light .input::placeholder,
+.theme-protocol-light textarea.input::placeholder {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .glyph {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .hints {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .hints kbd {
+  background: rgba(168, 188, 207, 0.15) !important;
+  border-color: rgba(168, 188, 207, 0.25) !important;
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .composer-inner {
+  background: transparent !important;
+}
+
+.theme-protocol-light .composer-wrap {
+  background: transparent !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   RoutinesHome Tabs — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .tab {
+  color: #6a7d94 !important;
+  background: transparent !important;
+  border-color: transparent !important;
+}
+
+.theme-protocol-light .tab:hover {
+  color: #1a2332 !important;
+  background: rgba(80, 150, 179, 0.08) !important;
+  border-color: rgba(80, 150, 179, 0.2) !important;
+}
+
+.theme-protocol-light .tab.on {
+  color: #1a2332 !important;
+  background: rgba(80, 150, 179, 0.15) !important;
+  border-color: rgba(80, 150, 179, 0.4) !important;
+  box-shadow: 0 6px 20px rgba(80, 150, 179, 0.15) !important;
+}
+
+.theme-protocol-light .tab-num {
+  background: rgba(168, 188, 207, 0.2) !important;
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .tab.on .tab-num {
+  background: rgba(80, 150, 179, 0.25) !important;
+  color: #5096b3 !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Chat Transcript — Light Mode Text Colors
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .time-marker span {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .time-marker::before,
+.theme-protocol-light .time-marker::after {
+  background: linear-gradient(90deg, transparent, rgba(168, 188, 207, 0.4), transparent) !important;
+}
+
+.theme-protocol-light .chat-role {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .chat-turn.you .chat-role {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .chat-turn.sulla .chat-role {
+  color: #5096b3 !important;
+}
+
+.theme-protocol-light .chat-turn.you .chat-body {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .chat-turn.sulla .chat-body {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .chat-turn.sulla .chat-body em {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .chat-turn.sulla .chat-body strong {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .chat-turn.sulla .chat-body code,
+.theme-protocol-light .chat-turn.sulla .chat-body .term {
+  color: #3d4f63 !important;
+  background: rgba(168, 188, 207, 0.15) !important;
+  border-color: rgba(168, 188, 207, 0.25) !important;
+}
+
+.theme-protocol-light .chat-turn.sulla .chat-body h3 {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .chat-turn.sulla .chat-body h3::before {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .chat-turn.sulla .chat-body blockquote {
+  color: #6a7d94 !important;
+  border-left-color: rgba(80, 150, 179, 0.4) !important;
+}
+
+.theme-protocol-light .chat-cursor {
+  background: #a8bccf !important;
+  box-shadow: 0 0 14px #a8bccf !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Thinking Component — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .thinking {
+  border-left-color: rgba(80, 150, 179, 0.3) !important;
+}
+
+.theme-protocol-light .thinking:hover {
+  border-left-color: rgba(80, 150, 179, 0.5) !important;
+}
+
+.theme-protocol-light .thinking::before {
+  background: rgba(80, 150, 179, 0.5) !important;
+}
+
+.theme-protocol-light .thinking.live {
+  border-left-color: rgba(80, 150, 179, 0.6) !important;
+}
+
+.theme-protocol-light .thinking.live::before {
+  background: #5096b3 !important;
+  box-shadow: 0 0 14px #5096b3 !important;
+}
+
+.theme-protocol-light .thinking .head {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .thinking .head .summary {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .thinking.settled:hover .head .summary {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .thinking .head .elapsed {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .thinking .head .chev {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .thought {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .thought:nth-child(3) {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .expanded li {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .expanded li::before {
+  color: #a8bccf !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Interim (Listening) — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .chat-turn.interim .chat-role {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .chat-turn.interim .chat-role::before {
+  background: #5096b3 !important;
+  box-shadow: 0 0 10px #5096b3 !important;
+}
+
+.theme-protocol-light .chat-turn.interim .chat-body {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .chat-turn.interim .chat-body::after {
+  background: #5096b3 !important;
+  box-shadow: 0 0 12px #5096b3 !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Attachment chips in messages
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .att-chip {
+  background: rgba(238, 242, 248, 0.8) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .att-chip .ic {
+  color: #5096b3 !important;
+}
+
+.theme-protocol-light .att-chip .size {
+  color: #a8bccf !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   ActSection & RoutineStrip — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .act .head {
+  border-bottom-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .act .num {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .act .title {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .act .count {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .strip {
+  background: linear-gradient(90deg, rgba(238, 242, 248, 0.8), rgba(221, 230, 240, 0.6)) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .strip:hover {
+  background: linear-gradient(90deg, rgba(221, 230, 240, 0.9), rgba(200, 213, 228, 0.7)) !important;
+  border-color: rgba(80, 150, 179, 0.5) !important;
+}
+
+.theme-protocol-light .strip::before {
+  background: linear-gradient(180deg, transparent, #a8bccf, transparent) !important;
+}
+
+.theme-protocol-light .strip.featured {
+  border-color: rgba(124, 86, 200, 0.35) !important;
+  background: linear-gradient(90deg, rgba(237, 230, 255, 0.5), rgba(238, 242, 248, 0.5)) !important;
+}
+
+.theme-protocol-light .strip .cat {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .strip .title {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .strip .desc {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .strip .chip {
+  background: rgba(238, 242, 248, 0.8) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .strip .chip.blue {
+  border-color: rgba(80, 150, 179, 0.4) !important;
+  color: #3a7fa0 !important;
+  background: rgba(210, 230, 240, 0.6) !important;
+}
+
+.theme-protocol-light .strip .chip.violet {
+  border-color: rgba(124, 86, 200, 0.4) !important;
+  color: #7c56c8 !important;
+  background: rgba(237, 230, 255, 0.6) !important;
+}
+
+.theme-protocol-light .strip .chip.warn {
+  border-color: rgba(180, 83, 9, 0.4) !important;
+  color: #92400e !important;
+  background: rgba(254, 243, 199, 0.6) !important;
+}
+
+.theme-protocol-light .strip .chip.live {
+  border-color: rgba(185, 28, 28, 0.4) !important;
+  color: #b91c1c !important;
+  background: rgba(254, 226, 226, 0.6) !important;
+}
+
+.theme-protocol-light .strip .chip.live .d {
+  background: #b91c1c !important;
+}
+
+.theme-protocol-light .strip .metrics {
+  color: #6a7d94 !important;
+  border-left-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .strip .metrics .big {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .strip .metrics .big small {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .metrics .row span b {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .strip .btn {
+  background: rgba(238, 242, 248, 0.8) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .strip .btn:hover {
+  border-color: rgba(80, 150, 179, 0.5) !important;
+  color: #1a2332 !important;
+  background: rgba(80, 150, 179, 0.1) !important;
+}
+
+.theme-protocol-light .strip .btn.primary {
+  border-color: rgba(80, 150, 179, 0.6) !important;
+  color: #ffffff !important;
+  background: linear-gradient(135deg, rgba(80, 150, 179, 0.85), rgba(58, 127, 160, 0.9)) !important;
+  box-shadow: 0 8px 22px rgba(80, 150, 179, 0.25), 0 0 14px rgba(80, 150, 179, 0.15) !important;
+}
+
+.theme-protocol-light .strip .btn.primary:hover {
+  background: linear-gradient(135deg, rgba(80, 150, 179, 1), rgba(58, 127, 160, 1)) !important;
+}
+
+.theme-protocol-light .strip .btn.ghost {
+  background: transparent !important;
+}
+
+.theme-protocol-light .strip .btn.kebab {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .strip .btn.kebab:hover,
+.theme-protocol-light .strip .btn.kebab.on {
+  color: #1a2332 !important;
+  background: rgba(80, 150, 179, 0.15) !important;
+  border-color: rgba(80, 150, 179, 0.4) !important;
+}
+
+.theme-protocol-light .strip .menu {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 247, 251, 0.98)) !important;
+  border-color: rgba(168, 188, 207, 0.35) !important;
+  box-shadow: 0 18px 40px rgba(26, 35, 50, 0.12), 0 0 20px rgba(168, 188, 207, 0.1) !important;
+}
+
+.theme-protocol-light .strip .menu-item {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .strip .menu-item:hover {
+  background: rgba(80, 150, 179, 0.1) !important;
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .strip .menu-item.danger {
+  color: #b91c1c !important;
+}
+
+.theme-protocol-light .strip .menu-item.danger:hover {
+  background: rgba(185, 28, 28, 0.1) !important;
+  color: #991b1b !important;
+}
+
+.theme-protocol-light .strip .menu-sep {
+  background: rgba(168, 188, 207, 0.25) !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   RoutinesHome Hero & Rollup Row — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .hero {
+  border-bottom-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .kicker {
+  color: #5096b3 !important;
+}
+
+.theme-protocol-light .kicker::before {
+  background: #a8bccf !important;
+}
+
+.theme-protocol-light .kicker .d {
+  background: #5096b3 !important;
+  box-shadow: 0 0 8px #5096b3 !important;
+}
+
+.theme-protocol-light .hero h1 {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .hero .dek {
+  color: #3d4f63 !important;
+}
+
+.theme-protocol-light .rollup-row {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .rollup-row > div {
+  border-right-color: rgba(168, 188, 207, 0.3) !important;
+}
+
+.theme-protocol-light .rollup-row b {
+  color: #1a2332 !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   Library & Marketplace Search Box — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .search-box {
+  background: rgba(238, 242, 248, 0.8) !important;
+  border-color: rgba(168, 188, 207, 0.4) !important;
+}
+
+.theme-protocol-light .search-box svg {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .search-box input {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .search-box input::placeholder {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .search-box .count {
+  color: #6a7d94 !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   ModeRail — Light Mode Fixes
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .mode-rail {
+  overflow-x: hidden !important;
+  overflow-y: auto !important;
+}
+
+.theme-protocol-light header,
+.theme-protocol-light .top-bar,
+.theme-protocol-light .app-header {
+  z-index: 9999 !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   SessionMark — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .session-mark {
+  color: #a8bccf !important;
+}
+
+.theme-protocol-light .session-mark::before,
+.theme-protocol-light .session-mark::after {
+  background: #a8bccf !important;
+}
+
+.theme-protocol-light .session-mark .dot {
+  background: #5096b3 !important;
+  box-shadow: 0 0 8px #5096b3 !important;
+}
+
+.theme-protocol-light .session-mark .title {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .session-mark .title[contenteditable="true"]:focus {
+  background: rgba(80, 150, 179, 0.1) !important;
+}
+
+/* ═════════════════════════════════════════════════════════════════
+   StatusBadges — Light Mode
+   ═════════════════════════════════════════════════════════════════ */
+
+.theme-protocol-light .badge {
+  background: rgba(238, 242, 248, 0.9) !important;
+  border-color: rgba(168, 188, 207, 0.3) !important;
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .badge.model {
+  color: #5096b3 !important;
+}
+
+.theme-protocol-light .badge.model:hover {
+  color: #3a7fa0 !important;
+  border-color: #5096b3 !important;
+}
+
+.theme-protocol-light .badge .dot {
+  background: #16803c !important;
+  box-shadow: 0 0 8px rgba(22, 128, 60, 0.6) !important;
+}
+
+.theme-protocol-light .badge.model .dot {
+  background: #5096b3 !important;
+  box-shadow: 0 0 10px rgba(80, 150, 179, 0.6) !important;
+}
+
+.theme-protocol-light .badge.degraded {
+  border-color: rgba(180, 83, 9, 0.5) !important;
+}
+
+.theme-protocol-light .badge.degraded .dot {
+  background: #b45309 !important;
+  box-shadow: 0 0 8px rgba(180, 83, 9, 0.6) !important;
+}
+
+.theme-protocol-light .badge.offline {
+  border-color: rgba(185, 28, 28, 0.5) !important;
+}
+
+.theme-protocol-light .badge.offline .dot {
+  background: #b91c1c !important;
+  box-shadow: 0 0 8px rgba(185, 28, 28, 0.6) !important;
+}

--- a/pkg/rancher-desktop/components/Preferences/BodyAppearance.vue
+++ b/pkg/rancher-desktop/components/Preferences/BodyAppearance.vue
@@ -13,7 +13,7 @@ export default defineComponent({
   name: 'preferences-body-appearance',
   data() {
     return {
-      selectedTheme: localStorage.getItem(THEME_STORAGE_KEY) || 'default-light',
+      selectedTheme: localStorage.getItem(THEME_STORAGE_KEY) || 'protocol-dark',
       themeGroups,
     };
   },
@@ -200,6 +200,10 @@ export default defineComponent({
 
 .preview-nord-dark {
   background: linear-gradient(135deg, #2e3440 0%, #3b4252 50%, #434c5e 100%);
+}
+
+.preview-protocol-light {
+  background: linear-gradient(135deg, #f4f7fb 0%, #eef2f8 50%, #5096b3 100%);
 }
 
 .preview-protocol-dark {

--- a/pkg/rancher-desktop/composables/useBrowserTabs.ts
+++ b/pkg/rancher-desktop/composables/useBrowserTabs.ts
@@ -2,7 +2,7 @@ import { reactive, readonly, ref, watch } from 'vue';
 
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
-export type BrowserTabMode = 'welcome' | 'browser' | 'chat' | 'calendar' | 'integrations' | 'document' | 'secretary' | 'vault' | 'account' | 'history' | 'routines' | 'marketplace' | 'labs';
+export type BrowserTabMode = 'welcome' | 'browser' | 'chat' | 'calendar' | 'integrations' | 'document' | 'secretary' | 'vault' | 'account' | 'history' | 'routines' | 'marketplace' | 'labs' | 'file-editor';
 
 export interface BrowserTab {
   id:       string;
@@ -300,6 +300,7 @@ export function useBrowserTabs() {
     routines:     'Routines',
     marketplace:  'Sulla Studio',
     labs:         'Labs',
+    'file-editor': 'Editor',
   };
 
   function createTab(url = 'about:blank', opts?: { mode?: BrowserTabMode }): BrowserTab {

--- a/pkg/rancher-desktop/composables/useBrowserTabs.ts
+++ b/pkg/rancher-desktop/composables/useBrowserTabs.ts
@@ -49,11 +49,14 @@ function loadPersistedTabs(): BrowserTab[] {
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
+    // Drop stale file-editor tabs — they reference absolute paths that may
+    // no longer be valid (moved, outside sandbox, etc). The file tree reopens them.
+    const noFileEditor = parsed.filter((t: any) => t?.mode !== 'file-editor');
     // Dedupe by (url + mode) so a runaway "open same URL 500 times" loop
     // collapses to a single entry on restore.
     const seen = new Set<string>();
     const deduped: any[] = [];
-    for (const t of parsed) {
+    for (const t of noFileEditor) {
       const key = `${ t?.mode || '' }|${ t?.url || '' }`;
       if (seen.has(key)) continue;
       seen.add(key);
@@ -81,7 +84,10 @@ function persistTabs(tabList: BrowserTab[]): void {
     // them is exactly how we end up restoring hundreds of WebContentsViews
     // and blacking out the main chat window. Only user-initiated tabs
     // (no assetId) persist.
-    const userTabs = tabList.filter(t => !t.assetId);
+    // file-editor tabs reference absolute file paths that may become stale
+    // across sessions (e.g. moved files, path-validation errors on restart).
+    // The file tree is always available to reopen them, so don't persist them.
+    const userTabs = tabList.filter(t => !t.assetId && t.mode !== 'file-editor');
     // Strip large HTML content + enforce the cap on write too, so a live
     // runaway can't balloon localStorage between app launches.
     const capped = userTabs.length > MAX_RESTORED_TABS

--- a/pkg/rancher-desktop/composables/useTheme.ts
+++ b/pkg/rancher-desktop/composables/useTheme.ts
@@ -2,7 +2,7 @@ import { ref, computed, onMounted, watch } from 'vue';
 
 import { SullaSettingsModel } from '@pkg/agent/database/models/SullaSettingsModel';
 
-export type ThemeName = 'default-light' | 'default-dark' | 'ocean-light' | 'ocean-dark' | 'nord-light' | 'nord-dark' | 'protocol-dark';
+export type ThemeName = 'default-light' | 'default-dark' | 'ocean-light' | 'ocean-dark' | 'nord-light' | 'nord-dark' | 'protocol-dark' | 'protocol-light';
 
 export type ThemeScheme = 'default' | 'ocean' | 'nord' | 'protocol';
 
@@ -27,7 +27,8 @@ export const availableThemes: ThemeOption[] = [
   { id: 'ocean-dark', scheme: 'ocean', mode: 'dark', label: 'Ocean Dark', isDark: true },
   { id: 'nord-light', scheme: 'nord', mode: 'light', label: 'Nord Light', isDark: false },
   { id: 'nord-dark', scheme: 'nord', mode: 'dark', label: 'Nord Dark', isDark: true },
-  { id: 'protocol-dark', scheme: 'protocol', mode: 'dark', label: 'Protocol Dark', isDark: true },
+  { id: 'protocol-dark',  scheme: 'protocol', mode: 'dark',  label: 'Protocol Dark',  isDark: true },
+  { id: 'protocol-light', scheme: 'protocol', mode: 'light', label: 'Protocol Light', isDark: false },
 ];
 
 export const themeGroups: ThemeGroup[] = [
@@ -106,7 +107,7 @@ async function loadThemeFromSettings(): Promise<ThemeName> {
     return migratedStored;
   }
 
-  // Final fallback: OS preference
+  // Final fallback
   return 'protocol-dark';
 }
 
@@ -158,7 +159,7 @@ export function useTheme() {
     }
     const newMode = current.mode === 'dark' ? 'light' : 'dark';
     const target = availableThemes.find(t => t.scheme === current.scheme && t.mode === newMode);
-    // If the opposite mode doesn't exist for this scheme (e.g. Protocol has no light), stay put
+    // If the opposite mode doesn't exist for this scheme, stay put
     if (target) {
       setTheme(target.id);
     }

--- a/pkg/rancher-desktop/main/errorReporter.ts
+++ b/pkg/rancher-desktop/main/errorReporter.ts
@@ -12,6 +12,41 @@ import Electron from 'electron';
 
 const ERROR_REPORT_URL = 'https://error-reports.merchantprotocol.com';
 
+// Client-side flood guard: if a process gets stuck in a tight loop emitting the
+// same rejection (e.g. a `.once()` listener firing repeatedly), we'd otherwise
+// hammer the worker thousands of times in seconds. Keep the first N submissions
+// per signature within a window, then drop the rest until the window resets.
+const DEDUPE_WINDOW_MS = 60_000;
+const DEDUPE_MAX_PER_WINDOW = 3;
+const recentSubmissions = new Map<string, { firstSeenAt: number; count: number; suppressed: number }>();
+
+function dedupeSignature(report: ErrorReportPayload): string {
+  const firstStackFrame = (report.stack_trace || '').split('\n').find(line => line.trim().startsWith('at ')) || '';
+  return `${ report.error_type }|${ report.error_message }|${ firstStackFrame.trim() }`;
+}
+
+function shouldSuppress(report: ErrorReportPayload): boolean {
+  const sig = dedupeSignature(report);
+  const now = Date.now();
+  const entry = recentSubmissions.get(sig);
+
+  if (!entry || now - entry.firstSeenAt > DEDUPE_WINDOW_MS) {
+    recentSubmissions.set(sig, { firstSeenAt: now, count: 1, suppressed: 0 });
+    return false;
+  }
+
+  entry.count += 1;
+  if (entry.count <= DEDUPE_MAX_PER_WINDOW) {
+    return false;
+  }
+
+  entry.suppressed += 1;
+  if (entry.suppressed === 1 || entry.suppressed % 100 === 0) {
+    console.warn(`[ErrorReporter] Suppressed ${ entry.suppressed } duplicate report(s) for: ${ sig.slice(0, 200) }`);
+  }
+  return true;
+}
+
 export interface ErrorReportPayload {
   error_type:    string;
   error_message: string;
@@ -40,6 +75,10 @@ export async function submitErrorReport(report: ErrorReportPayload): Promise<{ s
 
   if (report.notify_email) {
     payload.notify_email = report.notify_email;
+  }
+
+  if (shouldSuppress(payload)) {
+    return { success: false, action: 'suppressed_duplicate' };
   }
 
   try {

--- a/pkg/rancher-desktop/main/openaiOAuth.ts
+++ b/pkg/rancher-desktop/main/openaiOAuth.ts
@@ -168,7 +168,7 @@ export function initOpenAIOAuthEvents(): void {
 
       // Bust the LLM service cache so the next call re-reads the new API key
       try {
-        const { resetOpenAIService } = await import('../languagemodels/OpenAIService');
+        const { resetOpenAIService } = await import('@pkg/agent/languagemodels/OpenAIService');
         resetOpenAIService();
       } catch { /* non-critical */ }
 

--- a/pkg/rancher-desktop/main/openaiOAuth.ts
+++ b/pkg/rancher-desktop/main/openaiOAuth.ts
@@ -166,6 +166,12 @@ export function initOpenAIOAuthEvents(): void {
 
       await integrationService.setConnectionStatus('openai', true, accountId);
 
+      // Bust the LLM service cache so the next call re-reads the new API key
+      try {
+        const { resetOpenAIService } = await import('../languagemodels/OpenAIService');
+        resetOpenAIService();
+      } catch { /* non-critical */ }
+
       console.log(`${ LOG_PREFIX } OAuth successful, tokens stored`);
       return { success: true };
     } catch (err) {

--- a/pkg/rancher-desktop/main/openaiOAuth.ts
+++ b/pkg/rancher-desktop/main/openaiOAuth.ts
@@ -1,0 +1,177 @@
+/**
+ * OpenAI OAuth handler — opens the OAuth flow in an embedded Electron BrowserWindow.
+ * Intercepts the callback to extract the authorization code, then exchanges it for tokens.
+ */
+
+import { BrowserWindow } from 'electron';
+
+import { getIntegrationService } from '@pkg/agent/services/IntegrationService';
+import { getIpcMainProxy } from '@pkg/main/ipcMain';
+import Logging from '@pkg/utils/logging';
+
+const console = Logging.background;
+
+const LOG_PREFIX = '[OpenAIOAuth]';
+
+/**
+ * Open the OAuth URL in an Electron BrowserWindow and intercept the callback.
+ */
+function openAuthWindow(url: string): { window: BrowserWindow; codePromise: Promise<{ code: string; state: string } | null> } {
+  const window = new BrowserWindow({
+    width:          800,
+    height:         600,
+    title:          'Sign in with OpenAI',
+    webPreferences: {
+      nodeIntegration:  false,
+      contextIsolation: true,
+      sandbox:          true,
+    },
+  });
+
+  const codePromise = new Promise<{ code: string; state: string } | null>((resolve) => {
+    let resolved = false;
+    const doResolve = (result: { code: string; state: string } | null) => {
+      if (resolved) return;
+      resolved = true;
+      resolve(result);
+    };
+
+    const handleUrl = (targetUrl: string) => {
+      try {
+        const parsed = new URL(targetUrl);
+        // OpenAI redirects to: http://localhost:1455/auth/callback?code=...&state=...
+        if (parsed.pathname === '/auth/callback') {
+          const code = parsed.searchParams.get('code');
+          const state = parsed.searchParams.get('state');
+          if (code && state) {
+            console.log(`${ LOG_PREFIX } Intercepted callback, code received`);
+            doResolve({ code, state });
+          }
+        }
+      } catch { /* not a URL */ }
+    };
+
+    // Watch all navigation events to catch the OAuth callback
+    window.webContents.on('will-redirect', (_event, u) => handleUrl(u));
+    window.webContents.on('will-navigate', (_event, u) => handleUrl(u));
+    window.webContents.on('did-navigate', (_event, u) => handleUrl(u));
+    window.webContents.on('did-navigate-in-page', (_event, u) => handleUrl(u));
+
+    window.on('closed', () => doResolve(null));
+  });
+
+  console.log(`${ LOG_PREFIX } Opening auth window for OpenAI OAuth`);
+  window.loadURL(url);
+  return { window, codePromise };
+}
+
+export function initOpenAIOAuthEvents(): void {
+  const ipcMainProxy = getIpcMainProxy(console);
+
+  /**
+   * Start OpenAI OAuth flow.
+   */
+  ipcMainProxy.handle('openai-oauth:start', async(): Promise<{ success: boolean; error?: string }> => {
+    try {
+      const integrationService = getIntegrationService();
+
+      // Build the authorize URL (same as OAuthService does)
+      const cfg = {
+        authorizeUrl: 'https://auth.openai.com/oauth/authorize',
+        scopeSeparator: ' ',
+      };
+      const scopes = ['openid', 'profile', 'email', 'offline_access'];
+      const clientId = 'app_EMoamEEZ73f0CkXaXp7hrann';
+      const redirectUri = 'http://localhost:1455/auth/callback';
+
+      // Generate PKCE
+      const crypto = await import('crypto');
+      const codeVerifier = crypto.randomBytes(64).toString('base64url');
+      const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+
+      // Generate state
+      const state = crypto.randomBytes(24).toString('hex');
+
+      const params = new URLSearchParams({
+        response_type:                 'code',
+        client_id:                     clientId,
+        redirect_uri:                  redirectUri,
+        scope:                         scopes.join(' '),
+        state,
+        code_challenge:                codeChallenge,
+        code_challenge_method:         'S256',
+        id_token_add_organizations:    'true',
+        originator:                    'pi',
+      });
+
+      const authorizeUrl = `${ cfg.authorizeUrl }?${ params.toString() }`;
+
+      // Open the OAuth window
+      const { window, codePromise } = openAuthWindow(authorizeUrl);
+
+      // Wait for the callback
+      const result = await Promise.race([
+        codePromise,
+        new Promise<null>((_, reject) => setTimeout(() => reject(new Error('OAuth timeout')), 300_000)),
+      ]);
+
+      if (!result) {
+        window.destroy();
+        return { success: false, error: 'User cancelled OAuth' };
+      }
+
+      const { code } = result;
+
+      // Exchange code for tokens
+      const body = new URLSearchParams({
+        grant_type:    'authorization_code',
+        code,
+        redirect_uri:  redirectUri,
+        client_id:     clientId,
+        code_verifier: codeVerifier,
+      });
+
+      const tokenRes = await fetch('https://auth.openai.com/oauth/token', {
+        method:  'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept:         'application/json',
+          'User-Agent':   'Sulla-Desktop/1.0',
+        },
+        body: body.toString(),
+      });
+
+      if (!tokenRes.ok) {
+        const text = await tokenRes.text().catch(() => '');
+        throw new Error(`Token exchange failed: ${ tokenRes.status } ${ text }`);
+      }
+
+      const tokens = await tokenRes.json() as any;
+      window.destroy();
+
+      // Store the tokens (don't store in oauth_tokens table, store the access_token as api_key)
+      const accountId = 'oauth';
+      const apiKey = tokens.access_token;
+      if (!apiKey) {
+        throw new Error('No access_token in OAuth response');
+      }
+
+      // Store the API key so OpenAIService.create() can use it
+      await integrationService.setIntegrationValue({
+        integration_id: 'openai',
+        account_id:     accountId,
+        property:       'api_key',
+        value:          apiKey,
+      });
+
+      await integrationService.setConnectionStatus('openai', true, accountId);
+
+      console.log(`${ LOG_PREFIX } OAuth successful, tokens stored`);
+      return { success: true };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      console.error(`${ LOG_PREFIX } OAuth failed:`, errMsg);
+      return { success: false, error: errMsg };
+    }
+  });
+}

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -3,6 +3,7 @@
  */
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 import { initTabsIpc } from './browserTabs/tabsIpc';
@@ -38,12 +39,23 @@ function getSullaHomeDir(): string {
   return resolveSullaHomeDir();
 }
 
-/** Ensure a path is inside the sulla home directory (sandbox guard) */
+/** Ensure a path is inside the sulla home directory (write sandbox guard) */
 function assertInsideSullaHome(targetPath: string): string {
   const root     = getSullaHomeDir();
   const resolved = path.resolve(targetPath);
   if (!resolved.startsWith(root + path.sep) && resolved !== root) {
     throw new Error(`Path is outside sulla home: ${ resolved }`);
+  }
+  return resolved;
+}
+
+/** Ensure a path is inside the user's home directory (read sandbox guard — allows browsing outside sulla home) */
+function assertInsideUserHome(targetPath: string): string {
+  const os       = require('os');
+  const home     = os.homedir();
+  const resolved = path.resolve(targetPath);
+  if (!resolved.startsWith(home + path.sep) && resolved !== home) {
+    throw new Error(`Path is outside user home: ${ resolved }`);
   }
   return resolved;
 }
@@ -838,7 +850,7 @@ export function initSullaEvents(): void {
   });
 
   ipcMainProxy.handle('filesystem-read-dir', async(_event: unknown, dirPath: string) => {
-    const resolved = assertInsideSullaHome(dirPath);
+    const resolved = assertInsideUserHome(dirPath);
     const entries  = fs.readdirSync(resolved, { withFileTypes: true });
     return entries
       .map((e) => {
@@ -855,7 +867,7 @@ export function initSullaEvents(): void {
   });
 
   ipcMainProxy.handle('filesystem-read-file', async(_event: unknown, filePath: string) => {
-    const resolved = assertInsideSullaHome(filePath);
+    const resolved = assertInsideUserHome(filePath);
     if (!fs.existsSync(resolved)) throw new Error(`File not found: ${ resolved }`);
     const stat = fs.statSync(resolved);
     if (stat.isDirectory()) throw new Error('Cannot read a directory as a file');
@@ -864,7 +876,7 @@ export function initSullaEvents(): void {
   });
 
   ipcMainProxy.handle('filesystem-write-file', async(_event: unknown, filePath: string, content: string) => {
-    const resolved = assertInsideSullaHome(filePath);
+    const resolved = assertInsideUserHome(filePath);
     fs.writeFileSync(resolved, content, 'utf-8');
   });
 

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -89,6 +89,15 @@ export function initSullaEvents(): void {
     const { SullaSettingsModel } = await import('@pkg/agent/database/models/SullaSettingsModel');
 
     await SullaSettingsModel.set(property, value, cast);
+
+    // Broadcast theme changes to all browser tab WebContentsViews so
+    // file:// pages can update their light/dark class via the preload bridge.
+    if (property === 'theme') {
+      const { webContents } = await import('electron');
+      for (const wc of webContents.getAllWebContents()) {
+        try { wc.send('sulla:theme-changed', value); } catch { /* disposed */ }
+      }
+    }
   });
 
   ipcMainProxy.handle('sulla-settings-delete', async(_event: unknown, property: string) => {

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -51,7 +51,6 @@ function assertInsideSullaHome(targetPath: string): string {
 
 /** Ensure a path is inside the user's home directory (read sandbox guard — allows browsing outside sulla home) */
 function assertInsideUserHome(targetPath: string): string {
-  const os       = require('os');
   const home     = os.homedir();
   const resolved = path.resolve(targetPath);
   if (!resolved.startsWith(home + path.sep) && resolved !== home) {

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -38,6 +38,16 @@ function getSullaHomeDir(): string {
   return resolveSullaHomeDir();
 }
 
+/** Ensure a path is inside the sulla home directory (sandbox guard) */
+function assertInsideSullaHome(targetPath: string): string {
+  const root     = getSullaHomeDir();
+  const resolved = path.resolve(targetPath);
+  if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+    throw new Error(`Path is outside sulla home: ${ resolved }`);
+  }
+  return resolved;
+}
+
 /**
  * Initialize Sulla-specific IPC handlers.
  */
@@ -807,4 +817,129 @@ export function initSullaEvents(): void {
       console.warn('[Sulla] Gateway lobby auto-connect failed:', err);
     }
   })();
+
+  // ─────────────────────────────────────────────────────────────
+  // Filesystem handlers (chat file explorer rail)
+  // ─────────────────────────────────────────────────────────────
+
+  ipcMainProxy.handle('filesystem-get-root', async() => {
+    const root = getSullaHomeDir();
+    fs.mkdirSync(root, { recursive: true });
+    return root;
+  });
+
+  ipcMainProxy.handle('filesystem-read-dir', async(_event: unknown, dirPath: string) => {
+    const resolved = assertInsideSullaHome(dirPath);
+    const entries  = fs.readdirSync(resolved, { withFileTypes: true });
+    return entries
+      .map((e) => {
+        const fullPath = path.join(resolved, e.name);
+        const isDir    = e.isDirectory();
+        let size = 0;
+        try { if (!isDir) size = fs.statSync(fullPath).size; } catch { /* ignore */ }
+        return { name: e.name, path: fullPath, isDir, size, ext: isDir ? '' : path.extname(e.name).toLowerCase() };
+      })
+      .sort((a, b) => {
+        if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+        return a.name.localeCompare(b.name);
+      });
+  });
+
+  ipcMainProxy.handle('filesystem-read-file', async(_event: unknown, filePath: string) => {
+    const resolved = assertInsideSullaHome(filePath);
+    if (!fs.existsSync(resolved)) throw new Error(`File not found: ${ resolved }`);
+    const stat = fs.statSync(resolved);
+    if (stat.isDirectory()) throw new Error('Cannot read a directory as a file');
+    if (stat.size > 5 * 1024 * 1024) throw new Error('File too large to open (>5MB)');
+    return fs.readFileSync(resolved, 'utf-8');
+  });
+
+  ipcMainProxy.handle('filesystem-write-file', async(_event: unknown, filePath: string, content: string) => {
+    const resolved = assertInsideSullaHome(filePath);
+    fs.writeFileSync(resolved, content, 'utf-8');
+  });
+
+  ipcMainProxy.handle('filesystem-rename', async(_event: unknown, oldPath: string, newName: string) => {
+    const resolved = assertInsideSullaHome(oldPath);
+    const newPath  = path.join(path.dirname(resolved), newName);
+    assertInsideSullaHome(newPath);
+    fs.renameSync(resolved, newPath);
+    return newPath;
+  });
+
+  ipcMainProxy.handle('filesystem-delete', async(_event: unknown, targetPath: string) => {
+    const resolved = assertInsideSullaHome(targetPath);
+    fs.rmSync(resolved, { recursive: true, force: true });
+  });
+
+  ipcMainProxy.handle('filesystem-create-file', async(_event: unknown, dirPath: string, fileName: string) => {
+    const dir      = assertInsideSullaHome(dirPath);
+    const filePath = path.join(dir, fileName);
+    assertInsideSullaHome(filePath);
+    if (fs.existsSync(filePath)) throw new Error(`File already exists: ${ fileName }`);
+    fs.writeFileSync(filePath, '', 'utf-8');
+    return filePath;
+  });
+
+  ipcMainProxy.handle('filesystem-create-dir', async(_event: unknown, dirPath: string, dirName: string) => {
+    const dir    = assertInsideSullaHome(dirPath);
+    const newDir = path.join(dir, dirName);
+    assertInsideSullaHome(newDir);
+    if (fs.existsSync(newDir)) throw new Error(`Directory already exists: ${ dirName }`);
+    fs.mkdirSync(newDir, { recursive: true });
+    return newDir;
+  });
+
+  ipcMainProxy.handle('filesystem-copy', async(_event: unknown, srcPath: string, destDir: string) => {
+    const resolvedSrc  = assertInsideSullaHome(srcPath);
+    const resolvedDest = assertInsideSullaHome(destDir);
+    const baseName     = path.basename(resolvedSrc);
+    let target = path.join(resolvedDest, baseName);
+    assertInsideSullaHome(target);
+    if (fs.existsSync(target)) {
+      const ext  = path.extname(baseName);
+      const stem = baseName.slice(0, baseName.length - ext.length);
+      let i = 1;
+      while (fs.existsSync(target)) { target = path.join(resolvedDest, `${ stem } (${ i })${ ext }`); i++; }
+    }
+    fs.cpSync(resolvedSrc, target, { recursive: true });
+    return target;
+  });
+
+  ipcMainProxy.handle('filesystem-move', async(_event: unknown, srcPath: string, destDir: string) => {
+    const resolvedSrc  = assertInsideSullaHome(srcPath);
+    const resolvedDest = assertInsideSullaHome(destDir);
+    const target       = path.join(resolvedDest, path.basename(resolvedSrc));
+    assertInsideSullaHome(target);
+    if (resolvedSrc === target) return target;
+    if (fs.existsSync(target)) throw new Error(`"${ path.basename(resolvedSrc) }" already exists in destination`);
+    fs.renameSync(resolvedSrc, target);
+    return target;
+  });
+
+  ipcMainProxy.handle('filesystem-reveal', async(_event: unknown, targetPath: string) => {
+    const resolved = assertInsideSullaHome(targetPath);
+    const { shell } = require('electron');
+    shell.showItemInFolder(resolved);
+  });
+
+  ipcMainProxy.handle('filesystem-open-external', async(_event: unknown, targetPath: string) => {
+    const resolved = assertInsideSullaHome(targetPath);
+    const { shell } = require('electron');
+    await shell.openPath(resolved);
+  });
+
+  ipcMainProxy.handle('filesystem-upload', async(_event: unknown, destDir: string, fileName: string, base64Data: string) => {
+    const dir = assertInsideSullaHome(destDir);
+    let target = path.join(dir, fileName);
+    assertInsideSullaHome(target);
+    if (fs.existsSync(target)) {
+      const ext  = path.extname(fileName);
+      const stem = fileName.slice(0, fileName.length - ext.length);
+      let i = 1;
+      while (fs.existsSync(target)) { target = path.join(dir, `${ stem } (${ i })${ ext }`); i++; }
+    }
+    fs.writeFileSync(target, Buffer.from(base64Data, 'base64'));
+    return target;
+  });
 }

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import { initTabsIpc } from './browserTabs/tabsIpc';
 import { initClaudeCodeTestEvents } from './claudeCodeTest';
 import { initClaudeOAuthEvents } from './claudeOAuth';
+import { initOpenAIOAuthEvents } from './openaiOAuth';
 import { initDesktopRelayEvents } from './desktopRelay';
 import { initSullaCloudAuthEvents } from './sullaCloudAuth';
 import { initConversationHistoryIpc } from './conversationHistoryIpc';
@@ -67,6 +68,7 @@ export function initSullaEvents(): void {
   initTabsIpc();
   initConversationHistoryIpc();
   initClaudeOAuthEvents();
+  initOpenAIOAuthEvents();
   initClaudeCodeTestEvents();
   initDesktopRelayEvents();
   initSullaCloudAuthEvents();

--- a/pkg/rancher-desktop/pages/AgentIntegrationDetail.vue
+++ b/pkg/rancher-desktop/pages/AgentIntegrationDetail.vue
@@ -1323,6 +1323,34 @@ const handleOAuthConnect = async() => {
     return;
   }
 
+  // OpenAI uses an embedded BrowserWindow OAuth flow. Route to its dedicated IPC handler.
+  if (integration.value.id === 'openai') {
+    isLoading.value = true;
+    try {
+      const result = await ipcRenderer.invoke('openai-oauth:start');
+      if (result?.error) {
+        oauthError.value = result.error;
+        return;
+      }
+      if (!result?.success) {
+        oauthError.value = 'OAuth authorization failed. Please try again.';
+        return;
+      }
+      // openaiOAuth.ts persisted the token + connection status to the vault
+      // already. Just refresh the UI.
+      await refreshAccounts();
+      integration.value.connected = await integrationService.isAnyAccountConnected(integration.value.id);
+      mergedIntegrations.value[integration.value.id].connected = integration.value.connected;
+      oauthSuccess.value = 'Successfully signed in with OpenAI — ready to use.';
+    } catch (error: any) {
+      console.error('OpenAI OAuth connection failed:', error);
+      oauthError.value = error?.message || 'OAuth authorization failed. Please try again.';
+    } finally {
+      isLoading.value = false;
+    }
+    return;
+  }
+
   // Sulla-managed OAuth (Apple Sign In, future Google sign-in, etc.) runs
   // through sulla-workers using Sulla's shared OAuth app credentials —
   // no user-supplied client_id/client_secret. The main-process IPC handler

--- a/pkg/rancher-desktop/pages/AgentRouter.vue
+++ b/pkg/rancher-desktop/pages/AgentRouter.vue
@@ -442,6 +442,11 @@ function onHistoryRestoreLastClosed() {
   }
 }
 
+function onNavigateTab(ev: Event) {
+  const tabId = (ev as CustomEvent<{ tabId: string }>).detail?.tabId;
+  if (tabId) router.push(`/Browser/${ tabId }`);
+}
+
 function onHistoryNavigate(_event: any, ...args: any[]) {
   const entry = args[0] as { id: string; type: string; url?: string; title?: string; tab_id?: string };
   if (!entry) return;
@@ -461,6 +466,7 @@ const presenceTracker = getHumanPresenceTracker();
 onMounted(async() => {
   // Register sub-tab change listener
   window.addEventListener('sulla:routines-subtab-change', onRoutinesSubTabChange as EventListener);
+  window.addEventListener('sulla:navigate-tab', onNavigateTab as EventListener);
 
   // Ensure at least one tab exists and navigate to it on fresh start
   const initialTab = ensureOneTab();
@@ -509,6 +515,7 @@ onUnmounted(() => {
     clearInterval(footerStatsTimer);
   }
   window.removeEventListener('sulla:routines-subtab-change', onRoutinesSubTabChange as EventListener);
+  window.removeEventListener('sulla:navigate-tab', onNavigateTab as EventListener);
   ipcRenderer.removeListener('route' as any, onRoute);
   ipcRenderer.removeListener('agent-command' as any, onAgentCommand);
   ipcRenderer.removeListener('k8s-check-state' as any, onK8sCheckState);

--- a/pkg/rancher-desktop/pages/AgentRouter.vue
+++ b/pkg/rancher-desktop/pages/AgentRouter.vue
@@ -16,7 +16,9 @@
         class="agent-router-rail"
         :active="activeTabMode"
         :active-sub-tab="activeSubTab"
+        :file-tree-open="fileTreeOpen"
         @set-mode="onModeRailSelect"
+        @toggle-file-tree="onToggleFileTree"
       />
 
       <div class="agent-router-content flex flex-col">
@@ -179,7 +181,8 @@ const activeTabMode = computed(() => {
 
 // Track active sub-tab for highlighting the correct ModeRail icon
 // (e.g., 'library' vs 'mywork' when mode is 'routines')
-const activeSubTab = ref<string | undefined>(undefined);
+const activeSubTab  = ref<string | undefined>(undefined);
+const fileTreeOpen  = ref(false);
 
 // Listen for sub-tab changes from BrowserTab
 function onRoutinesSubTabChange(event: Event) {
@@ -187,6 +190,15 @@ function onRoutinesSubTabChange(event: Event) {
   if (customEvent.detail?.subTab) {
     activeSubTab.value = customEvent.detail.subTab;
   }
+}
+
+function onToggleFileTree() {
+  window.dispatchEvent(new CustomEvent('sulla:toggle-file-tree'));
+}
+
+function onFileTreeStateChanged(event: Event) {
+  const open = (event as CustomEvent<{ open: boolean }>).detail?.open;
+  if (typeof open === 'boolean') fileTreeOpen.value = open;
 }
 
 function onModeRailSelect(mode: string, subTab?: string) {
@@ -467,6 +479,7 @@ onMounted(async() => {
   // Register sub-tab change listener
   window.addEventListener('sulla:routines-subtab-change', onRoutinesSubTabChange as EventListener);
   window.addEventListener('sulla:navigate-tab', onNavigateTab as EventListener);
+  window.addEventListener('sulla:file-tree-state-changed', onFileTreeStateChanged as EventListener);
 
   // Ensure at least one tab exists and navigate to it on fresh start
   const initialTab = ensureOneTab();
@@ -516,6 +529,7 @@ onUnmounted(() => {
   }
   window.removeEventListener('sulla:routines-subtab-change', onRoutinesSubTabChange as EventListener);
   window.removeEventListener('sulla:navigate-tab', onNavigateTab as EventListener);
+  window.removeEventListener('sulla:file-tree-state-changed', onFileTreeStateChanged as EventListener);
   ipcRenderer.removeListener('route' as any, onRoute);
   ipcRenderer.removeListener('agent-command' as any, onAgentCommand);
   ipcRenderer.removeListener('k8s-check-state' as any, onK8sCheckState);

--- a/pkg/rancher-desktop/pages/BrowserTab.vue
+++ b/pkg/rancher-desktop/pages/BrowserTab.vue
@@ -6,6 +6,7 @@
     <AgentHeader
       :is-dark="isDark"
       :toggle-theme="toggleTheme"
+      :can-toggle-mode="canToggleMode"
     />
 
     <!-- Browser toolbar — always visible in welcome and browser modes -->
@@ -267,6 +268,16 @@
         <LabsPage />
       </div>
     </template>
+
+    <!-- File editor: Monaco-based code editor for files from the file tree -->
+    <template v-else-if="tabMode === 'file-editor'">
+      <div class="flex-1 min-h-0 overflow-hidden">
+        <FileEditorTab
+          :file-path="getTab(props.tabId)?.url || ''"
+          :is-dark="isDark"
+        />
+      </div>
+    </template>
   </div>
 </template>
 
@@ -286,6 +297,7 @@ import HistoryTab from './HistoryTab.vue';
 import MyAccount from './MyAccount.vue';
 import NewTabWelcome from './NewTabWelcome.vue';
 import PasswordGenerator from './PasswordGenerator.vue';
+import FileEditorTab from './FileEditorTab.vue';
 import LabsPage from './LabsPage.vue';
 import RoutinesHome from './RoutinesHome.vue';
 import SecretaryMode from './SecretaryMode.vue';
@@ -312,6 +324,7 @@ const MODE_TITLES: Record<BrowserTabMode, string> = {
   routines:     'Routines',
   marketplace:  'Sulla Studio',
   labs:         'Labs',
+  'file-editor': 'Editor',
 };
 
 const props = defineProps<{
@@ -319,7 +332,12 @@ const props = defineProps<{
   isVisible: boolean;
 }>();
 
-const { isDark, toggleTheme } = useTheme();
+const { isDark, toggleTheme, currentScheme, availableThemes } = useTheme();
+
+const canToggleMode = computed(() => {
+  const schemeThemes = availableThemes.filter(t => t.scheme === currentScheme.value);
+  return schemeThemes.some(t => t.mode === 'light') && schemeThemes.some(t => t.mode === 'dark');
+});
 const { updateTab, getTab, createTab } = useBrowserTabs();
 const { showOverlay } = useStartupProgress();
 

--- a/pkg/rancher-desktop/pages/FileEditorTab.vue
+++ b/pkg/rancher-desktop/pages/FileEditorTab.vue
@@ -1,0 +1,266 @@
+<template>
+  <div class="file-editor-root">
+    <div class="file-editor-bar">
+      <span class="file-editor-name">{{ fileName }}</span>
+      <span
+        v-if="dirty"
+        class="dirty-dot"
+        title="Unsaved changes"
+      >●</span>
+      <span class="file-editor-path">{{ filePath }}</span>
+      <button
+        class="save-btn"
+        :disabled="!dirty || saving"
+        @click="save"
+      >
+        {{ saving ? 'Saving…' : 'Save' }}
+      </button>
+    </div>
+    <div
+      v-if="loadError"
+      class="file-editor-error"
+    >
+      {{ loadError }}
+    </div>
+    <div
+      ref="editorContainerRef"
+      class="editor-container"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, onMounted, onBeforeUnmount, watch } from 'vue';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+import * as monaco from 'monaco-editor';
+
+(self as any).MonacoEnvironment = {
+  getWorkerUrl(_moduleId: string, label: string): string {
+    if (label === 'json') return '/json.worker.bundle.js';
+    if (label === 'css' || label === 'scss' || label === 'less') return '/css.worker.bundle.js';
+    if (label === 'html' || label === 'handlebars' || label === 'razor') return '/html.worker.bundle.js';
+    if (label === 'typescript' || label === 'javascript') return '/ts.worker.bundle.js';
+    return '/editor.worker.bundle.js';
+  },
+};
+
+function extToLanguage(ext: string): string {
+  const map: Record<string, string> = {
+    ts: 'typescript', tsx: 'typescript',
+    js: 'javascript', jsx: 'javascript', mjs: 'javascript', cjs: 'javascript',
+    vue: 'html', html: 'html', htm: 'html',
+    css: 'css', scss: 'scss', less: 'less',
+    json: 'json', jsonc: 'json',
+    md: 'markdown', mdx: 'markdown',
+    py: 'python', rb: 'ruby', php: 'php',
+    go: 'go', rs: 'rust', java: 'java',
+    c: 'c', cpp: 'cpp', h: 'c',
+    sh: 'shell', bash: 'shell', zsh: 'shell',
+    yaml: 'yaml', yml: 'yaml',
+    xml: 'xml', svg: 'xml',
+    sql: 'sql', graphql: 'graphql',
+    dockerfile: 'dockerfile',
+    toml: 'ini',
+  };
+  return map[ext.toLowerCase()] || 'plaintext';
+}
+
+export default defineComponent({
+  name: 'FileEditorTab',
+
+  props: {
+    filePath: { type: String, required: true },
+    isDark:   { type: Boolean, default: true },
+  },
+
+  setup(props) {
+    const editorContainerRef = ref<HTMLDivElement | null>(null);
+    const dirty     = ref(false);
+    const saving    = ref(false);
+    const loadError = ref('');
+
+    let editor: monaco.editor.IStandaloneCodeEditor | null = null;
+    let currentModel: monaco.editor.ITextModel | null = null;
+
+    const fileName = computed(() => props.filePath.split('/').pop() || props.filePath);
+
+    async function loadFile() {
+      loadError.value = '';
+      try {
+        const content: string = await ipcRenderer.invoke('filesystem-read-file', props.filePath);
+        const ext  = (props.filePath.split('.').pop() || '').toLowerCase();
+        const lang = extToLanguage(ext);
+
+        if (editor) {
+          currentModel?.dispose();
+          currentModel = monaco.editor.createModel(content, lang);
+          editor.setModel(currentModel);
+          dirty.value = false;
+
+          editor.onDidChangeModelContent(() => {
+            dirty.value = true;
+          });
+        }
+      } catch (err: any) {
+        loadError.value = err?.message || 'Failed to load file';
+      }
+    }
+
+    async function save() {
+      if (!currentModel || saving.value) return;
+      saving.value = true;
+      try {
+        await ipcRenderer.invoke('filesystem-write-file', props.filePath, currentModel.getValue());
+        dirty.value = false;
+      } catch (err: any) {
+        console.error('[FileEditorTab] save failed:', err);
+      } finally {
+        saving.value = false;
+      }
+    }
+
+    function onGlobalKeydown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault();
+        save();
+      }
+    }
+
+    onMounted(async () => {
+      if (!editorContainerRef.value) return;
+
+      editor = monaco.editor.create(editorContainerRef.value, {
+        value:                '',
+        language:             'plaintext',
+        theme:                props.isDark ? 'vs-dark' : 'vs',
+        fontSize:             13,
+        fontFamily:           '"JetBrains Mono", "Fira Code", Menlo, Monaco, "Courier New", monospace',
+        fontLigatures:        true,
+        lineNumbers:          'on',
+        minimap:              { enabled: false },
+        scrollBeyondLastLine: false,
+        automaticLayout:      true,
+        wordWrap:             'off',
+        renderWhitespace:     'none',
+        folding:              true,
+        padding:              { top: 8, bottom: 8 },
+        smoothScrolling:      true,
+        cursorBlinking:       'smooth',
+        renderLineHighlight:  'all',
+        bracketPairColorization: { enabled: true },
+      });
+
+      await loadFile();
+      window.addEventListener('keydown', onGlobalKeydown);
+    });
+
+    onBeforeUnmount(() => {
+      window.removeEventListener('keydown', onGlobalKeydown);
+      currentModel?.dispose();
+      editor?.dispose();
+    });
+
+    watch(() => props.isDark, (dark) => {
+      monaco.editor.setTheme(dark ? 'vs-dark' : 'vs');
+    });
+
+    watch(() => props.filePath, () => {
+      dirty.value = false;
+      loadFile();
+    });
+
+    return {
+      editorContainerRef,
+      fileName,
+      filePath: computed(() => props.filePath),
+      dirty,
+      saving,
+      loadError,
+      save,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.file-editor-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  overflow: hidden;
+}
+
+.file-editor-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  height: 35px;
+  flex-shrink: 0;
+  background: var(--bg-surface-alt, var(--bg-surface));
+  border-bottom: 1px solid var(--border-default);
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+}
+
+.file-editor-name {
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+.dirty-dot {
+  color: var(--accent-primary, #5096b3);
+  font-size: 10px;
+  line-height: 1;
+}
+
+.file-editor-path {
+  flex: 1;
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.save-btn {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  border-radius: 4px;
+  border: 1px solid var(--border-default);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.save-btn:hover:not(:disabled) {
+  background: var(--accent-dim, rgba(80, 150, 179, 0.15));
+  border-color: var(--accent-border, rgba(80, 150, 179, 0.4));
+  color: var(--accent-primary, #5096b3);
+}
+
+.save-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.file-editor-error {
+  padding: 12px 16px;
+  font-size: 13px;
+  color: var(--danger, #e05b5b);
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border-default);
+}
+
+.editor-container {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+</style>

--- a/pkg/rancher-desktop/pages/LanguageModelSettings.vue
+++ b/pkg/rancher-desktop/pages/LanguageModelSettings.vue
@@ -217,8 +217,9 @@ export default defineComponent({
     try {
       const providers = await ipcRenderer.invoke('model-provider:get-providers');
       this.availableProviders = providers
+        .filter((p: { id: string; name: string; connected?: boolean }) => p.connected !== false)
         .map((p: { id: string; name: string; connected?: boolean }) => ({
-          id: p.id, name: p.connected === false ? `${ p.name } (not connected)` : p.name,
+          id: p.id, name: p.name,
         }));
     } catch (err) {
       console.warn('[LM Settings] Failed to load available providers:', err);
@@ -1108,8 +1109,8 @@ export default defineComponent({
             class="info-box"
           >
             <p>
-              Providers marked <em>(not connected)</em> require an API key. Open
-              <strong>Integrations</strong> to configure credentials for Grok, OpenAI, Anthropic, etc.
+              Only connected providers appear in these dropdowns. Open
+              <strong>Integrations</strong> to add credentials for Grok, OpenAI, Anthropic, etc.
             </p>
           </div>
         </div>

--- a/pkg/rancher-desktop/pages/agent/AgentHeader.vue
+++ b/pkg/rancher-desktop/pages/agent/AgentHeader.vue
@@ -234,7 +234,10 @@
           </svg>
         </button>
       </div>
-      <div class="relative z-10">
+      <div
+        v-if="canToggleMode !== false"
+        class="relative z-10"
+      >
         <label class="sr-only">Theme</label>
         <button
           class="flex h-5 w-5 items-center justify-center rounded-lg shadow-md ring-1 shadow-black/5 ring-black/5 cursor-pointer"
@@ -432,8 +435,9 @@ const router = useRouter();
 const { tabs: browserTabs, closedTabs, tabOrder, createTab, closeTab, updateTab, getTab, ensureOneTab, restoreClosedTab, reorderTabs } = useBrowserTabs();
 
 defineProps<{
-  isDark:      boolean;
-  toggleTheme: () => void;
+  isDark:         boolean;
+  toggleTheme:    () => void;
+  canToggleMode?: boolean;
 }>();
 
 const emit = defineEmits<{

--- a/pkg/rancher-desktop/pages/agent/AgentModelSelectorController.ts
+++ b/pkg/rancher-desktop/pages/agent/AgentModelSelectorController.ts
@@ -163,6 +163,7 @@ export class AgentModelSelectorController {
       const groups: ProviderGroup[] = [];
 
       for (const provider of providers) {
+        if (provider.connected === false) continue;
         const isActive = this.activePrimaryProvider.value === provider.id;
 
         const group: ProviderGroup = {

--- a/pkg/rancher-desktop/pages/chat/ChatPage.vue
+++ b/pkg/rancher-desktop/pages/chat/ChatPage.vue
@@ -238,6 +238,10 @@ watch(hasArtifact, v => { if (!v) artifactExpanded.value = false; });
 const historyOpen    = computed(() => controller.sidebar.value.historyOpen);
 const fileTreeOpen   = computed(() => controller.sidebar.value.fileTreeOpen);
 const activeThreadId = computed(() => controller.thread.value.id);
+
+watch(fileTreeOpen, (open) => {
+  window.dispatchEvent(new CustomEvent('sulla:file-tree-state-changed', { detail: { open } }));
+});
 // App-wide conversation history (Postgres-backed, shared across every
 // open chat). Fetched on mount via the main-process IPC. Merged into the
 // thread list below so the HistoryRail surfaces every past chat, not
@@ -493,15 +497,21 @@ function onFileSelected(entry: FileEntry): void {
   }
 }
 
+function onToggleFileTreeEvent() {
+  controller.toggleFileTree();
+}
+
 onMounted(() => {
-  window.addEventListener('chat:new-chat',       onNewChatEvent);
-  window.addEventListener('chat:fork',           onForkEvent);
-  window.addEventListener('chat:artifact-expand', onArtifactExpand);
+  window.addEventListener('chat:new-chat',          onNewChatEvent);
+  window.addEventListener('chat:fork',              onForkEvent);
+  window.addEventListener('chat:artifact-expand',   onArtifactExpand);
+  window.addEventListener('sulla:toggle-file-tree', onToggleFileTreeEvent);
 });
 onBeforeUnmount(() => {
-  window.removeEventListener('chat:new-chat',       onNewChatEvent);
-  window.removeEventListener('chat:fork',           onForkEvent);
-  window.removeEventListener('chat:artifact-expand', onArtifactExpand);
+  window.removeEventListener('chat:new-chat',          onNewChatEvent);
+  window.removeEventListener('chat:fork',              onForkEvent);
+  window.removeEventListener('chat:artifact-expand',   onArtifactExpand);
+  window.removeEventListener('sulla:toggle-file-tree', onToggleFileTreeEvent);
 });
 </script>
 

--- a/pkg/rancher-desktop/pages/chat/ChatPage.vue
+++ b/pkg/rancher-desktop/pages/chat/ChatPage.vue
@@ -13,10 +13,15 @@
       messages. The transcript replaces it once a conversation begins.
 -->
 <template>
-  <div class="chat-root" :class="{ 'artifact-open': hasArtifact, 'history-open': historyOpen, 'artifact-expanded': artifactExpanded }">
+  <div class="chat-root" :class="{ 'artifact-open': hasArtifact, 'history-open': historyOpen, 'file-tree-open': fileTreeOpen, 'artifact-expanded': artifactExpanded }">
     <Canvas />
 
     <div class="shell">
+      <FileTreeRail
+        :open="fileTreeOpen"
+        @close="controller.toggleFileTree()"
+        @file-selected="onFileSelected"
+      />
       <HistoryRail
         :open="historyOpen"
         :threads="allThreads"
@@ -83,6 +88,7 @@ import Transcript        from './components/transcript/Transcript.vue';
 import Composer          from './components/composer/Composer.vue';
 import ArtifactSidebar   from './components/artifact/ArtifactSidebar.vue';
 import HistoryRail       from './components/history/HistoryRail.vue';
+import FileTreeRail      from './components/files/FileTreeRail.vue';
 import EmptyState        from './components/empty/EmptyState.vue';
 
 import { AgentModelSelectorController } from '@pkg/pages/agent/AgentModelSelectorController';
@@ -102,6 +108,8 @@ import { useKeyboardShortcuts }  from './composables/useKeyboardShortcuts';
 import { useResizeSync }         from './composables/useResizeSync';
 
 import { ipcRenderer }           from '@pkg/utils/ipcRenderer';
+import { useBrowserTabs }        from '@pkg/composables/useBrowserTabs';
+import type { FileEntry }        from './components/files/FileTreeRail.vue';
 
 import type { Thread }   from './models/Thread';
 import { asThreadId, type ThreadId } from './types/chat';
@@ -228,6 +236,7 @@ function onArtifactExpand(ev: Event): void {
 // Reset when all artifacts close.
 watch(hasArtifact, v => { if (!v) artifactExpanded.value = false; });
 const historyOpen    = computed(() => controller.sidebar.value.historyOpen);
+const fileTreeOpen   = computed(() => controller.sidebar.value.fileTreeOpen);
 const activeThreadId = computed(() => controller.thread.value.id);
 // App-wide conversation history (Postgres-backed, shared across every
 // open chat). Fetched on mount via the main-process IPC. Merged into the
@@ -460,6 +469,30 @@ function onForkEvent(ev: Event): void {
   persister.save(snapshot);
 }
 
+// ─── File tree → file editor tab ────────────────────────────────────
+const { createTab, updateTab } = useBrowserTabs();
+
+const BROWSER_RENDERABLE_EXTS = new Set([
+  '.html', '.htm', '.md', '.markdown', '.json', '.jsonc',
+  '.pdf', '.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.ico',
+  '.mp4', '.webm', '.mp3', '.ogg', '.wav',
+]);
+
+function onFileSelected(entry: FileEntry): void {
+  if (entry.isDir) return;
+  const rawExt = (entry.ext || '').toLowerCase();
+  const ext    = rawExt.startsWith('.') ? rawExt : (rawExt ? `.${ rawExt }` : '');
+  if (BROWSER_RENDERABLE_EXTS.has(ext)) {
+    const tab = createTab(`file://${ entry.path }`, { mode: 'browser' });
+    updateTab(tab.id, { title: entry.name });
+    window.dispatchEvent(new CustomEvent('sulla:navigate-tab', { detail: { tabId: tab.id } }));
+  } else {
+    const tab = createTab(entry.path, { mode: 'file-editor' });
+    updateTab(tab.id, { title: entry.name });
+    window.dispatchEvent(new CustomEvent('sulla:navigate-tab', { detail: { tabId: tab.id } }));
+  }
+}
+
 onMounted(() => {
   window.addEventListener('chat:new-chat',       onNewChatEvent);
   window.addEventListener('chat:fork',           onForkEvent);
@@ -571,8 +604,9 @@ onBeforeUnmount(() => {
   -webkit-mask-composite: source-in;
 }
 
-.chat-root.history-open  .main { left: 260px; }
-.chat-root.artifact-open .main { right: 560px; }
+.chat-root.history-open   .main { left: 260px; }
+.chat-root.file-tree-open .main { left: 260px; }
+.chat-root.artifact-open  .main { right: 560px; }
 .chat-root.artifact-open.artifact-expanded .main { right: 70vw; }
 
 /* Rails float over the left/right edges at fixed widths. */
@@ -581,6 +615,12 @@ onBeforeUnmount(() => {
   top: 0; bottom: 0; left: 0;
   width: 260px;
   z-index: 6;
+}
+.shell :deep(.files) {
+  position: absolute;
+  top: 0; bottom: 0; left: 0;
+  width: 260px;
+  z-index: 7;
 }
 .shell :deep(.artifact) {
   position: absolute;

--- a/pkg/rancher-desktop/pages/chat/components/artifact/ArtifactSidebar.vue
+++ b/pkg/rancher-desktop/pages/chat/components/artifact/ArtifactSidebar.vue
@@ -44,8 +44,8 @@ function onExpand(): void {
 */
 .artifact {
   overflow: hidden;
-  border-left: 1px solid rgba(168, 192, 220, 0.1);
-  background: #0d131f;
+  border-left: 1px solid var(--border-default, rgba(168, 192, 220, 0.1));
+  background: var(--bg-surface, #0d131f);
   backdrop-filter: blur(10px);
   display: flex; flex-direction: column;
   height: 100%;

--- a/pkg/rancher-desktop/pages/chat/components/artifact/panes/CodeArtifact.vue
+++ b/pkg/rancher-desktop/pages/chat/components/artifact/panes/CodeArtifact.vue
@@ -24,13 +24,13 @@ function isCursor(line: { n: number }): boolean {
 <style scoped>
 .code-view {
   font-family: var(--mono); font-size: 12.5px; line-height: 1.75;
-  color: var(--read-2);
+  color: var(--text-primary, var(--read-2));
   padding: 4px 0;
 }
 .l { display: flex; gap: 14px; padding: 0 12px; }
-.l .n { color: var(--read-5); min-width: 30px; text-align: right; user-select: none; font-size: 11px; }
+.l .n { color: var(--text-muted, var(--read-5)); min-width: 30px; text-align: right; user-select: none; font-size: 11px; }
 .l.add { background: rgba(134, 239, 172, 0.08); }
-.l.add .n { color: var(--ok); }
+.l.add .n { color: var(--text-success, var(--ok)); }
 .l.remove { background: rgba(252, 165, 165, 0.08); }
 .l.cursor-line { background: rgba(80, 150, 179, 0.08); position: relative; }
 .l.cursor-line::before {

--- a/pkg/rancher-desktop/pages/chat/components/chrome/ModeRail.vue
+++ b/pkg/rancher-desktop/pages/chat/components/chrome/ModeRail.vue
@@ -19,6 +19,24 @@
     >
       <span class="icon" v-html="item.icon" />
     </button>
+
+    <div class="rail-spacer" />
+
+    <button
+      type="button"
+      :class="['mode-btn', { active: fileTreeOpen }]"
+      data-tooltip="File Explorer"
+      aria-label="File Explorer"
+      @click="$emit('toggle-file-tree')"
+    >
+      <span class="icon">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+          <line x1="9" y1="12" x2="15" y2="12"/>
+          <line x1="9" y1="15" x2="13" y2="15"/>
+        </svg>
+      </span>
+    </button>
   </nav>
 </template>
 
@@ -28,10 +46,12 @@ const props = defineProps<{
   active?:       string;
   /** When `active === 'routines'`, disambiguates My Work vs Library. */
   activeSubTab?: string;
+  fileTreeOpen?: boolean;
 }>();
 
 defineEmits<{
   (e: 'set-mode', mode: string, subTab?: string): void;
+  (e: 'toggle-file-tree'): void;
 }>();
 
 interface ModeItem {
@@ -139,6 +159,8 @@ const items: readonly ModeItem[] = Object.freeze([
   scrollbar-width: none;
 }
 .mode-rail::-webkit-scrollbar { display: none; }
+
+.rail-spacer { flex: 1; min-height: 8px; }
 
 .mode-btn {
   position: relative;

--- a/pkg/rancher-desktop/pages/chat/components/chrome/ShortcutsModal.vue
+++ b/pkg/rancher-desktop/pages/chat/components/chrome/ShortcutsModal.vue
@@ -21,6 +21,7 @@
             <div class="row"><span>Stop run</span><kbd>Esc</kbd></div>
             <div class="row"><span>Continue</span><kbd>⌘↵</kbd></div>
             <div class="row"><span>Toggle history</span><kbd>⌘⇧H</kbd></div>
+            <div class="row"><span>Toggle file explorer</span><kbd>⌘⇧E</kbd></div>
             <div class="row"><span>Help</span><kbd>?</kbd></div>
           </div>
         </div>

--- a/pkg/rancher-desktop/pages/chat/components/composer/ComposerAttach.vue
+++ b/pkg/rancher-desktop/pages/chat/components/composer/ComposerAttach.vue
@@ -5,7 +5,11 @@
     type="button"
     title="Attach a file"
     @click="$emit('pick')"
-  >◇</button>
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
+    </svg>
+  </button>
 </template>
 
 <script setup lang="ts">

--- a/pkg/rancher-desktop/pages/chat/components/composer/QueueStrip.vue
+++ b/pkg/rancher-desktop/pages/chat/components/composer/QueueStrip.vue
@@ -54,40 +54,40 @@ const queue = computed(() => controller.queue.value);
   padding: 12px 16px;
   border: 1px dashed rgba(80, 150, 179, 0.3);
   border-radius: 10px;
-  background: rgba(20, 30, 42, 0.4);
+  background: var(--bg-surface, rgba(20, 30, 42, 0.4));
 }
 .queue.has-items { display: block; }
 .qhead {
   font-family: var(--mono); font-size: 10px; letter-spacing: 0.25em;
-  text-transform: uppercase; color: var(--steel-400);
+  text-transform: uppercase; color: var(--accent-primary, var(--steel-400));
   margin-bottom: 10px; display: flex; align-items: center; gap: 12px;
 }
 .qhead .count {
-  background: rgba(80, 150, 179, 0.14); color: var(--steel-400);
+  background: rgba(80, 150, 179, 0.14); color: var(--accent-primary, var(--steel-400));
   padding: 1px 7px; border-radius: 3px; font-size: 9.5px;
 }
 .qhead .clear {
   margin-left: auto; background: transparent; border: none;
-  color: var(--read-4); font: inherit; cursor: pointer;
+  color: var(--text-muted, var(--read-4)); font: inherit; cursor: pointer;
   letter-spacing: 0.2em;
 }
-.qhead .clear:hover { color: var(--err); }
+.qhead .clear:hover { color: var(--text-error, var(--err)); }
 .qitem {
   display: flex; align-items: center; gap: 6px;
   padding: 8px 0; border-top: 1px solid rgba(80, 150, 179, 0.15);
   font-family: var(--serif); font-style: italic; font-size: 14px;
-  color: var(--read-3);
+  color: var(--text-secondary, var(--read-3));
 }
 .qitem:first-of-type { border-top: none; padding-top: 4px; }
 .qitem .text { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .qitem button {
-  background: transparent; border: none; color: var(--read-4);
+  background: transparent; border: none; color: var(--text-muted, var(--read-4));
   cursor: pointer; width: 24px; height: 24px; border-radius: 4px;
   font-family: var(--mono); font-size: 12px;
   transition: all 0.15s ease;
 }
-.qitem button:hover      { color: var(--steel-400); background: rgba(80, 150, 179, 0.1); }
-.qitem .inject           { color: var(--ok); font-size: 10px; }
-.qitem .inject:hover     { color: var(--ok);  background: rgba(134, 239, 172, 0.1); }
-.qitem .rm:hover         { color: var(--err); background: rgba(252, 165, 165, 0.1); }
+.qitem button:hover      { color: var(--accent-primary, var(--steel-400)); background: rgba(80, 150, 179, 0.1); }
+.qitem .inject           { color: var(--text-success, var(--ok)); font-size: 10px; }
+.qitem .inject:hover     { color: var(--text-success, var(--ok)); background: rgba(134, 239, 172, 0.1); }
+.qitem .rm:hover         { color: var(--text-error, var(--err)); background: rgba(252, 165, 165, 0.1); }
 </style>

--- a/pkg/rancher-desktop/pages/chat/components/files/FileContextMenu.vue
+++ b/pkg/rancher-desktop/pages/chat/components/files/FileContextMenu.vue
@@ -1,0 +1,177 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="visible"
+      ref="menuRef"
+      class="file-ctx-menu"
+      :style="{ top: posY + 'px', left: posX + 'px' }"
+      @contextmenu.prevent
+    >
+      <button class="ctx-item" @click="action('new-file')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="12" y1="18" x2="12" y2="12" /><line x1="9" y1="15" x2="15" y2="15" />
+        </svg>
+        <span>New File</span>
+      </button>
+      <button class="ctx-item" @click="action('new-folder')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+          <line x1="12" y1="11" x2="12" y2="17" /><line x1="9" y1="14" x2="15" y2="14" />
+        </svg>
+        <span>New Folder</span>
+      </button>
+      <div class="ctx-sep" />
+
+      <button class="ctx-item" @click="action('cut')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="6" cy="6" r="3" /><circle cx="6" cy="18" r="3" />
+          <line x1="20" y1="4" x2="8.12" y2="15.88" /><line x1="14.47" y1="14.48" x2="20" y2="20" /><line x1="8.12" y1="8.12" x2="12" y2="12" />
+        </svg>
+        <span>Cut</span><span class="ctx-shortcut">⌘X</span>
+      </button>
+      <button class="ctx-item" @click="action('copy')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+          <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+        </svg>
+        <span>Copy</span><span class="ctx-shortcut">⌘C</span>
+      </button>
+      <button v-if="hasClipboard" class="ctx-item" @click="action('paste')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+          <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+        </svg>
+        <span>Paste</span><span class="ctx-shortcut">⌘V</span>
+      </button>
+      <div class="ctx-sep" />
+
+      <button class="ctx-item" @click="action('rename')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" /><path d="m15 5 4 4" />
+        </svg>
+        <span>Rename</span>
+      </button>
+      <button class="ctx-item danger" @click="action('delete')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3 6h18" /><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+          <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+          <line x1="10" y1="11" x2="10" y2="17" /><line x1="14" y1="11" x2="14" y2="17" />
+        </svg>
+        <span>Delete</span>
+      </button>
+      <div class="ctx-sep" />
+
+      <button class="ctx-item" @click="action('copy-path')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+        <span>Copy Path</span>
+      </button>
+      <button class="ctx-item" @click="action('copy-relative-path')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+        <span>Copy Relative Path</span>
+      </button>
+      <div class="ctx-sep" />
+
+      <button class="ctx-item" @click="action('reveal')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" /><circle cx="12" cy="12" r="3" />
+        </svg>
+        <span>Reveal in Finder</span>
+      </button>
+      <button v-if="!isDir" class="ctx-item" @click="action('open-external')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+          <polyline points="15 3 21 3 21 9" /><line x1="10" y1="14" x2="21" y2="3" />
+        </svg>
+        <span>Open with Default App</span>
+      </button>
+    </div>
+  </Teleport>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted, onBeforeUnmount, nextTick } from 'vue';
+
+export default defineComponent({
+  name: 'FileContextMenu',
+
+  props: {
+    hasClipboard: { type: Boolean, default: false },
+  },
+
+  emits: ['action'],
+
+  setup(props, { emit, expose }) {
+    const visible  = ref(false);
+    const posX     = ref(0);
+    const posY     = ref(0);
+    const isDir    = ref(false);
+    const menuRef  = ref<HTMLElement | null>(null);
+    let targetPath = '';
+
+    function show(event: MouseEvent, filePath: string, dir: boolean) {
+      targetPath   = filePath;
+      isDir.value  = dir;
+      posX.value   = event.clientX;
+      posY.value   = event.clientY;
+      visible.value = true;
+      nextTick(() => {
+        if (!menuRef.value) return;
+        const r = menuRef.value.getBoundingClientRect();
+        if (r.right  > window.innerWidth)  posX.value = window.innerWidth  - r.width  - 4;
+        if (r.bottom > window.innerHeight) posY.value = window.innerHeight - r.height - 4;
+      });
+    }
+    function hide()   { visible.value = false; }
+    function action(type: string) { emit('action', { type, path: targetPath, isDir: isDir.value }); hide(); }
+
+    function onClickOutside(e: MouseEvent) {
+      if (menuRef.value && !menuRef.value.contains(e.target as Node)) hide();
+    }
+    function onEsc(e: KeyboardEvent) { if (e.key === 'Escape') hide(); }
+
+    onMounted(() => {
+      document.addEventListener('mousedown', onClickOutside);
+      document.addEventListener('keydown', onEsc);
+    });
+    onBeforeUnmount(() => {
+      document.removeEventListener('mousedown', onClickOutside);
+      document.removeEventListener('keydown', onEsc);
+    });
+
+    expose({ show, hide });
+    return { visible, posX, posY, isDir, menuRef, action, hasClipboard: props.hasClipboard };
+  },
+});
+</script>
+
+<style scoped>
+.file-ctx-menu {
+  position: fixed; z-index: 9999;
+  min-width: 180px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 0;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.24), 0 1px 3px rgba(0,0,0,0.12);
+  font-size: var(--fs-code);
+}
+.ctx-item {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%; padding: 6px 12px;
+  border: none; background: none;
+  color: var(--text); cursor: pointer; text-align: left; line-height: 1;
+}
+.ctx-item:hover { background: var(--surface-3); }
+.ctx-item.danger { color: var(--danger); }
+.ctx-item.danger:hover { background: rgba(var(--danger), 0.1); }
+.ctx-shortcut { margin-left: auto; font-size: var(--fs-body-sm); color: var(--text-muted); padding-left: 16px; }
+.ctx-sep { height: 1px; background: var(--border-muted); margin: 4px 0; }
+</style>

--- a/pkg/rancher-desktop/pages/chat/components/files/FileDrawer.vue
+++ b/pkg/rancher-desktop/pages/chat/components/files/FileDrawer.vue
@@ -1,0 +1,432 @@
+<template>
+  <aside v-if="open" class="file-drawer">
+    <div class="fd-header">
+      <span class="fd-title">EXPLORER</span>
+      <div class="fd-actions">
+        <button class="fd-btn" title="New File" @click="newFileAtRoot">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+            <line x1="12" y1="18" x2="12" y2="12" /><line x1="9" y1="15" x2="15" y2="15" />
+          </svg>
+        </button>
+        <button class="fd-btn" title="New Folder" @click="newFolderAtRoot">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+            <line x1="12" y1="11" x2="12" y2="17" /><line x1="9" y1="14" x2="15" y2="14" />
+          </svg>
+        </button>
+        <button class="fd-btn" title="Upload File" @click="triggerUpload">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="17 8 12 3 7 8" /><line x1="12" y1="3" x2="12" y2="15" />
+          </svg>
+        </button>
+        <button class="fd-btn" title="Close (⌘⇧E)" @click="$emit('close')">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+      <input ref="uploadInputRef" type="file" multiple style="display:none" @change="onUploadInput">
+    </div>
+
+    <div v-if="loading && entries.length === 0" class="fd-loading">Loading…</div>
+    <div
+      v-else
+      class="fd-scroll"
+      :class="{ 'drop-active': dropTargetPath === rootPath }"
+      @dragover.prevent="onScrollDragOver"
+      @dragleave="onScrollDragLeave"
+      @drop.prevent="onScrollDrop"
+    >
+      <FileTreeNode
+        v-for="entry in entries"
+        :key="entry.path"
+        :entry="entry"
+        :depth="0"
+        :expanded-dirs="expandedDirs"
+        :children-map="childrenMap"
+        :loading-dirs="loadingDirs"
+        :selected-paths="selectedPaths"
+        :drop-target-path="dropTargetPath"
+        :highlight-path="highlightPath"
+        @toggle-dir="toggleDir"
+        @select-file="selectFile"
+        @context-menu="onContextMenu"
+        @drop-files="onDropFiles"
+        @drag-hover="onDragHover"
+      />
+    </div>
+
+    <FileContextMenu ref="contextMenuRef" :has-clipboard="!!fileClipboard" @action="onContextAction" />
+    <InlinePrompt ref="inlinePromptRef" />
+  </aside>
+</template>
+
+<script lang="ts">
+import { ipcRenderer, clipboard } from 'electron';
+import { defineComponent, ref, onMounted, onBeforeUnmount, watch } from 'vue';
+
+import FileContextMenu from './FileContextMenu.vue';
+import FileTreeNode    from './FileTreeNode.vue';
+import InlinePrompt    from './InlinePrompt.vue';
+
+export interface FileEntry {
+  name:        string;
+  path:        string;
+  isDir:       boolean;
+  size:        number;
+  ext:         string;
+  editorType?: 'code';
+  line?:       number;
+}
+
+export default defineComponent({
+  name: 'FileDrawer',
+  components: { FileTreeNode, FileContextMenu, InlinePrompt },
+
+  props: {
+    open:          { type: Boolean, default: false },
+    highlightPath: { type: String,  default: '' },
+  },
+
+  emits: ['file-selected', 'tree-changed', 'close'],
+
+  setup(props, { emit }) {
+    const entries       = ref<FileEntry[]>([]);
+    const expandedDirs  = ref<Set<string>>(new Set());
+    const childrenMap   = ref<Record<string, FileEntry[]>>({});
+    const loadingDirs   = ref<Set<string>>(new Set());
+    const loading       = ref(true);
+    const selectedPaths = ref<Set<string>>(new Set());
+    const lastSelectedPath = ref('');
+    const rootPath      = ref('');
+    const inlinePromptRef  = ref<InstanceType<typeof InlinePrompt> | null>(null);
+
+    async function loadRoot() {
+      loading.value = true;
+      try {
+        rootPath.value = await ipcRenderer.invoke('filesystem-get-root');
+        entries.value  = await ipcRenderer.invoke('filesystem-read-dir', rootPath.value);
+      } catch (err) {
+        console.error('[FileDrawer] loadRoot failed:', err);
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function loadChildren(dirPath: string) {
+      loadingDirs.value.add(dirPath);
+      try {
+        const result = await ipcRenderer.invoke('filesystem-read-dir', dirPath);
+        childrenMap.value = { ...childrenMap.value, [dirPath]: result };
+      } catch (err) {
+        console.error('[FileDrawer] loadChildren failed:', dirPath, err);
+      } finally {
+        loadingDirs.value.delete(dirPath);
+      }
+    }
+
+    async function toggleDir(dirPath: string) {
+      const expanded = new Set(expandedDirs.value);
+      if (expanded.has(dirPath)) {
+        expanded.delete(dirPath);
+      } else {
+        expanded.add(dirPath);
+        if (!childrenMap.value[dirPath]) await loadChildren(dirPath);
+      }
+      expandedDirs.value = expanded;
+    }
+
+    function getVisiblePaths(): string[] {
+      const result: string[] = [];
+      function walk(items: FileEntry[]) {
+        for (const item of items) {
+          result.push(item.path);
+          if (item.isDir && expandedDirs.value.has(item.path)) {
+            const kids = childrenMap.value[item.path];
+            if (kids) walk(kids);
+          }
+        }
+      }
+      walk(entries.value);
+      return result;
+    }
+
+    function selectFile(payload: { entry: FileEntry; shiftKey: boolean; metaKey: boolean }) {
+      const { entry, shiftKey, metaKey } = payload;
+      if (shiftKey && lastSelectedPath.value) {
+        const visible  = getVisiblePaths();
+        const startIdx = visible.indexOf(lastSelectedPath.value);
+        const endIdx   = visible.indexOf(entry.path);
+        if (startIdx !== -1 && endIdx !== -1) {
+          const from = Math.min(startIdx, endIdx);
+          const to   = Math.max(startIdx, endIdx);
+          const rangeSet = new Set(selectedPaths.value);
+          for (let i = from; i <= to; i++) rangeSet.add(visible[i]);
+          selectedPaths.value = rangeSet;
+        }
+      } else if (metaKey) {
+        const next = new Set(selectedPaths.value);
+        if (next.has(entry.path)) next.delete(entry.path); else next.add(entry.path);
+        selectedPaths.value = next;
+        lastSelectedPath.value = entry.path;
+      } else {
+        selectedPaths.value = new Set([entry.path]);
+        lastSelectedPath.value = entry.path;
+      }
+      if (!entry.isDir && !metaKey && !shiftKey) emit('file-selected', entry);
+    }
+
+    const contextMenuRef  = ref<InstanceType<typeof FileContextMenu> | null>(null);
+    const fileClipboard   = ref<{ path: string; operation: 'copy' | 'cut' } | null>(null);
+
+    function onContextMenu(payload: { event: MouseEvent; entry: FileEntry }) {
+      contextMenuRef.value?.show(payload.event, payload.entry.path, payload.entry.isDir);
+    }
+
+    async function refreshDir(dirPath: string) {
+      try {
+        const result = await ipcRenderer.invoke('filesystem-read-dir', dirPath);
+        childrenMap.value = { ...childrenMap.value, [dirPath]: result };
+      } catch { /* ignore */ }
+    }
+
+    async function refreshParentOrRoot(targetPath: string) {
+      const parentDir = targetPath.substring(0, targetPath.lastIndexOf('/'));
+      if (parentDir === rootPath.value) await loadRoot(); else await refreshDir(parentDir);
+    }
+
+    async function onContextAction(payload: { type: string; path: string; isDir: boolean }) {
+      const { type, path: targetPath } = payload;
+      try {
+        switch (type) {
+          case 'new-file': {
+            const name = await inlinePromptRef.value?.show('New file name:');
+            if (!name) return;
+            await ipcRenderer.invoke('filesystem-create-file', targetPath, name);
+            await refreshDir(targetPath);
+            if (!expandedDirs.value.has(targetPath)) expandedDirs.value = new Set([...expandedDirs.value, targetPath]);
+            emit('tree-changed'); break;
+          }
+          case 'new-folder': {
+            const name = await inlinePromptRef.value?.show('New folder name:');
+            if (!name) return;
+            await ipcRenderer.invoke('filesystem-create-dir', targetPath, name);
+            await refreshDir(targetPath);
+            if (!expandedDirs.value.has(targetPath)) expandedDirs.value = new Set([...expandedDirs.value, targetPath]);
+            emit('tree-changed'); break;
+          }
+          case 'cut':   fileClipboard.value = { path: targetPath, operation: 'cut' }; break;
+          case 'copy':  fileClipboard.value = { path: targetPath, operation: 'copy' }; break;
+          case 'paste': {
+            if (!fileClipboard.value) return;
+            const { path: srcPath, operation } = fileClipboard.value;
+            if (operation === 'copy') await ipcRenderer.invoke('filesystem-copy', srcPath, targetPath);
+            else { await ipcRenderer.invoke('filesystem-move', srcPath, targetPath); await refreshParentOrRoot(srcPath); fileClipboard.value = null; }
+            await refreshDir(targetPath);
+            if (!expandedDirs.value.has(targetPath)) expandedDirs.value = new Set([...expandedDirs.value, targetPath]);
+            emit('tree-changed'); break;
+          }
+          case 'rename': {
+            const oldName = targetPath.substring(targetPath.lastIndexOf('/') + 1);
+            const newName = await inlinePromptRef.value?.show('Rename to:', oldName);
+            if (!newName || newName === oldName) return;
+            await ipcRenderer.invoke('filesystem-rename', targetPath, newName);
+            await refreshParentOrRoot(targetPath); emit('tree-changed'); break;
+          }
+          case 'delete': {
+            const name = targetPath.substring(targetPath.lastIndexOf('/') + 1);
+            if (!confirm(`Delete "${name}"? This cannot be undone.`)) return;
+            await ipcRenderer.invoke('filesystem-delete', targetPath);
+            await refreshParentOrRoot(targetPath);
+            if (fileClipboard.value?.path.startsWith(targetPath)) fileClipboard.value = null;
+            emit('tree-changed'); break;
+          }
+          case 'copy-path':          clipboard.writeText(targetPath); break;
+          case 'copy-relative-path': clipboard.writeText(targetPath.replace(rootPath.value, '').replace(/^\//, '')); break;
+          case 'reveal':             await ipcRenderer.invoke('filesystem-reveal', targetPath); break;
+          case 'open-external':      await ipcRenderer.invoke('filesystem-open-external', targetPath); break;
+          case 'open-code-editor':
+            emit('file-selected', { name: targetPath.split('/').pop() || '', path: targetPath, isDir: false, size: 0, ext: targetPath.split('.').pop() || '', editorType: 'code' });
+            break;
+        }
+      } catch (err: any) {
+        console.error(`[FileDrawer] context action "${type}" failed:`, err);
+        alert(err?.message || 'Operation failed');
+      }
+    }
+
+    const uploadInputRef = ref<HTMLInputElement | null>(null);
+
+    async function newFileAtRoot() {
+      const name = await inlinePromptRef.value?.show('New file name:');
+      if (!name) return;
+      try { await ipcRenderer.invoke('filesystem-create-file', rootPath.value, name); await loadRoot(); emit('tree-changed'); }
+      catch (err: any) { alert(err?.message || 'Failed to create file'); }
+    }
+    async function newFolderAtRoot() {
+      const name = await inlinePromptRef.value?.show('New folder name:');
+      if (!name) return;
+      try { await ipcRenderer.invoke('filesystem-create-dir', rootPath.value, name); await loadRoot(); emit('tree-changed'); }
+      catch (err: any) { alert(err?.message || 'Failed to create folder'); }
+    }
+    function triggerUpload() { uploadInputRef.value?.click(); }
+
+    async function uploadFiles(files: FileList | File[], destDir: string) {
+      for (const file of Array.from(files)) {
+        try {
+          const buffer = await file.arrayBuffer();
+          const base64 = btoa(new Uint8Array(buffer).reduce((d, b) => d + String.fromCharCode(b), ''));
+          await ipcRenderer.invoke('filesystem-upload', destDir, file.name, base64);
+        } catch (err: any) { console.error(`[FileDrawer] upload failed for ${file.name}:`, err); }
+      }
+    }
+    async function onUploadInput(event: Event) {
+      const input = event.target as HTMLInputElement;
+      if (!input.files?.length) return;
+      await uploadFiles(input.files, rootPath.value);
+      input.value = '';
+      await loadRoot(); emit('tree-changed');
+    }
+
+    const dropTargetPath = ref('');
+    function onScrollDragOver(event: DragEvent) {
+      if (!event.dataTransfer?.types.includes('Files')) return;
+      event.dataTransfer.dropEffect = 'copy';
+      dropTargetPath.value = rootPath.value;
+    }
+    function onScrollDragLeave() { dropTargetPath.value = ''; }
+    async function onScrollDrop(event: DragEvent) {
+      dropTargetPath.value = '';
+      if (!event.dataTransfer?.files.length) return;
+      await uploadFiles(event.dataTransfer.files, rootPath.value);
+      await loadRoot(); emit('tree-changed');
+    }
+    function onDragHover(dirPath: string) { dropTargetPath.value = dirPath; }
+    async function onDropFiles(payload: { dirPath: string; files: FileList }) {
+      dropTargetPath.value = '';
+      await uploadFiles(payload.files, payload.dirPath);
+      await refreshDir(payload.dirPath);
+      if (!expandedDirs.value.has(payload.dirPath)) expandedDirs.value = new Set([...expandedDirs.value, payload.dirPath]);
+      emit('tree-changed');
+    }
+
+    watch(() => props.highlightPath, async (newPath: string) => {
+      if (!newPath) return;
+      const segments = newPath.split('/').filter((s: string) => s);
+      let currentPath = '';
+      for (const segment of segments) {
+        currentPath += '/' + segment;
+        if (currentPath === newPath) break;
+        if (!expandedDirs.value.has(currentPath)) {
+          expandedDirs.value = new Set([...expandedDirs.value, currentPath]);
+          if (!childrenMap.value[currentPath]) await loadChildren(currentPath);
+        }
+      }
+      selectedPaths.value = new Set([newPath]);
+      lastSelectedPath.value = newPath;
+    }, { immediate: true });
+
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+    async function heartbeat() {
+      if (!rootPath.value) return;
+      try {
+        const freshRoot = await ipcRenderer.invoke('filesystem-read-dir', rootPath.value);
+        const oldNames  = entries.value.map(e => `${e.name}:${e.isDir}`).join(',');
+        const newNames  = freshRoot.map((e: FileEntry) => `${e.name}:${e.isDir}`).join(',');
+        if (oldNames !== newNames) entries.value = freshRoot;
+        for (const dirPath of expandedDirs.value) {
+          const freshChildren = await ipcRenderer.invoke('filesystem-read-dir', dirPath);
+          const oldChildNames = (childrenMap.value[dirPath] || []).map((e: FileEntry) => `${e.name}:${e.isDir}`).join(',');
+          const newChildNames = freshChildren.map((e: FileEntry) => `${e.name}:${e.isDir}`).join(',');
+          if (oldChildNames !== newChildNames) childrenMap.value = { ...childrenMap.value, [dirPath]: freshChildren };
+        }
+      } catch { /* ignore */ }
+    }
+
+    onMounted(() => { loadRoot(); heartbeatTimer = setInterval(heartbeat, 3000); });
+    onBeforeUnmount(() => { if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; } });
+
+    return {
+      entries, expandedDirs, childrenMap, loadingDirs, loading,
+      selectedPaths, rootPath, toggleDir, selectFile,
+      contextMenuRef, inlinePromptRef, fileClipboard,
+      onContextMenu, onContextAction,
+      uploadInputRef, newFileAtRoot, newFolderAtRoot, triggerUpload, onUploadInput,
+      dropTargetPath, onScrollDragOver, onScrollDragLeave, onScrollDrop, onDragHover, onDropFiles,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.file-drawer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--surface-1);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--fs-code);
+  user-select: none;
+  overflow: hidden;
+  border-right: 1px solid var(--border-muted);
+}
+
+.fd-header {
+  display: flex;
+  align-items: center;
+  padding: 0 8px 0 12px;
+  height: 35px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--surface-1);
+  border-bottom: 1px solid var(--border-muted);
+  flex-shrink: 0;
+}
+
+.fd-title { flex: 1; }
+
+.fd-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.fd-btn {
+  display: flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px;
+  border: none; background: none;
+  border-radius: 4px; cursor: pointer;
+  color: var(--text-muted);
+  transition: color 0.15s, background 0.15s;
+}
+.fd-btn:hover { background: var(--surface-3); color: var(--text); }
+
+.fd-loading {
+  padding: 16px 12px;
+  color: var(--text-muted);
+  font-size: var(--fs-body-sm);
+}
+
+.fd-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 2px 0;
+}
+.fd-scroll::-webkit-scrollbar { width: 4px; }
+.fd-scroll::-webkit-scrollbar-track { background: transparent; }
+.fd-scroll::-webkit-scrollbar-thumb { background: var(--border-muted); border-radius: 2px; }
+
+.fd-scroll.drop-active {
+  background: var(--accent-dim);
+  outline: 2px dashed var(--accent-border);
+  outline-offset: -2px;
+}
+</style>

--- a/pkg/rancher-desktop/pages/chat/components/files/FileTreeNode.vue
+++ b/pkg/rancher-desktop/pages/chat/components/files/FileTreeNode.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="file-tree-node">
+    <div
+      class="file-tree-row"
+      :class="{
+        'is-dir': entry.isDir,
+        'is-selected': selectedPaths.has(entry.path),
+        'is-highlighted': highlightPath === entry.path,
+        'drop-target': entry.isDir && dropTargetPath === entry.path,
+      }"
+      :style="{ paddingLeft: (depth * 16 + 8) + 'px' }"
+      @click="handleClick($event)"
+      @contextmenu.prevent="handleContextMenu"
+      @dragover.prevent.stop="handleDragOver"
+      @dragleave.stop="handleDragLeave"
+      @drop.prevent.stop="handleDrop"
+    >
+      <span
+        v-if="entry.isDir"
+        class="chevron"
+        :class="{ expanded: isExpanded }"
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M6 4l4 4-4 4" />
+        </svg>
+      </span>
+      <span v-else class="chevron-spacer" />
+
+      <span class="node-icon">
+        <svg
+          v-if="entry.isDir && isExpanded"
+          width="16" height="16" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"
+          class="icon-folder"
+        >
+          <path d="M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2H5a2 2 0 0 1-2-2V7" />
+          <path d="M8 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
+          <path d="M21 15H9.5a2 2 0 0 0-1.9 1.4L6 21h11.5a2 2 0 0 0 1.9-1.4L21 15Z" />
+        </svg>
+        <svg
+          v-else-if="entry.isDir"
+          width="16" height="16" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"
+          class="icon-folder"
+        >
+          <path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" />
+        </svg>
+        <svg
+          v-else
+          width="16" height="16" viewBox="0 0 24 24" fill="none"
+          stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"
+          class="icon-file"
+        >
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" fill="currentColor" opacity="0.08" />
+          <polyline points="14 2 14 8 20 8" />
+        </svg>
+      </span>
+
+      <span class="node-label" :title="entry.path">{{ entry.name }}</span>
+    </div>
+
+    <div v-if="entry.isDir && isExpanded">
+      <div
+        v-if="isLoading"
+        class="file-tree-row"
+        :style="{ paddingLeft: ((depth + 1) * 16 + 8) + 'px' }"
+      >
+        <span class="loading-text">Loading…</span>
+      </div>
+      <FileTreeNode
+        v-for="child in children"
+        :key="child.path"
+        :entry="child"
+        :depth="depth + 1"
+        :expanded-dirs="expandedDirs"
+        :children-map="childrenMap"
+        :loading-dirs="loadingDirs"
+        :selected-paths="selectedPaths"
+        :drop-target-path="dropTargetPath"
+        :highlight-path="highlightPath"
+        @toggle-dir="$emit('toggle-dir', $event)"
+        @select-file="$emit('select-file', $event)"
+        @context-menu="$emit('context-menu', $event)"
+        @drop-files="$emit('drop-files', $event)"
+        @drag-hover="$emit('drag-hover', $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed, type PropType } from 'vue';
+
+interface FileEntry {
+  name:  string;
+  path:  string;
+  isDir: boolean;
+  size:  number;
+  ext:   string;
+}
+
+export default defineComponent({
+  name: 'FileTreeNode',
+
+  props: {
+    entry:          { type: Object as PropType<FileEntry>, required: true },
+    depth:          { type: Number, required: true },
+    expandedDirs:   { type: Object as PropType<Set<string>>, required: true },
+    childrenMap:    { type: Object as PropType<Record<string, FileEntry[]>>, required: true },
+    loadingDirs:    { type: Object as PropType<Set<string>>, required: true },
+    selectedPaths:  { type: Object as PropType<Set<string>>, default: () => new Set() },
+    dropTargetPath: { type: String, default: '' },
+    highlightPath:  { type: String, default: '' },
+  },
+
+  emits: ['toggle-dir', 'select-file', 'context-menu', 'drop-files', 'drag-hover'],
+
+  setup(props, { emit }) {
+    const isExpanded = computed(() => props.expandedDirs.has(props.entry.path));
+    const isLoading  = computed(() => props.loadingDirs.has(props.entry.path));
+    const children   = computed(() => props.childrenMap[props.entry.path] || []);
+
+    function handleClick(event: MouseEvent) {
+      if (props.entry.isDir) emit('toggle-dir', props.entry.path);
+      emit('select-file', { entry: props.entry, shiftKey: event.shiftKey, metaKey: event.metaKey || event.ctrlKey });
+    }
+    function handleContextMenu(event: MouseEvent) { emit('context-menu', { event, entry: props.entry }); }
+    function handleDragOver(event: DragEvent) {
+      if (!props.entry.isDir || !event.dataTransfer?.types.includes('Files')) return;
+      event.dataTransfer.dropEffect = 'copy';
+      emit('drag-hover', props.entry.path);
+    }
+    function handleDragLeave() { if (props.entry.isDir) emit('drag-hover', ''); }
+    function handleDrop(event: DragEvent) {
+      if (!props.entry.isDir || !event.dataTransfer?.files.length) return;
+      emit('drop-files', { dirPath: props.entry.path, files: event.dataTransfer.files });
+    }
+
+    return { isExpanded, isLoading, children, handleClick, handleContextMenu, handleDragOver, handleDragLeave, handleDrop };
+  },
+});
+</script>
+
+<style scoped>
+.file-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding-right: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.file-tree-row:hover { background: var(--bg-hover); }
+.file-tree-row.is-selected { background: var(--accent-dim); }
+.file-tree-row.is-highlighted {
+  background: var(--accent-dim);
+  border-left: 2px solid var(--accent);
+}
+.chevron {
+  display: flex; align-items: center; justify-content: center;
+  width: 16px; height: 16px; flex-shrink: 0;
+  transition: transform 0.1s ease;
+  transform: rotate(0deg);
+  color: var(--text-muted);
+}
+.chevron.expanded { transform: rotate(90deg); }
+.chevron-spacer { display: inline-block; width: 16px; flex-shrink: 0; }
+.node-icon { display: flex; align-items: center; flex-shrink: 0; width: 16px; height: 16px; color: var(--text-muted); }
+.icon-folder { color: var(--accent); }
+.icon-file { color: var(--text-dim); }
+.node-label {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-size: var(--fs-code); line-height: 22px; color: var(--text);
+}
+.loading-text { color: var(--text-muted); font-size: var(--fs-body-sm); font-style: italic; }
+.file-tree-row.drop-target { background: var(--accent-dim); outline: 1px dashed var(--accent-border); outline-offset: -1px; }
+</style>

--- a/pkg/rancher-desktop/pages/chat/components/files/FileTreeRail.vue
+++ b/pkg/rancher-desktop/pages/chat/components/files/FileTreeRail.vue
@@ -1,0 +1,512 @@
+<!--
+  Left-side file explorer rail.
+  Opens/closes the same way as HistoryRail — toggled via ⌘⇧E or
+  controller.toggleFileTree(). Rooted at ~/sulla/ (the sulla home dir).
+-->
+<template>
+  <aside v-if="open" class="files">
+    <div class="files-header">
+      <span class="files-title">Explorer</span>
+      <div class="files-actions">
+        <button class="action-btn" title="New File" @click="newFileAtRoot">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+            <line x1="12" y1="18" x2="12" y2="12" /><line x1="9" y1="15" x2="15" y2="15" />
+          </svg>
+        </button>
+        <button class="action-btn" title="New Folder" @click="newFolderAtRoot">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+            <line x1="12" y1="11" x2="12" y2="17" /><line x1="9" y1="14" x2="15" y2="14" />
+          </svg>
+        </button>
+        <button class="action-btn" title="Upload" @click="triggerUpload">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="17 8 12 3 7 8" />
+            <line x1="12" y1="3" x2="12" y2="15" />
+          </svg>
+        </button>
+        <button class="action-btn" title="Close Explorer (⌘⇧E)" @click="$emit('close')">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      </div>
+      <input
+        ref="uploadInputRef"
+        type="file"
+        multiple
+        style="display: none"
+        @change="onUploadInput"
+      >
+    </div>
+
+    <div v-if="loading && entries.length === 0" class="files-loading">
+      Loading…
+    </div>
+    <div
+      v-else
+      class="files-scroll"
+      :class="{ 'drop-active': dropTargetPath === rootPath }"
+      @dragover.prevent="onScrollDragOver"
+      @dragleave="onScrollDragLeave"
+      @drop.prevent="onScrollDrop"
+    >
+      <FileTreeNode
+        v-for="entry in entries"
+        :key="entry.path"
+        :entry="entry"
+        :depth="0"
+        :expanded-dirs="expandedDirs"
+        :children-map="childrenMap"
+        :loading-dirs="loadingDirs"
+        :selected-paths="selectedPaths"
+        :drop-target-path="dropTargetPath"
+        :highlight-path="highlightPath"
+        @toggle-dir="toggleDir"
+        @select-file="onSelectFile"
+        @context-menu="onContextMenu"
+        @drop-files="onDropFiles"
+        @drag-hover="onDragHover"
+      />
+    </div>
+
+    <FileContextMenu
+      ref="contextMenuRef"
+      :has-clipboard="!!fileClipboard"
+      @action="onContextAction"
+    />
+    <InlinePrompt ref="inlinePromptRef" />
+  </aside>
+</template>
+
+<script lang="ts">
+import { ipcRenderer, clipboard } from 'electron';
+import { defineComponent, ref, onMounted, onBeforeUnmount, watch } from 'vue';
+
+import FileContextMenu from './FileContextMenu.vue';
+import FileTreeNode    from './FileTreeNode.vue';
+import InlinePrompt   from './InlinePrompt.vue';
+
+export interface FileEntry {
+  name:        string;
+  path:        string;
+  isDir:       boolean;
+  size:        number;
+  ext:         string;
+  editorType?: 'code';
+  line?:       number;
+}
+
+export default defineComponent({
+  name: 'FileTreeRail',
+
+  components: { FileTreeNode, FileContextMenu, InlinePrompt },
+
+  props: {
+    open:          { type: Boolean, required: true },
+    highlightPath: { type: String, default: '' },
+  },
+
+  emits: ['file-selected', 'tree-changed', 'close'],
+
+  setup(props, { emit }) {
+    const entries      = ref<FileEntry[]>([]);
+    const expandedDirs = ref<Set<string>>(new Set());
+    const childrenMap  = ref<Record<string, FileEntry[]>>({});
+    const loadingDirs  = ref<Set<string>>(new Set());
+    const loading      = ref(true);
+    const selectedPaths    = ref<Set<string>>(new Set());
+    const lastSelectedPath = ref('');
+    const rootPath         = ref('');
+
+    const inlinePromptRef = ref<InstanceType<typeof InlinePrompt> | null>(null);
+    const contextMenuRef  = ref<any>(null);
+    const uploadInputRef  = ref<HTMLInputElement | null>(null);
+    const fileClipboard   = ref<{ path: string; operation: 'copy' | 'cut' } | null>(null);
+    const dropTargetPath  = ref('');
+
+    // ── Data loading ────────────────────────────────────────────
+    async function loadRoot() {
+      loading.value = true;
+      try {
+        rootPath.value = await ipcRenderer.invoke('filesystem-get-root');
+        entries.value  = await ipcRenderer.invoke('filesystem-read-dir', rootPath.value);
+      } catch (err) {
+        console.error('[FileTreeRail] loadRoot:', err);
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function loadChildren(dirPath: string) {
+      loadingDirs.value.add(dirPath);
+      try {
+        const result = await ipcRenderer.invoke('filesystem-read-dir', dirPath);
+        childrenMap.value = { ...childrenMap.value, [dirPath]: result };
+      } catch (err) {
+        console.error('[FileTreeRail] loadChildren:', dirPath, err);
+      } finally {
+        loadingDirs.value.delete(dirPath);
+      }
+    }
+
+    async function refreshDir(dirPath: string) {
+      try {
+        childrenMap.value = {
+          ...childrenMap.value,
+          [dirPath]: await ipcRenderer.invoke('filesystem-read-dir', dirPath),
+        };
+      } catch { /* ignore */ }
+    }
+
+    async function refreshParentOrRoot(targetPath: string) {
+      const parentDir = targetPath.substring(0, targetPath.lastIndexOf('/'));
+      if (parentDir === rootPath.value) await loadRoot();
+      else await refreshDir(parentDir);
+    }
+
+    // ── Tree interaction ─────────────────────────────────────────
+    async function toggleDir(dirPath: string) {
+      const next = new Set(expandedDirs.value);
+      if (next.has(dirPath)) {
+        next.delete(dirPath);
+      } else {
+        next.add(dirPath);
+        if (!childrenMap.value[dirPath]) await loadChildren(dirPath);
+      }
+      expandedDirs.value = next;
+    }
+
+    function getVisiblePaths(): string[] {
+      const result: string[] = [];
+      function walk(items: FileEntry[]) {
+        for (const item of items) {
+          result.push(item.path);
+          if (item.isDir && expandedDirs.value.has(item.path)) {
+            const kids = childrenMap.value[item.path];
+            if (kids) walk(kids);
+          }
+        }
+      }
+      walk(entries.value);
+      return result;
+    }
+
+    function onSelectFile(payload: { entry: FileEntry; shiftKey?: boolean; metaKey?: boolean }) {
+      const { entry, shiftKey, metaKey } = payload;
+
+      if (shiftKey && lastSelectedPath.value) {
+        const visible = getVisiblePaths();
+        const startIdx = visible.indexOf(lastSelectedPath.value);
+        const endIdx   = visible.indexOf(entry.path);
+        if (startIdx !== -1 && endIdx !== -1) {
+          const rangeSet = new Set(selectedPaths.value);
+          const from = Math.min(startIdx, endIdx);
+          const to   = Math.max(startIdx, endIdx);
+          for (let i = from; i <= to; i++) rangeSet.add(visible[i]);
+          selectedPaths.value = rangeSet;
+        }
+      } else if (metaKey) {
+        const next = new Set(selectedPaths.value);
+        if (next.has(entry.path)) next.delete(entry.path);
+        else next.add(entry.path);
+        selectedPaths.value = next;
+        lastSelectedPath.value = entry.path;
+      } else {
+        selectedPaths.value    = new Set([entry.path]);
+        lastSelectedPath.value = entry.path;
+      }
+
+      if (!entry.isDir && !metaKey && !shiftKey) emit('file-selected', entry);
+    }
+
+    // ── Context menu ─────────────────────────────────────────────
+    function onContextMenu(payload: { event: MouseEvent; entry: FileEntry }) {
+      contextMenuRef.value?.show(payload.event, payload.entry.path, payload.entry.isDir, payload.entry.ext);
+    }
+
+    async function onContextAction(payload: { type: string; path: string; isDir: boolean }) {
+      const { type, path: targetPath } = payload;
+      try {
+        switch (type) {
+        case 'new-file': {
+          const name = await inlinePromptRef.value?.show('New file name:');
+          if (!name) return;
+          await ipcRenderer.invoke('filesystem-create-file', targetPath, name);
+          await refreshDir(targetPath);
+          if (!expandedDirs.value.has(targetPath)) {
+            expandedDirs.value = new Set([...expandedDirs.value, targetPath]);
+          }
+          emit('tree-changed');
+          break;
+        }
+        case 'new-folder': {
+          const name = await inlinePromptRef.value?.show('New folder name:');
+          if (!name) return;
+          await ipcRenderer.invoke('filesystem-create-dir', targetPath, name);
+          await refreshDir(targetPath);
+          if (!expandedDirs.value.has(targetPath)) {
+            expandedDirs.value = new Set([...expandedDirs.value, targetPath]);
+          }
+          emit('tree-changed');
+          break;
+        }
+        case 'cut':
+          fileClipboard.value = { path: targetPath, operation: 'cut' };
+          break;
+        case 'copy':
+          fileClipboard.value = { path: targetPath, operation: 'copy' };
+          break;
+        case 'paste': {
+          if (!fileClipboard.value) return;
+          const { path: srcPath, operation } = fileClipboard.value;
+          if (operation === 'copy') await ipcRenderer.invoke('filesystem-copy', srcPath, targetPath);
+          else {
+            await ipcRenderer.invoke('filesystem-move', srcPath, targetPath);
+            await refreshParentOrRoot(srcPath);
+            fileClipboard.value = null;
+          }
+          await refreshDir(targetPath);
+          if (!expandedDirs.value.has(targetPath)) {
+            expandedDirs.value = new Set([...expandedDirs.value, targetPath]);
+          }
+          emit('tree-changed');
+          break;
+        }
+        case 'rename': {
+          const oldName = targetPath.substring(targetPath.lastIndexOf('/') + 1);
+          const newName = await inlinePromptRef.value?.show('Rename to:', oldName);
+          if (!newName || newName === oldName) return;
+          await ipcRenderer.invoke('filesystem-rename', targetPath, newName);
+          await refreshParentOrRoot(targetPath);
+          emit('tree-changed');
+          break;
+        }
+        case 'delete': {
+          const name      = targetPath.substring(targetPath.lastIndexOf('/') + 1);
+          const confirmed = confirm(`Delete "${ name }"? This cannot be undone.`);
+          if (!confirmed) return;
+          await ipcRenderer.invoke('filesystem-delete', targetPath);
+          await refreshParentOrRoot(targetPath);
+          if (fileClipboard.value?.path.startsWith(targetPath)) fileClipboard.value = null;
+          emit('tree-changed');
+          break;
+        }
+        case 'copy-path':
+          clipboard.writeText(targetPath);
+          break;
+        case 'copy-relative-path':
+          clipboard.writeText(targetPath.replace(rootPath.value, '').replace(/^\//, ''));
+          break;
+        case 'reveal':
+          await ipcRenderer.invoke('filesystem-reveal', targetPath);
+          break;
+        case 'open-external':
+          await ipcRenderer.invoke('filesystem-open-external', targetPath);
+          break;
+        case 'open-code-editor':
+          emit('file-selected', {
+            name: targetPath.split('/').pop() || '',
+            path: targetPath, isDir: false, size: 0,
+            ext: targetPath.split('.').pop() || '',
+            editorType: 'code',
+          });
+          break;
+        }
+      } catch (err: any) {
+        console.error(`Context action "${ type }" failed:`, err);
+        alert(err?.message || 'Operation failed');
+      }
+    }
+
+    // ── Toolbar ───────────────────────────────────────────────────
+    async function newFileAtRoot() {
+      const name = await inlinePromptRef.value?.show('New file name:');
+      if (!name) return;
+      try {
+        await ipcRenderer.invoke('filesystem-create-file', rootPath.value, name);
+        await loadRoot();
+        emit('tree-changed');
+      } catch (err: any) { alert(err?.message || 'Failed'); }
+    }
+
+    async function newFolderAtRoot() {
+      const name = await inlinePromptRef.value?.show('New folder name:');
+      if (!name) return;
+      try {
+        await ipcRenderer.invoke('filesystem-create-dir', rootPath.value, name);
+        await loadRoot();
+        emit('tree-changed');
+      } catch (err: any) { alert(err?.message || 'Failed'); }
+    }
+
+    function triggerUpload() { uploadInputRef.value?.click(); }
+
+    async function uploadFiles(files: FileList | File[], destDir: string) {
+      for (const file of Array.from(files)) {
+        try {
+          const buffer = await file.arrayBuffer();
+          const base64 = btoa(new Uint8Array(buffer).reduce((d, b) => d + String.fromCharCode(b), ''));
+          await ipcRenderer.invoke('filesystem-upload', destDir, file.name, base64);
+        } catch (err: any) { console.error(`Upload failed for ${ file.name }:`, err); }
+      }
+    }
+
+    async function onUploadInput(event: Event) {
+      const input = event.target as HTMLInputElement;
+      if (!input.files?.length) return;
+      await uploadFiles(input.files, rootPath.value);
+      input.value = '';
+      await loadRoot();
+      emit('tree-changed');
+    }
+
+    // ── Drag and drop ─────────────────────────────────────────────
+    function onScrollDragOver(event: DragEvent) {
+      if (!event.dataTransfer?.types.includes('Files')) return;
+      event.dataTransfer.dropEffect = 'copy';
+      dropTargetPath.value = rootPath.value;
+    }
+    function onScrollDragLeave() { dropTargetPath.value = ''; }
+    async function onScrollDrop(event: DragEvent) {
+      dropTargetPath.value = '';
+      if (!event.dataTransfer?.files.length) return;
+      await uploadFiles(event.dataTransfer.files, rootPath.value);
+      await loadRoot();
+      emit('tree-changed');
+    }
+    function onDragHover(dirPath: string) { dropTargetPath.value = dirPath; }
+    async function onDropFiles(payload: { dirPath: string; files: FileList }) {
+      dropTargetPath.value = '';
+      await uploadFiles(payload.files, payload.dirPath);
+      await refreshDir(payload.dirPath);
+      if (!expandedDirs.value.has(payload.dirPath)) {
+        expandedDirs.value = new Set([...expandedDirs.value, payload.dirPath]);
+      }
+      emit('tree-changed');
+    }
+
+    // ── Highlight path → auto-expand ──────────────────────────────
+    watch(() => props.highlightPath, async(newPath: string) => {
+      if (!newPath) return;
+      const segments = newPath.split('/').filter(Boolean);
+      let currentPath = '';
+      for (const segment of segments) {
+        currentPath += '/' + segment;
+        if (currentPath === newPath) break;
+        if (!expandedDirs.value.has(currentPath)) {
+          expandedDirs.value = new Set([...expandedDirs.value, currentPath]);
+          if (!childrenMap.value[currentPath]) await loadChildren(currentPath);
+        }
+      }
+      selectedPaths.value    = new Set([newPath]);
+      lastSelectedPath.value = newPath;
+    }, { immediate: true });
+
+    // Reload tree when the rail opens so content is always fresh.
+    watch(() => props.open, (isOpen) => { if (isOpen) loadRoot(); });
+
+    // ── Heartbeat ─────────────────────────────────────────────────
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+    async function heartbeat() {
+      if (!rootPath.value || !props.open) return;
+      try {
+        const fresh = await ipcRenderer.invoke('filesystem-read-dir', rootPath.value);
+        const oldKey = entries.value.map(e => `${ e.name }:${ e.isDir }`).join(',');
+        const newKey = fresh.map((e: FileEntry) => `${ e.name }:${ e.isDir }`).join(',');
+        if (oldKey !== newKey) entries.value = fresh;
+        for (const dir of expandedDirs.value) {
+          const fc = await ipcRenderer.invoke('filesystem-read-dir', dir);
+          const ok = (childrenMap.value[dir] || []).map(e => `${ e.name }:${ e.isDir }`).join(',');
+          const nk = fc.map((e: FileEntry) => `${ e.name }:${ e.isDir }`).join(',');
+          if (ok !== nk) childrenMap.value = { ...childrenMap.value, [dir]: fc };
+        }
+      } catch { /* ignore */ }
+    }
+
+    onMounted(() => {
+      if (props.open) loadRoot();
+      heartbeatTimer = setInterval(heartbeat, 3000);
+    });
+    onBeforeUnmount(() => {
+      if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
+    });
+
+    return {
+      entries, expandedDirs, childrenMap, loadingDirs, loading,
+      selectedPaths, rootPath, dropTargetPath,
+      toggleDir, onSelectFile, contextMenuRef, inlinePromptRef,
+      fileClipboard, onContextMenu, onContextAction,
+      uploadInputRef, newFileAtRoot, newFolderAtRoot, triggerUpload, onUploadInput,
+      onScrollDragOver, onScrollDragLeave, onScrollDrop, onDragHover, onDropFiles,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.files {
+  overflow: hidden;
+  border-right: 1px solid rgba(168, 192, 220, 0.08);
+  background: rgba(7, 13, 26, 0.4);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  user-select: none;
+}
+
+.files-header {
+  display: flex;
+  align-items: center;
+  padding: 0 8px 0 16px;
+  height: 35px;
+  flex-shrink: 0;
+  border-bottom: 1px solid rgba(168, 192, 220, 0.08);
+}
+
+.files-title {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--steel-400, rgba(80,150,179,0.7));
+}
+
+.files-actions {
+  display: flex; align-items: center; gap: 2px; margin-left: auto;
+}
+
+.action-btn {
+  display: flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px; border: none; background: none;
+  border-radius: 4px; cursor: pointer;
+  color: var(--read-4, rgba(168,192,220,0.5));
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.action-btn:hover {
+  background: rgba(80, 150, 179, 0.10);
+  color: var(--read-2, rgba(215,225,235,0.9));
+}
+
+.files-loading {
+  padding: 16px; font-family: var(--mono); font-size: 11px;
+  color: var(--read-5, rgba(168,192,220,0.35)); font-style: italic;
+}
+
+.files-scroll {
+  flex: 1; overflow-y: auto; overflow-x: hidden; padding: 6px 0;
+}
+.files-scroll::-webkit-scrollbar { width: 4px; }
+.files-scroll::-webkit-scrollbar-track { background: transparent; }
+.files-scroll::-webkit-scrollbar-thumb {
+  background: rgba(80,150,179,0.2); border-radius: 2px;
+}
+
+.files-scroll.drop-active {
+  outline: 2px dashed rgba(80, 150, 179, 0.4);
+  outline-offset: -2px;
+  background: rgba(80, 150, 179, 0.05);
+}
+</style>

--- a/pkg/rancher-desktop/pages/chat/components/files/FileTreeRail.vue
+++ b/pkg/rancher-desktop/pages/chat/components/files/FileTreeRail.vue
@@ -451,9 +451,8 @@ export default defineComponent({
 <style scoped>
 .files {
   overflow: hidden;
-  border-right: 1px solid rgba(168, 192, 220, 0.08);
-  background: rgba(7, 13, 26, 0.4);
-  backdrop-filter: blur(8px);
+  border-right: 1px solid var(--border-muted);
+  background: var(--bg-surface);
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -466,12 +465,12 @@ export default defineComponent({
   padding: 0 8px 0 16px;
   height: 35px;
   flex-shrink: 0;
-  border-bottom: 1px solid rgba(168, 192, 220, 0.08);
+  border-bottom: 1px solid var(--border-muted);
 }
 
 .files-title {
   font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.28em;
-  text-transform: uppercase; color: var(--steel-400, rgba(80,150,179,0.7));
+  text-transform: uppercase; color: var(--accent);
 }
 
 .files-actions {
@@ -482,17 +481,17 @@ export default defineComponent({
   display: flex; align-items: center; justify-content: center;
   width: 22px; height: 22px; border: none; background: none;
   border-radius: 4px; cursor: pointer;
-  color: var(--read-4, rgba(168,192,220,0.5));
+  color: var(--text-muted);
   transition: background 0.12s ease, color 0.12s ease;
 }
 .action-btn:hover {
-  background: rgba(80, 150, 179, 0.10);
-  color: var(--read-2, rgba(215,225,235,0.9));
+  background: var(--accent-dim);
+  color: var(--text);
 }
 
 .files-loading {
   padding: 16px; font-family: var(--mono); font-size: 11px;
-  color: var(--read-5, rgba(168,192,220,0.35)); font-style: italic;
+  color: var(--text-dim); font-style: italic;
 }
 
 .files-scroll {
@@ -501,12 +500,12 @@ export default defineComponent({
 .files-scroll::-webkit-scrollbar { width: 4px; }
 .files-scroll::-webkit-scrollbar-track { background: transparent; }
 .files-scroll::-webkit-scrollbar-thumb {
-  background: rgba(80,150,179,0.2); border-radius: 2px;
+  background: var(--border-muted, rgba(80,150,179,0.2)); border-radius: 2px;
 }
 
 .files-scroll.drop-active {
-  outline: 2px dashed rgba(80, 150, 179, 0.4);
+  outline: 2px dashed var(--accent-border, rgba(80, 150, 179, 0.4));
   outline-offset: -2px;
-  background: rgba(80, 150, 179, 0.05);
+  background: var(--bg-hover, rgba(80, 150, 179, 0.05));
 }
 </style>

--- a/pkg/rancher-desktop/pages/chat/components/files/InlinePrompt.vue
+++ b/pkg/rancher-desktop/pages/chat/components/files/InlinePrompt.vue
@@ -1,0 +1,92 @@
+<template>
+  <Teleport to="body">
+    <div v-if="visible" class="inline-prompt-overlay" @mousedown.self="cancel">
+      <div class="inline-prompt-dialog">
+        <div class="inline-prompt-title">{{ title }}</div>
+        <input
+          ref="inputRef"
+          v-model="inputValue"
+          class="inline-prompt-input"
+          :placeholder="placeholder"
+          @keydown.enter="confirm"
+          @keydown.escape="cancel"
+        >
+        <div class="inline-prompt-actions">
+          <button class="inline-prompt-btn cancel" @click="cancel">Cancel</button>
+          <button class="inline-prompt-btn confirm" @click="confirm">OK</button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick } from 'vue';
+
+const visible     = ref(false);
+const title       = ref('');
+const placeholder = ref('');
+const inputValue  = ref('');
+const inputRef    = ref<HTMLInputElement | null>(null);
+
+let resolvePromise: ((value: string | null) => void) | null = null;
+
+async function show(promptTitle: string, defaultValue = '', promptPlaceholder = ''): Promise<string | null> {
+  title.value       = promptTitle;
+  inputValue.value  = defaultValue;
+  placeholder.value = promptPlaceholder;
+  visible.value     = true;
+  await nextTick();
+  inputRef.value?.focus();
+  inputRef.value?.select();
+  return new Promise<string | null>((resolve) => { resolvePromise = resolve; });
+}
+
+function confirm() {
+  visible.value = false;
+  resolvePromise?.(inputValue.value);
+  resolvePromise = null;
+}
+function cancel() {
+  visible.value = false;
+  resolvePromise?.(null);
+  resolvePromise = null;
+}
+
+defineExpose({ show });
+</script>
+
+<style scoped>
+.inline-prompt-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 10000;
+}
+.inline-prompt-dialog {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px; padding: 16px; width: 320px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+  display: flex; flex-direction: column; gap: 12px;
+}
+.inline-prompt-title { font-size: var(--fs-code); font-weight: 600; color: var(--text); }
+.inline-prompt-input {
+  width: 100%; padding: 8px 10px;
+  font-size: var(--fs-code);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text); outline: none; box-sizing: border-box;
+}
+.inline-prompt-input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-dim); }
+.inline-prompt-actions { display: flex; justify-content: flex-end; gap: 8px; }
+.inline-prompt-btn {
+  padding: 6px 14px; font-size: var(--fs-code);
+  border: none; border-radius: 5px; cursor: pointer;
+}
+.inline-prompt-btn.cancel { background: var(--surface-3); color: var(--text-muted); }
+.inline-prompt-btn.cancel:hover { background: var(--border); }
+.inline-prompt-btn.confirm { background: var(--accent); color: #fff; }
+.inline-prompt-btn.confirm:hover { background: var(--accent-hover); }
+</style>

--- a/pkg/rancher-desktop/pages/chat/components/filesystem/FileTreeRail.vue
+++ b/pkg/rancher-desktop/pages/chat/components/filesystem/FileTreeRail.vue
@@ -1,0 +1,43 @@
+<template>
+  <aside
+    v-if="open"
+    class="file-tree-rail"
+  >
+    <FileTreeSidebar
+      :is-dark="isDark"
+      @file-selected="$emit('file-selected', $event)"
+      @tree-changed="$emit('tree-changed')"
+      @close="$emit('close')"
+    />
+  </aside>
+</template>
+
+<script setup lang="ts">
+import FileTreeSidebar from '@pkg/pages/filesystem/FileTreeSidebar.vue';
+import { useTheme } from '@pkg/composables/useTheme';
+
+defineProps<{
+  open: boolean;
+}>();
+
+defineEmits<{
+  (e: 'file-selected', entry: unknown): void;
+  (e: 'tree-changed'): void;
+  (e: 'close'): void;
+}>();
+
+const { isDark } = useTheme();
+</script>
+
+<style scoped>
+.file-tree-rail {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 260px;
+  z-index: 6;
+  border-right: 1px solid var(--border);
+  overflow: hidden;
+}
+</style>

--- a/pkg/rancher-desktop/pages/chat/components/patch/PatchBlock.vue
+++ b/pkg/rancher-desktop/pages/chat/components/patch/PatchBlock.vue
@@ -101,38 +101,38 @@ function open(): void {
   background: rgba(80, 150, 179, 0.55);
 }
 .patch-head {
-  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.18em;
-  text-transform: uppercase; color: var(--steel-400);
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10.5px; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--accent-primary, var(--accent));
   display: flex; align-items: baseline; gap: 14px; margin: 8px 0 10px;
 }
 .patch-head .path {
-  font-family: var(--mono); font-size: 11px;
-  color: var(--read-2); letter-spacing: 0.02em; text-transform: none;
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 11px;
+  color: var(--text-primary); letter-spacing: 0.02em; text-transform: none;
 }
-.patch-head .stat { margin-left: auto; font-size: 10px; color: var(--read-4); }
-.patch-head .stat .plus  { color: var(--ok); }
-.patch-head .stat .minus { color: var(--err); margin-left: 6px; }
+.patch-head .stat { margin-left: auto; font-size: 10px; color: var(--text-secondary); }
+.patch-head .stat .plus  { color: var(--text-success); }
+.patch-head .stat .minus { color: var(--text-error); margin-left: 6px; }
 .patch-body {
-  font-family: var(--mono); font-size: 13px; line-height: 1.7;
-  color: var(--read-2);
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 13px; line-height: 1.7;
+  color: var(--text-primary);
   padding: 14px 0 16px;
   border-top: 1px solid rgba(80, 150, 179, 0.18);
   border-bottom: 1px solid rgba(80, 150, 179, 0.18);
 }
 .patch-body .l { display: flex; gap: 12px; padding: 0 2px; }
-.patch-body .l .n { color: var(--read-5); min-width: 22px; text-align: right; user-select: none; font-size: 11.5px; }
-.patch-body .l.add { background: rgba(134, 239, 172, 0.06); border-radius: 2px; }
-.patch-body .l.add .n { color: var(--ok); }
-.patch-body .l.add::before { content: "+ "; color: var(--ok); margin-left: 2px; }
+.patch-body .l .n { color: var(--text-muted); min-width: 22px; text-align: right; user-select: none; font-size: 11.5px; }
+.patch-body .l.add { background: var(--diff-ins-bg, rgba(34, 197, 94, 0.15)); border-radius: 2px; }
+.patch-body .l.add .n { color: var(--text-success); }
+.patch-body .l.add::before { content: "+ "; color: var(--text-success); margin-left: 2px; }
 .patch-body .l.context::before { content: "  "; white-space: pre; }
-.patch-body .l.context { color: var(--read-3); }
-.patch-body .l.remove { background: rgba(252, 165, 165, 0.06); }
-.patch-body .l.remove .n { color: var(--err); }
-.patch-body .l.remove::before { content: "- "; color: var(--err); margin-left: 2px; }
+.patch-body .l.context { color: var(--text-secondary); }
+.patch-body .l.remove { background: var(--diff-del-bg, rgba(239, 68, 68, 0.15)); }
+.patch-body .l.remove .n { color: var(--text-error); }
+.patch-body .l.remove::before { content: "- "; color: var(--text-error); margin-left: 2px; }
 
 .patch-actions {
   display: flex; gap: 14px; margin-top: 14px; align-items: center;
-  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.2em;
+  font-family: var(--font-mono, ui-monospace, monospace); font-size: 10.5px; letter-spacing: 0.2em;
   text-transform: uppercase;
 }
 .patch-actions button {
@@ -140,18 +140,18 @@ function open(): void {
   padding: 0; letter-spacing: inherit; text-transform: inherit;
   transition: color 0.15s ease;
 }
-.patch-actions .apply  { color: white; font-weight: 700; }
-.patch-actions .apply:hover { color: var(--steel-400); }
-.patch-actions .open   { color: var(--steel-400); }
-.patch-actions .open:hover { color: white; }
-.patch-actions .reject { color: var(--read-4); }
-.patch-actions .reject:hover { color: var(--err); }
-.patch-actions .revert { color: var(--read-4); }
-.patch-actions .revert:hover { color: var(--err); }
-.patch-actions .revert:disabled { color: var(--read-5); cursor: wait; }
-.patch-actions .sep    { color: var(--read-5); }
+.patch-actions .apply  { color: var(--text-primary); font-weight: 700; }
+.patch-actions .apply:hover { color: var(--accent-primary, var(--accent)); }
+.patch-actions .open   { color: var(--accent-primary, var(--accent)); }
+.patch-actions .open:hover { color: var(--text-primary); }
+.patch-actions .reject { color: var(--text-secondary); }
+.patch-actions .reject:hover { color: var(--text-error); }
+.patch-actions .revert { color: var(--text-secondary); }
+.patch-actions .revert:hover { color: var(--text-error); }
+.patch-actions .revert:disabled { color: var(--text-muted); cursor: wait; }
+.patch-actions .sep    { color: var(--text-muted); }
 .patch.applied .patch-body { opacity: 0.55; }
-.patch.applied .patch-head::before { content: "◆ APPLIED · "; color: var(--ok); letter-spacing: 0.18em; }
+.patch.applied .patch-head::before { content: "◆ APPLIED · "; color: var(--text-success); letter-spacing: 0.18em; }
 .patch.rejected .patch-body { opacity: 0.4; filter: saturate(0.3); }
-.patch.rejected .patch-head::before { content: "◇ REJECTED · "; color: var(--err); letter-spacing: 0.18em; }
+.patch.rejected .patch-head::before { content: "◇ REJECTED · "; color: var(--text-error); letter-spacing: 0.18em; }
 </style>

--- a/pkg/rancher-desktop/pages/chat/components/transcript/IsolatedHtml.vue
+++ b/pkg/rancher-desktop/pages/chat/components/transcript/IsolatedHtml.vue
@@ -51,7 +51,6 @@ const BASE_STYLES = `
     font-family: var(--font-body, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif);
     font-size: 14px;
     line-height: 1.55;
-    color-scheme: dark;
 
     --bg: var(--bg-page, #0d1117);
     --surface-1: var(--bg-surface, #161b22);
@@ -60,6 +59,11 @@ const BASE_STYLES = `
     --text: var(--text-primary, #e6edf3);
     --text-muted: #8b949e;
     --text-dim: #6e7681;
+    --accent: var(--accent-primary, #5096b3);
+    --accent-hover: var(--accent-primary-hover, #6ab0cc);
+    --accent-dim: rgba(80, 150, 179, 0.15);
+    --accent-border: rgba(80, 150, 179, 0.5);
+    --accent-glow: rgba(80, 150, 179, 0.4);
     --green: #2ea043;
     --green-bright: #3fb950;
     --green-glow: rgba(46, 160, 67, 0.4);
@@ -138,6 +142,10 @@ function render(html: string): void {
     FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur'],
   });
   const themeClass = activeThemeClass();
+  const isLight = themeClass.includes('light');
+
+  // Mirror color-scheme so browser built-ins (scrollbars, inputs) match the active theme.
+  if (hostEl.value) hostEl.value.style.colorScheme = isLight ? 'light' : 'dark';
 
   shadow.innerHTML = themeClass
     ? `<div class="${ themeClass }">${ safe }</div>`

--- a/pkg/rancher-desktop/pages/chat/composables/useKeyboardShortcuts.ts
+++ b/pkg/rancher-desktop/pages/chat/composables/useKeyboardShortcuts.ts
@@ -40,6 +40,10 @@ export function useKeyboardShortcuts(opts: KeyboardShortcutOptions = {}): void {
     if (metaish && e.shiftKey && e.key.toLowerCase() === 'h') {
       e.preventDefault(); c.toggleHistory(); return;
     }
+    // ⌘⇧E — toggle file explorer drawer
+    if (metaish && e.shiftKey && e.key.toLowerCase() === 'e') {
+      e.preventDefault(); c.toggleFileTree(); return;
+    }
     // ⌘/ — voice toggle
     if (metaish && e.key === '/') {
       e.preventDefault(); opts.onVoiceToggle?.(); return;

--- a/pkg/rancher-desktop/pages/chat/controller/ChatController.ts
+++ b/pkg/rancher-desktop/pages/chat/controller/ChatController.ts
@@ -580,6 +580,9 @@ export class ChatController {
   toggleHistory(): void {
     this.sidebar.value = { ...this.sidebar.value, historyOpen: !this.sidebar.value.historyOpen };
   }
+  toggleFileTree(): void {
+    this.sidebar.value = { ...this.sidebar.value, fileTreeOpen: !this.sidebar.value.fileTreeOpen };
+  }
 
   // ─── Model ──────────────────────────────────────────────────────
   switchModel(model: ModelDescriptor): void {
@@ -708,7 +711,7 @@ export class ChatController {
       activeArtifactId: null,
       popover: popoverClosed(),
       modals: { which: null },
-      sidebar: { historyOpen: false },
+      sidebar: { historyOpen: false, fileTreeOpen: false },
       connection: 'online',
       model: DEFAULT_MODEL,
     };

--- a/pkg/rancher-desktop/pages/chat/models/Thread.ts
+++ b/pkg/rancher-desktop/pages/chat/models/Thread.ts
@@ -49,7 +49,8 @@ export const emptyTokenUsage = (): TokenUsage => ({
 });
 
 export interface SidebarState {
-  historyOpen: boolean;
+  historyOpen:  boolean;
+  fileTreeOpen: boolean;
 }
 
 /**

--- a/pkg/rancher-desktop/pages/editor/InlinePrompt.vue
+++ b/pkg/rancher-desktop/pages/editor/InlinePrompt.vue
@@ -1,0 +1,167 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="visible"
+      class="inline-prompt-overlay"
+      @mousedown.self="cancel"
+    >
+      <div
+        class="inline-prompt-dialog"
+        :class="{ dark: isDark }"
+      >
+        <div class="inline-prompt-title">
+          {{ title }}
+        </div>
+        <input
+          ref="inputRef"
+          v-model="inputValue"
+          class="inline-prompt-input"
+          :class="{ dark: isDark }"
+          :placeholder="placeholder"
+          @keydown.enter="confirm"
+          @keydown.escape="cancel"
+        >
+        <div class="inline-prompt-actions">
+          <button
+            class="inline-prompt-btn cancel"
+            :class="{ dark: isDark }"
+            @click="cancel"
+          >
+            Cancel
+          </button>
+          <button
+            class="inline-prompt-btn confirm"
+            :class="{ dark: isDark }"
+            @click="confirm"
+          >
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick } from 'vue';
+
+defineProps<{
+  isDark: boolean;
+}>();
+
+const visible = ref(false);
+const title = ref('');
+const placeholder = ref('');
+const inputValue = ref('');
+const inputRef = ref<HTMLInputElement | null>(null);
+
+let resolvePromise: ((value: string | null) => void) | null = null;
+
+async function show(promptTitle: string, defaultValue = '', promptPlaceholder = ''): Promise<string | null> {
+  title.value = promptTitle;
+  inputValue.value = defaultValue;
+  placeholder.value = promptPlaceholder;
+  visible.value = true;
+
+  await nextTick();
+  inputRef.value?.focus();
+  inputRef.value?.select();
+
+  return new Promise<string | null>((resolve) => {
+    resolvePromise = resolve;
+  });
+}
+
+function confirm() {
+  visible.value = false;
+  resolvePromise?.(inputValue.value);
+  resolvePromise = null;
+}
+
+function cancel() {
+  visible.value = false;
+  resolvePromise?.(null);
+  resolvePromise = null;
+}
+
+defineExpose({ show });
+</script>
+
+<style scoped>
+.inline-prompt-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.inline-prompt-dialog {
+  background: var(--bg-surface);
+  border-radius: 8px;
+  padding: 16px;
+  width: 320px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.inline-prompt-title {
+  font-size: var(--fs-code);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.inline-prompt-input {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: var(--fs-code);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.inline-prompt-input:focus {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.15);
+}
+
+.inline-prompt-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.inline-prompt-btn {
+  padding: 6px 14px;
+  font-size: var(--fs-code);
+  font-weight: var(--weight-medium);
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.inline-prompt-btn.cancel {
+  background: var(--bg-surface-alt);
+  color: var(--text-secondary);
+}
+
+.inline-prompt-btn.cancel:hover {
+  background: var(--bg-surface-hover);
+}
+
+.inline-prompt-btn.confirm {
+  background: var(--accent-primary);
+  color: var(--text-on-accent);
+}
+
+.inline-prompt-btn.confirm:hover {
+  background: var(--accent-primary-hover);
+}
+</style>

--- a/pkg/rancher-desktop/pages/filesystem/CodeEditor.vue
+++ b/pkg/rancher-desktop/pages/filesystem/CodeEditor.vue
@@ -1,0 +1,303 @@
+<template>
+  <div
+    ref="containerRef"
+    class="code-editor-container"
+  />
+</template>
+
+<script lang="ts">
+import * as monaco from 'monaco-editor';
+import { defineComponent, ref, onMounted, onBeforeUnmount, watch } from 'vue';
+
+import { applyMonacoTheme } from './monacoThemeBridge';
+
+// Configure Monaco workers for Electron
+// See: https://github.com/microsoft/monaco-editor/blob/main/samples/electron-esm-webpack/index.js
+(self as any).MonacoEnvironment = {
+  getWorkerUrl(_moduleId: string, label: string) {
+    if (label === 'json') {
+      return './json.worker.bundle.js';
+    }
+    if (label === 'css' || label === 'scss' || label === 'less') {
+      return './css.worker.bundle.js';
+    }
+    if (label === 'html' || label === 'handlebars' || label === 'razor') {
+      return './html.worker.bundle.js';
+    }
+    if (label === 'typescript' || label === 'javascript') {
+      return './ts.worker.bundle.js';
+    }
+    return './editor.worker.bundle.js';
+  },
+};
+
+const EXT_LANGUAGE_MAP: Record<string, string> = {
+  '.ts':         'typescript',
+  '.tsx':        'typescript',
+  '.js':         'javascript',
+  '.jsx':        'javascript',
+  '.mjs':        'javascript',
+  '.cjs':        'javascript',
+  '.json':       'json',
+  '.jsonc':      'json',
+  '.html':       'html',
+  '.htm':        'html',
+  '.css':        'css',
+  '.scss':       'scss',
+  '.less':       'less',
+  '.xml':        'xml',
+  '.svg':        'xml',
+  '.yaml':       'yaml',
+  '.yml':        'yaml',
+  '.toml':       'ini',
+  '.py':         'python',
+  '.sh':         'shell',
+  '.bash':       'shell',
+  '.zsh':        'shell',
+  '.sql':        'sql',
+  '.graphql':    'graphql',
+  '.gql':        'graphql',
+  '.dockerfile': 'dockerfile',
+  '.go':         'go',
+  '.rs':         'rust',
+  '.rb':         'ruby',
+  '.php':        'php',
+  '.java':       'java',
+  '.c':          'c',
+  '.cpp':        'cpp',
+  '.h':          'cpp',
+  '.cs':         'csharp',
+  '.swift':      'swift',
+  '.kt':         'kotlin',
+  '.lua':        'lua',
+  '.r':          'r',
+  '.ini':        'ini',
+  '.conf':       'ini',
+  '.cfg':        'ini',
+  '.env':        'ini',
+  '.txt':        'plaintext',
+  '.log':        'plaintext',
+  '.gitignore':  'plaintext',
+};
+
+const FILENAME_LANGUAGE_MAP: Record<string, string> = {
+  dockerfile:      'dockerfile',
+  makefile:        'shell',
+  justfile:        'shell',
+  rakefile:        'ruby',
+  gemfile:         'ruby',
+  '.editorconfig': 'ini',
+};
+
+function getLanguageFromFile(ext: string, filePath?: string): string {
+  if (filePath) {
+    const basename = filePath.split('/').pop()?.toLowerCase() || '';
+    if (FILENAME_LANGUAGE_MAP[basename]) return FILENAME_LANGUAGE_MAP[basename];
+  }
+  return EXT_LANGUAGE_MAP[ext.toLowerCase()] || 'plaintext';
+}
+
+export default defineComponent({
+  name: 'CodeEditor',
+
+  props: {
+    content:  { type: String, default: '' },
+    filePath: { type: String, default: '' },
+    fileExt:  { type: String, default: '' },
+    isDark:   { type: Boolean, default: false },
+    readOnly: { type: Boolean, default: false },
+    line:     { type: Number, default: undefined },
+  },
+
+  emits: ['dirty'],
+
+  setup(props, { emit }) {
+    const containerRef = ref<HTMLDivElement | null>(null);
+    let editor: monaco.editor.IStandaloneCodeEditor | null = null;
+
+    function createEditor() {
+      if (!containerRef.value) {
+        console.warn('CodeEditor: Container ref not available');
+        return;
+      }
+
+      try {
+        const language = getLanguageFromFile(props.fileExt, props.filePath);
+
+        console.log('CodeEditor: Creating editor with content length:', props.content?.length);
+        console.log('CodeEditor: Editor language:', language);
+        console.log('CodeEditor: Initial content preview:', props.content?.substring(0, 100));
+
+        // Register the custom theme from CSS variables before creating the editor
+        applyMonacoTheme(props.isDark);
+
+        editor = monaco.editor.create(containerRef.value, {
+          value:                      props.content || '',
+          language,
+          theme:                      'sulla-custom',
+          readOnly:                   props.readOnly,
+          automaticLayout:            true,
+          minimap:                    { enabled: true },
+          scrollBeyondLastLine:       false,
+          fontSize:                   13,
+          lineNumbers:                'on',
+          renderLineHighlight:        'line',
+          wordWrap:                   'on',
+          padding:                    { top: 8 },
+          // Disable features that require web workers
+          hover:                      { enabled: false },
+          parameterHints:             { enabled: false },
+          // Disable language services that use workers
+          quickSuggestions:           { other: false, comments: false, strings: false },
+          suggestOnTriggerCharacters: false,
+          acceptSuggestionOnEnter:    'off',
+          tabCompletion:              'off',
+          wordBasedSuggestions:       'off',
+        });
+
+        // Check content immediately after creation and force render
+        setTimeout(() => {
+          if (editor) {
+            const model = editor.getModel();
+            if (model) {
+              console.log('CodeEditor: After creation - model value length:', model.getValue().length);
+              console.log('CodeEditor: After creation - model value preview:', model.getValue().substring(0, 100));
+
+              // Force Monaco to render the content
+              editor.layout();
+              const targetLine = props.line && props.line > 0 ? props.line : 1;
+              editor.revealLineInCenter(targetLine);
+              editor.setPosition({ lineNumber: targetLine, column: 1 });
+              editor.focus();
+
+              // Force a content refresh
+              setTimeout(() => {
+                if (editor) {
+                  editor.layout();
+                  const refreshedModel = editor.getModel();
+                  if (refreshedModel) {
+                    console.log('CodeEditor: After refresh - model value length:', refreshedModel.getValue().length);
+                  }
+                }
+              }, 200);
+            }
+          }
+        }, 100);
+
+        // Listen for content changes to mark as dirty
+        editor.onDidChangeModelContent(() => {
+          // Emit dirty event to parent component
+          emit('dirty');
+        });
+
+        console.log('CodeEditor: Editor created successfully');
+      } catch (error) {
+        console.error('CodeEditor: Failed to create editor', error);
+      }
+    }
+
+    function updateContent() {
+      if (editor) {
+        console.log('CodeEditor: Updating content, length:', props.content?.length);
+        const language = getLanguageFromFile(props.fileExt, props.filePath);
+        const model = editor.getModel();
+        if (model) {
+          console.log('CodeEditor: Setting model language to:', language);
+          monaco.editor.setModelLanguage(model, language);
+          console.log('CodeEditor: Setting model value, current value length:', model.getValue().length);
+          model.setValue(props.content || '');
+          console.log('CodeEditor: Model value set, new length:', model.getValue().length);
+
+          // Force display update
+          editor.layout();
+          const targetLine = props.line && props.line > 0 ? props.line : 1;
+          editor.revealLineInCenter(targetLine);
+          editor.setPosition({ lineNumber: targetLine, column: 1 });
+
+          // Additional force - recreate model if needed
+          setTimeout(() => {
+            if (editor && model.getValue().length === 0 && props.content?.length > 0) {
+              console.log('CodeEditor: Model still empty, forcing content...');
+              const newModel = monaco.editor.createModel(props.content || '', language);
+              editor.setModel(newModel);
+              editor.layout();
+              const tl = props.line && props.line > 0 ? props.line : 1;
+              editor.revealLineInCenter(tl);
+              editor.setPosition({ lineNumber: tl, column: 1 });
+            }
+          }, 100);
+        } else {
+          console.error('CodeEditor: No model found on editor');
+        }
+      } else {
+        console.warn('CodeEditor: Editor not available for content update');
+      }
+    }
+
+    function updateReadOnly() {
+      if (editor) {
+        editor.updateOptions({ readOnly: props.readOnly });
+      }
+    }
+
+    function updateTheme() {
+      // Re-register the custom theme with fresh CSS variable values, then apply
+      applyMonacoTheme(props.isDark);
+    }
+
+    onMounted(createEditor);
+
+    watch(() => props.content, updateContent);
+    watch(() => props.fileExt, updateContent);
+    watch(() => props.isDark, updateTheme);
+    watch(() => props.readOnly, updateReadOnly);
+    watch(() => props.line, (newLine) => {
+      if (editor && newLine && newLine > 0) {
+        editor.revealLineInCenter(newLine);
+        editor.setPosition({ lineNumber: newLine, column: 1 });
+        editor.focus();
+      }
+    });
+
+    onBeforeUnmount(() => {
+      if (editor) {
+        editor.dispose();
+        editor = null;
+      }
+    });
+
+    // Expose method to get current editor content
+    const getContent = () => {
+      return editor?.getValue() || props.content;
+    };
+
+    const insertAtCursor = (text: string) => {
+      if (!editor) return;
+      const selection = editor.getSelection();
+      if (selection) {
+        editor.executeEdits('inject-variable', [{
+          range:            selection,
+          text,
+          forceMoveMarkers: true,
+        }]);
+      }
+      editor.focus();
+    };
+
+    return {
+      containerRef,
+      getContent,
+      insertAtCursor,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.code-editor-container {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+</style>

--- a/pkg/rancher-desktop/pages/filesystem/FileContextMenu.vue
+++ b/pkg/rancher-desktop/pages/filesystem/FileContextMenu.vue
@@ -1,0 +1,495 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="visible"
+      ref="menuRef"
+      class="context-menu"
+      :class="{ dark: isDark }"
+      :style="{ top: posY + 'px', left: posX + 'px' }"
+      @contextmenu.prevent
+    >
+      <!-- New File / New Folder -->
+      <button
+        class="context-menu-item"
+        @click="action('new-file')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line
+            x1="12"
+            y1="18"
+            x2="12"
+            y2="12"
+          />
+          <line
+            x1="9"
+            y1="15"
+            x2="15"
+            y2="15"
+          />
+        </svg>
+        <span>New File</span>
+      </button>
+      <button
+        class="context-menu-item"
+        @click="action('new-folder')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+          <line
+            x1="12"
+            y1="11"
+            x2="12"
+            y2="17"
+          />
+          <line
+            x1="9"
+            y1="14"
+            x2="15"
+            y2="14"
+          />
+        </svg>
+        <span>New Folder</span>
+      </button>
+      <div class="context-menu-sep" />
+
+      <!-- Cut / Copy / Paste -->
+      <button
+        class="context-menu-item"
+        @click="action('cut')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle
+            cx="6"
+            cy="6"
+            r="3"
+          />
+          <circle
+            cx="6"
+            cy="18"
+            r="3"
+          />
+          <line
+            x1="20"
+            y1="4"
+            x2="8.12"
+            y2="15.88"
+          />
+          <line
+            x1="14.47"
+            y1="14.48"
+            x2="20"
+            y2="20"
+          />
+          <line
+            x1="8.12"
+            y1="8.12"
+            x2="12"
+            y2="12"
+          />
+        </svg>
+        <span>Cut</span>
+        <span class="context-menu-shortcut">⌘X</span>
+      </button>
+      <button
+        class="context-menu-item"
+        @click="action('copy')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <rect
+            width="14"
+            height="14"
+            x="8"
+            y="8"
+            rx="2"
+            ry="2"
+          />
+          <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+        </svg>
+        <span>Copy</span>
+        <span class="context-menu-shortcut">⌘C</span>
+      </button>
+      <button
+        v-if="hasClipboard"
+        class="context-menu-item"
+        @click="action('paste')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+          <rect
+            x="8"
+            y="2"
+            width="8"
+            height="4"
+            rx="1"
+            ry="1"
+          />
+        </svg>
+        <span>Paste</span>
+        <span class="context-menu-shortcut">⌘V</span>
+      </button>
+      <div class="context-menu-sep" />
+
+      <!-- Rename / Delete -->
+      <button
+        class="context-menu-item"
+        @click="action('rename')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+          <path d="m15 5 4 4" />
+        </svg>
+        <span>Rename</span>
+      </button>
+      <button
+        class="context-menu-item danger"
+        @click="action('delete')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M3 6h18" />
+          <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+          <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+          <line
+            x1="10"
+            y1="11"
+            x2="10"
+            y2="17"
+          />
+          <line
+            x1="14"
+            y1="11"
+            x2="14"
+            y2="17"
+          />
+        </svg>
+        <span>Delete</span>
+      </button>
+      <div class="context-menu-sep" />
+
+      <!-- Copy Path / Copy Relative Path -->
+      <button
+        class="context-menu-item"
+        @click="action('copy-path')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+        <span>Copy Path</span>
+      </button>
+      <button
+        class="context-menu-item"
+        @click="action('copy-relative-path')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+        <span>Copy Relative Path</span>
+      </button>
+      <div class="context-menu-sep" />
+
+      <!-- Reveal / Open -->
+      <button
+        class="context-menu-item"
+        @click="action('reveal')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+          <circle
+            cx="12"
+            cy="12"
+            r="3"
+          />
+        </svg>
+        <span>Reveal in Finder</span>
+      </button>
+      <button
+        v-if="!isDir"
+        class="context-menu-item"
+        @click="action('open-external')"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+          <polyline points="15 3 21 3 21 9" />
+          <line
+            x1="10"
+            y1="14"
+            x2="21"
+            y2="3"
+          />
+        </svg>
+        <span>Open with Default App</span>
+      </button>
+      <div
+        v-if="!isDir"
+        class="context-menu-sep"
+      />
+
+      <!-- Open with... (files only) -->
+      <template v-if="!isDir">
+        <div class="context-menu-subheader">
+          Open with…
+        </div>
+        <button
+          class="context-menu-item"
+          @click="action('open-code-editor')"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
+          </svg>
+          <span>Code Editor</span>
+        </button>
+      </template>
+    </div>
+  </Teleport>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted, onBeforeUnmount, nextTick, computed } from 'vue';
+
+export default defineComponent({
+  name: 'FileContextMenu',
+
+  props: {
+    isDark:       { type: Boolean, default: false },
+    hasClipboard: { type: Boolean, default: false },
+  },
+
+  emits: ['action'],
+
+  setup(props, { emit, expose }) {
+    const visible = ref(false);
+    const posX = ref(0);
+    const posY = ref(0);
+    const isDir = ref(false);
+    const fileExt = ref('');
+    const menuRef = ref<HTMLElement | null>(null);
+
+    let targetPath = '';
+
+    function show(event: MouseEvent, filePath: string, dir: boolean, ext?: string) {
+      targetPath = filePath;
+      isDir.value = dir;
+      fileExt.value = ext || '';
+      posX.value = event.clientX;
+      posY.value = event.clientY;
+      visible.value = true;
+
+      nextTick(() => {
+        if (menuRef.value) {
+          const rect = menuRef.value.getBoundingClientRect();
+          const vw = window.innerWidth;
+          const vh = window.innerHeight;
+
+          if (rect.right > vw) posX.value = vw - rect.width - 4;
+          if (rect.bottom > vh) posY.value = vh - rect.height - 4;
+        }
+      });
+    }
+
+    function hide() {
+      visible.value = false;
+    }
+
+    function action(type: string) {
+      emit('action', { type, path: targetPath, isDir: isDir.value });
+      hide();
+    }
+
+    function onClickOutside(e: MouseEvent) {
+      if (menuRef.value && !menuRef.value.contains(e.target as Node)) {
+        hide();
+      }
+    }
+
+    function onEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') hide();
+    }
+
+    onMounted(() => {
+      document.addEventListener('mousedown', onClickOutside);
+      document.addEventListener('keydown', onEsc);
+    });
+
+    onBeforeUnmount(() => {
+      document.removeEventListener('mousedown', onClickOutside);
+      document.removeEventListener('keydown', onEsc);
+    });
+
+    expose({ show, hide });
+
+    return { visible, posX, posY, isDir, menuRef, action, hasClipboard: props.hasClipboard };
+  },
+});
+</script>
+
+<style scoped>
+.context-menu {
+  position: fixed;
+  z-index: 9999;
+  min-width: 180px;
+  background: var(--bg-surface);
+  border: 1px solid var(--bg-surface-hover);
+  border-radius: 6px;
+  padding: 4px 0;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12), 0 1px 3px rgba(0, 0, 0, 0.08);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: var(--fs-code);
+}
+
+.context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 12px;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+  line-height: 1;
+}
+
+.context-menu-item:hover {
+  background: var(--bg-hover);
+}
+
+.context-menu-item.danger {
+  color: var(--text-error);
+}
+
+.context-menu-item.danger:hover {
+  background: var(--bg-error);
+}
+
+.context-menu-shortcut {
+  margin-left: auto;
+  font-size: var(--fs-body-sm);
+  color: var(--text-muted);
+  padding-left: 16px;
+}
+
+.context-menu-sep {
+  height: 1px;
+  background: var(--bg-surface-hover);
+  margin: 4px 0;
+}
+
+.context-menu-subheader {
+  padding: 8px 12px;
+  font-weight: bold;
+  font-size: var(--fs-body-sm);
+  color: var(--text-secondary);
+}
+</style>

--- a/pkg/rancher-desktop/pages/filesystem/FileTreeNode.vue
+++ b/pkg/rancher-desktop/pages/filesystem/FileTreeNode.vue
@@ -1,0 +1,292 @@
+<template>
+  <div class="file-tree-node">
+    <div
+      class="file-tree-row"
+      :class="{
+        'is-dir': entry.isDir,
+        'is-selected': selectedPaths.has(entry.path),
+        'is-highlighted': highlightPath === entry.path,
+        'drop-target': entry.isDir && dropTargetPath === entry.path,
+      }"
+      :style="{ paddingLeft: (depth * 16 + 8) + 'px' }"
+      @click="handleClick($event)"
+      @contextmenu.prevent="handleContextMenu"
+      @dragover.prevent.stop="handleDragOver"
+      @dragleave.stop="handleDragLeave"
+      @drop.prevent.stop="handleDrop"
+    >
+      <!-- Chevron for directories -->
+      <span
+        v-if="entry.isDir"
+        class="chevron"
+        :class="{ expanded: isExpanded }"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="currentColor"
+        >
+          <path d="M6 4l4 4-4 4" />
+        </svg>
+      </span>
+      <span
+        v-else
+        class="chevron-spacer"
+      />
+
+      <!-- File/folder icon -->
+      <span class="node-icon">
+        <!-- Folder open -->
+        <svg
+          v-if="entry.isDir && isExpanded"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="icon-folder"
+        >
+          <path d="M3 7v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2H5a2 2 0 0 1-2-2V7" />
+          <path d="M8 5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2" />
+          <path d="M21 15H9.5a2 2 0 0 0-1.9 1.4L6 21h11.5a2 2 0 0 0 1.9-1.4L21 15Z" />
+        </svg>
+        <!-- Folder closed -->
+        <svg
+          v-else-if="entry.isDir"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="icon-folder"
+        >
+          <path d="M4 20h16a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13c0 1.1.9 2 2 2Z" />
+        </svg>
+        <!-- File -->
+        <svg
+          v-else
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          class="icon-file"
+        >
+          <path
+            d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+            fill="currentColor"
+            opacity="0.08"
+          />
+          <polyline points="14 2 14 8 20 8" />
+        </svg>
+      </span>
+
+      <!-- Label -->
+      <span
+        class="node-label"
+        :title="entry.path"
+      >{{ entry.name }}</span>
+    </div>
+
+    <!-- Children (if expanded directory) -->
+    <div v-if="entry.isDir && isExpanded">
+      <div
+        v-if="isLoading"
+        class="file-tree-row"
+        :style="{ paddingLeft: ((depth + 1) * 16 + 8) + 'px' }"
+      >
+        <span class="loading-text">Loading…</span>
+      </div>
+      <FileTreeNode
+        v-for="child in children"
+        :key="child.path"
+        :entry="child"
+        :depth="depth + 1"
+        :expanded-dirs="expandedDirs"
+        :children-map="childrenMap"
+        :loading-dirs="loadingDirs"
+        :selected-paths="selectedPaths"
+        :drop-target-path="dropTargetPath"
+        :highlight-path="highlightPath"
+        @toggle-dir="$emit('toggle-dir', $event)"
+        @select-file="$emit('select-file', $event)"
+        @context-menu="$emit('context-menu', $event)"
+        @drop-files="$emit('drop-files', $event)"
+        @drag-hover="$emit('drag-hover', $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed, type PropType } from 'vue';
+
+interface FileEntry {
+  name:  string;
+  path:  string;
+  isDir: boolean;
+  size:  number;
+  ext:   string;
+}
+
+export default defineComponent({
+  name: 'FileTreeNode',
+
+  props: {
+    entry:          { type: Object as PropType<FileEntry>, required: true },
+    depth:          { type: Number, required: true },
+    expandedDirs:   { type: Object as PropType<Set<string>>, required: true },
+    childrenMap:    { type: Object as PropType<Record<string, FileEntry[]>>, required: true },
+    loadingDirs:    { type: Object as PropType<Set<string>>, required: true },
+    selectedPaths:  { type: Object as PropType<Set<string>>, default: () => new Set() },
+    dropTargetPath: { type: String, default: '' },
+    highlightPath:  { type: String, default: '' },
+  },
+
+  emits: ['toggle-dir', 'select-file', 'context-menu', 'drop-files', 'drag-hover'],
+
+  setup(props, { emit }) {
+    const isExpanded = computed(() => props.expandedDirs.has(props.entry.path));
+    const isLoading = computed(() => props.loadingDirs.has(props.entry.path));
+    const children = computed(() => props.childrenMap[props.entry.path] || []);
+
+    function handleClick(event: MouseEvent) {
+      if (props.entry.isDir) {
+        emit('toggle-dir', props.entry.path);
+      }
+      emit('select-file', { entry: props.entry, shiftKey: event.shiftKey, metaKey: event.metaKey || event.ctrlKey });
+    }
+
+    function handleContextMenu(event: MouseEvent) {
+      emit('context-menu', { event, entry: props.entry });
+    }
+
+    function handleDragOver(event: DragEvent) {
+      if (!props.entry.isDir) return;
+      if (!event.dataTransfer?.types.includes('Files')) return;
+      event.dataTransfer.dropEffect = 'copy';
+      emit('drag-hover', props.entry.path);
+    }
+
+    function handleDragLeave() {
+      if (!props.entry.isDir) return;
+      emit('drag-hover', '');
+    }
+
+    function handleDrop(event: DragEvent) {
+      if (!props.entry.isDir) return;
+      if (!event.dataTransfer?.files.length) return;
+      emit('drop-files', { dirPath: props.entry.path, files: event.dataTransfer.files });
+    }
+
+    return { isExpanded, isLoading, children, handleClick, handleContextMenu, handleDragOver, handleDragLeave, handleDrop };
+  },
+});
+</script>
+
+<style scoped>
+.file-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding-right: 8px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.file-tree-row:hover {
+  background: var(--bg-hover);
+}
+
+.file-tree-row.is-selected {
+  background: var(--bg-surface,rgba(0, 120, 212, 0.1));
+}
+
+:global(.dark) .file-tree-row.is-selected {
+  background: var(--bg-surface,rgba(0, 120, 212, 0.3));
+}
+
+.file-tree-row.is-highlighted {
+  background: var(--bg-surface, rgba(0, 120, 212, 0.1));
+  border-left: 3px solid var(--accent-primary, rgba(0, 120, 212, 0.4));
+}
+
+:global(.dark) .file-tree-row.is-highlighted {
+  background: var(--bg-surface, rgba(0, 120, 212, 0.2));
+  border-left-color: var(--accent-primary, rgba(0, 120, 212, 0.5));
+}
+
+.chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  transition: transform 0.1s ease;
+  transform: rotate(0deg);
+  color: var(--text-muted);
+}
+
+.chevron.expanded {
+  transform: rotate(90deg);
+}
+
+.chevron-spacer {
+  display: inline-block;
+  width: 16px;
+  flex-shrink: 0;
+}
+
+.node-icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--text-secondary);
+}
+
+.icon-folder {
+  color: inherit;
+}
+
+.icon-file {
+  color: var(--text-muted);
+}
+
+.node-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--fs-code);
+  line-height: 22px;
+}
+
+.loading-text {
+  color: var(--text-muted);
+  font-size: var(--fs-body-sm);
+  font-style: italic;
+}
+
+.file-tree-row.drop-target {
+  background: var(--bg-surface);
+}
+
+:global(.dark) .file-tree-row.drop-target {
+  background: var(--bg-surface);
+}
+</style>

--- a/pkg/rancher-desktop/pages/filesystem/FileTreeSidebar.vue
+++ b/pkg/rancher-desktop/pages/filesystem/FileTreeSidebar.vue
@@ -1,0 +1,728 @@
+<template>
+  <div
+    class="file-tree-sidebar"
+    :class="{ dark: isDark }"
+  >
+    <div class="file-tree-header">
+      <span class="file-tree-title">EXPLORER</span>
+      <div class="file-tree-actions">
+        <button
+          class="action-btn"
+          title="New File"
+          @click="newFileAtRoot"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+            <line
+              x1="12"
+              y1="18"
+              x2="12"
+              y2="12"
+            />
+            <line
+              x1="9"
+              y1="15"
+              x2="15"
+              y2="15"
+            />
+          </svg>
+        </button>
+        <button
+          class="action-btn"
+          title="New Folder"
+          @click="newFolderAtRoot"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+            <line
+              x1="12"
+              y1="11"
+              x2="12"
+              y2="17"
+            />
+            <line
+              x1="9"
+              y1="14"
+              x2="15"
+              y2="14"
+            />
+          </svg>
+        </button>
+        <button
+          class="action-btn"
+          title="Upload File"
+          @click="triggerUpload"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="17 8 12 3 7 8" />
+            <line
+              x1="12"
+              y1="3"
+              x2="12"
+              y2="15"
+            />
+          </svg>
+        </button>
+        <button
+          class="action-btn"
+          title="Close Panel"
+          @click="$emit('close')"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <line
+              x1="18"
+              y1="6"
+              x2="6"
+              y2="18"
+            />
+            <line
+              x1="6"
+              y1="6"
+              x2="18"
+              y2="18"
+            />
+          </svg>
+        </button>
+      </div>
+      <input
+        ref="uploadInputRef"
+        type="file"
+        multiple
+        style="display: none"
+        @change="onUploadInput"
+      >
+    </div>
+    <div
+      v-if="loading && entries.length === 0"
+      class="file-tree-loading"
+    >
+      Loading…
+    </div>
+    <div
+      v-else
+      class="file-tree-scroll"
+      :class="{ 'drop-active': dropTargetPath === rootPath }"
+      @dragover.prevent="onScrollDragOver"
+      @dragleave="onScrollDragLeave"
+      @drop.prevent="onScrollDrop"
+    >
+      <FileTreeNode
+        v-for="entry in entries"
+        :key="entry.path"
+        :entry="entry"
+        :depth="0"
+        :expanded-dirs="expandedDirs"
+        :children-map="childrenMap"
+        :loading-dirs="loadingDirs"
+        :selected-paths="selectedPaths"
+        :drop-target-path="dropTargetPath"
+        :highlight-path="highlightPath"
+        @toggle-dir="toggleDir"
+        @select-file="selectFile"
+        @context-menu="onContextMenu"
+        @drop-files="onDropFiles"
+        @drag-hover="onDragHover"
+      />
+    </div>
+    <FileContextMenu
+      ref="contextMenuRef"
+      :is-dark="isDark"
+      :has-clipboard="!!fileClipboard"
+      @action="onContextAction"
+    />
+    <InlinePrompt
+      ref="inlinePromptRef"
+      :is-dark="isDark"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { ipcRenderer, clipboard } from 'electron';
+import { defineComponent, ref, onMounted, onBeforeUnmount, watch } from 'vue';
+
+import FileContextMenu from './FileContextMenu.vue';
+import FileTreeNode from './FileTreeNode.vue';
+import InlinePrompt from '../editor/InlinePrompt.vue';
+
+export interface FileEntry {
+  name:        string;
+  path:        string;
+  isDir:       boolean;
+  size:        number;
+  ext:         string;
+  editorType?: 'code';
+  line?:       number;
+}
+
+export default defineComponent({
+  name: 'FileTreeSidebar',
+
+  components: { FileTreeNode, FileContextMenu, InlinePrompt },
+
+  props: {
+    isDark:        { type: Boolean, default: false },
+    highlightPath: { type: String, default: '' },
+  },
+
+  emits: ['file-selected', 'tree-changed', 'close'],
+
+  setup(props, { emit }) {
+    const entries = ref<FileEntry[]>([]);
+    const expandedDirs = ref<Set<string>>(new Set());
+    const childrenMap = ref<Record<string, FileEntry[]>>({});
+    const loadingDirs = ref<Set<string>>(new Set());
+    const loading = ref(true);
+    const selectedPaths = ref<Set<string>>(new Set());
+    const lastSelectedPath = ref('');
+    const rootPath = ref('');
+    const inlinePromptRef = ref<InstanceType<typeof InlinePrompt> | null>(null);
+
+    async function loadRoot() {
+      loading.value = true;
+      try {
+        rootPath.value = await ipcRenderer.invoke('filesystem-get-root');
+        console.log('[FileTree] loadRoot rootPath:', rootPath.value);
+        const result = await ipcRenderer.invoke('filesystem-read-dir', rootPath.value);
+        console.log('[FileTree] loadRoot entries:', result.length, result.map((e: FileEntry) => `${ e.isDir ? 'D' : 'F' } ${ e.name } (ext: ${ e.ext })`));
+        entries.value = result;
+      } catch (err) {
+        console.error('[FileTree] Failed to load root:', err);
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    async function loadChildren(dirPath: string) {
+      console.log('[FileTree] loadChildren:', dirPath);
+      loadingDirs.value.add(dirPath);
+      try {
+        const result = await ipcRenderer.invoke('filesystem-read-dir', dirPath);
+        console.log('[FileTree] loadChildren result for', dirPath, ':', result.length, 'entries:', result.map((e: FileEntry) => `${ e.isDir ? 'D' : 'F' } ${ e.name }`));
+        childrenMap.value = { ...childrenMap.value, [dirPath]: result };
+      } catch (err) {
+        console.error('[FileTree] Failed to load dir:', dirPath, err);
+      } finally {
+        loadingDirs.value.delete(dirPath);
+      }
+    }
+
+    async function toggleDir(dirPath: string) {
+      const expanded = new Set(expandedDirs.value);
+      if (expanded.has(dirPath)) {
+        expanded.delete(dirPath);
+      } else {
+        expanded.add(dirPath);
+        if (!childrenMap.value[dirPath]) {
+          await loadChildren(dirPath);
+        }
+      }
+      expandedDirs.value = expanded;
+    }
+
+    /** Build a flat list of all visible entry paths in tree order */
+    function getVisiblePaths(): string[] {
+      const result: string[] = [];
+      function walk(items: FileEntry[]) {
+        for (const item of items) {
+          result.push(item.path);
+          if (item.isDir && expandedDirs.value.has(item.path)) {
+            const kids = childrenMap.value[item.path];
+            if (kids) walk(kids);
+          }
+        }
+      }
+      walk(entries.value);
+      return result;
+    }
+
+    function selectFile(payload: { entry: FileEntry; shiftKey: boolean; metaKey: boolean }) {
+      const { entry, shiftKey, metaKey } = payload;
+
+      if (shiftKey && lastSelectedPath.value) {
+        // Range select: select everything between lastSelectedPath and this entry
+        const visible = getVisiblePaths();
+        const startIdx = visible.indexOf(lastSelectedPath.value);
+        const endIdx = visible.indexOf(entry.path);
+        if (startIdx !== -1 && endIdx !== -1) {
+          const from = Math.min(startIdx, endIdx);
+          const to = Math.max(startIdx, endIdx);
+          const rangeSet = new Set(selectedPaths.value);
+          for (let i = from; i <= to; i++) {
+            rangeSet.add(visible[i]);
+          }
+          selectedPaths.value = rangeSet;
+        }
+      } else if (metaKey) {
+        // Toggle individual item
+        const next = new Set(selectedPaths.value);
+        if (next.has(entry.path)) {
+          next.delete(entry.path);
+        } else {
+          next.add(entry.path);
+        }
+        selectedPaths.value = next;
+        lastSelectedPath.value = entry.path;
+      } else {
+        // Normal click — single select
+        selectedPaths.value = new Set([entry.path]);
+        lastSelectedPath.value = entry.path;
+      }
+
+      // Open the file in the editor (only for non-dir single clicks without meta)
+      if (!entry.isDir && !metaKey && !shiftKey) {
+        emit('file-selected', entry);
+      }
+    }
+
+    const contextMenuRef = ref<any>(null);
+    const fileClipboard = ref<{ path: string; operation: 'copy' | 'cut' } | null>(null);
+
+    function onContextMenu(payload: { event: MouseEvent; entry: FileEntry }) {
+      contextMenuRef.value?.show(payload.event, payload.entry.path, payload.entry.isDir, payload.entry.ext);
+    }
+
+    async function refreshDir(dirPath: string) {
+      try {
+        const result = await ipcRenderer.invoke('filesystem-read-dir', dirPath);
+        childrenMap.value = { ...childrenMap.value, [dirPath]: result };
+      } catch { /* ignore */ }
+    }
+
+    async function refreshParentOrRoot(targetPath: string) {
+      const parentDir = targetPath.substring(0, targetPath.lastIndexOf('/'));
+      if (parentDir === rootPath.value) {
+        await loadRoot();
+      } else {
+        await refreshDir(parentDir);
+      }
+    }
+
+    async function onContextAction(payload: { type: string; path: string; isDir: boolean }) {
+      const { type, path: targetPath } = payload;
+
+      try {
+        switch (type) {
+        case 'new-file': {
+          const name = await inlinePromptRef.value?.show('New file name:');
+          if (!name) return;
+          await ipcRenderer.invoke('filesystem-create-file', targetPath, name);
+          await refreshDir(targetPath);
+          if (!expandedDirs.value.has(targetPath)) {
+            expandedDirs.value = new Set([...expandedDirs.value, targetPath]);
+          }
+          emit('tree-changed');
+          break;
+        }
+        case 'new-folder': {
+          const name = await inlinePromptRef.value?.show('New folder name:');
+          if (!name) return;
+          await ipcRenderer.invoke('filesystem-create-dir', targetPath, name);
+          await refreshDir(targetPath);
+          if (!expandedDirs.value.has(targetPath)) {
+            expandedDirs.value = new Set([...expandedDirs.value, targetPath]);
+          }
+          emit('tree-changed');
+          break;
+        }
+        case 'cut':
+          fileClipboard.value = { path: targetPath, operation: 'cut' };
+          break;
+        case 'copy':
+          fileClipboard.value = { path: targetPath, operation: 'copy' };
+          break;
+        case 'paste': {
+          if (!fileClipboard.value) return;
+          const { path: srcPath, operation } = fileClipboard.value;
+          if (operation === 'copy') {
+            await ipcRenderer.invoke('filesystem-copy', srcPath, targetPath);
+          } else {
+            await ipcRenderer.invoke('filesystem-move', srcPath, targetPath);
+            // Refresh source parent after move
+            await refreshParentOrRoot(srcPath);
+            fileClipboard.value = null;
+          }
+          await refreshDir(targetPath);
+          if (!expandedDirs.value.has(targetPath)) {
+            expandedDirs.value = new Set([...expandedDirs.value, targetPath]);
+          }
+          emit('tree-changed');
+          break;
+        }
+        case 'rename': {
+          const oldName = targetPath.substring(targetPath.lastIndexOf('/') + 1);
+          const newName = await inlinePromptRef.value?.show('Rename to:', oldName);
+          if (!newName || newName === oldName) return;
+          await ipcRenderer.invoke('filesystem-rename', targetPath, newName);
+          await refreshParentOrRoot(targetPath);
+          emit('tree-changed');
+          break;
+        }
+        case 'delete': {
+          const name = targetPath.substring(targetPath.lastIndexOf('/') + 1);
+          const confirmed = confirm(`Delete "${ name }"? This cannot be undone.`);
+          if (!confirmed) return;
+          await ipcRenderer.invoke('filesystem-delete', targetPath);
+          await refreshParentOrRoot(targetPath);
+          // Clear clipboard if the deleted item was in it
+          if (fileClipboard.value?.path.startsWith(targetPath)) {
+            fileClipboard.value = null;
+          }
+          emit('tree-changed');
+          break;
+        }
+        case 'copy-path':
+          clipboard.writeText(targetPath);
+          break;
+        case 'copy-relative-path': {
+          const relative = targetPath.replace(rootPath.value, '').replace(/^\//, '');
+          clipboard.writeText(relative);
+          break;
+        }
+        case 'reveal':
+          await ipcRenderer.invoke('filesystem-reveal', targetPath);
+          break;
+        case 'open-external':
+          await ipcRenderer.invoke('filesystem-open-external', targetPath);
+          break;
+        case 'open-code-editor':
+          // Emit file-selected with forced code editor
+          emit('file-selected', {
+            name:       targetPath.split('/').pop() || '',
+            path:       targetPath,
+            isDir:      false,
+            size:       0,
+            ext:        targetPath.split('.').pop() || '',
+            editorType: 'code',
+          });
+          break;
+        }
+      } catch (err: any) {
+        console.error(`Context action "${ type }" failed:`, err);
+        alert(err?.message || 'Operation failed');
+      }
+    }
+
+    // ── Toolbar actions ──────────────────────────────────────
+    const uploadInputRef = ref<HTMLInputElement | null>(null);
+
+    async function newFileAtRoot() {
+      const name = await inlinePromptRef.value?.show('New file name:');
+      if (!name) return;
+      try {
+        await ipcRenderer.invoke('filesystem-create-file', rootPath.value, name);
+        await loadRoot();
+        emit('tree-changed');
+      } catch (err: any) {
+        alert(err?.message || 'Failed to create file');
+      }
+    }
+
+    async function newFolderAtRoot() {
+      const name = await inlinePromptRef.value?.show('New folder name:');
+      if (!name) return;
+      try {
+        await ipcRenderer.invoke('filesystem-create-dir', rootPath.value, name);
+        await loadRoot();
+        emit('tree-changed');
+      } catch (err: any) {
+        alert(err?.message || 'Failed to create folder');
+      }
+    }
+
+    function triggerUpload() {
+      uploadInputRef.value?.click();
+    }
+
+    async function uploadFiles(files: FileList | File[], destDir: string) {
+      for (const file of Array.from(files)) {
+        try {
+          const buffer = await file.arrayBuffer();
+          const base64 = btoa(
+            new Uint8Array(buffer).reduce((data, byte) => data + String.fromCharCode(byte), ''),
+          );
+          await ipcRenderer.invoke('filesystem-upload', destDir, file.name, base64);
+        } catch (err: any) {
+          console.error(`Upload failed for ${ file.name }:`, err);
+        }
+      }
+    }
+
+    async function onUploadInput(event: Event) {
+      const input = event.target as HTMLInputElement;
+      if (!input.files || input.files.length === 0) return;
+      await uploadFiles(input.files, rootPath.value);
+      input.value = '';
+      await loadRoot();
+      emit('tree-changed');
+    }
+
+    // ── Drag and drop ────────────────────────────────────────
+    const dropTargetPath = ref('');
+
+    function onScrollDragOver(event: DragEvent) {
+      if (!event.dataTransfer?.types.includes('Files')) return;
+      event.dataTransfer.dropEffect = 'copy';
+      dropTargetPath.value = rootPath.value;
+    }
+
+    function onScrollDragLeave() {
+      dropTargetPath.value = '';
+    }
+
+    async function onScrollDrop(event: DragEvent) {
+      dropTargetPath.value = '';
+      if (!event.dataTransfer?.files.length) return;
+      await uploadFiles(event.dataTransfer.files, rootPath.value);
+      await loadRoot();
+      emit('tree-changed');
+    }
+
+    function onDragHover(dirPath: string) {
+      dropTargetPath.value = dirPath;
+    }
+
+    async function onDropFiles(payload: { dirPath: string; files: FileList }) {
+      dropTargetPath.value = '';
+      await uploadFiles(payload.files, payload.dirPath);
+      await refreshDir(payload.dirPath);
+      if (!expandedDirs.value.has(payload.dirPath)) {
+        expandedDirs.value = new Set([...expandedDirs.value, payload.dirPath]);
+      }
+      emit('tree-changed');
+    }
+
+    // Watch for highlightPath changes to expand directories
+    watch(() => props.highlightPath, async(newPath: string) => {
+      if (!newPath) return;
+
+      // Split the path into segments to expand each directory
+      const segments = newPath.split('/').filter((s: string) => s);
+      let currentPath = '';
+
+      for (const segment of segments) {
+        currentPath += '/' + segment;
+
+        // Skip if this is the file itself (last segment)
+        if (currentPath === newPath) break;
+
+        // Expand this directory if not already expanded
+        if (!expandedDirs.value.has(currentPath)) {
+          expandedDirs.value = new Set([...expandedDirs.value, currentPath]);
+          // Load children if not already loaded
+          if (!childrenMap.value[currentPath]) {
+            await loadChildren(currentPath);
+          }
+        }
+      }
+
+      // Set as selected path to highlight it
+      selectedPaths.value = new Set([newPath]);
+      lastSelectedPath.value = newPath;
+    }, { immediate: true });
+
+    // ── Auto-refresh heartbeat ─────────────────────────────
+    let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+    async function heartbeat() {
+      if (!rootPath.value) return;
+      try {
+        const freshRoot = await ipcRenderer.invoke('filesystem-read-dir', rootPath.value);
+        const oldNames = entries.value.map(e => `${ e.name }:${ e.isDir }`).join(',');
+        const newNames = freshRoot.map((e: FileEntry) => `${ e.name }:${ e.isDir }`).join(',');
+        if (oldNames !== newNames) {
+          entries.value = freshRoot;
+        }
+        // Also refresh any expanded directories
+        for (const dirPath of expandedDirs.value) {
+          const freshChildren = await ipcRenderer.invoke('filesystem-read-dir', dirPath);
+          const oldChildNames = (childrenMap.value[dirPath] || []).map((e: FileEntry) => `${ e.name }:${ e.isDir }`).join(',');
+          const newChildNames = freshChildren.map((e: FileEntry) => `${ e.name }:${ e.isDir }`).join(',');
+          if (oldChildNames !== newChildNames) {
+            childrenMap.value = { ...childrenMap.value, [dirPath]: freshChildren };
+          }
+        }
+      } catch { /* ignore */ }
+    }
+
+    // Expose refresh for parent components
+    function refresh() {
+      loadRoot();
+      // Also refresh expanded dirs
+      for (const dirPath of expandedDirs.value) {
+        refreshDir(dirPath);
+      }
+    }
+
+    onMounted(() => {
+      loadRoot();
+      heartbeatTimer = setInterval(heartbeat, 3000);
+    });
+
+    onBeforeUnmount(() => {
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer);
+        heartbeatTimer = null;
+      }
+    });
+
+    return {
+      entries,
+      expandedDirs,
+      childrenMap,
+      loadingDirs,
+      loading,
+      selectedPaths,
+      rootPath,
+      toggleDir,
+      selectFile,
+      contextMenuRef,
+      inlinePromptRef,
+      fileClipboard,
+      onContextMenu,
+      onContextAction,
+      uploadInputRef,
+      newFileAtRoot,
+      newFolderAtRoot,
+      triggerUpload,
+      onUploadInput,
+      dropTargetPath,
+      onScrollDragOver,
+      onScrollDragLeave,
+      onScrollDrop,
+      onDragHover,
+      onDropFiles,
+      refresh,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.file-tree-sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: var(--fs-code);
+  user-select: none;
+  overflow: hidden;
+}
+
+.file-tree-header {
+  display: flex;
+  align-items: center;
+  padding: 0 8px 0 12px;
+  height: 35px;
+  font-size: var(--fs-body-sm);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border-default);
+  flex-shrink: 0;
+}
+
+.file-tree-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: auto;
+}
+
+.action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: none;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+.action-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.file-tree-scroll.drop-active {
+  background: var(--bg-surface,rgba(0, 120, 212, 0.06));
+  outline: 2px dashed var(--accent-primary, rgba(0, 120, 212, 0.3));
+  outline-offset: -2px;
+}
+
+.dark .file-tree-scroll.drop-active {
+  background: var(--bg-surface,rgba(0, 120, 212, 0.1));
+  outline-color: var(--accent-primary, rgba(0, 120, 212, 0.4));
+}
+
+.file-tree-loading {
+  padding: 16px 12px;
+  color: var(--text-muted);
+  font-size: var(--fs-body-sm);
+}
+
+.file-tree-scroll {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 2px 0;
+}
+
+.file-tree-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.file-tree-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.file-tree-scroll::-webkit-scrollbar-thumb {
+  background: var(--bg-hover);
+  border-radius: 3px;
+}
+</style>

--- a/pkg/rancher-desktop/pages/filesystem/monacoThemeBridge.ts
+++ b/pkg/rancher-desktop/pages/filesystem/monacoThemeBridge.ts
@@ -1,0 +1,136 @@
+/**
+ * Monaco Theme Bridge
+ *
+ * Reads the current CSS custom-property values from the DOM and registers
+ * a matching Monaco editor theme so that the code editor stays in sync with
+ * the rest of the Sulla workbench theme system.
+ *
+ * Call `applyMonacoTheme(isDark)` whenever the app theme changes.
+ */
+import * as monaco from 'monaco-editor';
+
+const THEME_NAME = 'sulla-custom';
+
+/** Read a CSS custom property from :root (computed). */
+function cssVar(name: string, fallback: string): string {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return raw || fallback;
+}
+
+/**
+ * Build and register (or re-register) the `sulla-custom` Monaco theme
+ * based on the live CSS variables the current workbench theme exposes.
+ */
+export function applyMonacoTheme(isDark: boolean): void {
+  const base = isDark ? 'vs-dark' : 'vs';
+
+  // -- Read live CSS variables --------------------------------------------------
+  const editorBg = cssVar('--editor-bg', isDark ? '#1e1e2e' : '#f0f0f0');
+  const textPrimary = cssVar('--text-primary', isDark ? '#ffffff' : '#0d0d0d');
+  const textSecondary = cssVar('--text-secondary', isDark ? '#94a3b8' : '#64748b');
+  const textMuted = cssVar('--text-muted', isDark ? '#cbd5e1' : '#94a3b8');
+  const bgSurface = cssVar('--bg-surface', isDark ? '#1e293b' : '#f8fafc');
+  const bgSurfaceAlt = cssVar('--bg-surface-alt', isDark ? '#334155' : '#f1f5f9');
+  const borderDefault = cssVar('--border-default', isDark ? 'rgba(255,255,255,0.1)' : '#e2e8f0');
+  const accentPrimary = cssVar('--accent-primary', isDark ? '#38bdf8' : '#0ea5e9');
+  const textError = cssVar('--text-error', isDark ? '#f87171' : '#dc2626');
+  const textWarning = cssVar('--text-warning', isDark ? '#fbbf24' : '#d97706');
+  const textSuccess = cssVar('--text-success', isDark ? '#4ade80' : '#16a34a');
+  const textInfo = cssVar('--text-info', isDark ? '#38bdf8' : '#0284c7');
+  const editorBorder = cssVar('--editor-border', isDark ? '#334155' : '#cbd5e1');
+  const selectionBg = cssVar('--terminal-selection-bg', isDark ? 'rgba(59,130,246,0.5)' : 'rgba(59,130,246,0.25)');
+
+  // -- Define the theme ---------------------------------------------------------
+  monaco.editor.defineTheme(THEME_NAME, {
+    base,
+    inherit: true,
+    rules:   [
+      // Let the base theme handle most syntax highlighting.
+      // Override only semantic categories we want to lock to our palette.
+      { token: 'comment', foreground: toHex6(textMuted) },
+      { token: 'keyword', foreground: toHex6(accentPrimary) },
+      { token: 'string', foreground: toHex6(textSuccess) },
+      { token: 'number', foreground: toHex6(textWarning) },
+      { token: 'type', foreground: toHex6(textInfo) },
+      { token: 'delimiter', foreground: toHex6(textSecondary) },
+      { token: 'invalid', foreground: toHex6(textError) },
+    ],
+    colors: {
+      // Editor chrome
+      'editor.background':                 editorBg,
+      'editor.foreground':                 textPrimary,
+      'editorLineNumber.foreground':       textMuted,
+      'editorLineNumber.activeForeground': textSecondary,
+      'editorCursor.foreground':           accentPrimary,
+
+      // Selection
+      'editor.selectionBackground':            selectionBg,
+      'editor.inactiveSelectionBackground':    selectionBg,
+
+      // Current line highlight
+      'editor.lineHighlightBackground':    bgSurfaceAlt,
+      'editor.lineHighlightBorder':        '#00000000',
+
+      // Widget / suggest / hover panels
+      'editorWidget.background':                bgSurface,
+      'editorWidget.border':                    editorBorder,
+      'editorSuggestWidget.background':         bgSurface,
+      'editorSuggestWidget.border':             editorBorder,
+      'editorSuggestWidget.selectedBackground': bgSurfaceAlt,
+      'editorHoverWidget.background':           bgSurface,
+      'editorHoverWidget.border':               editorBorder,
+
+      // Gutter / rulers
+      'editorGutter.background':           editorBg,
+      'editorRuler.foreground':            borderDefault,
+
+      // Minimap
+      'minimap.background': editorBg,
+
+      // Scrollbar
+      'scrollbarSlider.background':        isDark ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.08)',
+      'scrollbarSlider.hoverBackground':   isDark ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.15)',
+      'scrollbarSlider.activeBackground':  isDark ? 'rgba(255,255,255,0.3)' : 'rgba(0,0,0,0.2)',
+
+      // Diff editor
+      'diffEditor.insertedTextBackground': isDark ? 'rgba(74,222,128,0.12)' : 'rgba(34,197,94,0.12)',
+      'diffEditor.removedTextBackground':  isDark ? 'rgba(248,113,113,0.12)' : 'rgba(220,38,38,0.12)',
+    },
+  });
+
+  monaco.editor.setTheme(THEME_NAME);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a CSS color value to a 6-digit hex string (without #) that Monaco
+ * expects for token `foreground` rules. Falls back gracefully.
+ */
+function toHex6(cssColor: string): string {
+  // Already a hex?
+  const hex = cssColor.replace('#', '');
+  if (/^[0-9a-fA-F]{6}$/.test(hex)) return hex;
+  if (/^[0-9a-fA-F]{3}$/.test(hex)) {
+    return hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+  }
+
+  // Try parsing via a temp element for rgb/rgba/named colors
+  try {
+    const el = document.createElement('div');
+    el.style.color = cssColor;
+    document.body.appendChild(el);
+    const computed = getComputedStyle(el).color;
+    document.body.removeChild(el);
+    const match = /(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/.exec(computed);
+    if (match) {
+      return [match[1], match[2], match[3]]
+        .map(n => parseInt(n, 10).toString(16).padStart(2, '0'))
+        .join('');
+    }
+  } catch { /* noop */ }
+
+  return '888888'; // safe fallback
+}

--- a/pkg/rancher-desktop/sulla.ts
+++ b/pkg/rancher-desktop/sulla.ts
@@ -136,34 +136,6 @@ export async function instantiateSullaStart(): Promise<void> {
 
   await bootstrapSullaHome();
 
-  // PG connection issue — keep global handler
-  process.on('unhandledRejection', (reason: any) => {
-    if (reason?.code === '57P01') {
-      console.warn('[Unhandled] Ignored Postgres admin termination');
-
-      return;
-    }
-    console.error('[Unhandled Rejection]', reason);
-    const err = reason instanceof Error ? reason : new Error(String(reason));
-
-    submitErrorReport({
-      error_type:    err.name || 'unhandledRejection',
-      error_message: err.message,
-      stack_trace:   err.stack || '',
-      user_context:  'unhandledRejection in sulla.ts (Sulla services)',
-    }).catch(() => {});
-  });
-
-  process.on('uncaughtException', (err: Error) => {
-    console.error('[Uncaught Exception]', err);
-    submitErrorReport({
-      error_type:    err.name || 'uncaughtException',
-      error_message: err.message,
-      stack_trace:   err.stack || '',
-      user_context:  'uncaughtException in sulla.ts (Sulla services)',
-    }).catch(() => {});
-  });
-
   const lifecycle = getServiceLifecycleManager();
 
   // ── Independent services (no DB/Redis dependency) ──────────────────────

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -294,6 +294,9 @@ export interface IpcMainInvokeEvents {
   'claude-oauth:start':  () => { token?: string; error?: string };
   'claude-oauth:cancel': () => void;
 
+  /** OpenAI OAuth flow */
+  'openai-oauth:start': () => { success: boolean; error?: string };
+
   /** Sulla Cloud account auth (phone OTP / email / Apple) */
   'sulla-cloud:get-status':            () => { signedIn: boolean; userId: string; activeContractorId: string; phone: string; name: string; contractorCount: number; lastError?: string };
   'sulla-cloud:send-otp':              (phone: string) => { ok: boolean; error?: string; status: { signedIn: boolean; userId: string; activeContractorId: string; phone: string; name: string; contractorCount: number; lastError?: string } };

--- a/pkg/rancher-desktop/utils/iterator.ts
+++ b/pkg/rancher-desktop/utils/iterator.ts
@@ -86,6 +86,7 @@ export default class AsyncCallbackIterator<T> implements AsyncIterableIterator<T
    * Notify the iterator that the enumeration has completed.
    */
   end() {
+    if (this.#done) return;
     this.#resolve(doneSentinel);
   }
 

--- a/pkg/rancher-desktop/window/browserTabPreload.ts
+++ b/pkg/rancher-desktop/window/browserTabPreload.ts
@@ -30,6 +30,32 @@ const IPC_CHANNEL = 'browser-tab-view:bridge-event';
 const LOG_PREFIX = '[SULLA_TAB_PRELOAD]';
 
 /* ------------------------------------------------------------------ */
+/*  Theme bridge: sync Sulla Desktop theme → file:// page classes     */
+/* ------------------------------------------------------------------ */
+
+// Only inject theme classes into local file:// pages (agent-created HTML docs).
+// Injecting on external URLs is harmless but unnecessary.
+const IS_FILE_URL = location.protocol === 'file:';
+
+function applyThemeToPage(theme: string): void {
+  if (!IS_FILE_URL) return;
+  const root = document.documentElement;
+  const isLight = typeof theme === 'string' && theme.includes('-light');
+  root.classList.remove('dark', 'light');
+  root.classList.add(isLight ? 'light' : 'dark');
+}
+
+// Apply on load — async IPC call, resolves before first meaningful paint
+ipcRenderer.invoke('sulla-settings-get', 'theme', 'protocol-dark')
+  .then((theme: unknown) => applyThemeToPage(String(theme || 'protocol-dark')))
+  .catch(() => IS_FILE_URL && document.documentElement.classList.add('dark'));
+
+// Listen for live theme changes pushed from the main process
+ipcRenderer.on('sulla:theme-changed', (_event, theme: string) => {
+  applyThemeToPage(theme);
+});
+
+/* ------------------------------------------------------------------ */
 /*  1. Set up the bridge emit function BEFORE any page JS runs        */
 /* ------------------------------------------------------------------ */
 

--- a/resources/design-system/sulla.css
+++ b/resources/design-system/sulla.css
@@ -1,0 +1,1221 @@
+/*
+ * sulla.css — Sulla Desktop Design System
+ * Standalone CSS for project documents, dashboards, and HTML reports.
+ * Mirrors Protocol Dark (dark) and Default Light (light) themes exactly.
+ *
+ * Usage:
+ *   <link rel="stylesheet" href="sulla.css">
+ *   <html class="dark">   ← Protocol Dark (steel blue noir)
+ *   <html class="light">  ← Default Light (clean sky blue)
+ *   Auto-detects OS preference if no class is set.
+ *
+ * Theme toggle: add data-theme="dark" | data-theme="light" to <html>
+ * or use JS: document.documentElement.classList.toggle('dark')
+ */
+
+/* ================================================================== */
+/*  Google Fonts                                                       */
+/* ================================================================== */
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap');
+
+/* ================================================================== */
+/*  CSS Custom Properties — Dark (Protocol Dark)                      */
+/* ================================================================== */
+:root,
+.dark,
+[data-theme="dark"],
+html.dark {
+  color-scheme: dark;
+
+  /* Core palette */
+  --bg:           #0d1117;
+  --surface-1:    #161b22;
+  --surface-2:    #1c2128;
+  --surface-3:    #21262d;
+  --border:       #30363d;
+  --border-muted: #21262d;
+  --border-strong: #484f58;
+
+  /* Text hierarchy */
+  --text:         #e6edf3;
+  --text-secondary: #b1bac4;
+  --text-muted:   #8b949e;
+  --text-dim:     #6e7681;
+  --text-link:    #5096b3;
+  --text-on-accent: #ffffff;
+
+  /* Brand / Accent — Steel Blue */
+  --accent:       #5096b3;
+  --accent-hover: #6ab0cc;
+  --accent-dim:   rgba(80, 150, 179, 0.15);
+  --accent-border: rgba(80, 150, 179, 0.5);
+  --accent-glow:  rgba(80, 150, 179, 0.4);
+  --accent-glow-soft: rgba(80, 150, 179, 0.15);
+
+  /* Status */
+  --success:      #3fb950;
+  --warning:      #e3b341;
+  --danger:       #f85149;
+  --info:         #58a6ff;
+  --green:        #39ff14;
+  --green-bright: #57ff38;
+  --green-glow:   rgba(57, 255, 20, 0.5);
+
+  /* Status backgrounds */
+  --bg-success:   rgba(63, 185, 80, 0.18);
+  --bg-warning:   rgba(227, 179, 65, 0.18);
+  --bg-danger:    rgba(248, 81, 73, 0.18);
+  --bg-info:      rgba(88, 166, 255, 0.18);
+  --bg-accent:    rgba(80, 150, 179, 0.12);
+
+  /* Status borders */
+  --border-success: rgba(63, 185, 80, 0.4);
+  --border-warning: rgba(227, 179, 65, 0.4);
+  --border-danger:  rgba(248, 81, 73, 0.4);
+  --border-info:    rgba(88, 166, 255, 0.4);
+
+  /* Shadows */
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.03);
+  --shadow-md: 0 8px 32px rgba(0,0,0,0.4), 0 2px 8px rgba(0,0,0,0.2);
+  --shadow-lg: 0 12px 48px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.04);
+  --ring:      rgba(80, 150, 179, 0.5);
+
+  /* Scrollbar */
+  --scrollbar-thumb: #4485a0;
+  --scrollbar-track: #0d1117;
+
+  /* Typography */
+  --font-mono:    'JetBrains Mono', 'SF Mono', 'Fira Code', 'Roboto Mono', monospace;
+  --font-display: 'Playfair Display', Georgia, serif;
+  --font-body:    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  /* Radii */
+  --radius:    4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+
+  /* Sizing */
+  --nav-width: 220px;
+}
+
+/* ================================================================== */
+/*  CSS Custom Properties — Light (Default Light)                     */
+/* ================================================================== */
+@media (prefers-color-scheme: light) {
+  :root:not(.dark):not([data-theme="dark"]) {
+    color-scheme: light;
+
+    --bg:           #ffffff;
+    --surface-1:    #f8fafc;
+    --surface-2:    #f1f5f9;
+    --surface-3:    #e2e8f0;
+    --border:       #e2e8f0;
+    --border-muted: #f1f5f9;
+    --border-strong: #cbd5e1;
+
+    --text:         #0d0d0d;
+    --text-secondary: #64748b;
+    --text-muted:   #94a3b8;
+    --text-dim:     #b0b8c4;
+    --text-link:    #0284c7;
+    --text-on-accent: #ffffff;
+
+    --accent:       #0ea5e9;
+    --accent-hover: #0284c7;
+    --accent-dim:   rgba(14, 165, 233, 0.1);
+    --accent-border: rgba(14, 165, 233, 0.5);
+    --accent-glow:  rgba(14, 165, 233, 0.3);
+    --accent-glow-soft: rgba(14, 165, 233, 0.1);
+
+    --success:      #16a34a;
+    --warning:      #d97706;
+    --danger:       #dc2626;
+    --info:         #0284c7;
+    --green:        #16a34a;
+    --green-bright: #22c55e;
+    --green-glow:   rgba(22, 163, 74, 0.3);
+
+    --bg-success:   rgba(34, 197, 94, 0.1);
+    --bg-warning:   rgba(245, 158, 11, 0.1);
+    --bg-danger:    rgba(239, 68, 68, 0.1);
+    --bg-info:      rgba(14, 165, 233, 0.1);
+    --bg-accent:    rgba(14, 165, 233, 0.08);
+
+    --border-success: #86efac;
+    --border-warning: #fde68a;
+    --border-danger:  #fca5a5;
+    --border-info:    #7dd3fc;
+
+    --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+    --shadow-md: 0 4px 6px rgba(0,0,0,0.07), 0 2px 4px rgba(0,0,0,0.05);
+    --shadow-lg: 0 10px 25px rgba(0,0,0,0.1), 0 4px 10px rgba(0,0,0,0.06);
+    --ring:      rgba(14, 165, 233, 0.5);
+
+    --scrollbar-thumb: #cbd5e1;
+    --scrollbar-track: transparent;
+  }
+}
+
+.light,
+[data-theme="light"],
+html.light {
+  color-scheme: light;
+
+  --bg:           #ffffff;
+  --surface-1:    #f8fafc;
+  --surface-2:    #f1f5f9;
+  --surface-3:    #e2e8f0;
+  --border:       #e2e8f0;
+  --border-muted: #f1f5f9;
+  --border-strong: #cbd5e1;
+
+  --text:         #0d0d0d;
+  --text-secondary: #64748b;
+  --text-muted:   #94a3b8;
+  --text-dim:     #b0b8c4;
+  --text-link:    #0284c7;
+  --text-on-accent: #ffffff;
+
+  --accent:       #0ea5e9;
+  --accent-hover: #0284c7;
+  --accent-dim:   rgba(14, 165, 233, 0.1);
+  --accent-border: rgba(14, 165, 233, 0.5);
+  --accent-glow:  rgba(14, 165, 233, 0.3);
+  --accent-glow-soft: rgba(14, 165, 233, 0.1);
+
+  --success:      #16a34a;
+  --warning:      #d97706;
+  --danger:       #dc2626;
+  --info:         #0284c7;
+  --green:        #16a34a;
+  --green-bright: #22c55e;
+  --green-glow:   rgba(22, 163, 74, 0.3);
+
+  --bg-success:   rgba(34, 197, 94, 0.1);
+  --bg-warning:   rgba(245, 158, 11, 0.1);
+  --bg-danger:    rgba(239, 68, 68, 0.1);
+  --bg-info:      rgba(14, 165, 233, 0.1);
+  --bg-accent:    rgba(14, 165, 233, 0.08);
+
+  --border-success: #86efac;
+  --border-warning: #fde68a;
+  --border-danger:  #fca5a5;
+  --border-info:    #7dd3fc;
+
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07), 0 2px 4px rgba(0,0,0,0.05);
+  --shadow-lg: 0 10px 25px rgba(0,0,0,0.1), 0 4px 10px rgba(0,0,0,0.06);
+  --ring:      rgba(14, 165, 233, 0.5);
+
+  --scrollbar-thumb: #cbd5e1;
+  --scrollbar-track: transparent;
+}
+
+/* ================================================================== */
+/*  Reset & Base                                                       */
+/* ================================================================== */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: var(--scrollbar-track); }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--accent); }
+
+/* Selection */
+::selection { background: var(--accent-dim); color: var(--text); }
+
+/* ================================================================== */
+/*  Typography                                                         */
+/* ================================================================== */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+h1 { font-size: 2rem; }
+h2 { font-size: 1.5rem; }
+h3 { font-size: 1.25rem; }
+h4 { font-size: 1.1rem; }
+h5 { font-size: 1rem; }
+h6 { font-size: 0.875rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); }
+
+p { color: var(--text-secondary); line-height: 1.7; margin-bottom: 1rem; }
+p:last-child { margin-bottom: 0; }
+
+a { color: var(--text-link); text-decoration: none; }
+a:hover { color: var(--accent-hover); text-decoration: underline; }
+
+strong, b { font-weight: 600; color: var(--text); }
+em, i { font-style: italic; }
+small { font-size: 0.75rem; color: var(--text-muted); }
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--surface-2);
+  color: var(--accent);
+  padding: 0.1em 0.4em;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+
+pre {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
+
+blockquote {
+  border-left: 3px solid var(--accent);
+  margin: 1rem 0;
+  padding: 0.75rem 1.25rem;
+  background: var(--accent-dim);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2rem 0;
+}
+
+ul, ol { color: var(--text-secondary); padding-left: 1.5rem; margin-bottom: 1rem; }
+li { margin-bottom: 0.35rem; line-height: 1.6; }
+li:last-child { margin-bottom: 0; }
+
+/* ================================================================== */
+/*  Layout                                                             */
+/* ================================================================== */
+.sulla-app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sulla-sidebar {
+  width: var(--nav-width);
+  background: var(--bg);
+  border-right: 1px solid var(--border);
+  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.sulla-main {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.sulla-header {
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: 0 1.5rem;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  gap: 1rem;
+}
+
+.sulla-header-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.sulla-header-brand .brand-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent-glow);
+}
+
+.sulla-content {
+  padding: 2rem;
+  max-width: 960px;
+}
+
+.sulla-content.full-width {
+  max-width: none;
+}
+
+/* Simple no-sidebar page */
+.sulla-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.sulla-page-wide {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+/* ================================================================== */
+/*  Navigation                                                         */
+/* ================================================================== */
+.sulla-nav {
+  padding: 0.5rem 0;
+  flex: 1;
+}
+
+.sulla-nav-section {
+  padding: 1rem 1rem 0.375rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+}
+
+.sulla-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.15s, background 0.15s;
+  border-radius: 0;
+  font-family: var(--font-mono);
+  font-weight: 400;
+}
+
+.sulla-nav-item:hover {
+  background: var(--surface-3);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.sulla-nav-item.active {
+  background: var(--accent-dim);
+  color: var(--accent);
+  border-right: 2px solid var(--accent);
+}
+
+.sulla-nav-item .nav-icon {
+  font-size: 0.875rem;
+  opacity: 0.7;
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+}
+
+/* ================================================================== */
+/*  Cards & Surfaces                                                   */
+/* ================================================================== */
+.card {
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.card-lg {
+  padding: 1.75rem;
+  border-radius: var(--radius-lg);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  padding-bottom: 0.875rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.card-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.card-subtitle {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-top: 0.2rem;
+}
+
+.card-body { color: var(--text-secondary); font-size: 0.875rem; }
+
+.card-footer {
+  margin-top: 1rem;
+  padding-top: 0.875rem;
+  border-top: 1px solid var(--border-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* Card states */
+.card.card-success { border-color: var(--border-success); background: var(--bg-success); }
+.card.card-warning { border-color: var(--border-warning); background: var(--bg-warning); }
+.card.card-danger  { border-color: var(--border-danger);  background: var(--bg-danger); }
+.card.card-info    { border-color: var(--border-info);    background: var(--bg-info); }
+.card.card-accent  { border-color: var(--accent-border);  background: var(--accent-dim); }
+
+/* Surface levels */
+.surface-1 { background: var(--surface-1); border: 1px solid var(--border); border-radius: var(--radius-md); }
+.surface-2 { background: var(--surface-2); border: 1px solid var(--border-muted); border-radius: var(--radius); }
+
+/* Glass effect for dark mode */
+.glass {
+  background: rgba(22, 27, 34, 0.6);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+/* ================================================================== */
+/*  Grid                                                               */
+/* ================================================================== */
+.grid { display: grid; gap: 1rem; }
+.grid-2 { grid-template-columns: repeat(2, 1fr); }
+.grid-3 { grid-template-columns: repeat(3, 1fr); }
+.grid-4 { grid-template-columns: repeat(4, 1fr); }
+.grid-auto { grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+@media (max-width: 768px) {
+  .grid-2, .grid-3, .grid-4 { grid-template-columns: 1fr; }
+}
+
+/* ================================================================== */
+/*  Stat / KPI Block                                                   */
+/* ================================================================== */
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.stat-label {
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.stat-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text);
+  font-family: var(--font-mono);
+  line-height: 1;
+}
+
+.stat-value.accent { color: var(--accent); }
+.stat-value.success { color: var(--success); }
+.stat-value.warning { color: var(--warning); }
+.stat-value.danger  { color: var(--danger); }
+
+.stat-delta {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.stat-delta.up   { color: var(--success); }
+.stat-delta.down { color: var(--danger); }
+
+/* ================================================================== */
+/*  Badges & Tags                                                      */
+/* ================================================================== */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15em 0.55em;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  border-radius: var(--radius);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  vertical-align: middle;
+  border: 1px solid transparent;
+}
+
+.badge-default { background: var(--surface-3); color: var(--text-muted); border-color: var(--border); }
+.badge-accent  { background: var(--accent-dim); color: var(--accent); border-color: var(--accent-border); }
+.badge-success { background: var(--bg-success); color: var(--success); border-color: var(--border-success); }
+.badge-warning { background: var(--bg-warning); color: var(--warning); border-color: var(--border-warning); }
+.badge-danger  { background: var(--bg-danger);  color: var(--danger);  border-color: var(--border-danger); }
+.badge-info    { background: var(--bg-info);    color: var(--info);    border-color: var(--border-info); }
+
+/* Pill variant */
+.badge.pill { border-radius: 999px; }
+
+/* Status dot */
+.badge::before {
+  content: '';
+  display: none;
+}
+
+.badge.with-dot::before {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+/* ================================================================== */
+/*  Status Row                                                         */
+/* ================================================================== */
+.status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 0;
+  border-bottom: 1px solid var(--border-muted);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+.status-row:last-child { border-bottom: none; }
+.status-row .label { color: var(--text-muted); }
+.status-row .value { color: var(--text); font-weight: 500; }
+
+/* ================================================================== */
+/*  Table                                                              */
+/* ================================================================== */
+.sulla-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+.sulla-table th {
+  background: var(--bg);
+  color: var(--text-muted);
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.625rem 0.875rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.sulla-table td {
+  padding: 0.625rem 0.875rem;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-muted);
+  vertical-align: middle;
+}
+
+.sulla-table tr:last-child td { border-bottom: none; }
+
+.sulla-table tbody tr:hover td {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.sulla-table .col-key {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.sulla-table .col-muted {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+/* Wrapper for scroll */
+.table-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  overflow-x: auto;
+}
+
+.table-wrap .sulla-table {
+  margin: 0;
+}
+
+/* ================================================================== */
+/*  Checklist                                                          */
+/* ================================================================== */
+.checklist {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.checklist li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  font-size: 0.875rem;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 0;
+}
+
+.checklist li .check {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  margin-top: 2px;
+  background: var(--surface-2);
+}
+
+.checklist li.done .check {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.checklist li.done .check::after { content: '✓'; }
+.checklist li.in-progress .check {
+  background: var(--bg-warning);
+  border-color: var(--border-warning);
+  color: var(--warning);
+}
+.checklist li.in-progress .check::after { content: '~'; }
+
+.checklist li.done > span { color: var(--text-muted); text-decoration: line-through; }
+
+/* ================================================================== */
+/*  Progress Bar                                                       */
+/* ================================================================== */
+.progress-bar {
+  background: var(--surface-3);
+  border-radius: 999px;
+  height: 6px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+
+.progress-fill.success { background: var(--success); }
+.progress-fill.warning { background: var(--warning); }
+.progress-fill.danger  { background: var(--danger); }
+
+.progress-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.375rem;
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.progress-label .pct {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ================================================================== */
+/*  Timeline                                                           */
+/* ================================================================== */
+.timeline {
+  position: relative;
+  padding-left: 1.75rem;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 8px;
+  bottom: 8px;
+  width: 1px;
+  background: var(--border);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 1.5rem;
+}
+
+.timeline-item:last-child { margin-bottom: 0; }
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: -1.375rem;
+  top: 6px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--border);
+  border: 2px solid var(--bg);
+}
+
+.timeline-item.done::before    { background: var(--success); }
+.timeline-item.active::before  { background: var(--accent); box-shadow: 0 0 0 3px var(--accent-dim); }
+.timeline-item.blocked::before { background: var(--danger); }
+
+.timeline-date {
+  font-size: 0.6875rem;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.2rem;
+}
+
+.timeline-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  font-family: var(--font-mono);
+  margin-bottom: 0.25rem;
+}
+
+.timeline-body {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ================================================================== */
+/*  Alert / Notice                                                     */
+/* ================================================================== */
+.alert {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.alert-icon { flex-shrink: 0; font-size: 1rem; margin-top: 0.05rem; }
+.alert-body { flex: 1; }
+.alert-title { font-weight: 600; margin-bottom: 0.2rem; }
+.alert-msg { opacity: 0.85; }
+
+.alert-success { background: var(--bg-success); border-color: var(--border-success); color: var(--success); }
+.alert-warning { background: var(--bg-warning); border-color: var(--border-warning); color: var(--warning); }
+.alert-danger  { background: var(--bg-danger);  border-color: var(--border-danger);  color: var(--danger); }
+.alert-info    { background: var(--bg-info);    border-color: var(--border-info);    color: var(--info); }
+.alert-accent  { background: var(--accent-dim); border-color: var(--accent-border);  color: var(--accent); }
+
+/* ================================================================== */
+/*  Buttons                                                            */
+/* ================================================================== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s, border-color 0.15s, box-shadow 0.15s;
+  letter-spacing: 0.02em;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--text-on-accent);
+  border-color: var(--accent);
+}
+
+.btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  box-shadow: 0 0 12px var(--accent-glow-soft);
+  color: var(--text-on-accent);
+  text-decoration: none;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border);
+}
+
+.btn-ghost:hover {
+  background: var(--surface-3);
+  color: var(--text);
+  border-color: var(--border-strong);
+  text-decoration: none;
+}
+
+.btn-outline-accent {
+  background: var(--accent-dim);
+  color: var(--accent);
+  border-color: var(--accent-border);
+}
+
+.btn-outline-accent:hover {
+  background: var(--accent);
+  color: var(--text-on-accent);
+  text-decoration: none;
+}
+
+.btn-sm { padding: 0.3rem 0.75rem; font-size: 0.75rem; }
+.btn-xs { padding: 0.2rem 0.5rem; font-size: 0.6875rem; }
+
+/* ================================================================== */
+/*  Key-Value Metadata                                                 */
+/* ================================================================== */
+.meta-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+.meta-key {
+  color: var(--text-muted);
+  font-weight: 500;
+  white-space: nowrap;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.meta-val {
+  color: var(--text);
+}
+
+/* ================================================================== */
+/*  Terminal / Log Block                                               */
+/* ================================================================== */
+.terminal {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+.terminal-bar {
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 0.875rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.terminal-dots {
+  display: flex;
+  gap: 5px;
+}
+
+.terminal-dots span {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.terminal-dots .dot-red    { background: #ff5f57; }
+.terminal-dots .dot-yellow { background: #febc2e; }
+.terminal-dots .dot-green  { background: #28c840; }
+
+.terminal-title {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  flex: 1;
+  text-align: center;
+  margin-left: -3.5rem; /* optical center with dots */
+}
+
+.terminal-body {
+  padding: 1rem 1.25rem;
+  color: var(--text);
+  line-height: 1.7;
+  min-height: 3rem;
+  overflow-x: auto;
+}
+
+.terminal-body .cmd  { color: var(--accent); }
+.terminal-body .out  { color: var(--text-secondary); }
+.terminal-body .err  { color: var(--danger); }
+.terminal-body .warn { color: var(--warning); }
+.terminal-body .ok   { color: var(--success); }
+.terminal-body .dim  { color: var(--text-dim); }
+
+/* Prompt indicator */
+.prompt::before {
+  content: '$ ';
+  color: var(--accent);
+  user-select: none;
+}
+
+/* ================================================================== */
+/*  Section Heading                                                    */
+/* ================================================================== */
+.section {
+  margin-bottom: 2rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.section-title {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+}
+
+.section-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+/* Page title section */
+.page-hero {
+  padding: 2rem 0 1.5rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+
+.page-hero h1 {
+  font-size: 1.875rem;
+  margin-bottom: 0.5rem;
+}
+
+.page-hero p {
+  color: var(--text-muted);
+  font-size: 0.9375rem;
+  margin: 0;
+}
+
+/* ================================================================== */
+/*  Theme Toggle Button                                                */
+/* ================================================================== */
+.theme-toggle {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.35rem 0.625rem;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: all 0.15s;
+}
+
+.theme-toggle:hover {
+  background: var(--surface-3);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+/* ================================================================== */
+/*  Utility Classes                                                    */
+/* ================================================================== */
+.flex        { display: flex; }
+.flex-col    { flex-direction: column; }
+.items-center { align-items: center; }
+.items-start  { align-items: flex-start; }
+.justify-between { justify-content: space-between; }
+.justify-end  { justify-content: flex-end; }
+.gap-1  { gap: 0.25rem; }
+.gap-2  { gap: 0.5rem; }
+.gap-3  { gap: 0.75rem; }
+.gap-4  { gap: 1rem; }
+.gap-6  { gap: 1.5rem; }
+.gap-8  { gap: 2rem; }
+.wrap   { flex-wrap: wrap; }
+
+.p-1    { padding: 0.25rem; }
+.p-2    { padding: 0.5rem; }
+.p-3    { padding: 0.75rem; }
+.p-4    { padding: 1rem; }
+.p-5    { padding: 1.25rem; }
+.p-6    { padding: 1.5rem; }
+
+.mt-1 { margin-top: 0.25rem; }
+.mt-2 { margin-top: 0.5rem; }
+.mt-3 { margin-top: 0.75rem; }
+.mt-4 { margin-top: 1rem; }
+.mt-6 { margin-top: 1.5rem; }
+.mt-8 { margin-top: 2rem; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-3 { margin-bottom: 0.75rem; }
+.mb-4 { margin-bottom: 1rem; }
+.mb-6 { margin-bottom: 1.5rem; }
+.mb-8 { margin-bottom: 2rem; }
+
+.text-xs    { font-size: 0.6875rem; }
+.text-sm    { font-size: 0.8125rem; }
+.text-base  { font-size: 0.875rem; }
+.text-lg    { font-size: 1rem; }
+.text-xl    { font-size: 1.125rem; }
+.text-2xl   { font-size: 1.375rem; }
+.text-3xl   { font-size: 1.75rem; }
+
+.font-mono    { font-family: var(--font-mono); }
+.font-display { font-family: var(--font-display); }
+.font-normal  { font-weight: 400; }
+.font-medium  { font-weight: 500; }
+.font-semibold { font-weight: 600; }
+.font-bold    { font-weight: 700; }
+
+.text-primary   { color: var(--text); }
+.text-secondary { color: var(--text-secondary); }
+.text-muted     { color: var(--text-muted); }
+.text-dim       { color: var(--text-dim); }
+.text-accent    { color: var(--accent); }
+.text-success   { color: var(--success); }
+.text-warning   { color: var(--warning); }
+.text-danger    { color: var(--danger); }
+.text-info      { color: var(--info); }
+
+.uppercase { text-transform: uppercase; }
+.tracking-wide { letter-spacing: 0.08em; }
+.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nowrap   { white-space: nowrap; }
+
+.rounded    { border-radius: var(--radius); }
+.rounded-md { border-radius: var(--radius-md); }
+.rounded-lg { border-radius: var(--radius-lg); }
+.rounded-full { border-radius: 999px; }
+
+.w-full  { width: 100%; }
+.h-full  { height: 100%; }
+.min-w-0 { min-width: 0; }
+
+.sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0,0,0,0); white-space: nowrap; border-width: 0;
+}
+
+/* Glowing accent text */
+.glow-text {
+  color: var(--accent);
+  text-shadow: 0 0 20px var(--accent-glow);
+}
+
+/* Divider with label */
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text-dim);
+  font-size: 0.6875rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 1.5rem 0;
+}
+
+.divider::before, .divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+/* ================================================================== */
+/*  Print Tweaks                                                       */
+/* ================================================================== */
+@media print {
+  body { background: white; color: black; }
+  .sulla-sidebar, .sulla-header, .theme-toggle { display: none; }
+  .sulla-content { max-width: 100%; padding: 0; }
+  .card { border: 1px solid #ccc; box-shadow: none; }
+}

--- a/resources/design-system/template.html
+++ b/resources/design-system/template.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Project Name — Sulla</title>
+  <!--
+    Adjust this path to wherever sulla.css lives relative to this file.
+    e.g. ../../../designs/sulla.css or https://your-cdn/sulla.css
+  -->
+  <link rel="stylesheet" href="sulla.css">
+</head>
+<body>
+
+<!-- ================================================================
+     OPTION A: Page with sidebar navigation
+     Remove if you don't need a sidebar.
+     ================================================================ -->
+<div class="sulla-app">
+
+  <!-- ── Sidebar ── -->
+  <aside class="sulla-sidebar">
+    <!-- Brand logo area -->
+    <div class="sulla-header" style="height:52px; border-right:none; border-bottom:1px solid var(--border);">
+      <div class="sulla-header-brand">
+        <span class="brand-dot"></span>
+        Sulla
+      </div>
+    </div>
+
+    <nav class="sulla-nav">
+      <div class="sulla-nav-section">Navigation</div>
+      <a href="#overview"    class="sulla-nav-item active">
+        <span class="nav-icon">◈</span> Overview
+      </a>
+      <a href="#status"      class="sulla-nav-item">
+        <span class="nav-icon">◎</span> Status
+      </a>
+      <a href="#roadmap"     class="sulla-nav-item">
+        <span class="nav-icon">◷</span> Roadmap
+      </a>
+      <a href="#components"  class="sulla-nav-item">
+        <span class="nav-icon">▦</span> Components
+      </a>
+      <a href="#terminal"    class="sulla-nav-item">
+        <span class="nav-icon">▸</span> Terminal
+      </a>
+
+      <div class="sulla-nav-section" style="margin-top:.5rem;">Resources</div>
+      <a href="#"            class="sulla-nav-item">
+        <span class="nav-icon">⌗</span> Docs
+      </a>
+      <a href="#"            class="sulla-nav-item">
+        <span class="nav-icon">⊹</span> Settings
+      </a>
+    </nav>
+
+    <!-- Sidebar footer -->
+    <div style="padding:.75rem 1rem; border-top:1px solid var(--border);">
+      <div class="meta-grid">
+        <span class="meta-key">version</span>
+        <span class="meta-val">1.0.0</span>
+        <span class="meta-key">env</span>
+        <span class="badge badge-success" style="font-size:.6rem;">live</span>
+      </div>
+    </div>
+  </aside>
+
+  <!-- ── Main ── -->
+  <div class="sulla-main">
+
+    <!-- Header bar -->
+    <header class="sulla-header">
+      <div class="sulla-header-brand">
+        <span class="brand-dot"></span>
+        Project Name
+      </div>
+      <div class="flex items-center gap-3">
+        <span class="badge badge-accent with-dot">Active</span>
+        <button class="theme-toggle" onclick="toggleTheme()">☀ / ☾ Theme</button>
+      </div>
+    </header>
+
+    <!-- ── Content ── -->
+    <div class="sulla-content" id="overview">
+
+      <!-- Page hero -->
+      <div class="page-hero">
+        <h1>Project Name</h1>
+        <p>Short description of what this document covers. Replace this with the actual project summary.</p>
+        <div class="flex items-center gap-3 mt-3 flex-wrap">
+          <span class="badge badge-accent">Phase 1</span>
+          <span class="badge badge-success with-dot">On Track</span>
+          <span class="text-sm text-muted">Updated: 2026-05-05</span>
+        </div>
+      </div>
+
+      <!-- ── KPI Stats ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Key Metrics</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="grid grid-4 gap-4">
+          <div class="card">
+            <div class="stat">
+              <span class="stat-label">Total Tasks</span>
+              <span class="stat-value">24</span>
+              <span class="stat-delta up">▲ 3 this week</span>
+            </div>
+          </div>
+          <div class="card">
+            <div class="stat">
+              <span class="stat-label">Completed</span>
+              <span class="stat-value success">18</span>
+              <span class="stat-delta">75% done</span>
+            </div>
+          </div>
+          <div class="card">
+            <div class="stat">
+              <span class="stat-label">Blocked</span>
+              <span class="stat-value danger">2</span>
+              <span class="stat-delta down">Needs attention</span>
+            </div>
+          </div>
+          <div class="card">
+            <div class="stat">
+              <span class="stat-label">Velocity</span>
+              <span class="stat-value accent">4.2</span>
+              <span class="stat-delta">tasks/day</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Progress ── -->
+      <div class="section" id="status">
+        <div class="section-header">
+          <span class="section-title">Progress</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="card">
+          <div class="flex flex-col gap-4">
+
+            <div>
+              <div class="progress-label">
+                <span>Phase 1 — Setup</span>
+                <span class="pct">100%</span>
+              </div>
+              <div class="progress-bar">
+                <div class="progress-fill success" style="width:100%"></div>
+              </div>
+            </div>
+
+            <div>
+              <div class="progress-label">
+                <span>Phase 2 — Build</span>
+                <span class="pct">62%</span>
+              </div>
+              <div class="progress-bar">
+                <div class="progress-fill" style="width:62%"></div>
+              </div>
+            </div>
+
+            <div>
+              <div class="progress-label">
+                <span>Phase 3 — Launch</span>
+                <span class="pct">10%</span>
+              </div>
+              <div class="progress-bar">
+                <div class="progress-fill warning" style="width:10%"></div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Alerts ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Alerts</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="flex flex-col gap-3">
+          <div class="alert alert-success">
+            <span class="alert-icon">✓</span>
+            <div class="alert-body">
+              <div class="alert-title">Deployment complete</div>
+              <div class="alert-msg">All services healthy. No downtime detected.</div>
+            </div>
+          </div>
+          <div class="alert alert-warning">
+            <span class="alert-icon">⚠</span>
+            <div class="alert-body">
+              <div class="alert-title">Rate limit approaching</div>
+              <div class="alert-msg">API usage at 82% of monthly quota.</div>
+            </div>
+          </div>
+          <div class="alert alert-danger">
+            <span class="alert-icon">✕</span>
+            <div class="alert-body">
+              <div class="alert-title">Build failing</div>
+              <div class="alert-msg">main branch CI failing — 3 tests broken.</div>
+            </div>
+          </div>
+          <div class="alert alert-info">
+            <span class="alert-icon">ℹ</span>
+            <div class="alert-body">
+              <div class="alert-title">New version available</div>
+              <div class="alert-msg">v1.4.0 released. Review changelog before upgrading.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── 2-col: Checklist + Metadata ── -->
+      <div class="section" id="components">
+        <div class="section-header">
+          <span class="section-title">Phase Checklist</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="grid grid-2 gap-4">
+
+          <div class="card">
+            <div class="card-header">
+              <span class="card-title">Phase 1 Tasks</span>
+              <span class="badge badge-success">Done</span>
+            </div>
+            <ul class="checklist">
+              <li class="done"><span class="check"></span><span>LLC registration filed</span></li>
+              <li class="done"><span class="check"></span><span>Domain purchased</span></li>
+              <li class="done"><span class="check"></span><span>Brand identity complete</span></li>
+              <li class="in-progress"><span class="check"></span><span>Website in review</span></li>
+              <li><span class="check"></span><span>Paid ads setup</span></li>
+              <li><span class="check"></span><span>First booking received</span></li>
+            </ul>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <span class="card-title">Project Metadata</span>
+            </div>
+            <div class="meta-grid mt-2">
+              <span class="meta-key">owner</span>
+              <span class="meta-val">Jonathon Byrdziak</span>
+              <span class="meta-key">started</span>
+              <span class="meta-val">2026-05-01</span>
+              <span class="meta-key">deadline</span>
+              <span class="meta-val">2026-06-30</span>
+              <span class="meta-key">market</span>
+              <span class="meta-val">Coeur d'Alene / Spokane</span>
+              <span class="meta-key">phase</span>
+              <span class="badge badge-accent">1 of 3</span>
+              <span class="meta-key">status</span>
+              <span class="badge badge-success with-dot">Active</span>
+              <span class="meta-key">budget</span>
+              <span class="meta-val">$12,500</span>
+              <span class="meta-key">priority</span>
+              <span class="badge badge-warning">High</span>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- ── Table ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Task Table</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="table-wrap">
+          <table class="sulla-table">
+            <thead>
+              <tr>
+                <th>Task</th>
+                <th>Owner</th>
+                <th>Status</th>
+                <th>Due</th>
+                <th>Priority</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="col-key">LLC registration</td>
+                <td>Jonathon</td>
+                <td><span class="badge badge-success with-dot">Done</span></td>
+                <td class="col-muted">2026-05-10</td>
+                <td><span class="badge badge-danger">Critical</span></td>
+              </tr>
+              <tr>
+                <td class="col-key">Website v1</td>
+                <td>Jonathon</td>
+                <td><span class="badge badge-warning with-dot">In Review</span></td>
+                <td class="col-muted">2026-05-20</td>
+                <td><span class="badge badge-warning">High</span></td>
+              </tr>
+              <tr>
+                <td class="col-key">Google Ads setup</td>
+                <td>Jonathon</td>
+                <td><span class="badge badge-default">Pending</span></td>
+                <td class="col-muted">2026-06-01</td>
+                <td><span class="badge badge-info">Medium</span></td>
+              </tr>
+              <tr>
+                <td class="col-key">First client booking</td>
+                <td>—</td>
+                <td><span class="badge badge-default">Waiting</span></td>
+                <td class="col-muted">2026-06-15</td>
+                <td><span class="badge badge-warning">High</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- ── Timeline ── -->
+      <div class="section" id="roadmap">
+        <div class="section-header">
+          <span class="section-title">Timeline</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="card">
+          <div class="timeline">
+            <div class="timeline-item done">
+              <div class="timeline-date">May 2026</div>
+              <div class="timeline-title">Phase 1 — Foundation</div>
+              <div class="timeline-body">LLC, brand, website, basic tooling. First quotes sent.</div>
+            </div>
+            <div class="timeline-item active">
+              <div class="timeline-date">June 2026</div>
+              <div class="timeline-title">Phase 2 — First Revenue</div>
+              <div class="timeline-body">Paid ads live. Storm-chasing starts. First 5 jobs completed.</div>
+            </div>
+            <div class="timeline-item">
+              <div class="timeline-date">Q3 2026</div>
+              <div class="timeline-title">Phase 3 — Scale</div>
+              <div class="timeline-body">Hire first crew. Expand to gutters and siding. iPad sales app.</div>
+            </div>
+            <div class="timeline-item">
+              <div class="timeline-date">Q4 2026</div>
+              <div class="timeline-title">Phase 4 — Systems</div>
+              <div class="timeline-body">Full estimating platform. Insurance claim pipeline. Solar expansion.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Terminal block ── -->
+      <div class="section" id="terminal">
+        <div class="section-header">
+          <span class="section-title">Terminal Output</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="terminal">
+          <div class="terminal-bar">
+            <div class="terminal-dots">
+              <span class="dot-red"></span>
+              <span class="dot-yellow"></span>
+              <span class="dot-green"></span>
+            </div>
+            <span class="terminal-title">sulla — zsh</span>
+          </div>
+          <div class="terminal-body">
+            <div class="prompt cmd">sulla github/git_push '{"branch":"main","message":"feat: init project"}'</div>
+            <div class="out">↑ Pushing to origin/main...</div>
+            <div class="ok">✓ Push successful — HEAD at 8582b4d</div>
+            <div class="dim mt-2">─────────────────────────────────</div>
+            <div class="prompt cmd">sulla workflow/import_workflow '{"name":"daily-report"}'</div>
+            <div class="warn">⚠ Workflow already exists — skipping import</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Badges showcase ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Badges &amp; Tags</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="card">
+          <div class="flex wrap gap-2">
+            <span class="badge badge-default">Default</span>
+            <span class="badge badge-accent">Accent</span>
+            <span class="badge badge-success">Success</span>
+            <span class="badge badge-warning">Warning</span>
+            <span class="badge badge-danger">Danger</span>
+            <span class="badge badge-info">Info</span>
+            <span class="badge badge-success pill with-dot">Online</span>
+            <span class="badge badge-danger pill with-dot">Offline</span>
+            <span class="badge badge-warning pill with-dot">Degraded</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Buttons ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Buttons</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="card">
+          <div class="flex wrap gap-3">
+            <button class="btn btn-primary">Primary Action</button>
+            <button class="btn btn-outline-accent">Outline Accent</button>
+            <button class="btn btn-ghost">Ghost Button</button>
+            <button class="btn btn-primary btn-sm">Small</button>
+            <button class="btn btn-ghost btn-xs">Tiny</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Typography ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Typography</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="card card-lg">
+          <h1>Display Heading (h1)</h1>
+          <h2 class="mt-3">Section Heading (h2)</h2>
+          <h3 class="mt-3">Subsection (h3)</h3>
+          <h4 class="mt-3">Card Title (h4)</h4>
+          <h6 class="mt-3">Label heading (h6)</h6>
+          <p class="mt-4">Body text uses the monospace stack for the terminal-noir aesthetic. This paragraph demonstrates normal reading flow with line-height and color hierarchy.</p>
+          <p>A link looks like <a href="#">this anchor</a> and has hover behavior.</p>
+          <blockquote class="mt-3">
+            "Looking at the outside of our house used to be stressful, but now it feels good to walk outside." — Customer review
+          </blockquote>
+          <pre class="mt-3"><code>// Code block example
+const sulla = await import('sulla-desktop');
+await sulla.workflow.run('daily-report');</code></pre>
+          <p class="mt-3">Inline <code>code snippets</code> look like this within prose. <strong>Bold text</strong> and <em>italic text</em> also work.</p>
+        </div>
+      </div>
+
+      <!-- Footer padding -->
+      <div style="height:3rem;"></div>
+
+    </div><!-- /.sulla-content -->
+  </div><!-- /.sulla-main -->
+</div><!-- /.sulla-app -->
+
+<!--
+  OPTION B: Simple page without sidebar
+  Just wrap your content in <div class="sulla-page"> instead of the entire sulla-app structure.
+  Example:
+
+  <body>
+    <div class="sulla-page">
+      <div class="page-hero">
+        <h1>Project Name</h1>
+        <p>Subtitle goes here.</p>
+      </div>
+      ... rest of content ...
+    </div>
+  </body>
+-->
+
+<script>
+  // ── Theme Toggle ──────────────────────────────────────────────
+  function toggleTheme() {
+    const html = document.documentElement;
+    if (html.classList.contains('dark')) {
+      html.classList.replace('dark', 'light');
+    } else {
+      html.classList.replace('light', 'dark');
+    }
+    localStorage.setItem('sulla-theme', html.className);
+  }
+
+  // Restore saved theme on load
+  (function () {
+    const saved = localStorage.getItem('sulla-theme');
+    if (saved) {
+      document.documentElement.className = saved;
+    } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+      document.documentElement.className = 'light';
+    }
+  })();
+</script>
+
+</body>
+</html>

--- a/resources/sulla-docs/INDEX.md
+++ b/resources/sulla-docs/INDEX.md
@@ -5,6 +5,28 @@ Searchable reference for agents running inside Lima. All files are at:
 
 Search: `grep -r "keyword" <path-to-this-dir>/`
 
+## Session start — load these before acting
+
+When you wake up on a non-trivial task, read these in order:
+
+1. This INDEX (you're here) — maps every topic to a doc
+2. `tools/inventory.md` — every tool by category, saves `browse_tools` round-trips
+3. `agent-patterns/user-stories.md` — concrete plans for common requests
+4. `agent-patterns/known-gaps.md` — what you CAN'T do today; don't fake it
+5. `agent-patterns/writing-voice.md` — required reading before writing any prose for a human
+6. `~/sulla/identity/human/identity.md` — who you work for, operating model
+7. `~/sulla/identity/business/identity.md` — business model, active deadlines
+8. `~/sulla/identity/human/goals.md` — current goals, financial targets, operating rules
+9. `~/sulla/projects/ACTIVE_PROJECTS.md` — active projects and blockers
+
+For unfamiliar requests: `grep -rli '<keyword>' <path-to-this-dir>/` to find the relevant doc.
+
+**Writing anything a human will read?**
+→ [`agent-patterns/writing-voice.md`](agent-patterns/writing-voice.md) — applies to chat replies, docs, social posts, marketing copy, commit messages, PR descriptions, emails, READMEs, anything prose. The two non-negotiables: no end-of-response summary, no short-burst fact format. Read this before you write.
+
+**Creating project docs / dashboards / reports?**
+→ [`design-system.md`](design-system.md) — all project HTML must use `sulla.css`. Copy `template.html`, link the CSS relative to `~/sulla/designs/`, default `class="dark"` on `<html>`.
+
 **Start here when a user request comes in:**
 - [`tools/inventory.md`](tools/inventory.md) — master list of every tool the agent can call (~183 tools)
 - [`agent-patterns/user-stories.md`](agent-patterns/user-stories.md) — request → action playbook (covers all subsystems)
@@ -13,6 +35,7 @@ Search: `grep -r "keyword" <path-to-this-dir>/`
 - [`agent-patterns/mentions.md`](agent-patterns/mentions.md) — how to interpret `@routine:…`, `@function:…`, `@project:…` tokens in user messages
 - [`agent-patterns/citations.md`](agent-patterns/citations.md) — how to emit `<citations>` blocks that render as source cards
 - [`agent-patterns/user-consent.md`](agent-patterns/user-consent.md) — when to call `meta/request_user_input` to pause mid-turn and get explicit approve/deny from the user
+- [`agent-patterns/writing-voice.md`](agent-patterns/writing-voice.md) — how to write so output doesn't read like AI; the two non-negotiables (no end-summary, no bullet-burst) plus the full tell catalogue
 - [`verification-2026-04-23.md`](verification-2026-04-23.md) — what was verified live against the running system, what was wrong, what got fixed
 
 ## environment/
@@ -67,6 +90,7 @@ Search: `grep -r "keyword" <path-to-this-dir>/`
 - `citations.md` — The `<citations><source …/></citations>` XML protocol; when to emit, exact shape, rules against hallucinated sources
 - `mentions.md` — `@kind:slug` tokens in user messages (routine / skill / function / recipe / integration / workflow / project); how to resolve each
 - `user-consent.md` — 🚦 When to call `meta/request_user_input` vs when to charge ahead vs when to end the turn blocked; how to phrase the approval card
+- `writing-voice.md` — ✍️ Required reading before writing any prose for a human; bans end-summary wrap-ups and bullet-burst fact dumps; full AI-tell catalogue + positive rules
 
 ## marketplace/
 - `overview.md` — Recipes (Docker compose), catalog, install/uninstall, extension UIs
@@ -80,6 +104,11 @@ Search: `grep -r "keyword" <path-to-this-dir>/`
 
 ## mobile/
 - `overview.md` — Sulla Mobile (iOS): AI iPhone receptionist, push-to-talk to Desktop, lead inbox
+
+## design-system (project HTML docs)
+- [`design-system.md`](design-system.md) — ⭐ **ALL project docs must be HTML using this system** — sulla.css tokens, component classes, quick-start, CSS path
+- Actual CSS: `<app-resources>/design-system/sulla.css` → also at `~/sulla/designs/sulla.css`
+- Actual template: `<app-resources>/design-system/template.html` → also at `~/sulla/designs/template.html`
 
 ## identity/
 - `structure.md` — ~/sulla/identity/ layout, file formats, observational memory

--- a/resources/sulla-docs/agent-patterns/writing-voice.md
+++ b/resources/sulla-docs/agent-patterns/writing-voice.md
@@ -1,0 +1,135 @@
+# Writing Voice — Don't Sound Like AI
+
+This doc applies any time you're producing prose for a human to read: chat replies, documentation, social posts, marketing copy, commit messages, PR descriptions, email drafts, project docs, README files, anything. If a human's eyes will land on it, this doc applies.
+
+The goal is simple: write so a reader can't tell a model wrote it. Not because we're hiding it — because the patterns AI defaults to are genuinely bad writing, and humans find them exhausting.
+
+## The two worst offenders
+
+These are the patterns that immediately expose copy-pasted AI content. Avoid them harder than anything else on this page.
+
+### 1. No end-of-response summary
+
+When the answer is finished, stop. Do not restate what was just said. Do not "land the plane." The reader just read the answer — a closing paragraph that summarizes it is condescending and is the #1 thing that screams "this was pasted from a chatbot."
+
+Banned closers:
+- "In conclusion,"
+- "To summarize,"
+- "Overall,"
+- "In short,"
+- "The takeaway is,"
+- "Hopefully this helps!"
+- "Let me know if you have any questions."
+- Any sentence that recaps what was already said in the body
+
+End on the last substantive sentence. If the last paragraph is doing real work — making a new point, surfacing a tradeoff, naming a next step — that's a fine ending. If it's restating the body in compressed form, delete it.
+
+### 2. No short-burst fact format
+
+Do not fragment ideas into staccato bullets when flowing prose carries them better. This is the dominant format of modern AI-generated content (every social post, every blog intro, every "5 ways to X" listicle) and humans hate reading it. A wall of disconnected one-line bullets forces the reader to thread the connections themselves — it looks fast but reads slow.
+
+Bullets are correct for genuinely discrete items: commands, options, distinct steps in a procedure, items in a list that are actually parallel. Bullets are wrong as a substitute for paragraphs of connected thought.
+
+When you catch yourself fragmenting a paragraph into bullets, write the paragraph instead.
+
+### Why these two specifically
+
+The user has explicitly flagged these as the most frustrating AI tells. The end-summary is the structural giveaway. The bullet-burst is the formatting giveaway. Get these two right and most of the "AI feel" disappears.
+
+## The rest of the AI-tell catalogue
+
+These are the patterns identified by the broader research community. Avoid them.
+
+### Punctuation tells
+- **Em dash overuse.** AI uses em dashes every 50–80 words; humans every ~500. Use em dashes sparingly. Comma and period are usually fine.
+- **Curly/smart quotes** ("" '') in casual contexts where humans would type straight quotes (`""`).
+- **Excessive colons** introducing lists or examples.
+
+### Vocabulary fingerprints (the "banned word" list)
+Avoid these words unless they're genuinely the right word in context:
+
+`delve, showcase, leverage, utilize, navigate, foster, realm, tapestry, beacon, multifaceted, noteworthy, robust, seamless, holistic, ever-evolving, paradigm, intricate, nuanced, embark, journey, unleash, unlock, harness, empower, dive into, explore, comprehensive, vast, myriad, plethora, navigate the complexities, in today's fast-paced world, in the realm of`
+
+Latinate bias is a related tell — picking `commence / utilize / demonstrate` over `start / use / show`. Default to the shorter Anglo-Saxon word.
+
+### Sentence-structure tells
+- **"It's not X, it's Y"** parallelisms. ("It's not just code, it's craft.")
+- **"From X to Y"** comprehensive-sounding constructions. ("From startups to enterprises.")
+- **Rule of three.** Every list defaults to exactly three items. Vary it.
+- **Uniform sentence length.** Metronome rhythm of 15–20 words per sentence. Mix in fragments. And short sentences. Like this.
+- **Present-participial sentence openers** at elevated frequency. ("Building on this idea, …" / "Considering the implications, …")
+
+### Opener fingerprints
+- ChatGPT family: "Certainly!" / "Great question!" / "Of course!"
+- Claude family: "I'd be happy to" / "Absolutely"
+- Generic AI: "In today's fast-paced world…"
+
+Skip the throat-clearing entirely. Open with the actual content.
+
+### Tonal tells
+- **Meta-commentary.** "It's important to note that," "Let's explore," "Now, let's dive into."
+- **Excessive hedging.** "Arguably," "potentially," "it could be said," "some might say."
+- **Motivational-poster tone.** Every challenge becomes an opportunity, relentless positivity. Real writing has edges.
+- **Hedging seesaw.** Presenting both sides as equally valid when one is clearly wrong.
+- **Compliment sandwich.** Refusing to pick a winner when comparing options.
+
+### Content-level tells (the deepest)
+- **Abstraction trap.** "A unique mix of smells" instead of "burnt espresso and old books." Pick concrete nouns.
+- **Sensing without sensing.** Describing experience with no lived sensory detail.
+- **Subtext vacuum.** Flat — no irony, no mood, no implication. Real writing leaves space for the reader.
+- **Ghost citations.** "Studies show" without naming one. Either name the source or drop the claim.
+- **Over-explanation.** Defining terms the audience already knows.
+- **Treadmill effect.** Restating the same idea without advancing it.
+- **Missing personal stakes.** No first-hand investment. No preference. No skin in the game.
+
+### Surface artifacts
+- Zero typos, zero quirks, perfect grammar — real writing has texture.
+- Stray markdown / bold artifacts in supposedly clean prose.
+- Symmetrical list items where every bullet matches in length and structure.
+
+## What to do instead
+
+The positive rule under all of this: **humans want storytelling done with brevity.** They don't have time, and they want narrative arc. These two requirements are not in tension — real brevity is a tight paragraph that arcs through three connected ideas, not the same three ideas atomized into bullets that the reader has to thread back together.
+
+Concrete habits:
+
+- **Pick winners.** When comparing options, recommend one and say why. Don't sandwich.
+- **Use concrete nouns.** "Burnt espresso" beats "a unique mix of smells." "Tuesday at 4pm" beats "in the near future."
+- **Vary sentence length deliberately.** Mix long sentences with short. Use fragments where they punch.
+- **Break grammar rules on purpose** when the rhythm calls for it. Sentence fragments. One-word lines. Dashes mid-thought when you actually need one.
+- **Show preferences.** Real writing reveals the writer's stance. "I'd avoid X because Y" beats "X has both pros and cons."
+- **Skip the throat-clearing.** Open with the actual point. End on the last real idea.
+- **Trust the reader.** They got this far — don't over-define, don't restate, don't summarize.
+- **Use first person where natural.** "I checked the config" beats "the system was checked."
+- **Drop the corporate tone.** Use contractions. Sound like a person.
+
+## Quick self-check before sending
+
+Before you finalize any prose, scan it once:
+
+1. Does the last paragraph restate what came before? → Cut it.
+2. Are there bullets that should be a paragraph? → Convert them.
+3. Em dash count looking high? → Replace some with periods.
+4. Any banned words that aren't earning their spot? → Swap.
+5. Did you pick a winner / take a stance? → If no, reconsider.
+6. Any sentence opener like "Certainly," "Of course," "I'd be happy"? → Delete.
+
+Pass that check, send it.
+
+## Where this doc applies
+
+| Output type | Apply this doc? |
+|-------------|-----------------|
+| Chat replies in Sulla Desktop | Yes |
+| Project documentation (HTML/MD) | Yes |
+| Social posts (LinkedIn, X, etc.) | Yes — most important here |
+| Marketing copy / landing pages | Yes |
+| Commit messages | Yes (and keep them short) |
+| PR descriptions | Yes |
+| Email drafts | Yes |
+| README files | Yes |
+| Code comments | Mostly — see CLAUDE.md (default to no comments) |
+| Technical specs / RFCs | Yes (the structure can be formal; the prose still shouldn't read like AI) |
+| Tool output / status messages | Skip — these are just data |
+
+If a human reads it, this doc applies.

--- a/resources/sulla-docs/design-system.md
+++ b/resources/sulla-docs/design-system.md
@@ -24,6 +24,25 @@ They are also copied to the user's Sulla home on first use:
 
 ---
 
+## ❌ Anti-Pattern — DO NOT DO THIS
+
+Never hardcode dark-mode colors in a `<style>` block. This breaks light mode permanently and makes theme-switching impossible.
+
+```html
+<!-- WRONG — locks the page to dark mode forever -->
+<style>
+  :root {
+    --bg: #0d1117;
+    --text: #e6edf3;
+    /* ... all hardcoded dark values ... */
+  }
+</style>
+```
+
+The correct approach is always: link `sulla.css` + add the theme detection script below. The CSS file handles both themes via the `dark` / `light` class on `<html>`.
+
+---
+
 ## Minimal HTML stub
 
 ```html
@@ -187,6 +206,34 @@ var(--radius-lg)  /* 8px */
 | `.btn.btn-ghost` | Outline/transparent |
 | `.btn.btn-outline-accent` | Accent outline |
 | `.btn-sm`, `.btn-xs` | Size variants |
+
+---
+
+## Migrating Legacy Inline-Style Files
+
+If you encounter a project HTML file with a hardcoded `:root {}` block, convert it:
+
+1. Add `class="dark"` to `<html>`
+2. Remove the Google Fonts `<link>` tags (`sulla.css` imports them)
+3. Add `<link rel="stylesheet" href="../../designs/sulla.css" />` before `<style>`
+4. Replace the `:root {}` block with a small alias block that maps any custom names to `sulla.css` equivalents:
+
+```css
+/* Keep only aliases for non-standard variable names used in this file */
+:root {
+  --accent-soft: var(--accent-dim);
+  --steel: var(--accent); --steel-hover: var(--accent-hover);
+  --steel-soft: var(--accent-dim); --steel-border: var(--accent-border);
+  --green: var(--success); --green-bg: var(--bg-success); --green-border: var(--border-success);
+  --red: var(--danger); --red-bg: var(--bg-danger); --red-border: var(--border-danger);
+  --yellow: var(--warning); --yellow-bg: var(--bg-warning); --yellow-border: var(--border-warning);
+  --blue: var(--info); --blue-bg: var(--bg-info); --blue-border: var(--border-info);
+}
+```
+
+5. Add the theme detection script before `</body>` (see Minimal HTML stub above)
+
+The component styles themselves don't need to change as long as they reference CSS variables — the variables will now resolve correctly for both themes.
 
 ---
 

--- a/resources/sulla-docs/design-system.md
+++ b/resources/sulla-docs/design-system.md
@@ -1,0 +1,216 @@
+# Sulla Design System — Project HTML Files
+
+When creating project documents, dashboards, PRDs, or any HTML file that the user will open in a browser, use the Sulla design system so they look like a native extension of the app.
+
+---
+
+## File Locations
+
+These files ship bundled with every Sulla Desktop installation:
+
+| File | Location |
+|------|----------|
+| Stylesheet | `<app-resources>/design-system/sulla.css` |
+| Starter template | `<app-resources>/design-system/template.html` |
+
+They are also copied to the user's Sulla home on first use:
+
+| File | Location |
+|------|----------|
+| Stylesheet | `~/sulla/designs/sulla.css` |
+| Starter template | `~/sulla/designs/template.html` |
+
+> **Always use the `~/sulla/designs/` paths** in project HTML `<link>` tags — they're stable across app upgrades and repackages.
+
+---
+
+## Minimal HTML stub
+
+```html
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My Project — Sulla</title>
+  <link rel="stylesheet" href="../../designs/sulla.css">
+  <!-- Adjust relative path from ~/sulla/projects/<name>/ to ~/sulla/designs/ -->
+</head>
+<body>
+  <div class="sulla-page">
+    <div class="page-hero">
+      <h1>Project Title</h1>
+      <p>Description</p>
+    </div>
+    <!-- content here -->
+  </div>
+  <script>
+    (function(){
+      const s = localStorage.getItem('sulla-theme');
+      if (s) document.documentElement.className = s;
+      else if (window.matchMedia('(prefers-color-scheme: light)').matches)
+        document.documentElement.className = 'light';
+    })();
+  </script>
+</body>
+</html>
+```
+
+---
+
+## Theme Classes
+
+Apply to the `<html>` element:
+
+| Class | Result |
+|-------|--------|
+| `class="dark"` | **Protocol Dark** — steel blue on noir black (`#0d1117` bg, `#5096b3` accent) |
+| `class="light"` | **Protocol Light** — steel blue on pale blue-white (`#f4f7fb` bg, `#5096b3` accent) |
+| *(none)* | Auto-detects OS `prefers-color-scheme` |
+
+---
+
+## CSS Variables — Quick Reference
+
+All variables are defined in `sulla.css` and automatically apply from the active theme class.
+
+### Colors
+```css
+var(--bg)            /* Page background */
+var(--surface-1)     /* Cards, panels */
+var(--surface-2)     /* Nested panels */
+var(--surface-3)     /* Hover states */
+var(--border)        /* Default border */
+var(--border-muted)  /* Subtle border */
+var(--text)          /* Primary text */
+var(--text-secondary)
+var(--text-muted)
+var(--text-dim)
+var(--accent)        /* Steel blue #5096b3 (dark) / sky blue (light) */
+var(--success)       /* Green */
+var(--warning)       /* Amber */
+var(--danger)        /* Red */
+var(--info)          /* Blue */
+```
+
+### Typography
+```css
+var(--font-mono)     /* JetBrains Mono — body, code, UI labels */
+var(--font-display)  /* Playfair Display — headings */
+var(--font-body)     /* System sans — long-form prose */
+```
+
+### Spacing / Radius
+```css
+var(--radius)     /* 4px */
+var(--radius-md)  /* 6px */
+var(--radius-lg)  /* 8px */
+```
+
+---
+
+## Layout Patterns
+
+### Simple page (no sidebar)
+```html
+<div class="sulla-page">       <!-- max 900px, centered, 2rem padding -->
+  <div class="page-hero">...</div>
+  ...
+</div>
+```
+
+### Full app with sidebar
+```html
+<div class="sulla-app">
+  <aside class="sulla-sidebar">
+    <nav class="sulla-nav">
+      <a href="#" class="sulla-nav-item active">Item</a>
+    </nav>
+  </aside>
+  <div class="sulla-main">
+    <header class="sulla-header">...</header>
+    <div class="sulla-content">...</div>
+  </div>
+</div>
+```
+
+---
+
+## Component Classes — Cheat Sheet
+
+### Surfaces
+| Class | Use |
+|-------|-----|
+| `.card` | Standard surface card |
+| `.card-lg` | Larger padding card |
+| `.card-success/warning/danger/info/accent` | Status-tinted card |
+| `.glass` | Frosted glass (dark mode) |
+
+### Grids
+| Class | Use |
+|-------|-----|
+| `.grid.grid-2` | 2-column |
+| `.grid.grid-3` | 3-column |
+| `.grid.grid-4` | 4-column |
+| `.grid.grid-auto` | Auto-fill, min 240px |
+
+### Status
+| Class | Use |
+|-------|-----|
+| `.badge-accent/success/warning/danger/info/default` | Status badges |
+| `.badge.pill` | Rounded pill shape |
+| `.badge.with-dot` | Adds a status dot |
+| `.alert-success/warning/danger/info/accent` | Alert / notice box |
+
+### Data
+| Class | Use |
+|-------|-----|
+| `.table-wrap > table.sulla-table` | Styled table with scroll |
+| `.meta-grid > .meta-key + .meta-val` | Key-value metadata |
+| `.stat > .stat-label + .stat-value + .stat-delta` | KPI stat block |
+| `.progress-bar > .progress-fill` | Progress bar |
+| `.checklist` with `li.done / li.in-progress` | Checklist |
+
+### Narrative
+| Class | Use |
+|-------|-----|
+| `.timeline > .timeline-item.done/.active/.blocked` | Timeline |
+| `.terminal > .terminal-bar + .terminal-body` | Terminal block |
+| `.section > .section-header > .section-title + .section-rule` | Labeled section |
+| `.page-hero` | Page title + subtitle |
+| `.divider` | Labeled divider line |
+
+### Buttons
+| Class | Use |
+|-------|-----|
+| `.btn.btn-primary` | Steel blue fill |
+| `.btn.btn-ghost` | Outline/transparent |
+| `.btn.btn-outline-accent` | Accent outline |
+| `.btn-sm`, `.btn-xs` | Size variants |
+
+---
+
+## Relative Path from `~/sulla/projects/`
+
+Projects live at `~/sulla/projects/<project-name>/`. The CSS is at `~/sulla/designs/sulla.css`.
+
+From a project file two levels deep (`~/sulla/projects/my-project/doc.html`):
+```html
+<link rel="stylesheet" href="../../designs/sulla.css">
+```
+
+From a project file one level deep (`~/sulla/projects/doc.html`):
+```html
+<link rel="stylesheet" href="../designs/sulla.css">
+```
+
+---
+
+## Updating the Design System
+
+The canonical source lives in **two places that must stay in sync**:
+
+1. `<app-resources>/design-system/sulla.css` — ships with the app (committed to repo)
+2. `~/sulla/designs/sulla.css` — user's local copy
+
+When making design changes, edit both files (or copy one to the other). The repo version ships to all new installations; the local version is what running HTML files actually load.

--- a/resources/sulla-docs/design-system/design-system.md
+++ b/resources/sulla-docs/design-system/design-system.md
@@ -1,0 +1,131 @@
+# Sulla Design System — HTML Project Documents
+
+All project documentation, PRDs, dashboards, reports, and roadmaps **must** be HTML files using the Sulla design system — not markdown. HTML renders directly in Sulla chat and looks like a native UI extension.
+
+## Files (bundled with every install)
+
+| File | Purpose |
+|------|---------|
+| `sulla.css` | Standalone design system CSS — all tokens, components, themes |
+| `template.html` | Full starter template showing every component with usage examples |
+
+At runtime these resolve to:
+```
+<app-resources-path>/sulla-docs/design-system/sulla.css
+<app-resources-path>/sulla-docs/design-system/template.html
+```
+
+## Quick start — creating a new project doc
+
+1. Copy `template.html` to the project directory (e.g. `~/sulla/projects/my-project/overview.html`)
+2. Update the `<link>` path to point back to `sulla.css` (relative or absolute)
+3. Change `<html class="dark">` to `class="light"` for light mode, or leave it for dark
+4. Replace the demo content — keep the structure
+
+```html
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <title>My Project — Sulla</title>
+  <link rel="stylesheet" href="/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop/resources/sulla-docs/design-system/sulla.css">
+</head>
+<body>
+  <div class="sulla-page">
+    <div class="page-hero">
+      <h1>Project Name</h1>
+      <p>Subtitle here.</p>
+    </div>
+    <!-- content -->
+  </div>
+</body>
+</html>
+```
+
+**Absolute path (always works from any project dir):**
+```
+/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop/resources/sulla-docs/design-system/sulla.css
+```
+
+## Themes
+
+| Class on `<html>` | Look |
+|-------------------|------|
+| `class="dark"` | Protocol Dark — `#0d1117` background, steel blue `#5096b3` accent |
+| `class="light"` | Protocol Light — `#f4f7fb` background, same steel blue accent |
+| _(none)_ | Auto-detects OS preference |
+
+Theme toggles at runtime via the included JS snippet in `template.html`.
+
+## CSS variables (key subset)
+
+```css
+/* Surfaces */
+--bg          /* page background */
+--surface-1   /* cards, panels */
+--surface-2   /* nested panels */
+--surface-3   /* hover states */
+
+/* Text */
+--text           /* primary */
+--text-secondary
+--text-muted
+--text-dim
+
+/* Brand */
+--accent         /* #5096b3 steel blue (dark) / #0ea5e9 sky (light) */
+--accent-hover
+--accent-dim     /* subtle fill */
+--accent-border  /* border with alpha */
+
+/* Status */
+--success  --warning  --danger  --info
+
+/* Borders */
+--border        /* default */
+--border-muted  /* subtle */
+--border-strong /* emphasized */
+
+/* Shadows */
+--shadow-sm  --shadow-md  --shadow-lg
+
+/* Typography */
+--font-mono     /* JetBrains Mono — body, code, UI */
+--font-display  /* Playfair Display — headings */
+```
+
+## Component classes (quick reference)
+
+**Layout**
+- `.sulla-page` — simple centered page (max 900px)
+- `.sulla-page-wide` — wide centered page (max 1200px)
+- `.sulla-app` + `.sulla-sidebar` + `.sulla-main` — full sidebar layout
+- `.sulla-header` — sticky top bar
+- `.sulla-content` — content area with padding
+- `.page-hero` — page title + subtitle block
+- `.section` + `.section-header` + `.section-title` + `.section-rule` — labeled section
+
+**Components**
+- `.card` `.card-lg` `.card-success/warning/danger/info/accent` — surfaces
+- `.grid-2/3/4` `.grid-auto` — CSS grid layouts
+- `.stat` `.stat-value` `.stat-label` `.stat-delta` — KPI numbers
+- `.badge-accent/success/warning/danger/info/default` `.badge.pill` `.badge.with-dot` — status tags
+- `.table-wrap` + `.sulla-table` — data tables
+- `.checklist` with `li.done` / `li.in-progress` — task lists
+- `.timeline` with `.timeline-item.done/.active/.blocked` — project timelines
+- `.terminal` — terminal/log output block
+- `.alert-success/warning/danger/info/accent` — notice boxes
+- `.progress-bar` + `.progress-fill.success/warning/danger` — progress bars
+- `.btn-primary` `.btn-ghost` `.btn-outline-accent` `.btn-sm` `.btn-xs` — buttons
+- `.meta-grid` + `.meta-key` + `.meta-val` — key-value metadata
+- `.divider` — labeled horizontal rule
+
+**Utilities:** `.flex` `.items-center` `.justify-between` `.gap-1..8` `.mt/mb-1..8` `.text-xs..3xl` `.font-mono` `.font-display` `.text-accent/success/warning/danger/muted/dim` `.rounded` `.w-full` `.truncate` `.glow-text`
+
+## Output conventions
+
+- Default all new project HTML to `class="dark"` (Protocol Dark)
+- Include the theme toggle `<script>` block from `template.html` so users can switch
+- Store project files at `~/sulla/projects/<project-name>/`
+- Use absolute path to `sulla.css` so files open correctly from any location
+- One file per document type: `overview.html`, `roadmap.html`, `competitor-analysis.html`, etc.

--- a/resources/sulla-docs/design-system/design-system.md
+++ b/resources/sulla-docs/design-system/design-system.md
@@ -124,8 +124,10 @@ Theme toggles at runtime via the included JS snippet in `template.html`.
 
 ## Output conventions
 
-- Default all new project HTML to `class="dark"` (Protocol Dark)
-- Include the theme toggle `<script>` block from `template.html` so users can switch
+- **ALWAYS** link `sulla.css` via `<link rel="stylesheet">` — NEVER define `:root { --bg: ... }` color vars inline
+- Default `<html class="dark">` — the browser tab preload overrides this automatically with the live app theme
+- The preload runs `ipcRenderer.invoke('sulla-settings-get', 'theme')` on load and listens for `sulla:theme-changed` to toggle `class="dark"` / `class="light"` on `<html>` — this is why the CSS link is required
+- Inline `<style>` blocks are fine for layout-only rules (grid, spacing, fonts) — just no theme tokens
 - Store project files at `~/sulla/projects/<project-name>/`
-- Use absolute path to `sulla.css` so files open correctly from any location
+- Use the relative path `../../designs/sulla.css` from `~/sulla/projects/<project-name>/` — this resolves to `~/sulla/designs/sulla.css`
 - One file per document type: `overview.html`, `roadmap.html`, `competitor-analysis.html`, etc.

--- a/resources/sulla-docs/design-system/sulla.css
+++ b/resources/sulla-docs/design-system/sulla.css
@@ -1,0 +1,1221 @@
+/*
+ * sulla.css — Sulla Desktop Design System
+ * Standalone CSS for project documents, dashboards, and HTML reports.
+ * Mirrors Protocol Dark (dark) and Default Light (light) themes exactly.
+ *
+ * Usage:
+ *   <link rel="stylesheet" href="sulla.css">
+ *   <html class="dark">   ← Protocol Dark (steel blue noir)
+ *   <html class="light">  ← Default Light (clean sky blue)
+ *   Auto-detects OS preference if no class is set.
+ *
+ * Theme toggle: add data-theme="dark" | data-theme="light" to <html>
+ * or use JS: document.documentElement.classList.toggle('dark')
+ */
+
+/* ================================================================== */
+/*  Google Fonts                                                       */
+/* ================================================================== */
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap');
+
+/* ================================================================== */
+/*  CSS Custom Properties — Dark (Protocol Dark)                      */
+/* ================================================================== */
+:root,
+.dark,
+[data-theme="dark"],
+html.dark {
+  color-scheme: dark;
+
+  /* Core palette */
+  --bg:           #0d1117;
+  --surface-1:    #161b22;
+  --surface-2:    #1c2128;
+  --surface-3:    #21262d;
+  --border:       #30363d;
+  --border-muted: #21262d;
+  --border-strong: #484f58;
+
+  /* Text hierarchy */
+  --text:         #e6edf3;
+  --text-secondary: #b1bac4;
+  --text-muted:   #8b949e;
+  --text-dim:     #6e7681;
+  --text-link:    #5096b3;
+  --text-on-accent: #ffffff;
+
+  /* Brand / Accent — Steel Blue */
+  --accent:       #5096b3;
+  --accent-hover: #6ab0cc;
+  --accent-dim:   rgba(80, 150, 179, 0.15);
+  --accent-border: rgba(80, 150, 179, 0.5);
+  --accent-glow:  rgba(80, 150, 179, 0.4);
+  --accent-glow-soft: rgba(80, 150, 179, 0.15);
+
+  /* Status */
+  --success:      #3fb950;
+  --warning:      #e3b341;
+  --danger:       #f85149;
+  --info:         #58a6ff;
+  --green:        #39ff14;
+  --green-bright: #57ff38;
+  --green-glow:   rgba(57, 255, 20, 0.5);
+
+  /* Status backgrounds */
+  --bg-success:   rgba(63, 185, 80, 0.18);
+  --bg-warning:   rgba(227, 179, 65, 0.18);
+  --bg-danger:    rgba(248, 81, 73, 0.18);
+  --bg-info:      rgba(88, 166, 255, 0.18);
+  --bg-accent:    rgba(80, 150, 179, 0.12);
+
+  /* Status borders */
+  --border-success: rgba(63, 185, 80, 0.4);
+  --border-warning: rgba(227, 179, 65, 0.4);
+  --border-danger:  rgba(248, 81, 73, 0.4);
+  --border-info:    rgba(88, 166, 255, 0.4);
+
+  /* Shadows */
+  --shadow-sm: 0 1px 3px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.03);
+  --shadow-md: 0 8px 32px rgba(0,0,0,0.4), 0 2px 8px rgba(0,0,0,0.2);
+  --shadow-lg: 0 12px 48px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.04);
+  --ring:      rgba(80, 150, 179, 0.5);
+
+  /* Scrollbar */
+  --scrollbar-thumb: #4485a0;
+  --scrollbar-track: #0d1117;
+
+  /* Typography */
+  --font-mono:    'JetBrains Mono', 'SF Mono', 'Fira Code', 'Roboto Mono', monospace;
+  --font-display: 'Playfair Display', Georgia, serif;
+  --font-body:    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  /* Radii */
+  --radius:    4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+
+  /* Sizing */
+  --nav-width: 220px;
+}
+
+/* ================================================================== */
+/*  CSS Custom Properties — Light (Default Light)                     */
+/* ================================================================== */
+@media (prefers-color-scheme: light) {
+  :root:not(.dark):not([data-theme="dark"]) {
+    color-scheme: light;
+
+    --bg:           #ffffff;
+    --surface-1:    #f8fafc;
+    --surface-2:    #f1f5f9;
+    --surface-3:    #e2e8f0;
+    --border:       #e2e8f0;
+    --border-muted: #f1f5f9;
+    --border-strong: #cbd5e1;
+
+    --text:         #0d0d0d;
+    --text-secondary: #64748b;
+    --text-muted:   #94a3b8;
+    --text-dim:     #b0b8c4;
+    --text-link:    #0284c7;
+    --text-on-accent: #ffffff;
+
+    --accent:       #0ea5e9;
+    --accent-hover: #0284c7;
+    --accent-dim:   rgba(14, 165, 233, 0.1);
+    --accent-border: rgba(14, 165, 233, 0.5);
+    --accent-glow:  rgba(14, 165, 233, 0.3);
+    --accent-glow-soft: rgba(14, 165, 233, 0.1);
+
+    --success:      #16a34a;
+    --warning:      #d97706;
+    --danger:       #dc2626;
+    --info:         #0284c7;
+    --green:        #16a34a;
+    --green-bright: #22c55e;
+    --green-glow:   rgba(22, 163, 74, 0.3);
+
+    --bg-success:   rgba(34, 197, 94, 0.1);
+    --bg-warning:   rgba(245, 158, 11, 0.1);
+    --bg-danger:    rgba(239, 68, 68, 0.1);
+    --bg-info:      rgba(14, 165, 233, 0.1);
+    --bg-accent:    rgba(14, 165, 233, 0.08);
+
+    --border-success: #86efac;
+    --border-warning: #fde68a;
+    --border-danger:  #fca5a5;
+    --border-info:    #7dd3fc;
+
+    --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+    --shadow-md: 0 4px 6px rgba(0,0,0,0.07), 0 2px 4px rgba(0,0,0,0.05);
+    --shadow-lg: 0 10px 25px rgba(0,0,0,0.1), 0 4px 10px rgba(0,0,0,0.06);
+    --ring:      rgba(14, 165, 233, 0.5);
+
+    --scrollbar-thumb: #cbd5e1;
+    --scrollbar-track: transparent;
+  }
+}
+
+.light,
+[data-theme="light"],
+html.light {
+  color-scheme: light;
+
+  --bg:           #ffffff;
+  --surface-1:    #f8fafc;
+  --surface-2:    #f1f5f9;
+  --surface-3:    #e2e8f0;
+  --border:       #e2e8f0;
+  --border-muted: #f1f5f9;
+  --border-strong: #cbd5e1;
+
+  --text:         #0d0d0d;
+  --text-secondary: #64748b;
+  --text-muted:   #94a3b8;
+  --text-dim:     #b0b8c4;
+  --text-link:    #0284c7;
+  --text-on-accent: #ffffff;
+
+  --accent:       #0ea5e9;
+  --accent-hover: #0284c7;
+  --accent-dim:   rgba(14, 165, 233, 0.1);
+  --accent-border: rgba(14, 165, 233, 0.5);
+  --accent-glow:  rgba(14, 165, 233, 0.3);
+  --accent-glow-soft: rgba(14, 165, 233, 0.1);
+
+  --success:      #16a34a;
+  --warning:      #d97706;
+  --danger:       #dc2626;
+  --info:         #0284c7;
+  --green:        #16a34a;
+  --green-bright: #22c55e;
+  --green-glow:   rgba(22, 163, 74, 0.3);
+
+  --bg-success:   rgba(34, 197, 94, 0.1);
+  --bg-warning:   rgba(245, 158, 11, 0.1);
+  --bg-danger:    rgba(239, 68, 68, 0.1);
+  --bg-info:      rgba(14, 165, 233, 0.1);
+  --bg-accent:    rgba(14, 165, 233, 0.08);
+
+  --border-success: #86efac;
+  --border-warning: #fde68a;
+  --border-danger:  #fca5a5;
+  --border-info:    #7dd3fc;
+
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.07), 0 2px 4px rgba(0,0,0,0.05);
+  --shadow-lg: 0 10px 25px rgba(0,0,0,0.1), 0 4px 10px rgba(0,0,0,0.06);
+  --ring:      rgba(14, 165, 233, 0.5);
+
+  --scrollbar-thumb: #cbd5e1;
+  --scrollbar-track: transparent;
+}
+
+/* ================================================================== */
+/*  Reset & Base                                                       */
+/* ================================================================== */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html {
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  scroll-behavior: smooth;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: var(--scrollbar-track); }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--accent); }
+
+/* Selection */
+::selection { background: var(--accent-dim); color: var(--text); }
+
+/* ================================================================== */
+/*  Typography                                                         */
+/* ================================================================== */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+h1 { font-size: 2rem; }
+h2 { font-size: 1.5rem; }
+h3 { font-size: 1.25rem; }
+h4 { font-size: 1.1rem; }
+h5 { font-size: 1rem; }
+h6 { font-size: 0.875rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); }
+
+p { color: var(--text-secondary); line-height: 1.7; margin-bottom: 1rem; }
+p:last-child { margin-bottom: 0; }
+
+a { color: var(--text-link); text-decoration: none; }
+a:hover { color: var(--accent-hover); text-decoration: underline; }
+
+strong, b { font-weight: 600; color: var(--text); }
+em, i { font-style: italic; }
+small { font-size: 0.75rem; color: var(--text-muted); }
+
+code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--surface-2);
+  color: var(--accent);
+  padding: 0.1em 0.4em;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+
+pre {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  overflow-x: auto;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
+
+blockquote {
+  border-left: 3px solid var(--accent);
+  margin: 1rem 0;
+  padding: 0.75rem 1.25rem;
+  background: var(--accent-dim);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2rem 0;
+}
+
+ul, ol { color: var(--text-secondary); padding-left: 1.5rem; margin-bottom: 1rem; }
+li { margin-bottom: 0.35rem; line-height: 1.6; }
+li:last-child { margin-bottom: 0; }
+
+/* ================================================================== */
+/*  Layout                                                             */
+/* ================================================================== */
+.sulla-app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sulla-sidebar {
+  width: var(--nav-width);
+  background: var(--bg);
+  border-right: 1px solid var(--border);
+  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.sulla-main {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.sulla-header {
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: 0 1.5rem;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  gap: 1rem;
+}
+
+.sulla-header-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.sulla-header-brand .brand-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent-glow);
+}
+
+.sulla-content {
+  padding: 2rem;
+  max-width: 960px;
+}
+
+.sulla-content.full-width {
+  max-width: none;
+}
+
+/* Simple no-sidebar page */
+.sulla-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+.sulla-page-wide {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+/* ================================================================== */
+/*  Navigation                                                         */
+/* ================================================================== */
+.sulla-nav {
+  padding: 0.5rem 0;
+  flex: 1;
+}
+
+.sulla-nav-section {
+  padding: 1rem 1rem 0.375rem;
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+}
+
+.sulla-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 1rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.15s, background 0.15s;
+  border-radius: 0;
+  font-family: var(--font-mono);
+  font-weight: 400;
+}
+
+.sulla-nav-item:hover {
+  background: var(--surface-3);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.sulla-nav-item.active {
+  background: var(--accent-dim);
+  color: var(--accent);
+  border-right: 2px solid var(--accent);
+}
+
+.sulla-nav-item .nav-icon {
+  font-size: 0.875rem;
+  opacity: 0.7;
+  flex-shrink: 0;
+  width: 16px;
+  text-align: center;
+}
+
+/* ================================================================== */
+/*  Cards & Surfaces                                                   */
+/* ================================================================== */
+.card {
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.card-lg {
+  padding: 1.75rem;
+  border-radius: var(--radius-lg);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  padding-bottom: 0.875rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.card-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.card-subtitle {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  margin-top: 0.2rem;
+}
+
+.card-body { color: var(--text-secondary); font-size: 0.875rem; }
+
+.card-footer {
+  margin-top: 1rem;
+  padding-top: 0.875rem;
+  border-top: 1px solid var(--border-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* Card states */
+.card.card-success { border-color: var(--border-success); background: var(--bg-success); }
+.card.card-warning { border-color: var(--border-warning); background: var(--bg-warning); }
+.card.card-danger  { border-color: var(--border-danger);  background: var(--bg-danger); }
+.card.card-info    { border-color: var(--border-info);    background: var(--bg-info); }
+.card.card-accent  { border-color: var(--accent-border);  background: var(--accent-dim); }
+
+/* Surface levels */
+.surface-1 { background: var(--surface-1); border: 1px solid var(--border); border-radius: var(--radius-md); }
+.surface-2 { background: var(--surface-2); border: 1px solid var(--border-muted); border-radius: var(--radius); }
+
+/* Glass effect for dark mode */
+.glass {
+  background: rgba(22, 27, 34, 0.6);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+/* ================================================================== */
+/*  Grid                                                               */
+/* ================================================================== */
+.grid { display: grid; gap: 1rem; }
+.grid-2 { grid-template-columns: repeat(2, 1fr); }
+.grid-3 { grid-template-columns: repeat(3, 1fr); }
+.grid-4 { grid-template-columns: repeat(4, 1fr); }
+.grid-auto { grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); }
+
+@media (max-width: 768px) {
+  .grid-2, .grid-3, .grid-4 { grid-template-columns: 1fr; }
+}
+
+/* ================================================================== */
+/*  Stat / KPI Block                                                   */
+/* ================================================================== */
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.stat-label {
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.stat-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text);
+  font-family: var(--font-mono);
+  line-height: 1;
+}
+
+.stat-value.accent { color: var(--accent); }
+.stat-value.success { color: var(--success); }
+.stat-value.warning { color: var(--warning); }
+.stat-value.danger  { color: var(--danger); }
+
+.stat-delta {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.stat-delta.up   { color: var(--success); }
+.stat-delta.down { color: var(--danger); }
+
+/* ================================================================== */
+/*  Badges & Tags                                                      */
+/* ================================================================== */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15em 0.55em;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  border-radius: var(--radius);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  vertical-align: middle;
+  border: 1px solid transparent;
+}
+
+.badge-default { background: var(--surface-3); color: var(--text-muted); border-color: var(--border); }
+.badge-accent  { background: var(--accent-dim); color: var(--accent); border-color: var(--accent-border); }
+.badge-success { background: var(--bg-success); color: var(--success); border-color: var(--border-success); }
+.badge-warning { background: var(--bg-warning); color: var(--warning); border-color: var(--border-warning); }
+.badge-danger  { background: var(--bg-danger);  color: var(--danger);  border-color: var(--border-danger); }
+.badge-info    { background: var(--bg-info);    color: var(--info);    border-color: var(--border-info); }
+
+/* Pill variant */
+.badge.pill { border-radius: 999px; }
+
+/* Status dot */
+.badge::before {
+  content: '';
+  display: none;
+}
+
+.badge.with-dot::before {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+/* ================================================================== */
+/*  Status Row                                                         */
+/* ================================================================== */
+.status-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.625rem 0;
+  border-bottom: 1px solid var(--border-muted);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+.status-row:last-child { border-bottom: none; }
+.status-row .label { color: var(--text-muted); }
+.status-row .value { color: var(--text); font-weight: 500; }
+
+/* ================================================================== */
+/*  Table                                                              */
+/* ================================================================== */
+.sulla-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+.sulla-table th {
+  background: var(--bg);
+  color: var(--text-muted);
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.625rem 0.875rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.sulla-table td {
+  padding: 0.625rem 0.875rem;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border-muted);
+  vertical-align: middle;
+}
+
+.sulla-table tr:last-child td { border-bottom: none; }
+
+.sulla-table tbody tr:hover td {
+  background: var(--surface-2);
+  color: var(--text);
+}
+
+.sulla-table .col-key {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.sulla-table .col-muted {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+/* Wrapper for scroll */
+.table-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  overflow-x: auto;
+}
+
+.table-wrap .sulla-table {
+  margin: 0;
+}
+
+/* ================================================================== */
+/*  Checklist                                                          */
+/* ================================================================== */
+.checklist {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.checklist li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  font-size: 0.875rem;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 0;
+}
+
+.checklist li .check {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  margin-top: 2px;
+  background: var(--surface-2);
+}
+
+.checklist li.done .check {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.checklist li.done .check::after { content: '✓'; }
+.checklist li.in-progress .check {
+  background: var(--bg-warning);
+  border-color: var(--border-warning);
+  color: var(--warning);
+}
+.checklist li.in-progress .check::after { content: '~'; }
+
+.checklist li.done > span { color: var(--text-muted); text-decoration: line-through; }
+
+/* ================================================================== */
+/*  Progress Bar                                                       */
+/* ================================================================== */
+.progress-bar {
+  background: var(--surface-3);
+  border-radius: 999px;
+  height: 6px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--accent);
+  transition: width 0.3s ease;
+}
+
+.progress-fill.success { background: var(--success); }
+.progress-fill.warning { background: var(--warning); }
+.progress-fill.danger  { background: var(--danger); }
+
+.progress-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.375rem;
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.progress-label .pct {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ================================================================== */
+/*  Timeline                                                           */
+/* ================================================================== */
+.timeline {
+  position: relative;
+  padding-left: 1.75rem;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 8px;
+  bottom: 8px;
+  width: 1px;
+  background: var(--border);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 1.5rem;
+}
+
+.timeline-item:last-child { margin-bottom: 0; }
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: -1.375rem;
+  top: 6px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--border);
+  border: 2px solid var(--bg);
+}
+
+.timeline-item.done::before    { background: var(--success); }
+.timeline-item.active::before  { background: var(--accent); box-shadow: 0 0 0 3px var(--accent-dim); }
+.timeline-item.blocked::before { background: var(--danger); }
+
+.timeline-date {
+  font-size: 0.6875rem;
+  font-family: var(--font-mono);
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.2rem;
+}
+
+.timeline-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text);
+  font-family: var(--font-mono);
+  margin-bottom: 0.25rem;
+}
+
+.timeline-body {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ================================================================== */
+/*  Alert / Notice                                                     */
+/* ================================================================== */
+.alert {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.alert-icon { flex-shrink: 0; font-size: 1rem; margin-top: 0.05rem; }
+.alert-body { flex: 1; }
+.alert-title { font-weight: 600; margin-bottom: 0.2rem; }
+.alert-msg { opacity: 0.85; }
+
+.alert-success { background: var(--bg-success); border-color: var(--border-success); color: var(--success); }
+.alert-warning { background: var(--bg-warning); border-color: var(--border-warning); color: var(--warning); }
+.alert-danger  { background: var(--bg-danger);  border-color: var(--border-danger);  color: var(--danger); }
+.alert-info    { background: var(--bg-info);    border-color: var(--border-info);    color: var(--info); }
+.alert-accent  { background: var(--accent-dim); border-color: var(--accent-border);  color: var(--accent); }
+
+/* ================================================================== */
+/*  Buttons                                                            */
+/* ================================================================== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s, border-color 0.15s, box-shadow 0.15s;
+  letter-spacing: 0.02em;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--text-on-accent);
+  border-color: var(--accent);
+}
+
+.btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  box-shadow: 0 0 12px var(--accent-glow-soft);
+  color: var(--text-on-accent);
+  text-decoration: none;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text-muted);
+  border-color: var(--border);
+}
+
+.btn-ghost:hover {
+  background: var(--surface-3);
+  color: var(--text);
+  border-color: var(--border-strong);
+  text-decoration: none;
+}
+
+.btn-outline-accent {
+  background: var(--accent-dim);
+  color: var(--accent);
+  border-color: var(--accent-border);
+}
+
+.btn-outline-accent:hover {
+  background: var(--accent);
+  color: var(--text-on-accent);
+  text-decoration: none;
+}
+
+.btn-sm { padding: 0.3rem 0.75rem; font-size: 0.75rem; }
+.btn-xs { padding: 0.2rem 0.5rem; font-size: 0.6875rem; }
+
+/* ================================================================== */
+/*  Key-Value Metadata                                                 */
+/* ================================================================== */
+.meta-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 1.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+.meta-key {
+  color: var(--text-muted);
+  font-weight: 500;
+  white-space: nowrap;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.meta-val {
+  color: var(--text);
+}
+
+/* ================================================================== */
+/*  Terminal / Log Block                                               */
+/* ================================================================== */
+.terminal {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+.terminal-bar {
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 0.875rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.terminal-dots {
+  display: flex;
+  gap: 5px;
+}
+
+.terminal-dots span {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+
+.terminal-dots .dot-red    { background: #ff5f57; }
+.terminal-dots .dot-yellow { background: #febc2e; }
+.terminal-dots .dot-green  { background: #28c840; }
+
+.terminal-title {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  flex: 1;
+  text-align: center;
+  margin-left: -3.5rem; /* optical center with dots */
+}
+
+.terminal-body {
+  padding: 1rem 1.25rem;
+  color: var(--text);
+  line-height: 1.7;
+  min-height: 3rem;
+  overflow-x: auto;
+}
+
+.terminal-body .cmd  { color: var(--accent); }
+.terminal-body .out  { color: var(--text-secondary); }
+.terminal-body .err  { color: var(--danger); }
+.terminal-body .warn { color: var(--warning); }
+.terminal-body .ok   { color: var(--success); }
+.terminal-body .dim  { color: var(--text-dim); }
+
+/* Prompt indicator */
+.prompt::before {
+  content: '$ ';
+  color: var(--accent);
+  user-select: none;
+}
+
+/* ================================================================== */
+/*  Section Heading                                                    */
+/* ================================================================== */
+.section {
+  margin-bottom: 2rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.section-title {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+}
+
+.section-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+/* Page title section */
+.page-hero {
+  padding: 2rem 0 1.5rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+
+.page-hero h1 {
+  font-size: 1.875rem;
+  margin-bottom: 0.5rem;
+}
+
+.page-hero p {
+  color: var(--text-muted);
+  font-size: 0.9375rem;
+  margin: 0;
+}
+
+/* ================================================================== */
+/*  Theme Toggle Button                                                */
+/* ================================================================== */
+.theme-toggle {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.35rem 0.625rem;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: all 0.15s;
+}
+
+.theme-toggle:hover {
+  background: var(--surface-3);
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+/* ================================================================== */
+/*  Utility Classes                                                    */
+/* ================================================================== */
+.flex        { display: flex; }
+.flex-col    { flex-direction: column; }
+.items-center { align-items: center; }
+.items-start  { align-items: flex-start; }
+.justify-between { justify-content: space-between; }
+.justify-end  { justify-content: flex-end; }
+.gap-1  { gap: 0.25rem; }
+.gap-2  { gap: 0.5rem; }
+.gap-3  { gap: 0.75rem; }
+.gap-4  { gap: 1rem; }
+.gap-6  { gap: 1.5rem; }
+.gap-8  { gap: 2rem; }
+.wrap   { flex-wrap: wrap; }
+
+.p-1    { padding: 0.25rem; }
+.p-2    { padding: 0.5rem; }
+.p-3    { padding: 0.75rem; }
+.p-4    { padding: 1rem; }
+.p-5    { padding: 1.25rem; }
+.p-6    { padding: 1.5rem; }
+
+.mt-1 { margin-top: 0.25rem; }
+.mt-2 { margin-top: 0.5rem; }
+.mt-3 { margin-top: 0.75rem; }
+.mt-4 { margin-top: 1rem; }
+.mt-6 { margin-top: 1.5rem; }
+.mt-8 { margin-top: 2rem; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-3 { margin-bottom: 0.75rem; }
+.mb-4 { margin-bottom: 1rem; }
+.mb-6 { margin-bottom: 1.5rem; }
+.mb-8 { margin-bottom: 2rem; }
+
+.text-xs    { font-size: 0.6875rem; }
+.text-sm    { font-size: 0.8125rem; }
+.text-base  { font-size: 0.875rem; }
+.text-lg    { font-size: 1rem; }
+.text-xl    { font-size: 1.125rem; }
+.text-2xl   { font-size: 1.375rem; }
+.text-3xl   { font-size: 1.75rem; }
+
+.font-mono    { font-family: var(--font-mono); }
+.font-display { font-family: var(--font-display); }
+.font-normal  { font-weight: 400; }
+.font-medium  { font-weight: 500; }
+.font-semibold { font-weight: 600; }
+.font-bold    { font-weight: 700; }
+
+.text-primary   { color: var(--text); }
+.text-secondary { color: var(--text-secondary); }
+.text-muted     { color: var(--text-muted); }
+.text-dim       { color: var(--text-dim); }
+.text-accent    { color: var(--accent); }
+.text-success   { color: var(--success); }
+.text-warning   { color: var(--warning); }
+.text-danger    { color: var(--danger); }
+.text-info      { color: var(--info); }
+
+.uppercase { text-transform: uppercase; }
+.tracking-wide { letter-spacing: 0.08em; }
+.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.nowrap   { white-space: nowrap; }
+
+.rounded    { border-radius: var(--radius); }
+.rounded-md { border-radius: var(--radius-md); }
+.rounded-lg { border-radius: var(--radius-lg); }
+.rounded-full { border-radius: 999px; }
+
+.w-full  { width: 100%; }
+.h-full  { height: 100%; }
+.min-w-0 { min-width: 0; }
+
+.sr-only {
+  position: absolute; width: 1px; height: 1px;
+  padding: 0; margin: -1px; overflow: hidden;
+  clip: rect(0,0,0,0); white-space: nowrap; border-width: 0;
+}
+
+/* Glowing accent text */
+.glow-text {
+  color: var(--accent);
+  text-shadow: 0 0 20px var(--accent-glow);
+}
+
+/* Divider with label */
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text-dim);
+  font-size: 0.6875rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin: 1.5rem 0;
+}
+
+.divider::before, .divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+/* ================================================================== */
+/*  Print Tweaks                                                       */
+/* ================================================================== */
+@media print {
+  body { background: white; color: black; }
+  .sulla-sidebar, .sulla-header, .theme-toggle { display: none; }
+  .sulla-content { max-width: 100%; padding: 0; }
+  .card { border: 1px solid #ccc; box-shadow: none; }
+}

--- a/resources/sulla-docs/design-system/template.html
+++ b/resources/sulla-docs/design-system/template.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Project Name — Sulla</title>
+  <!--
+    Adjust this path to wherever sulla.css lives relative to this file.
+    e.g. ../../../designs/sulla.css or https://your-cdn/sulla.css
+  -->
+  <link rel="stylesheet" href="sulla.css">
+</head>
+<body>
+
+<!-- ================================================================
+     OPTION A: Page with sidebar navigation
+     Remove if you don't need a sidebar.
+     ================================================================ -->
+<div class="sulla-app">
+
+  <!-- ── Sidebar ── -->
+  <aside class="sulla-sidebar">
+    <!-- Brand logo area -->
+    <div class="sulla-header" style="height:52px; border-right:none; border-bottom:1px solid var(--border);">
+      <div class="sulla-header-brand">
+        <span class="brand-dot"></span>
+        Sulla
+      </div>
+    </div>
+
+    <nav class="sulla-nav">
+      <div class="sulla-nav-section">Navigation</div>
+      <a href="#overview"    class="sulla-nav-item active">
+        <span class="nav-icon">◈</span> Overview
+      </a>
+      <a href="#status"      class="sulla-nav-item">
+        <span class="nav-icon">◎</span> Status
+      </a>
+      <a href="#roadmap"     class="sulla-nav-item">
+        <span class="nav-icon">◷</span> Roadmap
+      </a>
+      <a href="#components"  class="sulla-nav-item">
+        <span class="nav-icon">▦</span> Components
+      </a>
+      <a href="#terminal"    class="sulla-nav-item">
+        <span class="nav-icon">▸</span> Terminal
+      </a>
+
+      <div class="sulla-nav-section" style="margin-top:.5rem;">Resources</div>
+      <a href="#"            class="sulla-nav-item">
+        <span class="nav-icon">⌗</span> Docs
+      </a>
+      <a href="#"            class="sulla-nav-item">
+        <span class="nav-icon">⊹</span> Settings
+      </a>
+    </nav>
+
+    <!-- Sidebar footer -->
+    <div style="padding:.75rem 1rem; border-top:1px solid var(--border);">
+      <div class="meta-grid">
+        <span class="meta-key">version</span>
+        <span class="meta-val">1.0.0</span>
+        <span class="meta-key">env</span>
+        <span class="badge badge-success" style="font-size:.6rem;">live</span>
+      </div>
+    </div>
+  </aside>
+
+  <!-- ── Main ── -->
+  <div class="sulla-main">
+
+    <!-- Header bar -->
+    <header class="sulla-header">
+      <div class="sulla-header-brand">
+        <span class="brand-dot"></span>
+        Project Name
+      </div>
+      <div class="flex items-center gap-3">
+        <span class="badge badge-accent with-dot">Active</span>
+        <button class="theme-toggle" onclick="toggleTheme()">☀ / ☾ Theme</button>
+      </div>
+    </header>
+
+    <!-- ── Content ── -->
+    <div class="sulla-content" id="overview">
+
+      <!-- Page hero -->
+      <div class="page-hero">
+        <h1>Project Name</h1>
+        <p>Short description of what this document covers. Replace this with the actual project summary.</p>
+        <div class="flex items-center gap-3 mt-3 flex-wrap">
+          <span class="badge badge-accent">Phase 1</span>
+          <span class="badge badge-success with-dot">On Track</span>
+          <span class="text-sm text-muted">Updated: 2026-05-05</span>
+        </div>
+      </div>
+
+      <!-- ── KPI Stats ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Key Metrics</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="grid grid-4 gap-4">
+          <div class="card">
+            <div class="stat">
+              <span class="stat-label">Total Tasks</span>
+              <span class="stat-value">24</span>
+              <span class="stat-delta up">▲ 3 this week</span>
+            </div>
+          </div>
+          <div class="card">
+            <div class="stat">
+              <span class="stat-label">Completed</span>
+              <span class="stat-value success">18</span>
+              <span class="stat-delta">75% done</span>
+            </div>
+          </div>
+          <div class="card">
+            <div class="stat">
+              <span class="stat-label">Blocked</span>
+              <span class="stat-value danger">2</span>
+              <span class="stat-delta down">Needs attention</span>
+            </div>
+          </div>
+          <div class="card">
+            <div class="stat">
+              <span class="stat-label">Velocity</span>
+              <span class="stat-value accent">4.2</span>
+              <span class="stat-delta">tasks/day</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Progress ── -->
+      <div class="section" id="status">
+        <div class="section-header">
+          <span class="section-title">Progress</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="card">
+          <div class="flex flex-col gap-4">
+
+            <div>
+              <div class="progress-label">
+                <span>Phase 1 — Setup</span>
+                <span class="pct">100%</span>
+              </div>
+              <div class="progress-bar">
+                <div class="progress-fill success" style="width:100%"></div>
+              </div>
+            </div>
+
+            <div>
+              <div class="progress-label">
+                <span>Phase 2 — Build</span>
+                <span class="pct">62%</span>
+              </div>
+              <div class="progress-bar">
+                <div class="progress-fill" style="width:62%"></div>
+              </div>
+            </div>
+
+            <div>
+              <div class="progress-label">
+                <span>Phase 3 — Launch</span>
+                <span class="pct">10%</span>
+              </div>
+              <div class="progress-bar">
+                <div class="progress-fill warning" style="width:10%"></div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Alerts ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Alerts</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="flex flex-col gap-3">
+          <div class="alert alert-success">
+            <span class="alert-icon">✓</span>
+            <div class="alert-body">
+              <div class="alert-title">Deployment complete</div>
+              <div class="alert-msg">All services healthy. No downtime detected.</div>
+            </div>
+          </div>
+          <div class="alert alert-warning">
+            <span class="alert-icon">⚠</span>
+            <div class="alert-body">
+              <div class="alert-title">Rate limit approaching</div>
+              <div class="alert-msg">API usage at 82% of monthly quota.</div>
+            </div>
+          </div>
+          <div class="alert alert-danger">
+            <span class="alert-icon">✕</span>
+            <div class="alert-body">
+              <div class="alert-title">Build failing</div>
+              <div class="alert-msg">main branch CI failing — 3 tests broken.</div>
+            </div>
+          </div>
+          <div class="alert alert-info">
+            <span class="alert-icon">ℹ</span>
+            <div class="alert-body">
+              <div class="alert-title">New version available</div>
+              <div class="alert-msg">v1.4.0 released. Review changelog before upgrading.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── 2-col: Checklist + Metadata ── -->
+      <div class="section" id="components">
+        <div class="section-header">
+          <span class="section-title">Phase Checklist</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="grid grid-2 gap-4">
+
+          <div class="card">
+            <div class="card-header">
+              <span class="card-title">Phase 1 Tasks</span>
+              <span class="badge badge-success">Done</span>
+            </div>
+            <ul class="checklist">
+              <li class="done"><span class="check"></span><span>LLC registration filed</span></li>
+              <li class="done"><span class="check"></span><span>Domain purchased</span></li>
+              <li class="done"><span class="check"></span><span>Brand identity complete</span></li>
+              <li class="in-progress"><span class="check"></span><span>Website in review</span></li>
+              <li><span class="check"></span><span>Paid ads setup</span></li>
+              <li><span class="check"></span><span>First booking received</span></li>
+            </ul>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <span class="card-title">Project Metadata</span>
+            </div>
+            <div class="meta-grid mt-2">
+              <span class="meta-key">owner</span>
+              <span class="meta-val">Jonathon Byrdziak</span>
+              <span class="meta-key">started</span>
+              <span class="meta-val">2026-05-01</span>
+              <span class="meta-key">deadline</span>
+              <span class="meta-val">2026-06-30</span>
+              <span class="meta-key">market</span>
+              <span class="meta-val">Coeur d'Alene / Spokane</span>
+              <span class="meta-key">phase</span>
+              <span class="badge badge-accent">1 of 3</span>
+              <span class="meta-key">status</span>
+              <span class="badge badge-success with-dot">Active</span>
+              <span class="meta-key">budget</span>
+              <span class="meta-val">$12,500</span>
+              <span class="meta-key">priority</span>
+              <span class="badge badge-warning">High</span>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- ── Table ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Task Table</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="table-wrap">
+          <table class="sulla-table">
+            <thead>
+              <tr>
+                <th>Task</th>
+                <th>Owner</th>
+                <th>Status</th>
+                <th>Due</th>
+                <th>Priority</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="col-key">LLC registration</td>
+                <td>Jonathon</td>
+                <td><span class="badge badge-success with-dot">Done</span></td>
+                <td class="col-muted">2026-05-10</td>
+                <td><span class="badge badge-danger">Critical</span></td>
+              </tr>
+              <tr>
+                <td class="col-key">Website v1</td>
+                <td>Jonathon</td>
+                <td><span class="badge badge-warning with-dot">In Review</span></td>
+                <td class="col-muted">2026-05-20</td>
+                <td><span class="badge badge-warning">High</span></td>
+              </tr>
+              <tr>
+                <td class="col-key">Google Ads setup</td>
+                <td>Jonathon</td>
+                <td><span class="badge badge-default">Pending</span></td>
+                <td class="col-muted">2026-06-01</td>
+                <td><span class="badge badge-info">Medium</span></td>
+              </tr>
+              <tr>
+                <td class="col-key">First client booking</td>
+                <td>—</td>
+                <td><span class="badge badge-default">Waiting</span></td>
+                <td class="col-muted">2026-06-15</td>
+                <td><span class="badge badge-warning">High</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- ── Timeline ── -->
+      <div class="section" id="roadmap">
+        <div class="section-header">
+          <span class="section-title">Timeline</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="card">
+          <div class="timeline">
+            <div class="timeline-item done">
+              <div class="timeline-date">May 2026</div>
+              <div class="timeline-title">Phase 1 — Foundation</div>
+              <div class="timeline-body">LLC, brand, website, basic tooling. First quotes sent.</div>
+            </div>
+            <div class="timeline-item active">
+              <div class="timeline-date">June 2026</div>
+              <div class="timeline-title">Phase 2 — First Revenue</div>
+              <div class="timeline-body">Paid ads live. Storm-chasing starts. First 5 jobs completed.</div>
+            </div>
+            <div class="timeline-item">
+              <div class="timeline-date">Q3 2026</div>
+              <div class="timeline-title">Phase 3 — Scale</div>
+              <div class="timeline-body">Hire first crew. Expand to gutters and siding. iPad sales app.</div>
+            </div>
+            <div class="timeline-item">
+              <div class="timeline-date">Q4 2026</div>
+              <div class="timeline-title">Phase 4 — Systems</div>
+              <div class="timeline-body">Full estimating platform. Insurance claim pipeline. Solar expansion.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Terminal block ── -->
+      <div class="section" id="terminal">
+        <div class="section-header">
+          <span class="section-title">Terminal Output</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="terminal">
+          <div class="terminal-bar">
+            <div class="terminal-dots">
+              <span class="dot-red"></span>
+              <span class="dot-yellow"></span>
+              <span class="dot-green"></span>
+            </div>
+            <span class="terminal-title">sulla — zsh</span>
+          </div>
+          <div class="terminal-body">
+            <div class="prompt cmd">sulla github/git_push '{"branch":"main","message":"feat: init project"}'</div>
+            <div class="out">↑ Pushing to origin/main...</div>
+            <div class="ok">✓ Push successful — HEAD at 8582b4d</div>
+            <div class="dim mt-2">─────────────────────────────────</div>
+            <div class="prompt cmd">sulla workflow/import_workflow '{"name":"daily-report"}'</div>
+            <div class="warn">⚠ Workflow already exists — skipping import</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Badges showcase ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Badges &amp; Tags</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="card">
+          <div class="flex wrap gap-2">
+            <span class="badge badge-default">Default</span>
+            <span class="badge badge-accent">Accent</span>
+            <span class="badge badge-success">Success</span>
+            <span class="badge badge-warning">Warning</span>
+            <span class="badge badge-danger">Danger</span>
+            <span class="badge badge-info">Info</span>
+            <span class="badge badge-success pill with-dot">Online</span>
+            <span class="badge badge-danger pill with-dot">Offline</span>
+            <span class="badge badge-warning pill with-dot">Degraded</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Buttons ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Buttons</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="card">
+          <div class="flex wrap gap-3">
+            <button class="btn btn-primary">Primary Action</button>
+            <button class="btn btn-outline-accent">Outline Accent</button>
+            <button class="btn btn-ghost">Ghost Button</button>
+            <button class="btn btn-primary btn-sm">Small</button>
+            <button class="btn btn-ghost btn-xs">Tiny</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Typography ── -->
+      <div class="section">
+        <div class="section-header">
+          <span class="section-title">Typography</span>
+          <span class="section-rule"></span>
+        </div>
+        <div class="card card-lg">
+          <h1>Display Heading (h1)</h1>
+          <h2 class="mt-3">Section Heading (h2)</h2>
+          <h3 class="mt-3">Subsection (h3)</h3>
+          <h4 class="mt-3">Card Title (h4)</h4>
+          <h6 class="mt-3">Label heading (h6)</h6>
+          <p class="mt-4">Body text uses the monospace stack for the terminal-noir aesthetic. This paragraph demonstrates normal reading flow with line-height and color hierarchy.</p>
+          <p>A link looks like <a href="#">this anchor</a> and has hover behavior.</p>
+          <blockquote class="mt-3">
+            "Looking at the outside of our house used to be stressful, but now it feels good to walk outside." — Customer review
+          </blockquote>
+          <pre class="mt-3"><code>// Code block example
+const sulla = await import('sulla-desktop');
+await sulla.workflow.run('daily-report');</code></pre>
+          <p class="mt-3">Inline <code>code snippets</code> look like this within prose. <strong>Bold text</strong> and <em>italic text</em> also work.</p>
+        </div>
+      </div>
+
+      <!-- Footer padding -->
+      <div style="height:3rem;"></div>
+
+    </div><!-- /.sulla-content -->
+  </div><!-- /.sulla-main -->
+</div><!-- /.sulla-app -->
+
+<!--
+  OPTION B: Simple page without sidebar
+  Just wrap your content in <div class="sulla-page"> instead of the entire sulla-app structure.
+  Example:
+
+  <body>
+    <div class="sulla-page">
+      <div class="page-hero">
+        <h1>Project Name</h1>
+        <p>Subtitle goes here.</p>
+      </div>
+      ... rest of content ...
+    </div>
+  </body>
+-->
+
+<script>
+  // ── Theme Toggle ──────────────────────────────────────────────
+  function toggleTheme() {
+    const html = document.documentElement;
+    if (html.classList.contains('dark')) {
+      html.classList.replace('dark', 'light');
+    } else {
+      html.classList.replace('light', 'dark');
+    }
+    localStorage.setItem('sulla-theme', html.className);
+  }
+
+  // Restore saved theme on load
+  (function () {
+    const saved = localStorage.getItem('sulla-theme');
+    if (saved) {
+      document.documentElement.className = saved;
+    } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+      document.documentElement.className = 'light';
+    }
+  })();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add internal OpenAI OAuth with embedded BrowserWindow (not system browser)
- Fix Claude Code provider visibility in model selector by checking vault instead of old settings location
- Implement LLM cache invalidation after OAuth to ensure credentials are re-read

## Changes

### OpenAI OAuth (`openaiOAuth.ts`)
- New specialized OAuth handler that opens auth flow in embedded Electron BrowserWindow
- Intercepts navigation events to capture OAuth callback
- Exchanges authorization code for access token
- Stores access_token as `api_key` in vault via IntegrationService
- Resets OpenAIService singleton cache after credential storage

### Claude Code Provider Fix (`ModelProviderService.ts`)
- Unified provider connection status check to use vault for all providers
- Claude Code OAuth tokens now stored in vault (via claudeOAuth.ts)
- ModelProviderService was checking old SullaSettingsModel location
- Now checks vault consistently across all providers

### Integration Wiring
- AgentIntegrationDetail.vue routes OpenAI OAuth to specialized handler
- Updated electron-ipc.d.ts with `openai-oauth:start` type definition
- OpenAIService reads api_key from vault, compatible with OAuth credentials
- OpenAIModels SelectBox fetches available models from OpenAI API using stored key

## Test Plan

1. Open Integrations → AI Infrastructure → OpenAI
2. Click "Sign in with OpenAI" 
3. OAuth window opens internally in Sulla (not Chrome)
4. After successful auth, integration shows as connected
5. Go to LM Settings → verify OpenAI appears in provider dropdown with available models
6. Select a model (gpt-4o recommended) and use in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)