### PR TITLE
feat: OpenAI Codex provider — codex CLI in VM on ChatGPT subscription

### DIFF
--- a/pkg/rancher-desktop/agent/integrations/native/ai_infrastructure.ts
+++ b/pkg/rancher-desktop/agent/integrations/native/ai_infrastructure.ts
@@ -81,6 +81,35 @@ export const nativeAiInfrastructureIntegrations: Record<string, Integration> = {
     ],
   },
 
+  codex: {
+    id:              'codex',
+    sort:            1,
+    paid:            true,
+    beta:            true,
+    comingSoon:      false,
+    connected:       false,
+    name:            'OpenAI Codex',
+    description:     'Run OpenAI\'s Codex agent inside the Sulla Desktop VM using your ChatGPT Plus/Pro subscription — no API costs.',
+    category:        'AI Infrastructure',
+    icon:            'openai.svg',
+    version:         '1.0.0',
+    lastUpdated:     '2026-06-12',
+    developer:       'OpenAI',
+    oauth:           true,
+    oauthProviderId: 'codex',
+    formGuide:       'Sign in with ChatGPT to run Codex on your ChatGPT Plus/Pro plan. Usage draws from your subscription quota, not metered API billing.',
+    properties:      [
+      {
+        key:         'model',
+        title:       'Model',
+        hint:        'Codex chooses its own model by default; this field is informational.',
+        type:        'text',
+        required:    false,
+        placeholder: 'codex',
+      },
+    ],
+  },
+
   grok: {
     id:          'grok',
     sort:        2,

--- a/pkg/rancher-desktop/agent/integrations/native/ai_infrastructure.ts
+++ b/pkg/rancher-desktop/agent/integrations/native/ai_infrastructure.ts
@@ -98,16 +98,11 @@ export const nativeAiInfrastructureIntegrations: Record<string, Integration> = {
     oauth:           true,
     oauthProviderId: 'codex',
     formGuide:       'Sign in with ChatGPT to run Codex on your ChatGPT Plus/Pro plan. Usage draws from your subscription quota, not metered API billing.',
-    properties:      [
-      {
-        key:         'model',
-        title:       'Model',
-        hint:        'Codex chooses its own model by default; this field is informational.',
-        type:        'text',
-        required:    false,
-        placeholder: 'codex',
-      },
-    ],
+    // No 'model' form property on purpose: ModelProviderService.loadStateFromDB
+    // treats the provider's 'model' form value as activeModelId, so a free-text
+    // field here would end up passed to `codex exec --model` verbatim. Model
+    // selection happens through the model picker (getModelsForProvider).
+    properties:      [],
   },
 
   grok: {

--- a/pkg/rancher-desktop/agent/integrations/oauth/OAuthProvider.ts
+++ b/pkg/rancher-desktop/agent/integrations/oauth/OAuthProvider.ts
@@ -82,6 +82,10 @@ export abstract class OAuthProvider {
   /** Override to post-process token responses (e.g. extract user info) */
   async onTokenReceived(_tokens: OAuthTokenSet): Promise<void> {}
 
+  /** Override to clean up provider-side credential state on disconnect
+   *  (e.g. credential files written by onTokenReceived). */
+  async onTokensRevoked(): Promise<void> {}
+
   /** Override to add per-request headers when calling the provider's API */
   buildAuthHeader(accessToken: string): Record<string, string> {
     return { Authorization: `Bearer ${ accessToken }` };

--- a/pkg/rancher-desktop/agent/integrations/oauth/index.ts
+++ b/pkg/rancher-desktop/agent/integrations/oauth/index.ts
@@ -1,6 +1,7 @@
 // Barrel: re-exports types + registry, auto-registers all providers.
 
 // Auto-register concrete providers on import
+import './providers/CodexOAuth';
 import './providers/GoogleOAuth';
 import './providers/IntuitOAuth';
 import './providers/OpenAIOAuth';

--- a/pkg/rancher-desktop/agent/integrations/oauth/providers/CodexOAuth.ts
+++ b/pkg/rancher-desktop/agent/integrations/oauth/providers/CodexOAuth.ts
@@ -1,0 +1,52 @@
+// OpenAI Codex OAuth 2.0 provider — PKCE public client flow.
+//
+// Same official Codex CLI OAuth app as OpenAIOAuth, but with a different
+// purpose: instead of exchanging the id_token for a metered platform API key,
+// the full token set is written to ~/.codex/auth.json so the `codex` CLI in
+// the Lima VM runs against the user's ChatGPT Plus/Pro subscription — no API
+// billing. onTokenReceived also fires on every scheduled refresh, which keeps
+// the auth file current from the host side.
+
+import { OAuthProvider, type OAuthProviderConfig, type OAuthTokenSet } from '../OAuthProvider';
+import { registerOAuthProvider } from '../registry';
+import { writeCodexAuthFile } from '../../../util/codexAuthFile';
+
+class CodexOAuthProvider extends OAuthProvider {
+  readonly config: OAuthProviderConfig = {
+    id:                   'codex',
+    name:                 'OpenAI Codex',
+    authorizeUrl:         'https://auth.openai.com/oauth/authorize',
+    tokenUrl:             'https://auth.openai.com/oauth/token',
+    scopes:               ['openid', 'profile', 'email', 'offline_access'],
+    scopeSeparator:       ' ',
+    clientAuthMethod:     'none',
+    usePKCE:              true,
+    builtInClientId:      'app_EMoamEEZ73f0CkXaXp7hrann',
+    fixedCallbackPort:    1455,
+    fixedCallbackPath:    '/auth/callback',
+    extraAuthorizeParams: {
+      id_token_add_organizations: 'true',
+      originator:                 'codex_cli_rs',
+    },
+    refreshBufferSeconds: 300,
+  };
+
+  override async onTokenReceived(tokens: OAuthTokenSet): Promise<void> {
+    if (writeCodexAuthFile(tokens)) {
+      console.log('[CodexOAuth] ~/.codex/auth.json updated');
+    }
+
+    // Bust the LLM cache so the next agent call sees the new credentials
+    try {
+      const { LLMRegistry } = await import('../../../languagemodels/index');
+      LLMRegistry.invalidate('codex');
+      const { resetCodexService } = await import('../../../languagemodels/CodexService');
+      resetCodexService();
+    } catch { /* non-critical */ }
+  }
+}
+
+const instance = new CodexOAuthProvider();
+registerOAuthProvider(instance);
+
+export default instance;

--- a/pkg/rancher-desktop/agent/integrations/oauth/providers/CodexOAuth.ts
+++ b/pkg/rancher-desktop/agent/integrations/oauth/providers/CodexOAuth.ts
@@ -9,7 +9,7 @@
 
 import { OAuthProvider, type OAuthProviderConfig, type OAuthTokenSet } from '../OAuthProvider';
 import { registerOAuthProvider } from '../registry';
-import { writeCodexAuthFile } from '../../../util/codexAuthFile';
+import { removeCodexAuthFile, writeCodexAuthFile } from '../../../util/codexAuthFile';
 
 class CodexOAuthProvider extends OAuthProvider {
   readonly config: OAuthProviderConfig = {
@@ -43,6 +43,13 @@ class CodexOAuthProvider extends OAuthProvider {
       const { resetCodexService } = await import('../../../languagemodels/CodexService');
       resetCodexService();
     } catch { /* non-critical */ }
+  }
+
+  override async onTokensRevoked(): Promise<void> {
+    // Disconnect must actually stop authentication — the CLI would otherwise
+    // keep using (and self-refreshing) the leftover auth file forever.
+    removeCodexAuthFile();
+    console.log('[CodexOAuth] ~/.codex/auth.json removed');
   }
 }
 

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -1,0 +1,808 @@
+import * as childProcess from 'child_process';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { BaseLanguageModel, type ChatMessage, type NormalizedResponse, type StreamCallbacks, FinishReason } from './BaseLanguageModel';
+import { ensureCodexAuthFile, codexAuthPath } from '../util/codexAuthFile';
+import { redisClient } from '../database/RedisClient';
+import Logging from '@pkg/utils/logging';
+import paths from '@pkg/utils/paths';
+
+import type { BaseThreadState } from '@pkg/agent/nodes/Graph';
+
+const log = Logging.background;
+
+/**
+ * CodexService — runs `codex exec` inside the Lima VM and streams the
+ * --json JSONL output back into Sulla's agent loop.
+ *
+ * The codex sibling of ClaudeCodeService: codex already owns its own agent
+ * loop, tool execution, and context management inside the CLI process, so
+ * from Sulla's perspective it behaves as a "one-shot completion" peer. Tool
+ * work happens internally (shell, file edits, and the `sulla` CLI which is
+ * on PATH in the VM — no MCP wiring needed for native tool access).
+ *
+ * Auth: ~/.codex/auth.json, written by CodexOAuth on sign-in and on every
+ * scheduled token refresh. The home dir is mounted writable in the VM, so
+ * the CLI also self-refreshes tokens in place. With ChatGPT sign-in, usage
+ * draws from the user's ChatGPT Plus/Pro plan — no API billing.
+ *
+ * Token strategy — hybrid (first-turn seed + `exec resume` thereafter):
+ *   - First turn for a conversation: serialize the full curated
+ *     state.messages[] as a transcript so codex catches up to wherever
+ *     Sulla is.
+ *   - Subsequent turns: `codex exec resume <threadId>` with ONLY the latest
+ *     user message; codex's own session state keeps prior context warm.
+ *   - Resume failures (expired/missing thread): drop the cached id and
+ *     retry once with a fresh session (full history).
+ */
+export class CodexService extends BaseLanguageModel {
+  // conversationId → codex thread_id — in-memory cache backed by Redis.
+  private sessions = new Map<string, string>();
+
+  /**
+   * Tracks the hash of the stable <sulla_context> payload last sent per
+   * conversation so we only re-send it when it actually changes — same
+   * dedup as ClaudeCodeService (each send becomes permanent history).
+   */
+  private lastStableContextHash = new Map<string, string>();
+
+  private readonly SESSION_KEY_PREFIX = 'codex_session:';
+  private readonly SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+  private async getSession(convId: string): Promise<string | undefined> {
+    const cached = this.sessions.get(convId);
+    if (cached) return cached;
+    try {
+      const stored = await redisClient.get(`${ this.SESSION_KEY_PREFIX }${ convId }`);
+      if (stored) {
+        this.sessions.set(convId, stored);
+        return stored;
+      }
+    } catch { /* Redis unavailable — start fresh session */ }
+    return undefined;
+  }
+
+  private async setSession(convId: string, sessionId: string): Promise<void> {
+    this.sessions.set(convId, sessionId);
+    try {
+      await redisClient.set(`${ this.SESSION_KEY_PREFIX }${ convId }`, sessionId, this.SESSION_TTL_SECONDS);
+    } catch { /* Redis unavailable — session persists in memory only this run */ }
+  }
+
+  private async deleteSession(convId: string): Promise<void> {
+    this.sessions.delete(convId);
+    try {
+      await redisClient.del(`${ this.SESSION_KEY_PREFIX }${ convId }`);
+    } catch { /* Redis unavailable — non-fatal */ }
+  }
+
+  override getContextWindow(): number {
+    return 272_000;
+  }
+
+  override getModel(): string {
+    return this.model || 'codex';
+  }
+
+  override getProviderName(): string {
+    return 'OpenAI Codex';
+  }
+
+  protected async healthCheck(): Promise<boolean> {
+    // Credentials presence is deferred until spawn time (see runCodex).
+    return true;
+  }
+
+  constructor() {
+    super({ id: 'codex', model: 'codex', baseUrl: 'local-vm' });
+  }
+
+  /** Non-streaming chat — buffers the whole response and returns it. */
+  protected async sendRawRequest(messages: ChatMessage[], options: any): Promise<any> {
+    const { text } = await this.runCodex(messages, {}, options);
+    return { text };
+  }
+
+  protected normalizeResponse(raw: any): NormalizedResponse {
+    const text: string = raw?.text ?? '';
+    return {
+      content:  text,
+      metadata: {
+        tokens_used:       0,
+        time_spent:        0,
+        prompt_tokens:     0,
+        completion_tokens: 0,
+        model:             this.getModel(),
+        finish_reason:     FinishReason.Stop,
+      },
+    };
+  }
+
+  /** Streaming path — forwards agent message chunks to onToken. */
+  override async chatStream(
+    messages: ChatMessage[],
+    callbacks: StreamCallbacks,
+    options: {
+      signal?:         AbortSignal;
+      conversationId?: string;
+      state?:          BaseThreadState | any;
+    } = {},
+  ): Promise<NormalizedResponse | null> {
+    const startTime = performance.now();
+
+    try {
+      const { text } = await this.runCodex(messages, callbacks, options);
+
+      return {
+        content:  text,
+        metadata: {
+          tokens_used:       0,
+          time_spent:        Math.round(performance.now() - startTime),
+          prompt_tokens:     0,
+          completion_tokens: 0,
+          model:             this.getModel(),
+          finish_reason:     FinishReason.Stop,
+        },
+      };
+    } catch (err) {
+      console.warn('[CodexService] chatStream failed:', err);
+      throw err;
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────
+
+  /**
+   * Save a base64 image block to ~/sulla/workspaces/attachments/ so the
+   * Lima VM agent can read it from disk. Returns the saved path.
+   */
+  private saveImageAttachment(b: any): string | null {
+    try {
+      const data: string | undefined = b?.source?.data;
+      const mediaType: string = b?.source?.media_type || 'image/png';
+      if (!data) return null;
+
+      const ext = mediaType.split('/')[1]?.split('+')[0] || 'png';
+      const dir = path.join(paths.sullaHome, 'workspaces', 'attachments');
+      fs.mkdirSync(dir, { recursive: true });
+
+      const filename = `attachment-${ Date.now() }.${ ext }`;
+      const filepath = path.join(dir, filename);
+      fs.writeFileSync(filepath, Buffer.from(data, 'base64'));
+
+      log.info(`[CodexService] Image saved: ${ filepath }`);
+      return filepath;
+    } catch (err) {
+      log.error('[CodexService] Failed to save image attachment:', err);
+      return null;
+    }
+  }
+
+  /**
+   * Extract the last user message. Walks backward to find the newest
+   * user-role content, flattening string + content-block shapes. When a
+   * resume session exists, this is all we send — codex already has
+   * everything earlier in its session state.
+   */
+  private extractLatestUserMessage(messages: ChatMessage[]): string {
+    const blockToText = (b: any): string => {
+      if (typeof b === 'string') return b;
+      if (!b || typeof b !== 'object') return '';
+      if (b.type === 'text' && typeof b.text === 'string') return b.text;
+      if (b.type === 'image' && b?.source?.type === 'base64') {
+        const savedPath = this.saveImageAttachment(b);
+        return savedPath ? `[Image attached — read it at: ${ savedPath }]` : '';
+      }
+      if (b.type === 'tool_result') {
+        if (typeof b.content === 'string') return b.content;
+        if (Array.isArray(b.content)) return b.content.map(blockToText).filter(Boolean).join('\n');
+      }
+      return '';
+    };
+
+    const msgToText = (m: ChatMessage): string => {
+      const c: any = m.content;
+      if (typeof c === 'string') return c;
+      if (Array.isArray(c)) return c.map(blockToText).filter(Boolean).join('\n');
+      return '';
+    };
+
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') {
+        const text = msgToText(messages[i]).trim();
+        if (text) return text;
+      }
+    }
+    // Fallback — pick any extractable text so a tool_result-dominated turn
+    // still has something to send.
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const text = msgToText(messages[i]).trim();
+      if (text) return text;
+    }
+    return '';
+  }
+
+  /**
+   * Serialize Sulla's curated conversation into a full transcript — used
+   * only when seeding a fresh codex session. System-role messages are
+   * INTENTIONALLY excluded — the system prompt reaches codex via
+   * ~/.codex/AGENTS.md (see generateCodexMemoryFile), so including them
+   * here would deliver it twice.
+   */
+  private serializeFullTranscript(messages: ChatMessage[]): string {
+    const blockToText = (b: any): string => {
+      if (typeof b === 'string') return b;
+      if (!b || typeof b !== 'object') return '';
+      if (b.type === 'text' && typeof b.text === 'string') return b.text;
+      if (b.type === 'tool_use') {
+        const name = b.name ?? 'tool';
+        const input = b.input ? JSON.stringify(b.input) : '';
+        return `[tool_use ${ name }${ input ? ` ${ input }` : '' }]`;
+      }
+      if (b.type === 'tool_result') {
+        if (typeof b.content === 'string') return `[tool_result] ${ b.content }`;
+        if (Array.isArray(b.content)) return `[tool_result] ${ b.content.map(blockToText).filter(Boolean).join('\n') }`;
+      }
+      return '';
+    };
+
+    const msgToText = (m: ChatMessage): string => {
+      const c: any = m.content;
+      if (typeof c === 'string') return c;
+      if (Array.isArray(c)) return c.map(blockToText).filter(Boolean).join('\n');
+      return '';
+    };
+
+    const labelFor = (role: string) => {
+      switch (role) {
+      case 'assistant': return 'Assistant';
+      case 'user':      return 'User';
+      default:          return role;
+      }
+    };
+
+    const lines: string[] = [];
+    for (const m of messages) {
+      if (m.role === 'system') continue; // delivered via ~/.codex/AGENTS.md
+      const text = msgToText(m).trim();
+      if (!text) continue;
+      lines.push(`${ labelFor(m.role) }: ${ text }`);
+    }
+    return lines.join('\n\n');
+  }
+
+  /**
+   * Build a <sulla_context> prefix for the outgoing user message — same
+   * two-tier strategy as ClaudeCodeService: the stable tier (platform rules
+   * + high-priority memories) is sent on the first turn and again only when
+   * its content changes; per-turn recall/observation context always rides
+   * along when present.
+   */
+  private async buildUserMessageContextPrefix(
+    state: BaseThreadState | undefined,
+    opts: { convId: string; isNewSession: boolean },
+  ): Promise<string> {
+    const stableParts: string[] = [];
+
+    stableParts.push(`<platform_context>
+You are operating inside Sulla Desktop — an autonomous agentic platform built by Jonathon Byrdziak. You are not a chatbot or a brain being asked questions. You are an agent with real tools and real execution capability.
+
+Rules that apply on every turn:
+- Execute tasks — don't describe what you would do, do it with tools
+- Use the Sulla CLI (\`sulla <category>/<tool>\`) for all platform operations
+- Scheduling → Sulla Workflows (\`sulla workflow/import_workflow\`), never cron
+- Git/GitHub → \`sulla github/git_push\` / \`sulla github/git_pull\`, never SSH or raw curl
+- Browser → \`sulla browser/tab\` with action \`upsert\` or \`remove\` only
+- Recurring tasks become workflows, not one-off commands
+- You are part of a live multi-agent network — Heartbeat, Workbench, and other agents are active
+</platform_context>`);
+
+    // High-priority observational memory
+    try {
+      const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');
+      const { parseJson } = await import('../services/JsonParseService');
+      const raw     = await SullaSettingsModel.get('observationalMemory', '[]');
+      const entries = parseJson(raw);
+      if (Array.isArray(entries)) {
+        const high = (entries as any[]).filter(e =>
+          ['critical', 'high'].includes((e?.priority ?? '').toLowerCase()),
+        );
+        if (high.length > 0) {
+          const lines = high.map((e: any) => `- ${ e.content ?? '' }`).join('\n');
+          stableParts.push(`<observational_memory>\n${ lines }\n</observational_memory>`);
+        }
+      }
+    } catch { /* non-fatal */ }
+
+    const parts: string[] = [];
+
+    // Only send the stable tier when it's new to this session or has changed
+    // since it was last sent.
+    const stableText = stableParts.join('\n\n');
+    const stableHash = crypto.createHash('sha1').update(stableText).digest('hex');
+    if (opts.isNewSession || this.lastStableContextHash.get(opts.convId) !== stableHash) {
+      parts.push(stableText);
+    }
+    this.lastStableContextHash.set(opts.convId, stableHash);
+
+    // Recall context from subconscious middleware (may be null on first turn)
+    const recallContext = (state?.metadata as any)?.recallContext;
+    if (recallContext && typeof recallContext === 'string' && recallContext.trim()) {
+      parts.push(`<recall_context>\n${ recallContext.trim() }\n</recall_context>`);
+    }
+
+    // Observation context from observation-recall agent (targeted DB observations)
+    const observationContext = (state?.metadata as any)?.observationContext;
+    if (observationContext && typeof observationContext === 'string' && observationContext.trim()) {
+      parts.push(`<observation_context>\n${ observationContext.trim() }\n</observation_context>`);
+    }
+
+    if (parts.length === 0) return '';
+    return `<sulla_context>\n${ parts.join('\n\n') }\n</sulla_context>`;
+  }
+
+  /**
+   * Spawn codex exec in the VM, stream agent message chunks to the
+   * callback, return the final text.
+   *
+   * @param retryWithoutSession — internal flag for the resume-failure retry
+   *   path; do not pass from callers.
+   */
+  private async runCodex(
+    messages: ChatMessage[],
+    callbacks: Partial<StreamCallbacks>,
+    options: { signal?: AbortSignal; conversationId?: string; state?: BaseThreadState },
+    retryWithoutSession = false,
+  ): Promise<{ text: string }> {
+    // Auth lives in ~/.codex/auth.json (written by CodexOAuth, self-refreshed
+    // by the CLI). Rebuild it from the stored OAuth tokens if missing.
+    const hasAuth = await ensureCodexAuthFile();
+    if (!hasAuth) {
+      throw new Error('No Codex credentials configured. Sign in with ChatGPT via Integrations → OpenAI Codex.');
+    }
+
+    const convId = options.conversationId ?? '__default__';
+    const existingSession = retryWithoutSession ? undefined : await this.getSession(convId);
+
+    // Prompt strategy:
+    //   - existingSession → send only the latest user message (codex has the
+    //     rest via `exec resume`)
+    //   - no session    → seed codex with the full curated transcript
+    const basePrompt = existingSession
+      ? this.extractLatestUserMessage(messages)
+      : this.serializeFullTranscript(messages);
+
+    if (!basePrompt.trim()) {
+      const roles = messages.map(m => m.role).join(',');
+      throw new Error(`Codex got no extractable prompt from ${ messages.length } messages (roles=${ roles })`);
+    }
+
+    const contextPrefix = await this.buildUserMessageContextPrefix(options.state, {
+      convId,
+      isNewSession: !existingSession,
+    });
+    const prompt = contextPrefix ? `${ contextPrefix }\n\n${ basePrompt }` : basePrompt;
+
+    log.log(`[CodexService] runCodex: messages=${ messages.length } promptLen=${ prompt.length } conversationId=${ convId } session=${ existingSession ?? '(new)' } authFile=${ codexAuthPath() }`);
+
+    // Lima only exists on macOS/Linux; paths.limactl is a throwing getter on
+    // Windows. Surface a clear, user-readable error instead of an opaque crash.
+    if (process.platform === 'win32') {
+      throw new Error('Codex execution requires the Lima VM, which is not available on Windows yet. This feature currently supports macOS and Linux only.');
+    }
+
+    const limactlPath = paths.limactl;
+    const limaHome = paths.lima;
+
+    // POSIX single-quote escape. Single-quoted strings are literal in sh, so
+    // no backtick/$VAR/! expansion can fire against untrusted text.
+    const shq = (s: string) => `'${ s.replace(/'/g, "'\\''") }'`;
+
+    // Refresh ~/.codex/AGENTS.md with the full system prompt before spawning.
+    // AGENTS.md is the sole source of system context for codex.
+    import('../prompts/generateCodexMemoryFile').then(({ generateCodexMemoryFile }) => {
+      generateCodexMemoryFile().catch(() => {});
+    }).catch(() => {});
+
+    // The prompt is fed via stdin (`-` positional), NOT as an argv element —
+    // a large transcript on the command line overflows limactl's SSH
+    // multiplexing channel (same failure mode ClaudeCodeService hit).
+    //
+    // --dangerously-bypass-approvals-and-sandbox: codex runs inside the Lima
+    // VM, which IS the sandbox — its own landlock layer is redundant here and
+    // approval prompts have no TTY to land on.
+    const codexArgs = ['codex', 'exec'];
+    if (existingSession) {
+      codexArgs.push('resume', shq(existingSession));
+    }
+    codexArgs.push(
+      '--json',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--skip-git-repo-check',
+    );
+    // Pass --model only when explicitly overridden. The 'codex' sentinel means
+    // "auto" — omit the flag and let the CLI use its configured default.
+    if (this.model && this.model !== 'codex') {
+      codexArgs.push('--model', shq(this.model));
+    }
+    codexArgs.push('-'); // read the prompt from stdin
+
+    // `exec` replaces the inner sh with codex so there's no shell layer
+    // between the SSH session and the CLI — best chance of signal
+    // propagation when we kill limactl on the host side.
+    const innerCmd = `exec ${ codexArgs.join(' ') }`;
+    const args = ['shell', '0', '--', 'sh', '-c', innerCmd];
+
+    return await new Promise((resolve, reject) => {
+      const proc = childProcess.spawn(limactlPath, args, {
+        env: { ...process.env, LIMA_HOME: limaHome, TERM: 'dumb' },
+      });
+
+      // Feed the prompt through stdin instead of the command line. Guard
+      // against EPIPE in case codex exits before we finish.
+      proc.stdin.on('error', () => { /* EPIPE — codex already gone, non-fatal */ });
+      try {
+        proc.stdin.write(prompt);
+        proc.stdin.end();
+      } catch { /* stdin already closed */ }
+
+      // Heartbeat ticker — keeps the renderer informed during the cold-start
+      // gap between spawn and the first event. Cleared on first real stream
+      // event or close/error/abort.
+      let heartbeatTimer: NodeJS.Timeout | null = null;
+      const directActivity = (msg: string) => {
+        if (!msg) return;
+        try { callbacks.onActivity?.(msg) } catch { /* ignore */ }
+      };
+      const stopHeartbeat = () => {
+        if (heartbeatTimer) {
+          clearInterval(heartbeatTimer);
+          heartbeatTimer = null;
+        }
+      };
+
+      proc.once('spawn', () => {
+        directActivity('Booting isolated environment…');
+        heartbeatTimer = setInterval(() => {
+          // Transient status only — tool activities and agent messages
+          // provide the real feedback once the stream starts.
+        }, 3000);
+      });
+
+      let stdoutBuffer = '';
+      let stderrBuffer = '';
+      let textCollected = '';
+      let sawDelta = false;
+      let capturedSessionId: string | undefined = existingSession;
+      let errored = false;
+      let errorMessage = '';
+
+      const onAbort = () => {
+        stopHeartbeat();
+        // 1) Kill the host-side limactl process (closes the SSH session; with
+        //    `exec` in the inner shell the remote codex usually gets SIGHUP).
+        try { proc.kill('SIGTERM') } catch { /* already dead */ }
+
+        // 2) Belt-and-suspenders: explicitly kill any lingering codex process
+        //    inside the VM so an orphan doesn't keep burning plan quota.
+        try {
+          const killProc = childProcess.spawn(
+            limactlPath,
+            ['shell', '0', '--', 'pkill', '-TERM', '-f', 'codex exec'],
+            {
+              env:      { ...process.env, LIMA_HOME: limaHome, TERM: 'dumb' },
+              stdio:    'ignore',
+              detached: true,
+            },
+          );
+          killProc.unref();
+        } catch (err) {
+          log.log(`[CodexService] Remote pkill failed: ${ (err as Error)?.message ?? err }`);
+        }
+      };
+      if (options.signal) {
+        if (options.signal.aborted) onAbort();
+        else options.signal.addEventListener('abort', onAbort);
+      }
+
+      const emitActivity = (msg: string) => {
+        if (!msg) return;
+        try { callbacks.onActivity?.(msg) } catch { /* ignore */ }
+      };
+
+      const pretty = (s: string) => s.length > 80 ? `${ s.slice(0, 77) }…` : s;
+
+      /** Append a complete agent message, skipping it when deltas already
+       *  streamed its content into textCollected. */
+      const appendAgentMessage = (text: string) => {
+        if (!text) return;
+        if (sawDelta) {
+          // Deltas already delivered this content; reset for the next message.
+          sawDelta = false;
+          return;
+        }
+        const sep = textCollected.trim() ? '\n\n' : '';
+        textCollected += sep + text;
+        try { callbacks.onToken?.(sep + text) } catch { /* ignore */ }
+      };
+
+      /** Activity line for a thread-event item (command_execution, etc.). */
+      const activityForItem = (item: any) => {
+        const kind = item?.item_type ?? item?.type;
+        switch (kind) {
+        case 'command_execution':
+          if (typeof item.command === 'string') return `$ ${ pretty(item.command) }`;
+          return 'Running a shell command';
+        case 'file_change': {
+          const first = Array.isArray(item.changes) ? item.changes[0] : null;
+          if (first?.path) return `Editing ${ pretty(String(first.path)) }`;
+          return 'Editing files';
+        }
+        case 'web_search':
+          if (typeof item.query === 'string') return `Searching web: ${ pretty(item.query) }`;
+          return 'Searching the web';
+        case 'mcp_tool_call':
+          if (typeof item.tool === 'string') return `Using ${ item.tool }`;
+          return 'Calling a tool';
+        case 'reasoning':
+          return ''; // thinking — no activity line needed
+        default:
+          return '';
+        }
+      };
+
+      const processLine = (line: string) => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        let parsed: any;
+        try {
+          parsed = JSON.parse(trimmed);
+        } catch {
+          return;
+        }
+
+        // ── Thread-event schema (codex exec --json) ──────────────
+        if (typeof parsed.type === 'string') {
+          if (parsed.type === 'thread.started' && parsed.thread_id) {
+            stopHeartbeat();
+            capturedSessionId = parsed.thread_id;
+            emitActivity('Session started — calling model');
+            return;
+          }
+          if (parsed.type === 'item.started' || parsed.type === 'item.completed') {
+            stopHeartbeat();
+            const item = parsed.item ?? {};
+            const kind = item.item_type ?? item.type;
+            if (kind === 'agent_message' && parsed.type === 'item.completed') {
+              appendAgentMessage(typeof item.text === 'string' ? item.text : '');
+              return;
+            }
+            if (parsed.type === 'item.started') {
+              const activity = activityForItem(item);
+              if (activity) emitActivity(activity);
+            }
+            if (kind === 'error' && parsed.type === 'item.completed') {
+              errored = true;
+              if (typeof item.message === 'string') errorMessage = item.message;
+            }
+            return;
+          }
+          if (parsed.type === 'turn.completed') {
+            recordUsage(parsed.usage, this.getModel()).catch(() => { /* ignore */ });
+            return;
+          }
+          if (parsed.type === 'turn.failed') {
+            errored = true;
+            const msg = parsed.error?.message;
+            if (typeof msg === 'string' && msg) errorMessage = msg;
+            return;
+          }
+          if (parsed.type === 'error') {
+            errored = true;
+            if (typeof parsed.message === 'string' && parsed.message) errorMessage = parsed.message;
+            return;
+          }
+        }
+
+        // ── Legacy event schema ({id, msg:{type,...}}) ───────────
+        const msg = parsed?.msg;
+        if (!msg || typeof msg.type !== 'string') return;
+
+        switch (msg.type) {
+        case 'session_configured':
+          stopHeartbeat();
+          if (msg.session_id) capturedSessionId = msg.session_id;
+          emitActivity('Session started — calling model');
+          break;
+        case 'agent_message_delta':
+          stopHeartbeat();
+          if (typeof msg.delta === 'string') {
+            sawDelta = true;
+            textCollected += msg.delta;
+            try { callbacks.onToken?.(msg.delta) } catch { /* ignore */ }
+          }
+          break;
+        case 'agent_message':
+          stopHeartbeat();
+          appendAgentMessage(typeof msg.message === 'string' ? msg.message : '');
+          break;
+        case 'exec_command_begin': {
+          stopHeartbeat();
+          const cmd = Array.isArray(msg.command) ? msg.command.join(' ') : String(msg.command ?? '');
+          emitActivity(cmd ? `$ ${ pretty(cmd) }` : 'Running a shell command');
+          break;
+        }
+        case 'token_count':
+          recordUsage(msg.info?.total_token_usage ?? msg.info, this.getModel()).catch(() => { /* ignore */ });
+          break;
+        case 'task_complete':
+          if (typeof msg.last_agent_message === 'string' && !textCollected.trim()) {
+            appendAgentMessage(msg.last_agent_message);
+          }
+          break;
+        case 'error':
+        case 'stream_error':
+          errored = true;
+          if (typeof msg.message === 'string' && msg.message) errorMessage = msg.message;
+          break;
+        default:
+          break;
+        }
+      };
+
+      proc.stdout.on('data', (chunk) => {
+        stdoutBuffer += chunk.toString('utf-8');
+        const lines = stdoutBuffer.split('\n');
+        stdoutBuffer = lines.pop() ?? '';
+        for (const line of lines) processLine(line);
+      });
+
+      proc.stderr.on('data', (chunk) => {
+        const text = chunk.toString('utf-8');
+        stderrBuffer += text;
+        const trimmed = text.trim();
+        if (trimmed) {
+          console.log(`[CodexService][stderr] ${ trimmed.slice(0, 200) }`);
+        }
+      });
+
+      proc.on('error', (err) => {
+        stopHeartbeat();
+        options.signal?.removeEventListener('abort', onAbort);
+        reject(err);
+      });
+
+      proc.on('close', (code) => {
+        stopHeartbeat();
+        options.signal?.removeEventListener('abort', onAbort);
+        if (stdoutBuffer.trim()) processLine(stdoutBuffer);
+
+        // Resume failure (expired/missing thread) — drop the cached id and
+        // retry once with a fresh session so the user doesn't see a dead end.
+        const resumeFailed = existingSession && !retryWithoutSession &&
+          (errored || code !== 0) &&
+          /thread|session|resume|rollout|not found/i.test(`${ errorMessage } ${ stderrBuffer }`);
+        if (resumeFailed) {
+          log.warn(`[CodexService] Resume of "${ existingSession }" failed; retrying with a fresh session for conversationId=${ convId }`);
+          this.deleteSession(convId).catch(() => {});
+          this.runCodex(messages, callbacks, options, true).then(
+            r => resolve(r),
+            reject,
+          );
+          return;
+        }
+
+        if (capturedSessionId) {
+          this.setSession(convId, capturedSessionId).catch(() => {});
+        }
+
+        if (code === 127) {
+          reject(new Error('codex CLI is not installed in the VM yet. Restart Sulla Desktop to re-provision, or run: npm install --prefix /mnt/data/npm-global -g @openai/codex'));
+          return;
+        }
+
+        if (errored || (code !== 0 && !textCollected.trim())) {
+          const msg = errorMessage || stderrBuffer.trim().slice(-200) || `codex exited with code ${ code }`;
+          log.warn(`[CodexService] runCodex errored: ${ msg.slice(0, 200) }`);
+          reject(new Error(`Codex: ${ msg }`));
+          return;
+        }
+
+        if (!textCollected.trim()) {
+          const stderrTail = stderrBuffer.trim().slice(-200);
+          log.warn(`[CodexService] runCodex exited with no text (code=${ code }) stderr=${ stderrTail }`);
+          reject(new Error(`Codex returned no output (exit code ${ code }). ${ stderrTail || 'Check credentials and VM status.' }`));
+          return;
+        }
+
+        log.log(`[CodexService] runCodex ok: ${ textCollected.length } chars, session=${ capturedSessionId ?? '(none)' }`);
+        resolve({ text: textCollected });
+      });
+    });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Usage capture
+// ─────────────────────────────────────────────────────────────
+
+interface UsageRecord {
+  ts:             string;
+  input_tokens?:  number;
+  output_tokens?: number;
+  cached_input_tokens?: number;
+  model?:         string;
+}
+
+const USAGE_SETTING_KEY = 'codexUsage';
+const USAGE_RETENTION_MS = 24 * 60 * 60 * 1000; // 24 hours
+const USAGE_MAX_ENTRIES = 500;
+
+/**
+ * Append a single usage sample from codex's turn.completed / token_count
+ * events to SullaSettingsModel.codexUsage. Trims to a rolling 24h window
+ * and caps the array length so the settings row can't grow unbounded.
+ */
+async function recordUsage(usage: any, model: string): Promise<void> {
+  if (!usage || typeof usage !== 'object') return;
+
+  try {
+    const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');
+    const raw = await SullaSettingsModel.get(USAGE_SETTING_KEY, '[]');
+    let records: UsageRecord[] = [];
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) records = parsed;
+    } catch { /* ignore unparseable prior value */ }
+
+    const entry: UsageRecord = {
+      ts:                  new Date().toISOString(),
+      input_tokens:        typeof usage.input_tokens === 'number' ? usage.input_tokens : undefined,
+      output_tokens:       typeof usage.output_tokens === 'number' ? usage.output_tokens : undefined,
+      cached_input_tokens: typeof usage.cached_input_tokens === 'number' ? usage.cached_input_tokens : undefined,
+      model,
+    };
+
+    records.push(entry);
+
+    const cutoff = Date.now() - USAGE_RETENTION_MS;
+    records = records.filter(r => {
+      const t = Date.parse(r.ts);
+      return Number.isFinite(t) && t >= cutoff;
+    });
+
+    if (records.length > USAGE_MAX_ENTRIES) {
+      records = records.slice(-USAGE_MAX_ENTRIES);
+    }
+
+    await SullaSettingsModel.set(USAGE_SETTING_KEY, JSON.stringify(records));
+  } catch {
+    /* persistence failure — don't disturb the chat */
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────
+
+let codexInstance: CodexService | null = null;
+
+export function getCodexService(): CodexService {
+  if (!codexInstance) {
+    codexInstance = new CodexService();
+  }
+  return codexInstance;
+}
+
+/** Create a fresh (non-singleton) CodexService with a specific model override. */
+export function createCodexService(model: string): CodexService {
+  const svc = new CodexService();
+  svc.setModel(model);
+  return svc;
+}
+
+export function resetCodexService(): void {
+  codexInstance = null;
+}

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -168,7 +168,9 @@ export class CodexService extends BaseLanguageModel {
       const dir = path.join(paths.sullaHome, 'workspaces', 'attachments');
       fs.mkdirSync(dir, { recursive: true });
 
-      const filename = `attachment-${ Date.now() }.${ ext }`;
+      // Random suffix: two image blocks in one message save within the same
+      // millisecond, and Date.now() alone would overwrite the first.
+      const filename = `attachment-${ Date.now() }-${ crypto.randomBytes(4).toString('hex') }.${ ext }`;
       const filepath = path.join(dir, filename);
       fs.writeFileSync(filepath, Buffer.from(data, 'base64'));
 
@@ -236,6 +238,10 @@ export class CodexService extends BaseLanguageModel {
       if (typeof b === 'string') return b;
       if (!b || typeof b !== 'object') return '';
       if (b.type === 'text' && typeof b.text === 'string') return b.text;
+      if (b.type === 'image' && b?.source?.type === 'base64') {
+        const savedPath = this.saveImageAttachment(b);
+        return savedPath ? `[Image attached — read it at: ${ savedPath }]` : '';
+      }
       if (b.type === 'tool_use') {
         const name = b.name ?? 'tool';
         const input = b.input ? JSON.stringify(b.input) : '';
@@ -279,11 +285,15 @@ export class CodexService extends BaseLanguageModel {
    * + high-priority memories) is sent on the first turn and again only when
    * its content changes; per-turn recall/observation context always rides
    * along when present.
+   *
+   * Returns the stable-tier hash alongside the prefix; the caller commits it
+   * to lastStableContextHash only after a successful run, so changed context
+   * isn't marked "delivered" when the spawn fails.
    */
   private async buildUserMessageContextPrefix(
     state: BaseThreadState | undefined,
     opts: { convId: string; isNewSession: boolean },
-  ): Promise<string> {
+  ): Promise<{ prefix: string; stableHash: string }> {
     const stableParts: string[] = [];
 
     stableParts.push(`<platform_context>
@@ -292,7 +302,7 @@ You are operating inside Sulla Desktop — an autonomous agentic platform built 
 Rules that apply on every turn:
 - Execute tasks — don't describe what you would do, do it with tools
 - Use the Sulla CLI (\`sulla <category>/<tool>\`) for all platform operations
-- Scheduling → Sulla Workflows (\`sulla workflow/import_workflow\`), never cron
+- Scheduling → Sulla Workflows (\`sulla workflow/import_workflow\`), never CronCreate or cron
 - Git/GitHub → \`sulla github/git_push\` / \`sulla github/git_pull\`, never SSH or raw curl
 - Browser → \`sulla browser/tab\` with action \`upsert\` or \`remove\` only
 - Recurring tasks become workflows, not one-off commands
@@ -325,7 +335,6 @@ Rules that apply on every turn:
     if (opts.isNewSession || this.lastStableContextHash.get(opts.convId) !== stableHash) {
       parts.push(stableText);
     }
-    this.lastStableContextHash.set(opts.convId, stableHash);
 
     // Recall context from subconscious middleware (may be null on first turn)
     const recallContext = (state?.metadata as any)?.recallContext;
@@ -339,8 +348,8 @@ Rules that apply on every turn:
       parts.push(`<observation_context>\n${ observationContext.trim() }\n</observation_context>`);
     }
 
-    if (parts.length === 0) return '';
-    return `<sulla_context>\n${ parts.join('\n\n') }\n</sulla_context>`;
+    if (parts.length === 0) return { prefix: '', stableHash };
+    return { prefix: `<sulla_context>\n${ parts.join('\n\n') }\n</sulla_context>`, stableHash };
   }
 
   /**
@@ -379,7 +388,7 @@ Rules that apply on every turn:
       throw new Error(`Codex got no extractable prompt from ${ messages.length } messages (roles=${ roles })`);
     }
 
-    const contextPrefix = await this.buildUserMessageContextPrefix(options.state, {
+    const { prefix: contextPrefix, stableHash } = await this.buildUserMessageContextPrefix(options.state, {
       convId,
       isNewSession: !existingSession,
     });
@@ -401,10 +410,17 @@ Rules that apply on every turn:
     const shq = (s: string) => `'${ s.replace(/'/g, "'\\''") }'`;
 
     // Refresh ~/.codex/AGENTS.md with the full system prompt before spawning.
-    // AGENTS.md is the sole source of system context for codex.
-    import('../prompts/generateCodexMemoryFile').then(({ generateCodexMemoryFile }) => {
-      generateCodexMemoryFile().catch(() => {});
-    }).catch(() => {});
+    // AGENTS.md is the sole source of system context for codex. On a NEW
+    // session the write must land before the spawn — codex reads the file at
+    // startup, and a seed turn launched without it runs unconfigured for the
+    // lifetime of the thread (resume only sends the latest user message).
+    // Resume turns tolerate a stale file, so they don't pay the build latency.
+    const memoryFileWrite = import('../prompts/generateCodexMemoryFile')
+      .then(({ generateCodexMemoryFile }) => generateCodexMemoryFile())
+      .catch(() => {});
+    if (!existingSession) {
+      await memoryFileWrite;
+    }
 
     // The prompt is fed via stdin (`-` positional), NOT as an argv element —
     // a large transcript on the command line overflows limactl's SSH
@@ -448,27 +464,13 @@ Rules that apply on every turn:
         proc.stdin.end();
       } catch { /* stdin already closed */ }
 
-      // Heartbeat ticker — keeps the renderer informed during the cold-start
-      // gap between spawn and the first event. Cleared on first real stream
-      // event or close/error/abort.
-      let heartbeatTimer: NodeJS.Timeout | null = null;
-      const directActivity = (msg: string) => {
+      const emitActivity = (msg: string) => {
         if (!msg) return;
         try { callbacks.onActivity?.(msg) } catch { /* ignore */ }
       };
-      const stopHeartbeat = () => {
-        if (heartbeatTimer) {
-          clearInterval(heartbeatTimer);
-          heartbeatTimer = null;
-        }
-      };
 
       proc.once('spawn', () => {
-        directActivity('Booting isolated environment…');
-        heartbeatTimer = setInterval(() => {
-          // Transient status only — tool activities and agent messages
-          // provide the real feedback once the stream starts.
-        }, 3000);
+        emitActivity('Booting isolated environment…');
       });
 
       let stdoutBuffer = '';
@@ -478,9 +480,9 @@ Rules that apply on every turn:
       let capturedSessionId: string | undefined = existingSession;
       let errored = false;
       let errorMessage = '';
+      let lastUsage: any = null;
 
       const onAbort = () => {
-        stopHeartbeat();
         // 1) Kill the host-side limactl process (closes the SSH session; with
         //    `exec` in the inner shell the remote codex usually gets SIGHUP).
         try { proc.kill('SIGTERM') } catch { /* already dead */ }
@@ -506,11 +508,6 @@ Rules that apply on every turn:
         if (options.signal.aborted) onAbort();
         else options.signal.addEventListener('abort', onAbort);
       }
-
-      const emitActivity = (msg: string) => {
-        if (!msg) return;
-        try { callbacks.onActivity?.(msg) } catch { /* ignore */ }
-      };
 
       const pretty = (s: string) => s.length > 80 ? `${ s.slice(0, 77) }…` : s;
 
@@ -566,13 +563,11 @@ Rules that apply on every turn:
         // ── Thread-event schema (codex exec --json) ──────────────
         if (typeof parsed.type === 'string') {
           if (parsed.type === 'thread.started' && parsed.thread_id) {
-            stopHeartbeat();
             capturedSessionId = parsed.thread_id;
             emitActivity('Session started — calling model');
             return;
           }
           if (parsed.type === 'item.started' || parsed.type === 'item.completed') {
-            stopHeartbeat();
             const item = parsed.item ?? {};
             const kind = item.item_type ?? item.type;
             if (kind === 'agent_message' && parsed.type === 'item.completed') {
@@ -590,7 +585,9 @@ Rules that apply on every turn:
             return;
           }
           if (parsed.type === 'turn.completed') {
-            recordUsage(parsed.usage, this.getModel()).catch(() => { /* ignore */ });
+            // Recorded once on close — codex can emit several usage events
+            // per run (one per model call) and each carries cumulative totals.
+            lastUsage = parsed.usage;
             return;
           }
           if (parsed.type === 'turn.failed') {
@@ -612,12 +609,10 @@ Rules that apply on every turn:
 
         switch (msg.type) {
         case 'session_configured':
-          stopHeartbeat();
           if (msg.session_id) capturedSessionId = msg.session_id;
           emitActivity('Session started — calling model');
           break;
         case 'agent_message_delta':
-          stopHeartbeat();
           if (typeof msg.delta === 'string') {
             sawDelta = true;
             textCollected += msg.delta;
@@ -625,17 +620,16 @@ Rules that apply on every turn:
           }
           break;
         case 'agent_message':
-          stopHeartbeat();
           appendAgentMessage(typeof msg.message === 'string' ? msg.message : '');
           break;
         case 'exec_command_begin': {
-          stopHeartbeat();
           const cmd = Array.isArray(msg.command) ? msg.command.join(' ') : String(msg.command ?? '');
           emitActivity(cmd ? `$ ${ pretty(cmd) }` : 'Running a shell command');
           break;
         }
         case 'token_count':
-          recordUsage(msg.info?.total_token_usage ?? msg.info, this.getModel()).catch(() => { /* ignore */ });
+          // Cumulative running total — keep the latest, record once on close.
+          lastUsage = msg.info?.total_token_usage ?? msg.info;
           break;
         case 'task_complete':
           if (typeof msg.last_agent_message === 'string' && !textCollected.trim()) {
@@ -643,8 +637,13 @@ Rules that apply on every turn:
           }
           break;
         case 'error':
-        case 'stream_error':
           errored = true;
+          if (typeof msg.message === 'string' && msg.message) errorMessage = msg.message;
+          break;
+        case 'stream_error':
+          // Retryable — codex retries the model stream internally and the
+          // turn can still succeed. Keep the message for context in case the
+          // process later exits non-zero, but don't mark the run failed.
           if (typeof msg.message === 'string' && msg.message) errorMessage = msg.message;
           break;
         default:
@@ -669,21 +668,32 @@ Rules that apply on every turn:
       });
 
       proc.on('error', (err) => {
-        stopHeartbeat();
         options.signal?.removeEventListener('abort', onAbort);
         reject(err);
       });
 
       proc.on('close', (code) => {
-        stopHeartbeat();
         options.signal?.removeEventListener('abort', onAbort);
         if (stdoutBuffer.trim()) processLine(stdoutBuffer);
 
-        // Resume failure (expired/missing thread) — drop the cached id and
-        // retry once with a fresh session so the user doesn't see a dead end.
+        // Binary missing — checked BEFORE the resume heuristic: sh's
+        // "codex: not found" must not be mistaken for a dead thread (and the
+        // session must survive so the conversation resumes once codex is
+        // re-provisioned).
+        if (code === 127) {
+          reject(new Error('codex CLI is not installed in the VM yet. Restart Sulla Desktop to re-provision, or run: npm install --prefix /mnt/data/npm-global -g @openai/codex'));
+          return;
+        }
+
+        // Resume failure (expired/missing thread, or an older codex without
+        // the `exec resume` subcommand) — drop the cached id and retry once
+        // with a fresh session so the user doesn't see a dead end. The match
+        // deliberately omits generic words like 'session'/'not found':
+        // limactl's SSH-mux noise ("mux_client_request_session ... Broken
+        // pipe") lands in stderr and must not wipe a valid thread.
         const resumeFailed = existingSession && !retryWithoutSession &&
           (errored || code !== 0) &&
-          /thread|session|resume|rollout|not found/i.test(`${ errorMessage } ${ stderrBuffer }`);
+          /thread|rollout|conversation|resume/i.test(`${ errorMessage } ${ stderrBuffer.slice(-500) }`);
         if (resumeFailed) {
           log.warn(`[CodexService] Resume of "${ existingSession }" failed; retrying with a fresh session for conversationId=${ convId }`);
           this.deleteSession(convId).catch(() => {});
@@ -698,11 +708,6 @@ Rules that apply on every turn:
           this.setSession(convId, capturedSessionId).catch(() => {});
         }
 
-        if (code === 127) {
-          reject(new Error('codex CLI is not installed in the VM yet. Restart Sulla Desktop to re-provision, or run: npm install --prefix /mnt/data/npm-global -g @openai/codex'));
-          return;
-        }
-
         if (errored || (code !== 0 && !textCollected.trim())) {
           const msg = errorMessage || stderrBuffer.trim().slice(-200) || `codex exited with code ${ code }`;
           log.warn(`[CodexService] runCodex errored: ${ msg.slice(0, 200) }`);
@@ -715,6 +720,13 @@ Rules that apply on every turn:
           log.warn(`[CodexService] runCodex exited with no text (code=${ code }) stderr=${ stderrTail }`);
           reject(new Error(`Codex returned no output (exit code ${ code }). ${ stderrTail || 'Check credentials and VM status.' }`));
           return;
+        }
+
+        // Success: commit the stable-context hash (the context was actually
+        // delivered) and record this run's final usage snapshot.
+        this.lastStableContextHash.set(convId, stableHash);
+        if (lastUsage) {
+          recordUsage(lastUsage, this.getModel()).catch(() => { /* ignore */ });
         }
 
         log.log(`[CodexService] runCodex ok: ${ textCollected.length } chars, session=${ capturedSessionId ?? '(none)' }`);

--- a/pkg/rancher-desktop/agent/languagemodels/ModelTierResolver.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ModelTierResolver.ts
@@ -98,8 +98,8 @@ export async function resolveTierToModelId(
   providerId: string,
   tier: ModelTier,
 ): Promise<string | undefined> {
-  // claude-code delegates model selection to the CLI — never override
-  if (providerId === 'claude-code') return undefined;
+  // claude-code / codex delegate model selection to the CLI — never override
+  if (providerId === 'claude-code' || providerId === 'codex') return undefined;
 
   try {
     const apiKey = await getApiKeyForProvider(providerId);

--- a/pkg/rancher-desktop/agent/languagemodels/index.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/index.ts
@@ -21,6 +21,7 @@ import { getIntegrationService } from '../services/IntegrationService';
 // Provider factory map — lazy-loaded to avoid circular imports
 const PROVIDER_FACTORIES: Record<string, () => Promise<BaseLanguageModel>> = {
   'claude-code': async() => { const { getClaudeCodeService } = await import('./ClaudeCodeService'); return getClaudeCodeService() },
+  codex:         async() => { const { getCodexService } = await import('./CodexService'); return getCodexService() },
   arcee:         async() => { const { getArceeService } = await import('./ArceeService'); return getArceeService() },
   cohere:        async() => { const { getCohereService } = await import('./CohereService'); return getCohereService() },
   deepseek:      async() => { const { getDeepSeekService } = await import('./DeepSeekService'); return getDeepSeekService() },
@@ -103,6 +104,10 @@ class LLMRegistryImpl {
         // override doesn't bleed into the primary orchestrator's instance.
         const { createClaudeCodeService } = await import('./ClaudeCodeService');
         svc = createClaudeCodeService(modelOverride);
+      } else if (modelOverride && providerId === 'codex') {
+        // Same singleton concern as claude-code.
+        const { createCodexService } = await import('./CodexService');
+        svc = createCodexService(modelOverride);
       } else {
         const factory = PROVIDER_FACTORIES[providerId];
         if (!factory) {
@@ -136,8 +141,8 @@ class LLMRegistryImpl {
     const activeModelId = mps
       ? mps.getActiveModelId()
       : await SullaSettingsModel.get('activeModelId', '');
-    // 'claude-code' sentinel means "auto" — omit the override so the CLI picks freely.
-    const modelOverride = activeModelId && activeModelId !== 'claude-code' ? activeModelId : undefined;
+    // 'claude-code' / 'codex' sentinels mean "auto" — omit the override so the CLI picks freely.
+    const modelOverride = activeModelId && activeModelId !== 'claude-code' && activeModelId !== 'codex' ? activeModelId : undefined;
     return this.getServiceByProvider(providerId, modelOverride);
   }
 

--- a/pkg/rancher-desktop/agent/languagemodels/index.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/index.ts
@@ -141,8 +141,12 @@ class LLMRegistryImpl {
     const activeModelId = mps
       ? mps.getActiveModelId()
       : await SullaSettingsModel.get('activeModelId', '');
-    // 'claude-code' / 'codex' sentinels mean "auto" — omit the override so the CLI picks freely.
-    const modelOverride = activeModelId && activeModelId !== 'claude-code' && activeModelId !== 'codex' ? activeModelId : undefined;
+    // CLI-agent providers use their own provider id as the "auto" sentinel
+    // model id (see ModelProviderService.getModelsForProvider) — omit the
+    // override so the CLI picks freely. Comparing against providerId instead
+    // of a literal list keeps a model genuinely named e.g. 'codex' on some
+    // other provider working.
+    const modelOverride = activeModelId && activeModelId !== providerId ? activeModelId : undefined;
     return this.getServiceByProvider(providerId, modelOverride);
   }
 

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -1196,7 +1196,8 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
       // specific provider they want to know it failed, not get an answer from
       // a different model pretending to be the same assistant. Fallback only
       // runs when the primary is a generic/unselected provider.
-      const explicitPrimary = primaryId === 'claude-code' || primaryName === 'Claude Code';
+      const explicitPrimary = primaryId === 'claude-code' || primaryName === 'Claude Code' ||
+        primaryId === 'codex' || primaryName === 'OpenAI Codex';
       if (explicitPrimary) {
         throw new Error(`${ primaryName } failed: ${ errMsg }`);
       }

--- a/pkg/rancher-desktop/agent/prompts/generateCodexMemoryFile.ts
+++ b/pkg/rancher-desktop/agent/prompts/generateCodexMemoryFile.ts
@@ -1,0 +1,28 @@
+/**
+ * Overwrites ~/.codex/AGENTS.md with the full Sulla system prompt so the
+ * codex CLI picks it up natively at startup — the codex equivalent of
+ * generateClaudeCodeMemoryFile (codex reads AGENTS.md from CODEX_HOME the
+ * way Claude Code reads ~/.claude/CLAUDE.md).
+ *
+ * Called on every codex session spawn so the file stays current.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { codexHomeDir } from '../util/codexAuthFile';
+
+export async function generateCodexMemoryFile(): Promise<void> {
+  try {
+    const { buildFullSystemPrompt } = await import('./buildFullSystemPrompt');
+    const systemPrompt = await buildFullSystemPrompt({ provider: 'openai' });
+
+    if (!systemPrompt?.trim()) return;
+
+    const dir = codexHomeDir();
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'AGENTS.md'), systemPrompt, 'utf-8');
+  } catch {
+    // Non-fatal — don't block the agent spawn if the write fails
+  }
+}

--- a/pkg/rancher-desktop/agent/services/ModelProviderService.ts
+++ b/pkg/rancher-desktop/agent/services/ModelProviderService.ts
@@ -201,6 +201,16 @@ class ModelProviderService {
       ];
     }
 
+    // Codex accepts an explicit --model flag; expose the known models plus
+    // an "auto" sentinel that omits the flag and lets the CLI choose.
+    if (providerId === 'codex') {
+      return [
+        { id: 'codex',         name: 'Auto (CLI default)', description: 'Let Codex choose the best model automatically' },
+        { id: 'gpt-5.3-codex', name: 'GPT-5.3 Codex',      description: 'Latest Codex flagship model' },
+        { id: 'gpt-5-codex',   name: 'GPT-5 Codex',        description: 'Previous Codex model' },
+      ];
+    }
+
     const integration = integrations[providerId];
     if (!integration) return [];
 

--- a/pkg/rancher-desktop/agent/services/OAuthCallbackServer.ts
+++ b/pkg/rancher-desktop/agent/services/OAuthCallbackServer.ts
@@ -133,10 +133,24 @@ export function startOAuthCallbackServer(
     cleanup();
   });
 
+  // Surface listen failures (EADDRINUSE on fixed-port providers when a
+  // previous flow is still pending) as a rejected flow instead of an
+  // unhandled 'error' event crashing the process.
+  server.on('error', (err) => {
+    rejectFn(new Error(`OAuth callback server error: ${ err.message }`));
+    cleanup();
+  });
+
   // Listen on the configured port (0 = random) on loopback
   server.listen(listenPort, '127.0.0.1');
+  // server.address() is null until the async 'listening' event fires, so it
+  // cannot be read synchronously after listen(). For fixed-port providers
+  // (e.g. the Codex OAuth app's hardcoded redirect_uri) the port is known up
+  // front — use it directly so the redirect_uri is correct.
   const address = server.address();
-  const port = typeof address === 'object' && address ? address.port : 0;
+  const port = listenPort !== 0
+    ? listenPort
+    : (typeof address === 'object' && address ? address.port : 0);
   const redirectUri = `http://${ hostname }:${ port }${ callbackPath }`;
 
   const timeoutHandle = setTimeout(() => {

--- a/pkg/rancher-desktop/agent/services/OAuthService.ts
+++ b/pkg/rancher-desktop/agent/services/OAuthService.ts
@@ -392,6 +392,15 @@ export class OAuthService {
     const integrationService = getIntegrationService();
     await integrationService.setConnectionStatus(integrationId, false, accountId);
 
+    // Let the provider clean up credential state it materialized outside the
+    // DB (e.g. CodexOAuth's ~/.codex/auth.json) so disconnect actually stops
+    // authentication.
+    try {
+      await provider?.onTokensRevoked();
+    } catch (err) {
+      console.warn(`${ LOG_PREFIX } provider onTokensRevoked failed (non-fatal):`, err);
+    }
+
     console.log(`${ LOG_PREFIX } Tokens removed for ${ integrationId }/${ accountId }`);
   }
 

--- a/pkg/rancher-desktop/agent/util/codexAuthFile.ts
+++ b/pkg/rancher-desktop/agent/util/codexAuthFile.ts
@@ -65,6 +65,14 @@ export function writeCodexAuthFile(tokens: OAuthTokenSet): boolean {
   }
 }
 
+/** Delete ~/.codex/auth.json — called when the codex integration is
+ *  disconnected so the CLI stops authenticating with revoked credentials. */
+export function removeCodexAuthFile(): void {
+  try {
+    fs.unlinkSync(codexAuthPath());
+  } catch { /* already gone */ }
+}
+
 /**
  * Make sure ~/.codex/auth.json exists, rebuilding it from the stored OAuth
  * token row when missing (fresh install, wiped home dir). The file is the
@@ -75,12 +83,27 @@ export async function ensureCodexAuthFile(): Promise<boolean> {
   if (fs.existsSync(codexAuthPath())) return true;
   try {
     const { getOAuthService } = await import('../services/OAuthService');
-    const stored = await getOAuthService().getStoredTokens('codex');
-    if (!stored?.raw_response) return false;
-    const tokens = (typeof stored.raw_response === 'string'
-      ? JSON.parse(stored.raw_response)
-      : stored.raw_response) as OAuthTokenSet;
-    return writeCodexAuthFile(tokens);
+    const oauthService = getOAuthService();
+
+    // The UI's OAuth connect flow stores tokens under account id 'oauth';
+    // older/headless flows use 'default'. Prefer the integration's active
+    // account when one is set.
+    const accountIds = ['oauth', 'default'];
+    try {
+      const { getIntegrationService } = await import('../services/IntegrationService');
+      const active = await getIntegrationService().getActiveAccountId('codex');
+      if (active && !accountIds.includes(active)) accountIds.unshift(active);
+    } catch { /* fall back to the known account ids */ }
+
+    for (const accountId of accountIds) {
+      const stored = await oauthService.getStoredTokens('codex', accountId);
+      if (!stored?.raw_response) continue;
+      const tokens = (typeof stored.raw_response === 'string'
+        ? JSON.parse(stored.raw_response)
+        : stored.raw_response) as OAuthTokenSet;
+      if (writeCodexAuthFile(tokens)) return true;
+    }
+    return false;
   } catch (err) {
     console.warn('[codexAuthFile] Could not rebuild auth.json from stored tokens:', err);
     return false;

--- a/pkg/rancher-desktop/agent/util/codexAuthFile.ts
+++ b/pkg/rancher-desktop/agent/util/codexAuthFile.ts
@@ -1,0 +1,88 @@
+// ~/.codex/auth.json — the Codex CLI's credential store.
+//
+// The Lima VM mounts the host home directory writable at the same path, so a
+// single file serves both sides: Sulla's OAuth layer writes it from the host
+// (on initial sign-in and on every scheduled refresh), and the codex CLI
+// inside the VM reads it and self-refreshes tokens in place. With ChatGPT
+// sign-in tokens present, codex usage draws from the user's ChatGPT plan —
+// no metered API billing.
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import type { OAuthTokenSet } from '../integrations/oauth/OAuthProvider';
+
+export function codexHomeDir(): string {
+  return path.join(os.homedir(), '.codex');
+}
+
+export function codexAuthPath(): string {
+  return path.join(codexHomeDir(), 'auth.json');
+}
+
+/**
+ * Pull the ChatGPT account id out of the id_token JWT — codex routes plan
+ * usage through it. A missing claim is non-fatal (the CLI re-derives it).
+ */
+function extractAccountId(idToken: string | undefined): string | null {
+  if (!idToken) return null;
+  try {
+    const payload = idToken.split('.')[1];
+    if (!payload) return null;
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf-8'));
+    const auth = claims['https://api.openai.com/auth'];
+    return (auth && typeof auth.chatgpt_account_id === 'string') ? auth.chatgpt_account_id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the codex CLI auth file from an OAuth token set. Returns false (and
+ * logs) on failure — callers treat that as "codex not signed in".
+ */
+export function writeCodexAuthFile(tokens: OAuthTokenSet): boolean {
+  if (!tokens?.access_token) return false;
+  try {
+    const idToken = typeof tokens.id_token === 'string' ? tokens.id_token : undefined;
+    const payload = {
+      OPENAI_API_KEY: null,
+      tokens:         {
+        id_token:      idToken ?? null,
+        access_token:  tokens.access_token,
+        refresh_token: tokens.refresh_token ?? null,
+        account_id:    extractAccountId(idToken),
+      },
+      last_refresh: new Date().toISOString(),
+    };
+    fs.mkdirSync(codexHomeDir(), { recursive: true });
+    fs.writeFileSync(codexAuthPath(), JSON.stringify(payload, null, 2), { mode: 0o600 });
+    return true;
+  } catch (err) {
+    console.error('[codexAuthFile] Failed to write auth.json:', err);
+    return false;
+  }
+}
+
+/**
+ * Make sure ~/.codex/auth.json exists, rebuilding it from the stored OAuth
+ * token row when missing (fresh install, wiped home dir). The file is the
+ * CLI's live store — when it already exists we leave it alone, since the CLI
+ * may hold fresher tokens than the DB row.
+ */
+export async function ensureCodexAuthFile(): Promise<boolean> {
+  if (fs.existsSync(codexAuthPath())) return true;
+  try {
+    const { getOAuthService } = await import('../services/OAuthService');
+    const stored = await getOAuthService().getStoredTokens('codex');
+    if (!stored?.raw_response) return false;
+    const tokens = (typeof stored.raw_response === 'string'
+      ? JSON.parse(stored.raw_response)
+      : stored.raw_response) as OAuthTokenSet;
+    return writeCodexAuthFile(tokens);
+  } catch (err) {
+    console.warn('[codexAuthFile] Could not rebuild auth.json from stored tokens:', err);
+    return false;
+  }
+}

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -787,6 +787,39 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       script: claudeCodeScript,
     });
 
+    // Install the OpenAI Codex CLI — same persistent-prefix + per-boot
+    // symlink strategy (and the same CRNG-retry rationale) as claude above.
+    const codexScript = [
+      '#!/bin/sh',
+      'PREFIX=/mnt/data/npm-global',
+      'LINK=/usr/local/bin/codex',
+      'if [ -x "$PREFIX/bin/codex" ]; then',
+      '  ln -sf "$PREFIX/bin/codex" "$LINK"',
+      '  exit 0',
+      'fi',
+      'mkdir -p "$PREFIX"',
+      'dd if=/dev/random of=/dev/null bs=1 count=1 2>/dev/null',
+      'attempt=0',
+      'while [ "$attempt" -lt 5 ]; do',
+      '  if npm install --prefix "$PREFIX" -g @openai/codex; then',
+      '    ln -sf "$PREFIX/bin/codex" "$LINK"',
+      '    exit 0',
+      '  fi',
+      '  attempt=$((attempt + 1))',
+      '  echo "[codex-install] npm install attempt $attempt failed; retrying in 5s" >&2',
+      '  sleep 5',
+      'done',
+      'echo "[codex-install] failed after 5 attempts — codex CLI will not be available" >&2',
+      'exit 1',
+    ].join('\n');
+    config.provision = config.provision.filter((p: { script?: string }) => {
+      return !(p.script ?? '').includes('@openai/codex');
+    });
+    config.provision.push({
+      mode:   'system',
+      script: codexScript,
+    });
+
     this.updateConfigPortForwards(config);
     if (currentConfig) {
       // update existing configuration
@@ -2034,6 +2067,53 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
   }
 
   /**
+   * Ensure the `codex` CLI binary is installed in the VM — same safety net
+   * as ensureClaudeBinaryInstalled (the lima.yaml provision script is the
+   * primary installer; this covers first-boot CRNG install failures and the
+   * tmpfs-wiped /usr/local symlink).
+   */
+  protected async ensureCodexBinaryInstalled() {
+    try {
+      // Fast path: already on PATH.
+      await this.execCommand({ root: false }, 'sh', '-c', '[ -x /usr/local/bin/codex ]');
+      return;
+    } catch { /* fall through */ }
+
+    try {
+      // Persistent install exists but /usr/local symlink is missing — restore it.
+      await this.execCommand({ root: false }, 'sh', '-c', '[ -x /mnt/data/npm-global/bin/codex ]');
+      await this.execCommand({ root: true }, 'ln', '-sf', '/mnt/data/npm-global/bin/codex', '/usr/local/bin/codex');
+      console.log('[Lima] codex symlink restored from persistent install');
+      return;
+    } catch { /* fall through */ }
+
+    console.log('[Lima] codex CLI missing — running npm install (1-2 min)');
+    const installScript = [
+      'PREFIX=/mnt/data/npm-global',
+      'LINK=/usr/local/bin/codex',
+      'mkdir -p "$PREFIX"',
+      'dd if=/dev/random of=/dev/null bs=1 count=1 2>/dev/null',
+      'attempt=0',
+      'while [ "$attempt" -lt 5 ]; do',
+      '  if npm install --prefix "$PREFIX" -g @openai/codex; then',
+      '    ln -sf "$PREFIX/bin/codex" "$LINK"',
+      '    exit 0',
+      '  fi',
+      '  attempt=$((attempt + 1))',
+      '  echo "[codex-install] npm install attempt $attempt failed; retrying in 5s" >&2',
+      '  sleep 5',
+      'done',
+      'exit 1',
+    ].join('\n');
+    try {
+      await this.execCommand({ root: true }, 'sh', '-c', installScript);
+      console.log('[Lima] codex CLI installed successfully');
+    } catch (err) {
+      console.warn('[Lima] Failed to install codex CLI — the Codex provider will not work until this is resolved:', err);
+    }
+  }
+
+  /**
    * Install Claude Code auth credentials into the VM.
    *
    * Supports two auth modes:
@@ -2553,6 +2633,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
           this.progressTracker.action('Installing credential helper', 50, this.installCredentialHelper()),
           this.progressTracker.action('Installing sulla CLI', 50, this.installSullaCli()),
           this.progressTracker.action('Verifying Claude Code CLI install', 50, this.ensureClaudeBinaryInstalled()),
+          this.progressTracker.action('Verifying Codex CLI install', 50, this.ensureCodexBinaryInstalled()),
           this.progressTracker.action('Configuring Claude Code', 50, this.installClaudeCode()),
           this.progressTracker.action('Installing threat-scanning proxy', 50, this.installThreatProxy()),
         ];

--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -2632,8 +2632,11 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
           this.progressTracker.action('Installing image scanner', 50, this.installTrivy()),
           this.progressTracker.action('Installing credential helper', 50, this.installCredentialHelper()),
           this.progressTracker.action('Installing sulla CLI', 50, this.installSullaCli()),
-          this.progressTracker.action('Verifying Claude Code CLI install', 50, this.ensureClaudeBinaryInstalled()),
-          this.progressTracker.action('Verifying Codex CLI install', 50, this.ensureCodexBinaryInstalled()),
+          // Chained, not parallel: both slow paths run `npm install -g` into
+          // the same /mnt/data/npm-global prefix, and concurrent global
+          // installs race on the shared lib/bin trees.
+          this.progressTracker.action('Verifying agent CLI installs', 50,
+            this.ensureClaudeBinaryInstalled().then(() => this.ensureCodexBinaryInstalled())),
           this.progressTracker.action('Configuring Claude Code', 50, this.installClaudeCode()),
           this.progressTracker.action('Installing threat-scanning proxy', 50, this.installThreatProxy()),
         ];


### PR DESCRIPTION
## What

Adds a `codex` remote provider that runs OpenAI's Codex CLI inside the Lima VM, authenticated via **ChatGPT OAuth** — usage draws from the user's ChatGPT Plus/Pro subscription instead of metered API billing. Fully opt-in: a new **OpenAI Codex** card under AI Infrastructure integrations; nothing changes for users who don't connect it.

## How it works

- **CodexService** (`agent/languagemodels/CodexService.ts`) mirrors ClaudeCodeService: spawns `codex exec --json` via `limactl shell`, feeds the prompt over stdin (avoids the SSH-mux size limit), resumes the per-conversation codex thread (`codex exec resume <id>`, Redis-cached 7 days), and applies the same stable-`<sulla_context>` hash dedup so platform rules aren't re-billed every turn. Parses both codex JSONL schemas (thread events + legacy `msg` events) defensively.
- **CodexOAuth**: PKCE sign-in using the official Codex CLI OAuth app; writes the token set to `~/.codex/auth.json` on sign-in **and on every scheduled refresh**. The home dir is mounted writable in the VM, so the CLI also self-refreshes in place. Disconnect deletes the file (new `onTokensRevoked` hook).
- **System prompt** travels via `~/.codex/AGENTS.md` (codex's CLAUDE.md equivalent); awaited before seeding a new session.
- **Provisioning** (`backend/lima.ts`): `@openai/codex` installs to the persistent npm prefix with per-boot symlink restore + boot-time safety net, chained after the claude install (shared prefix — concurrent global installs race).
- **Wiring**: PROVIDER_FACTORIES + fresh-instance-on-override, integration catalog entry, model picker list (Auto / gpt-5.3-codex / gpt-5-codex), tier-resolver delegation, BaseNode fail-loud for explicit codex primary.

## Important distinction

The existing **OpenAI** integration's OAuth exchanges the ChatGPT id_token for a regular platform API key — that path bills at API rates and is unchanged. Only this new codex provider routes through the subscription.

## Review

An adversarial multi-agent review ran on the initial commit; the second commit fixes everything confirmed, including two bugs that would have made codex unconnectable through the UI (callback server read `server.address()` before 'listening' → `localhost:0` redirect URI; auth rebuild queried `account_id 'default'` while the UI stores `'oauth'`). Also fixed: disconnect not revoking the auth file, free-text model field leaking into `--model`, resume-retry regex matching SSH-mux noise, cumulative usage double-counting, stream_error treated as fatal, stable-context hash committed before delivery, npm install race, image filename collisions.

## Known limitations / follow-ups

- JSONL parser is written against known codex CLI output formats; **watch the first live run** after rebuild — if the installed codex emits an unexpected schema, the parser is one contained function.
- `pkill -f 'codex exec'` abort cleanup is VM-global (same single-runner assumption as the claude equivalent).
- Host-side token refresh and the CLI's self-refresh both rotate the same refresh token; OpenAI tolerates parallel refreshers in practice, but worth watching.
- Follow-up refactor candidate: extract the shared CLI-agent machinery (transcript serialization, session store, context prefix, npm install scripts) — ClaudeCodeService and CodexService duplicate it by design to keep this diff low-risk.
- Typecheck clean on all touched files; ESLint couldn't run locally (native binding built for the host platform) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)