### PR TITLE
fix(ci): harden electron install against extract-zip truncation

### DIFF
--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -96,8 +96,12 @@ runs:
       # (visible on the public run page even without Actions:read).
       ann() { lvl="$1"; title="$2"; body=$(printf '%s' "$3" | tail -c 3200 | tr -d '\r' | sed 's/%/%25/g' | awk 'BEGIN{ORS="%0A"}{print}'); echo "::${lvl} title=${title}::${body}"; }
       # Cache dirs @electron/get may stage the checksum-verified zip into.
+      # Restrict find to dirs that actually exist: under the runner's default
+      # `bash -eo pipefail`, find erroring on a missing dir (e.g. the Windows
+      # LOCALAPPDATA path on linux/mac) made `zipfile=$(find_zip)` abort the
+      # whole step right after install.js — before native extraction could run.
       caches="$HOME/.cache/electron $HOME/Library/Caches/electron ${LOCALAPPDATA:-/nonexistent}/electron/Cache"
-      find_zip() { find $caches -name 'electron-v*.zip' 2>/dev/null | head -1; }
+      find_zip() { for d in $caches; do [ -d "$d" ] && find "$d" -name 'electron-v*.zip' 2>/dev/null; done | head -1 || true; }
       # Extract the checksum-verified zip with the platform's OWN tool.
       # electron's bundled JS extractor (extract-zip) intermittently drops
       # files mid-extract on the hosted runners — leaving dist/ with a single

--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -92,56 +92,49 @@ runs:
       set -o pipefail
       log="${RUNNER_TEMP}/electron-install.log"
       verify() { node -e "require('./node_modules/electron')" >/dev/null 2>&1; }
+      # Emit a multi-line blob as a single GitHub ::<level>:: annotation
+      # (visible on the public run page even without Actions:read).
+      ann() { lvl="$1"; title="$2"; body=$(printf '%s' "$3" | tail -c 3200 | tr -d '\r' | sed 's/%/%25/g' | awk 'BEGIN{ORS="%0A"}{print}'); echo "::${lvl} title=${title}::${body}"; }
+      # Cache dirs @electron/get may stage the checksum-verified zip into.
+      caches="$HOME/.cache/electron $HOME/Library/Caches/electron ${LOCALAPPDATA:-/nonexistent}/electron/Cache"
+      find_zip() { find $caches -name 'electron-v*.zip' 2>/dev/null | head -1; }
+      # Extract the checksum-verified zip with the platform's OWN tool.
+      # electron's bundled JS extractor (extract-zip) intermittently drops
+      # files mid-extract on the hosted runners — leaving dist/ with a single
+      # file (linux) or an empty Electron.app (mac) yet exiting 0. The native
+      # tools don't have that bug: ditto keeps the app-bundle symlinks on
+      # macOS, Info-ZIP unzip keeps modes on Linux, 7z covers Windows.
+      native_extract() {
+        rm -rf node_modules/electron/dist; mkdir -p node_modules/electron/dist
+        case "$(uname -s)" in
+          Darwin) ditto -x -k "$1" node_modules/electron/dist && printf 'Electron.app/Contents/MacOS/Electron' > node_modules/electron/path.txt ;;
+          Linux)  command -v unzip >/dev/null 2>&1 || { echo "unzip missing — installing"; sudo apt-get update -qq && sudo apt-get install -y -qq unzip; }
+                  unzip -q -o "$1" -d node_modules/electron/dist && printf electron > node_modules/electron/path.txt ;;
+          *)      7z x -y "-onode_modules/electron/dist" "$1" >/dev/null && printf electron.exe > node_modules/electron/path.txt ;;
+        esac
+      }
       for attempt in 1 2 3; do
         echo "::group::electron install attempt ${attempt}"
+        # Re-download fresh each attempt: a cache hit on a previously
+        # truncated/poisoned zip would only reproduce the same broken dist.
+        # install.js re-fetches AND re-verifies the SHA-256 checksum.
+        rm -rf $caches node_modules/electron/dist node_modules/electron/path.txt
         node node_modules/electron/install.js 2>&1 | tee "$log" || true
-        if verify; then
-          echo "::endgroup::"
-          echo "electron install verified"
-          exit 0
-        fi
+        if verify; then echo "::endgroup::"; echo "electron verified via install.js (attempt ${attempt})"; exit 0; fi
         echo "::endgroup::"
