### PR TITLE
fix(crm): undo of updateRecord nulls the record title

### DIFF
--- a/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
+++ b/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
@@ -1,3 +1,4 @@
+
 /**
  * CrmSchemaService — the guarded Schema API for the dynamic CRM.
  *
@@ -845,7 +846,14 @@ export class CrmSchemaService {
               if (!col) continue;
               await CrmSchemaService.upsertFieldValue(tx, row.tenant_id, row.entity_id, field.id, col, val);
             }
-            const { title, searchText } = CrmSchemaService.computeDenormalized(fields, before);
+            // Recompute denormalized core from the FULL post-revert value set
+            // (loaded fresh after the upserts above), NOT the partial `before`
+            // delta. `before` holds only the fields the original update changed,
+            // so the is_title field is usually absent — feeding it to
+            // computeDenormalized() resolves title to null and blanks the
+            // record's title (and truncates search_text). Mirrors updateRecord().
+            const merged = await CrmSchemaService.loadRecordValues(tx, row.entity_id, fields);
+            const { title, searchText } = CrmSchemaService.computeDenormalized(fields, merged);
             await tx.query(`UPDATE crm_records SET title=$2, search_text=$3, updated_at=now() WHERE id=$1`,
               [row.entity_id, title, searchText]);
           }


### PR DESCRIPTION
## Bug

`crm/undo` of an `updateRecord` **nulls the record's denormalized `title`** (and truncates `search_text`), breaking list/sort/display for any record whose field edit is reverted.

### Root cause
In `CrmSchemaService.undo()` (the `updateRecord` branch), the denormalized core was recomputed from the audit `before` payload:

```ts
const { title, searchText } = CrmSchemaService.computeDenormalized(fields, before);
```

`before` holds **only the fields the original update changed** (e.g. `{tier}`). The `is_title` field (e.g. `name`) is almost never among them, so `computeDenormalized()` resolves `title` to `null`. `updateRecord()` itself does this correctly by recomputing from the **merged full value set**; `undo()` skipped that.

### Fix
After reverting the changed values, reload the full record value set and compute the denormalized core from it — mirroring `updateRecord()`:

```ts
const merged = await CrmSchemaService.loadRecordValues(tx, row.entity_id, fields);
const { title, searchText } = CrmSchemaService.computeDenormalized(fields, merged);
```

## Reproduction (verified live against the running engine)
1. `create_record` with a title field set -> title denormalizes correctly.
2. `update_record` changing a **non-title** field -> title preserved (correct).
3. `crm/undo` the update -> **title becomes `null`** (bug). With this fix, title is preserved.

Found while end-to-end validating the dynamic-CRM surface (relationships, link/unlink, update+undo) now that the CLI is callable. One-file, localized change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)