### PR TITLE
Fix subconscious token memory races

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/ObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/ObservationsModel.ts
@@ -27,10 +27,10 @@ export interface ObservationRecord {
 }
 
 export interface InsertObservationInput {
-  id:        string;
-  priority:  string;
-  content:   string;
-  source?:   string;
+  id:          string;
+  priority:    string;
+  content:     string;
+  source?:     string;
   /** ISO timestamp to preserve original timestamp on import */
   created_at?: string;
 }
@@ -115,9 +115,18 @@ export class ObservationsModel {
     const values: any[] = [];
     let idx = 1;
 
-    if (changes.priority !== undefined) { setClauses.push(`priority = $${ idx++ }`); values.push(changes.priority); }
-    if (changes.content  !== undefined) { setClauses.push(`content  = $${ idx++ }`); values.push(changes.content); }
-    if (changes.source   !== undefined) { setClauses.push(`source   = $${ idx++ }`); values.push(changes.source); }
+    if (changes.priority !== undefined) {
+      setClauses.push(`priority = $${ idx++ }`);
+      values.push(changes.priority);
+    }
+    if (changes.content !== undefined) {
+      setClauses.push(`content = $${ idx++ }`);
+      values.push(changes.content);
+    }
+    if (changes.source !== undefined) {
+      setClauses.push(`source = $${ idx++ }`);
+      values.push(changes.source);
+    }
 
     if (setClauses.length === 1) return null; // nothing to update
     values.push(id);
@@ -282,7 +291,7 @@ export class ObservationsModel {
    * Used by the migration runner on first boot after 0028 runs.
    */
   static async importLegacy(
-    entries: Array<{ id?: string; priority?: string; content?: string; timestamp?: string }>,
+    entries: { id?: string; priority?: string; content?: string; timestamp?: string }[],
   ): Promise<number> {
     let imported = 0;
     for (const entry of entries) {

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -150,22 +150,10 @@ export async function runSubconsciousMiddleware(
 
   console.log(`[SubconsciousMiddleware] Launched: ${ launched.join(', ') } | messages: ${ state.messages.length }`);
 
-  // Await only the agents that modify state, but cap total wait so the primary
-  // agent always starts promptly even when a subconscious provider is slow
-  // (e.g. Claude Code subprocess boot + model call = 30-60 s).
-  const SUBCONSCIOUS_TIMEOUT_MS = 15_000;
-  let timedOut = false;
-  const timeoutFence = new Promise<'timeout'>(resolve =>
-    setTimeout(() => { timedOut = true; resolve('timeout'); }, SUBCONSCIOUS_TIMEOUT_MS),
-  );
-  const raceResult = await Promise.race([
-    Promise.allSettled(awaitedTasks).then(r => ({ kind: 'settled' as const, results: r })),
-    timeoutFence.then(() => ({ kind: 'timeout' as const, results: [] as PromiseSettledResult<void>[] })),
-  ]);
-  if (timedOut) {
-    console.warn(`[SubconsciousMiddleware] Timed out after ${ SUBCONSCIOUS_TIMEOUT_MS }ms — proceeding without full subconscious results`);
-  }
-  const settledResults = raceResult.results;
+  // Every task in awaitedTasks writes into the live turn state. The primary
+  // agent must never start while one of these tasks can still mutate messages
+  // or metadata underneath it.
+  const settledResults = await Promise.allSettled(awaitedTasks);
 
   const failures = settledResults.filter(r => r.status === 'rejected');
   const elapsed = Date.now() - startTime;

--- a/pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts
+++ b/pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts
@@ -22,6 +22,7 @@
 import { ObservationsModel } from '../../database/models/ObservationsModel';
 import { SullaSettingsModel } from '../../database/models/SullaSettingsModel';
 import { parseJson } from '../../services/JsonParseService';
+
 import type { PromptBuildContext, PromptSection } from '../SystemPromptBuilder';
 
 /** Max observations to inject into the system prompt. */
@@ -48,12 +49,7 @@ export async function buildObservationalMemorySection(
 
       const content = `## Memory (top-${ TOP_N } observations)
 
-Critical and high-priority facts about the user and their business. Full memory is searchable via \`search_observations\` / \`list_observations\` tools. To add or archive, use the appropriate Sulla tool:
-
-\`\`\`bash
-sulla meta/add_observational_memory '{"priority":"high","content":"…"}'
-sulla meta/remove_observational_memory '{"id":"abcd"}'
-\`\`\`
+Critical and high-priority facts about the user and their business. Full memory is searchable via \`search_observations\` / \`list_observations\` tools. To add, update, or archive observations, call the matching memory/observation tool exposed in your tool list. When updating an existing observation, pass its \`id\` to \`add_observational_memory\`.
 
 ${ lines.join('\n') }`;
 
@@ -115,12 +111,7 @@ ${ lines.join('\n') }`;
 
   const content = `## Memory (persistent observations — legacy)
 
-These are durable facts about the user and their business. Use them to stay consistent across turns. If a new observation should be stored or a stale one removed, call the appropriate Sulla tool:
-
-\`\`\`bash
-sulla meta/add_observational_memory '{"priority":"high","content":"…"}'
-sulla meta/remove_observational_memory '{"id":"abcd"}'
-\`\`\`
+These are durable facts about the user and their business. Use them to stay consistent across turns. If a new observation should be stored, an existing one updated, or a stale one archived, call the matching memory/observation tool exposed in your tool list. When updating an existing observation, pass its \`id\` to \`add_observational_memory\`.
 
 ${ lines.join('\n') }`;
 

--- a/pkg/rancher-desktop/agent/prompts/turnContext.ts
+++ b/pkg/rancher-desktop/agent/prompts/turnContext.ts
@@ -67,10 +67,10 @@ const INTAKE_TURN_DIRECTIVE = 'intake mode: continuous voice intake — never em
 
 function voiceDirectiveFor(chatMode: ChatMode): string | null {
   switch (chatMode) {
-  case 'voice':     return VOICE_TURN_DIRECTIVE;
+  case 'voice': return VOICE_TURN_DIRECTIVE;
   case 'secretary': return SECRETARY_TURN_DIRECTIVE;
-  case 'intake':    return INTAKE_TURN_DIRECTIVE;
-  default:          return null;
+  case 'intake': return INTAKE_TURN_DIRECTIVE;
+  default: return null;
   }
 }
 

--- a/pkg/rancher-desktop/agent/tools/meta/add_observational_memory.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/add_observational_memory.ts
@@ -5,19 +5,36 @@ import { BaseTool, ToolResponse } from '../base';
 /**
  * Add Observational Memory Tool
  *
- * Inserts a new observation row into the `observations` table.
+ * Inserts or updates an observation row in the `observations` table.
  * No 50-cap pruning — observations are never automatically removed.
- * De-duplication: if a substantially similar active observation already
- * exists, the existing row is updated in place (priority + content refreshed).
+ * If an id is provided, that exact row is updated in place. Otherwise,
+ * de-duplication updates a substantially similar active observation.
  */
 export class AddObservationalMemoryWorker extends BaseTool {
   name = '';
   description = '';
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
-    const { priority, content, source } = input;
+    const { id, priority, content, source } = input;
+    const existingId = typeof id === 'string' ? id.trim() : '';
 
     try {
+      if (existingId) {
+        const updated = await ObservationsModel.update(existingId, { priority, content, source });
+        if (!updated) {
+          return {
+            successBoolean: false,
+            responseString: `No observation found with id: ${ existingId }`,
+          };
+        }
+
+        generateClaudeCodeMemoryFile().catch(() => {});
+        return {
+          successBoolean: true,
+          responseString: `Remembering (updated): "${ content }" (id: ${ updated.id }, priority: ${ updated.priority })`,
+        };
+      }
+
       // Check for an existing similar observation to avoid duplicates.
       const duplicate = await ObservationsModel.findDuplicate(content);
 

--- a/pkg/rancher-desktop/agent/tools/meta/list_observations.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/list_observations.ts
@@ -13,12 +13,13 @@ export class ListObservationsWorker extends BaseTool {
   description = '';
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
-    const { priority, limit = 50, include_archived = false } = input;
+    const { priority, limit = 50 } = input;
+    const includeArchived = Boolean(input.include_archived ?? input.includeArchived ?? false);
 
     try {
       let rows;
 
-      if (include_archived) {
+      if (includeArchived) {
         // When include_archived is requested use the raw search with wildcard
         // to get all rows (both active and archived).
         rows = await ObservationsModel.search('%', Number(limit) || 50, true);

--- a/pkg/rancher-desktop/agent/tools/meta/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/manifests.ts
@@ -6,8 +6,10 @@ export const metaToolManifests: ToolManifest[] = [
     description: 'Use this tool to store the observations you make into long-term memory.',
     category:    'observation',
     schemaDef:   {
+      id:       { type: 'string', optional: true, description: 'Existing observation ID to update in place. Omit to add a new observation or update a duplicate by content.' },
       priority: { type: 'string', optional: true, default: '🟡', description: 'Priority tag for this observation. Any short label works — common values: 🔴 / high, 🟡 / medium, ⚪ / low.' },
       content:  { type: 'string', description: 'One sentence only — extremely concise, always include the context' },
+      source:   { type: 'string', optional: true, description: 'Optional source label for this observation.' },
     },
     operationTypes: ['create', 'read', 'update', 'delete'],
     loader:         () => import('./add_observational_memory'),

--- a/pkg/rancher-desktop/agent/tools/meta/search_observations.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/search_observations.ts
@@ -13,7 +13,8 @@ export class SearchObservationsWorker extends BaseTool {
   description = '';
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
-    const { query, limit = 20, include_archived = false } = input;
+    const { query, limit = 20 } = input;
+    const includeArchived = Boolean(input.include_archived ?? input.includeArchived ?? false);
 
     if (!query || typeof query !== 'string' || !query.trim()) {
       return {
@@ -23,7 +24,7 @@ export class SearchObservationsWorker extends BaseTool {
     }
 
     try {
-      const rows = await ObservationsModel.search(query.trim(), Number(limit) || 20, Boolean(include_archived));
+      const rows = await ObservationsModel.search(query.trim(), Number(limit) || 20, includeArchived);
       const words = ObservationsModel.tokenizeQuery(query.trim());
       const matchDesc = words.length > 1 ? `"${ query }" (any of: ${ words.join(', ') })` : `"${ query }"`;
 


### PR DESCRIPTION
## Summary
- Remove the 15s timeout race for subconscious tasks that mutate live turn state
- Support explicit observation update-by-id in add_observational_memory and expose id/source in the tool schema
- Remove stale sulla meta/... examples from observational memory prompt text
- Clean focused lint issues in the token/memory observation files

## Verification
- yarn lint:typescript:nofix -- pkg/rancher-desktop/agent/database/migrations/0028_create_observations_table.ts pkg/rancher-desktop/agent/database/models/ObservationsModel.ts pkg/rancher-desktop/agent/database/seeders/ObservationsImportSeeder.ts pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts pkg/rancher-desktop/agent/prompts/turnContext.ts pkg/rancher-desktop/agent/services/RecallIndexService.ts pkg/rancher-desktop/agent/tools/meta/add_observational_memory.ts pkg/rancher-desktop/agent/tools/meta/remove_observational_memory.ts pkg/rancher-desktop/agent/tools/meta/search_observations.ts pkg/rancher-desktop/agent/tools/meta/list_observations.ts pkg/rancher-desktop/agent/tools/meta/recall_index_lookup.ts pkg/rancher-desktop/agent/tools/meta/recall_index_store.ts pkg/rancher-desktop/agent/tools/meta/manifests.ts