### PR TITLE
fix: stop auto-titling subconscious conversations on Claude Code

### DIFF
--- a/pkg/rancher-desktop/agent/services/ConversationTitleService.ts
+++ b/pkg/rancher-desktop/agent/services/ConversationTitleService.ts
@@ -28,6 +28,21 @@ const AUTO_TITLE_THRESHOLD = 3;
 const titledConversations = new Set<string>();
 
 /**
+ * Internal / ephemeral conversations that must never be auto-titled.
+ *
+ * Subconscious agents (memory-recall, observation-writer/recall, summarizer,
+ * tool-result digester) each run as their own short-lived conversation with a
+ * `subconscious_<ts>_<n>` id. They are NOT user-facing history rows, so titling
+ * them is pure waste — and worse, every internal run crossed the 3-message
+ * threshold and fired a title-generation LLM call with no conversationId,
+ * dumping the agent's instruction into the shared `__default__` Claude Code
+ * session once per turn. Skip them entirely.
+ */
+function isInternalConversationId(conversationId: string): boolean {
+  return typeof conversationId === 'string' && conversationId.startsWith('subconscious_');
+}
+
+/**
  * Generate a short title (<=6 words) from the first few messages of a conversation.
  *
  * Attempts to call the active LLM for a summary. Falls back to extracting
@@ -43,10 +58,13 @@ export async function generateTitle(messages: TitleMessage[]): Promise<string> {
     return 'Untitled Conversation';
   }
 
-  // Try LLM-based title generation
+  // Try LLM-based title generation. Use the subconscious (cheap/fast) service,
+  // not the primary — a <=6-word summary is a trivial task and should never
+  // burn the expensive primary (e.g. Claude Code) model. Falls back to the
+  // primary internally if no subconscious provider is configured.
   try {
-    const { getPrimaryService } = await import('../languagemodels/index');
-    const llm = await getPrimaryService();
+    const { getSubconsciousService } = await import('../languagemodels/index');
+    const llm = await getSubconsciousService();
 
     if (llm) {
       const prompt = relevantMessages
@@ -123,6 +141,11 @@ export async function autoTitleAfterMessages(
   conversationId: string,
   messages: TitleMessage[],
 ): Promise<void> {
+  // Never title internal/ephemeral (subconscious) conversations — see
+  // isInternalConversationId. This is the fix for the per-turn duplicate
+  // Claude Code dispatch into the __default__ session.
+  if (isInternalConversationId(conversationId)) return;
+
   // Only trigger once per conversation, after reaching the threshold
   if (titledConversations.has(conversationId)) return;
   if (messages.length < AUTO_TITLE_THRESHOLD) return;


### PR DESCRIPTION
## The duplicate Claude Code dispatch — found it

The Alibaba upgrade correctly routes the subconscious **agents** (memory-recall, observation-writer/recall, summarizer, digester) to qwen3.5-plus. Verified from `conv_subconscious_*.jsonl` — full transcripts, model=qwen3.5-plus, base chatStream path. That part works.

But live logs showed a *separate* claude-code dispatch firing every turn: `messages=2 promptLen=190/232/271 conversationId=__default__` — one per subconscious agent, into a shared, ever-growing `__default__` Claude Code session. It was never the agent. It is **auto-title generation**:

    SullaLogger.logMessage -> autoTitleAfterMessages (fires once per conversation
    after 3 messages) -> generateTitle -> getPrimaryService() [Claude Code]
    .chat([system, user])   // no conversationId -> __default__

Every internal subconscious conversation crosses the 3-message threshold, so it gets titled — on the expensive primary, with no conversationId. The Alibaba work never touched this path, which is why it survived.

## Fix

1. **autoTitleAfterMessages** — skip internal (`subconscious_*`) conversation ids. They are ephemeral agent runs, not user-facing history rows; titling them is pure waste. Eliminates the per-turn duplicate dispatch.
2. **generateTitle** — route to `getSubconsciousService` (cheap/fast) instead of the primary. A 6-word title never warrants Claude Code; also keeps real conversation titles off the expensive model. Falls back to primary internally if no subconscious provider is set.

All five subconscious agent types share the `subconscious_` threadId prefix (GraphRegistry buildSubconsciousState), so the single guard covers them all.

Typecheck clean. Confirm after rebuild: the `190/232/271 -> __default__` runClaude lines in background.log should stop appearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
