### PR TITLE
fix(cli): add crm to the sulla wrapper TOOL_CATEGORIES (unblocks sulla crm/*)

### DIFF
--- a/resources/darwin/bin/sulla
+++ b/resources/darwin/bin/sulla
@@ -1,3 +1,4 @@
+
 #!/bin/sh
 # sulla — unified CLI for Sulla Desktop
 #
@@ -25,7 +26,7 @@ BODY="$2"
 # Known internal tool categories. Must stay in sync with agent/tools/registry.ts
 # `categoriesList` so `sulla <category>/<tool>` routes to /v1/tools/internal
 # instead of falling through as a proxy call.
-TOOL_CATEGORIES="agents|applescript|bridge|browser|calendar|capture|docker|extensions|fs|function|github|integrations|kubectl|lima|marketplace|memory|meta|mobile|notify|observation|pg|projects|rdctl|redis|skills|slack|ui|vault|workflow|workspace"
+TOOL_CATEGORIES="agents|applescript|bridge|browser|calendar|capture|crm|docker|extensions|fs|function|github|integrations|kubectl|lima|marketplace|memory|meta|mobile|notify|observation|pg|projects|rdctl|redis|skills|slack|ui|vault|workflow|workspace"
 
 # ── Help & discovery ─────────────────────────────────────────────
 # sulla --help | sulla -h | sulla help | sulla (no args) — query the backend


### PR DESCRIPTION
## Bug

Every `sulla crm/<tool>` command fails with `Missing required field "path"` — the entire dynamic-CRM engine is uncallable from the CLI.

## Root cause

The `sulla` CLI wrapper (`resources/darwin/bin/sulla`, line 28) hardcodes `TOOL_CATEGORIES`. Its dispatch routes `<seg1>/<tool>` to the internal-tools endpoint **only if `seg1` matches that list**; otherwise it falls through to the proxy path (`/v1/proxy/<seg1>/<tool>`), which is the integration proxy that demands a `path` field.

The dynamic-CRM category shipped in PR #453 was added to `agent/tools/registry.ts` `categoriesList` (so the backend knows it), but the wrapper's hardcoded mirror — which the file's own comment says *"must stay in sync with registry.ts categoriesList"* — was never updated. So `crm` fell through to the proxy. (`github/*` etc. work only because no proxy account shares their name.)

## Fix

Add `crm` to `TOOL_CATEGORIES`. One token. Verified live: with `crm` present, `sulla crm/*` routes internally and the full engine (record types, fields, relationships, records, views, dashboards, widgets, undo) is callable end-to-end.

## Follow-up (optional)

The wrapper already curls `/v1/tools/help` for the live category list in its `--help` path. Having the **dispatch** derive `TOOL_CATEGORIES` from the backend the same way would eliminate this hardcoded mirror and prevent future drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)