### PR TITLE
perf: reduce token costs via prompt caching and stable-context dedup

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/AnthropicService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/AnthropicService.ts
@@ -36,7 +36,7 @@ export class AnthropicService extends BaseLanguageModel {
 
     return new AnthropicService({
       id:      'anthropic',
-      model:   valMap.model || 'claude-sonnet-4-20250514',
+      model:   valMap.model || 'claude-sonnet-4-6',
       baseUrl: 'https://api.anthropic.com/v1',
       apiKey:  valMap.api_key || '',
     });
@@ -219,9 +219,52 @@ export class AnthropicService extends BaseLanguageModel {
       });
     }
 
+    // Cache the conversation history: mark the last content block of the
+    // final message so the next request reads the entire prior transcript
+    // from the prompt cache (~0.1x input price) instead of re-billing it at
+    // full price. The API's automatic prefix lookup finds the previous
+    // request's cache entry, so hits accrue incrementally as the
+    // conversation grows. Without this, only the system prompt is cached and
+    // history (including tool results) is reprocessed uncached on every turn.
+    //
+    // Anthropic allows at most 4 cache_control breakpoints per request
+    // (2 are used by the system blocks), and message objects here share
+    // content arrays with the persistent state.messages history — so we must
+    // (a) strip any markers that leaked into history on prior rounds, and
+    // (b) mark via cloned blocks, never by mutating a shared one.
+    for (const msg of processedMessages) {
+      if (Array.isArray(msg.content)) {
+        msg.content = msg.content.map((b: any) => {
+          if (b && typeof b === 'object' && b.cache_control) {
+            const { cache_control: _stripped, ...rest } = b;
+            return rest;
+          }
+          return b;
+        });
+      }
+    }
+    const lastMessage = processedMessages[processedMessages.length - 1];
+    if (lastMessage) {
+      if (typeof lastMessage.content === 'string') {
+        lastMessage.content = [{
+          type:          'text',
+          text:          lastMessage.content,
+          cache_control: { type: 'ephemeral' },
+        }];
+      } else if (Array.isArray(lastMessage.content) && lastMessage.content.length > 0) {
+        const lastIdx = lastMessage.content.length - 1;
+        const lastBlock = lastMessage.content[lastIdx];
+        if (lastBlock && typeof lastBlock === 'object') {
+          lastMessage.content[lastIdx] = { ...lastBlock, cache_control: { type: 'ephemeral' } };
+        }
+      }
+    }
+
     const anthropicBody: any = {
       model:      this.model,
-      max_tokens: options.maxTokens ?? 1024,
+      // Low caps force extra AGENT_CONTINUE round trips, and every round trip
+      // re-bills the full prompt — a generous default is cheaper overall.
+      max_tokens: options.maxTokens ?? 8192,
       messages:   processedMessages,
     };
 