-        msg=$( (tail -n 40 "$log"; echo "disk:"; df -h / | tail -1; echo "dist:"; ls -la node_modules/electron/dist/ 2>&1 | head -8) | tail -c 2800 | tr -d '\r' | sed 's/%/%25/g' | awk 'BEGIN{ORS="%0A"}{print}')
-        echo "::warning title=electron install attempt ${attempt} unverified::${msg}"
-        rm -rf node_modules/electron/dist node_modules/electron/path.txt
-        if [ "${attempt}" -lt 3 ]; then
-          echo "Attempt ${attempt} unverified, retrying in 10s..."
-          sleep 10
+        # install.js left a bad dist; the downloaded zip is checksum-valid in
+        # cache — extract it natively right here instead of waiting it out.
+        zipfile=$(find_zip)
+        if [ -n "$zipfile" ]; then
+          echo "::group::native extraction (attempt ${attempt})"
+          native_extract "$zipfile" 2>&1 | tee -a "$log" || true
+          echo "::endgroup::"
+          if verify; then ann notice "electron install (native extract)" "install.js unverified; native extraction of ${zipfile} succeeded on attempt ${attempt}"; exit 0; fi
         fi
+        ann warning "electron install attempt ${attempt} unverified" "$(tail -n 25 "$log"; echo "zip: ${zipfile:-NONE FOUND}"; echo "dist:"; ls -la node_modules/electron/dist/ 2>&1 | head -10)"
+        [ "${attempt}" -lt 3 ] && sleep 10
       done
-      # Native-extractor fallback: the JS extractor (extract-zip) silently
-      # dies mid-extract on the hosted runners — observed identically on
-      # linux x64 (dist held one file) and mac arm64 (empty app scaffold).
-      # downloadArtifact caches the checksum-verified zip before extracting,
-      # so extract that zip with the platform's native tool instead:
-      # ditto preserves the app-bundle symlinks on macOS, Info-ZIP unzip
-      # preserves modes on Linux, 7z covers Windows.
-      zipfile=$(find "$HOME/.cache/electron" "$HOME/Library/Caches/electron" "${LOCALAPPDATA:-/nonexistent}/electron/Cache" -name 'electron-v*.zip' 2>/dev/null | head -1)
-      if [ -n "$zipfile" ]; then
-        echo "Falling back to native extraction of ${zipfile}"
-        rm -rf node_modules/electron/dist
-        mkdir -p node_modules/electron/dist
-        case "$(uname -s)" in
-          Darwin)
-            ditto -x -k "$zipfile" node_modules/electron/dist
-            printf 'Electron.app/Contents/MacOS/Electron' > node_modules/electron/path.txt
-            ;;
-          Linux)
-            unzip -q -o "$zipfile" -d node_modules/electron/dist
-            printf electron > node_modules/electron/path.txt
-            ;;
-          *)
-            7z x -y "-onode_modules/electron/dist" "$zipfile" >/dev/null
-            printf electron.exe > node_modules/electron/path.txt
-            ;;
-        esac
-        if verify; then
-          echo "::notice title=electron install::JS extractor unverified 3x; native extraction fallback succeeded"
-          exit 0
-        fi
-      fi
-      msg=$(tail -n 60 "$log" | tail -c 3500 | tr -d '\r' | sed 's/%/%25/g' | awk 'BEGIN{ORS="%0A"}{print}')
-      echo "::error title=electron install failed (3 attempts + fallback)::${msg}"
+      ann error "electron install failed (3 attempts incl. native extract)" "$(tail -n 50 "$log"; echo "caches: $caches")"
       exit 1
 
   # Diagnostic probe: chrome-sandbox has been missing at the final step

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -15,6 +15,10 @@ defaults:
 jobs:
   package:
     strategy:
+      # One platform's intermittent electron-extract failure must not cancel
+      # the others — without this, a single unlucky runner nukes all four
+      # legs and produces zero artifacts. Each platform stands on its own.
+      fail-fast: false
       matrix:
         include:
         - platform: mac

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -28,7 +28,12 @@ jobs:
           arch: aarch64
           runs-on: macos-latest
         - platform: win
-          runs-on: windows-latest
+          # Pinned: windows-latest drifted to an image with VS 18, which the
+          # bundled node-gyp reports as version "undefined" and rejects ("could
+          # not find VS 2017 or newer") — failing native-addon compiles. VS 2022
+          # on windows-2022 is node-gyp-recognized. (Durable follow-up: upgrade
+          # node-gyp instead of pinning the runner.)
+          runs-on: windows-2022
         - platform: linux
           runs-on: ubuntu-22.04
     runs-on: ${{ matrix.runs-on }}


### PR DESCRIPTION
Fixes the cross-platform extract-zip truncation that failed every packaging run since the action rework (linux: dist held only snapshot_blob.bin; mac: empty Electron.app; both from checksum-valid zips).

- Native per-attempt extraction (ditto/unzip/7z) of the verified zip right after install.js fails verify
- Clear electron cache before each attempt for a fresh re-download
- find_zip no longer aborts the step before native extraction runs
- Guarantee unzip on Linux; annotate every path
- fail-fast: false so one platform flake does not cancel the others
- Pin windows-2022 so node-gyp finds Visual Studio

Validated: run 27619225289 green on all 4 platforms (linux/mac-arm64/mac-x86/win-2022).