### PR TITLE
fix(crm): create_widget validates parents instead of leaking a raw FK error

### DIFF
--- a/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
+++ b/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
@@ -1,3 +1,4 @@
+
 /**
  * CrmSchemaService — the guarded Schema API for the dynamic CRM.
  *
@@ -363,6 +364,12 @@ export class CrmSchemaService {
     tenantId = DEFAULT_TENANT_ID,
   ): Promise<OpResult> {
     if (!WIDGET_KINDS.includes(input.kind)) return { ok: false, error: `unknown widget kind "${ input.kind }"` };
+    // Validate parent refs up front so a bad id returns an actionable message
+    // instead of a raw Postgres FK-constraint error (crm_widgets_dashboard_id_fkey).
+    const dash = await postgresClient.query(`SELECT 1 FROM crm_dashboards WHERE id = $1`, [dashboardId]);
+    if (!dash[0]) return { ok: false, error: `dashboard "${ dashboardId }" not found — create it first with crm/create_dashboard` };
+    const rt = await postgresClient.query(`SELECT 1 FROM crm_record_types WHERE id = $1`, [input.recordTypeId]);
+    if (!rt[0]) return { ok: false, error: `record type "${ input.recordTypeId }" not found` };
     const id = newId();
     await postgresClient.query(
       `INSERT INTO crm_widgets (id, tenant_id, dashboard_id, record_type_id, name, kind, config)


### PR DESCRIPTION
## Problem

`crm/create_widget` with a nonexistent `dashboard_id` returned the **raw Postgres error** `insert or update on table "crm_widgets" violates foreign key constraint "crm_widgets_dashboard_id_fkey"`. The CRM tools are AI-driven, so a raw DB-internals error is unactionable — the agent can't self-correct from it.

## Fix

`createWidget()` now validates both parent refs (`dashboard_id`, `record_type_id`) up front and returns a clean, actionable message — e.g. `dashboard "<id>" not found — create it first with crm/create_dashboard`. Mirrors the existing not-found pattern in `archiveRecordType()`. Fails safe exactly as before (no widget created on a bad id); only the error message changes.

Found while end-to-end validating the dynamic-CRM presentation layer. One-method, localized change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)