--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -1,4 +1,5 @@
 import * as childProcess from 'child_process';
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -41,6 +42,15 @@ const log = Logging.background;
 export class ClaudeCodeService extends BaseLanguageModel {
   // conversationId → Claude session_id — in-memory cache backed by Redis.
   private sessions = new Map<string, string>();
+
+  /**
+   * Tracks the hash of the stable <sulla_context> payload (platform rules +
+   * high-priority memories) last sent per conversation, so we only re-send it
+   * when it actually changes. Without this, every turn stamps a fresh copy
+   * into the permanent conversation history — N turns means N copies, each
+   * re-billed on every subsequent request.
+   */
+  private lastStableContextHash = new Map<string, string>();
 
   private readonly SESSION_KEY_PREFIX = 'claude_code_session:';
   private readonly SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
@@ -306,23 +316,30 @@ export class ClaudeCodeService extends BaseLanguageModel {
   }
 
   /**
-   * Build a <sulla_context> prefix to prepend to every outgoing user message.
-   * Includes:
-   *   - High-priority observational memory entries (critical + high)
-   *   - Recall context produced by the subconscious middleware this turn
+   * Build a <sulla_context> prefix for the outgoing user message.
    *
-   * Injecting here rather than relying solely on --append-system-prompt ensures
-   * Claude treats this context as part of the user turn — which it weights more
-   * heavily than appended system prompt content. It also fixes the resumed-
-   * session gap: --resume sends only the latest user message, so recall context
-   * merged into prior assistant messages was silently dropped.
+   * Two tiers:
+   *   - Stable context (platform rules + critical/high observational memory):
+   *     sent on the first turn of a session and again ONLY when its content
+   *     changes. Each send becomes permanent conversation history, so
+   *     repeating it verbatim every turn multiplies token cost with zero
+   *     information gain.
+   *   - Recall context (subconscious middleware output for THIS turn): always
+   *     included when present — it's the per-turn payload the recall agent
+   *     produced specifically so the primary agent doesn't have to research.
+   *
+   * Injecting in the user turn rather than relying solely on
+   * --append-system-prompt ensures Claude weights it properly, and fixes the
+   * resumed-session gap: --resume sends only the latest user message, so
+   * recall context merged into prior assistant messages was silently dropped.
    */
-  private async buildUserMessageContextPrefix(state?: BaseThreadState): Promise<string> {
-    const parts: string[] = [];
+  private async buildUserMessageContextPrefix(
+    state: BaseThreadState | undefined,
+    opts: { convId: string; isNewSession: boolean },
+  ): Promise<string> {
+    const stableParts: string[] = [];
 
-    // Platform identity — injected on every turn so Claude Code always knows
-    // it's operating inside an agentic platform, not a standalone chat session.
-    parts.push(`<platform_context>
+    stableParts.push(`<platform_context>
 You are operating inside Sulla Desktop — an autonomous agentic platform built by Jonathon Byrdziak. You are not a chatbot or a brain being asked questions. You are an agent with real tools and real execution capability.
 
 Rules that apply on every turn:
@@ -347,10 +364,21 @@ Rules that apply on every turn:
         );
         if (high.length > 0) {
           const lines = high.map((e: any) => `- ${ e.content ?? '' }`).join('\n');
-          parts.push(`<observational_memory>\n${ lines }\n</observational_memory>`);
+          stableParts.push(`<observational_memory>\n${ lines }\n</observational_memory>`);
         }
       }
     } catch { /* non-fatal */ }
+
+    const parts: string[] = [];
+
+    // Only send the stable tier when it's new to this session or has changed
+    // since it was last sent.
+    const stableText = stableParts.join('\n\n');
+    const stableHash = crypto.createHash('sha1').update(stableText).digest('hex');
+    if (opts.isNewSession || this.lastStableContextHash.get(opts.convId) !== stableHash) {
+      parts.push(stableText);
+    }
+    this.lastStableContextHash.set(opts.convId, stableHash);
 
     // Recall context from subconscious middleware (may be null on first turn)
     const recallContext = (state?.metadata as any)?.recallContext;
@@ -417,10 +445,14 @@ Rules that apply on every turn:
       throw new Error(`Claude Code got no extractable prompt from ${ messages.length } messages (roles=${ roles })`);
     }
 
-    // Prepend Sulla context (high-priority observational memory + recall context)
-    // to the outgoing user message. This travels with every turn regardless of
-    // whether the session is resumed, so Claude can't deprioritize it.
-    const contextPrefix = await this.buildUserMessageContextPrefix(options.state);
+    // Prepend Sulla context to the outgoing user message. Recall context
+    // travels every turn; the stable tier (platform rules + memories) is only
+    // re-sent when new to the session or changed — see
+    // buildUserMessageContextPrefix.
+    const contextPrefix = await this.buildUserMessageContextPrefix(options.state, {
+      convId,
+      isNewSession: !existingSession,
+    });
     const prompt = contextPrefix ? `${ contextPrefix }\n\n${ basePrompt }` : basePrompt;
 
     log.log(`[ClaudeCodeService] runClaude: messages=${ messages.length } promptLen=${ prompt.length } conversationId=${ convId } session=${ existingSession ?? '(new)' } hasOAuth=${ !!oauthToken } hasApiKey=${ !!apiKey }`);

--- a/pkg/rancher-desktop/agent/prompts/SystemPromptBuilder.ts
+++ b/pkg/rancher-desktop/agent/prompts/SystemPromptBuilder.ts
@@ -24,8 +24,16 @@ export interface PromptSection {
   content:        string;
   /** Sort order — lower = earlier in the prompt */
   priority:       number;
-  /** Whether this section is stable (cacheable) or dynamic (changes per turn) */
-  cacheStability: 'stable' | 'dynamic';
+  /**
+   * Cache tier:
+   * - 'stable'      — effectively frozen for the session (soul, safety, tooling)
+   * - 'semi-stable' — changes occasionally, not per turn (observational memory).
+   *                   Gets its own cache breakpoint so an update only
+   *                   invalidates this segment, not the whole stable prefix.
+   * - 'dynamic'     — changes every turn (runtime, channel awareness); sits
+   *                   after the cache boundary.
+   */
+  cacheStability: 'stable' | 'semi-stable' | 'dynamic';
 }
 
 export interface PromptBuildContext {
@@ -79,7 +87,7 @@ export interface BuiltPrompt {
 export interface AnthropicSystemBlock {
   type:           'text';
   text:           string;
-  cache_control?: { type: 'ephemeral' };
+  cache_control?: { type: 'ephemeral'; ttl?: '1h' };
 }
 
 /** Factory function that produces a section or null to skip it */
@@ -201,15 +209,16 @@ class SystemPromptBuilderImpl {
       });
     }
 
-    // Split into stable and dynamic
+    // Split by cache tier
     const stableSections = builtSections.filter(s => s.cacheStability === 'stable');
+    const semiStableSections = builtSections.filter(s => s.cacheStability === 'semi-stable');
     const dynamicSections = builtSections.filter(s => s.cacheStability === 'dynamic');
 
     // For local/ollama providers, enforce stable-before-dynamic ordering in the text output.
     // llama-server's KV cache reuses the longest matching prefix — putting all stable (unchanging)
     // content first maximizes cache hits across turns, even if a dynamic section has a low priority.
     const orderedSections = (ctx.provider === 'ollama' || ctx.mode === 'local')
-      ? [...stableSections, ...dynamicSections]
+      ? [...stableSections, ...semiStableSections, ...dynamicSections]
       : builtSections;
 
     // Build full text
@@ -217,25 +226,42 @@ class SystemPromptBuilderImpl {
     const text = allContent.join('\n\n');
     const includedSections = orderedSections.map(s => s.id);
 
-    // Build Anthropic-optimized blocks (stable block with cache_control, then dynamic)
+    // Build Anthropic-optimized blocks: stable (cached) → semi-stable (own
+    // cache breakpoint) → dynamic (uncached, after the boundary). Prompt
+    // caching is a prefix match, so giving semi-stable content (observational
+    // memory) its own breakpoint means a memory update only re-writes that
+    // segment — the stable prefix's cache entry stays valid.
     let anthropicSystem: AnthropicSystemBlock[] | undefined;
     if (ctx.provider === 'anthropic') {
       anthropicSystem = [];
 
+      // The heartbeat fires every 15 minutes, but the default cache TTL is
+      // 5 minutes — every cycle would pay the cache-write premium and never
+      // read. The 1h TTL costs 2x to write but is read by the next ~3 cycles.
+      const cacheControl: AnthropicSystemBlock['cache_control'] = ctx.isHeartbeat
+        ? { type: 'ephemeral', ttl: '1h' }
+        : { type: 'ephemeral' };
+
       if (stableSections.length > 0) {
-        const stableText = stableSections.map(s => s.content).join('\n\n');
         anthropicSystem.push({
           type:          'text',
-          text:          stableText,
-          cache_control: { type: 'ephemeral' },
+          text:          stableSections.map(s => s.content).join('\n\n'),
+          cache_control: cacheControl,
+        });
+      }
+
+      if (semiStableSections.length > 0) {
+        anthropicSystem.push({
+          type:          'text',
+          text:          semiStableSections.map(s => s.content).join('\n\n'),
+          cache_control: cacheControl,
         });
       }
 
       if (dynamicSections.length > 0) {
-        const dynamicText = dynamicSections.map(s => s.content).join('\n\n');
         anthropicSystem.push({
           type: 'text',
-          text: dynamicText,
+          text: dynamicSections.map(s => s.content).join('\n\n'),
         });
       }
     }

--- a/pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts
+++ b/pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts
@@ -82,6 +82,10 @@ ${ lines.join('\n') }`;
     id:             'observational_memory',
     content,
     priority:       45,
-    cacheStability: 'stable',
+    // semi-stable: memories change whenever the observation agent writes —
+    // far more often than the rest of the prompt. Keeping this out of the
+    // stable block means a memory update no longer invalidates the cached
+    // soul/safety/tooling/workspace prefix.
+    cacheStability: 'semi-stable',
   };
 }


### PR DESCRIPTION
## Summary

- **AnthropicService** — marks the last content block of every outgoing message with `cache_control: ephemeral` so full conversation history is served from prompt cache (~0.1x input price) on each turn. Also bumps `max_tokens` default `1024 → 8192` (low caps forced AGENT_CONTINUE round-trips re-billing the full prompt) and updates default model to `claude-sonnet-4-6`.
- **ClaudeCodeService** — SHA1-hashes the stable `<sulla_context>` tier (platform rules + critical/high observational memory) per conversation and only re-injects it when the session is new or content changed. Without this every turn appended a fresh copy into permanent history re-billed on all future turns.
- **SystemPromptBuilder + observationalMemory** — introduces a `semi-stable` cache tier so frequent observation-agent writes no longer invalidate the cached soul/safety/tooling prefix. Heartbeat runs get a 1h TTL (cadence is 15 min; 5-min default meant every write was paid but never read).

## Test plan

- [ ] Confirm `cache_read_input_tokens > 0` in Anthropic usage logs by turn 2+
- [ ] Verify stable `<sulla_context>` not re-injected on turn 2 when content unchanged
- [ ] Confirm heartbeat still fires at 15-min cadence
- [ ] Confirm `max_tokens: 8192` does not break existing tool-call flows

🤖 Generated with Claude Code