### PR TITLE
feat(meta): exechost — silent host command execution without Terminal windows

### DIFF
--- a/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
+++ b/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
@@ -864,4 +864,283 @@ export class CrmSchemaService {
       return { ok: false, error: String(err?.message ?? err) };
     }
   }
+
+  // ── Read / discovery ──────────────────────────────────────────────────────
+
+  static async describeRecordType(
+    keyOrId: string,
+    tenantId = DEFAULT_TENANT_ID,
+  ): Promise<{
+    id: string; key: string; label: string; label_plural: string | null;
+    icon: string | null; color: string | null; description: string | null;
+    fields: any[]; relationships: any[];
+  } | null> {
+    let type: any = await CrmSchemaService.getRecordTypeByKey(keyOrId, tenantId);
+    if (!type) {
+      const rows = await postgresClient.query(
+        `SELECT id, key, label, label_plural, icon, color, description
+         FROM crm_record_types WHERE id = $1 AND tenant_id = $2 AND archived = false LIMIT 1`,
+        [keyOrId, tenantId],
+      );
+      type = rows[0] ?? null;
+    }
+    if (!type) return null;
+
+    const fields = await postgresClient.query(
+      `SELECT id, key, label, data_type, is_title, is_required, is_system, position, config
+       FROM crm_fields WHERE record_type_id = $1 AND archived = false ORDER BY position ASC`,
+      [type.id],
+    );
+
+    const relationships = await postgresClient.query(
+      `SELECT rel.id, rel.key, rel.cardinality,
+              ft.key AS from_type_key, tt.key AS to_type_key,
+              rel.from_label, rel.to_label
+       FROM crm_relationships rel
+       JOIN crm_record_types ft ON ft.id = rel.from_type_id
+       JOIN crm_record_types tt ON tt.id = rel.to_type_id
+       WHERE (rel.from_type_id = $1 OR rel.to_type_id = $1)
+         AND rel.tenant_id = $2 AND rel.archived = false`,
+      [type.id, tenantId],
+    );
+
+    return {
+      id: type.id, key: type.key, label: type.label,
+      label_plural: type.label_plural ?? null,
+      icon: type.icon ?? null, color: type.color ?? null,
+      description: type.description ?? null,
+      fields, relationships,
+    };
+  }
+
+  static async getRecord(
+    recordId: string,
+    tenantId = DEFAULT_TENANT_ID,
+  ): Promise<Record<string, unknown> | null> {
+    const records = await postgresClient.query(
+      `SELECT r.id, r.title, r.created_at, r.record_type_id
+       FROM crm_records r WHERE r.id = $1 AND r.tenant_id = $2 AND r.archived = false LIMIT 1`,
+      [recordId, tenantId],
+    );
+    if (!records.length) return null;
+    const r = records[0];
+
+    const values = await postgresClient.query(
+      `SELECT fv.field_id, f.key, f.data_type,
+              fv.value_text, fv.value_number, fv.value_bool, fv.value_datetime, fv.value_json
+       FROM crm_field_values fv
+       JOIN crm_fields f ON f.id = fv.field_id
+       WHERE fv.record_id = $1`,
+      [recordId],
+    );
+
+    const out: Record<string, unknown> = { id: r.id, title: r.title, created_at: r.created_at };
+    for (const v of values) {
+      const col = valueColumnFor(v.data_type);
+      out[v.key] = col ? v[col] : null;
+    }
+    return out;
+  }
+
+  static async getLinkedRecords(
+    recordId: string,
+    opts: { relationshipId?: string; direction?: 'from' | 'to' | 'both'; limit?: number } = {},
+  ): Promise<any[]> {
+    const { relationshipId, direction = 'both', limit = 50 } = opts;
+    const params: any[] = [recordId];
+    const push = (v: any): string => { params.push(v); return `$${ params.length }`; };
+
+    const dirCond = direction === 'from'
+      ? 'l.from_record_id = $1'
+      : direction === 'to'
+        ? 'l.to_record_id = $1'
+        : '(l.from_record_id = $1 OR l.to_record_id = $1)';
+
+    const relCond = relationshipId ? ` AND l.relationship_id = ${ push(relationshipId) }` : '';
+    const limitPh = push(limit);
+
+    return postgresClient.query(
+      `SELECT r.id, r.title, r.created_at,
+              rt.key AS record_type_key, rt.label AS record_type_label,
+              rel.key AS relationship_key, rel.cardinality,
+              CASE WHEN l.from_record_id = $1 THEN 'outgoing' ELSE 'incoming' END AS direction
+       FROM crm_record_links l
+       JOIN crm_records r ON r.id = CASE WHEN l.from_record_id = $1 THEN l.to_record_id ELSE l.from_record_id END
+       JOIN crm_record_types rt ON rt.id = r.record_type_id
+       JOIN crm_relationships rel ON rel.id = l.relationship_id
+       WHERE ${ dirCond }${ relCond } AND r.archived = false
+       ORDER BY r.created_at DESC LIMIT ${ limitPh }`,
+      params,
+    );
+  }
+
+  static async aggregateRecords(
+    recordTypeId: string,
+    opts: {
+      metric?: 'count' | 'sum' | 'avg' | 'min' | 'max';
+      field?: string;
+      groupBy?: string;
+      filter?: Filter;
+      limit?: number;
+      tenantId?: string;
+    } = {},
+  ): Promise<Array<{ group_value?: unknown; count: number; metric: number | null }>> {
+    const tenantId = opts.tenantId ?? DEFAULT_TENANT_ID;
+    const { metric = 'count', field, groupBy, limit = 100 } = opts;
+
+    const fieldRows = await postgresClient.query(
+      `SELECT id, key, data_type FROM crm_fields WHERE record_type_id = $1 AND archived = false`,
+      [recordTypeId],
+    );
+    const byKey = new Map<string, { id: string; data_type: DataType }>(
+      fieldRows.map((f: any) => [f.key, { id: f.id, data_type: f.data_type }]),
+    );
+
+    const params: any[] = [tenantId, recordTypeId];
+    const push = (v: any): string => { params.push(v); return `$${ params.length }`; };
+    const where: string[] = ['r.tenant_id = $1', 'r.record_type_id = $2', 'r.archived = false'];
+
+    for (const [key, cond] of Object.entries(opts.filter ?? {})) {
+      const frag = CrmSchemaService.compileFilterCond(key, cond, byKey, push);
+      if (frag) where.push(frag);
+    }
+
+    let metricCol = 'NULL::numeric';
+    let metricJoin = '';
+    if (metric !== 'count' && field) {
+      const mf = byKey.get(field);
+      if (mf) {
+        const col = valueColumnFor(mf.data_type) ?? 'value_number';
+        metricJoin = `LEFT JOIN crm_field_values mfv ON mfv.record_id = r.id AND mfv.field_id = ${ push(mf.id) }`;
+        metricCol = `${ metric.toUpperCase() }(mfv.${ col })`;
+      }
+    }
+
+    let groupSelect = '';
+    let groupJoin = '';
+    let groupByClause = '';
+    if (groupBy) {
+      const gf = byKey.get(groupBy);
+      if (gf) {
+        const col = valueColumnFor(gf.data_type) ?? 'value_text';
+        groupJoin = `LEFT JOIN crm_field_values gfv ON gfv.record_id = r.id AND gfv.field_id = ${ push(gf.id) }`;
+        groupSelect = `gfv.${ col } AS group_value, `;
+        groupByClause = `GROUP BY gfv.${ col }`;
+      }
+    }
+
+    const limitPh = push(limit);
+    return postgresClient.query(
+      `SELECT ${ groupSelect }COUNT(*)::int AS count, ${ metricCol } AS metric
+       FROM crm_records r
+       ${ metricJoin }
+       ${ groupJoin }
+       WHERE ${ where.join(' AND ') }
+       ${ groupByClause }
+       ORDER BY count DESC LIMIT ${ limitPh }`,
+      params,
+    );
+  }
+
+  static async getFieldByKey(
+    recordTypeId: string,
+    key: string,
+    tenantId = DEFAULT_TENANT_ID,
+  ): Promise<{ id: string; key: string; label: string; data_type: string; is_system: boolean; is_title: boolean } | null> {
+    const rows = await postgresClient.query(
+      `SELECT id, key, label, data_type, is_system, is_title
+       FROM crm_fields WHERE record_type_id = $1 AND key = $2 AND tenant_id = $3 AND archived = false LIMIT 1`,
+      [recordTypeId, key, tenantId],
+    );
+    return rows[0] ?? null;
+  }
+
+  static async updateField(
+    fieldId: string,
+    updates: {
+      label?: string;
+      config?: Record<string, unknown>;
+      is_required?: boolean;
+      is_unique?: boolean;
+      is_title?: boolean;
+    },
+    tenantId = DEFAULT_TENANT_ID,
+  ): Promise<OpResult> {
+    try {
+      const rows = await postgresClient.query(
+        `SELECT id, key, label, config, is_required, is_unique, is_title, is_system, record_type_id
+         FROM crm_fields WHERE id = $1 AND tenant_id = $2 AND archived = false LIMIT 1`,
+        [fieldId, tenantId],
+      );
+      if (!rows.length) return { ok: false, error: `Field ${ fieldId } not found.` };
+      const field = rows[0];
+      if (field.is_system) return { ok: false, error: `Field "${ field.key }" is a system field and cannot be modified.` };
+
+      const before = {
+        label: field.label, config: field.config,
+        is_required: field.is_required, is_unique: field.is_unique, is_title: field.is_title,
+      };
+
+      const setParts: string[] = [];
+      const params: any[] = [fieldId, tenantId];
+      const push = (v: any): string => { params.push(v); return `$${ params.length }`; };
+
+      if (updates.label !== undefined) setParts.push(`label = ${ push(updates.label) }`);
+      if (updates.config !== undefined) setParts.push(`config = ${ push(JSON.stringify(updates.config)) }::jsonb`);
+      if (updates.is_required !== undefined) setParts.push(`is_required = ${ push(updates.is_required) }`);
+      if (updates.is_unique !== undefined) setParts.push(`is_unique = ${ push(updates.is_unique) }`);
+      if (updates.is_title === true) {
+        await postgresClient.query(
+          `UPDATE crm_fields SET is_title = false, updated_at = now()
+           WHERE record_type_id = $1 AND is_title = true AND id != $2`,
+          [field.record_type_id, fieldId],
+        );
+        setParts.push(`is_title = true`);
+      } else if (updates.is_title === false) {
+        setParts.push(`is_title = false`);
+      }
+
+      if (!setParts.length) return { ok: false, error: 'No updatable fields provided.' };
+      setParts.push('updated_at = now()');
+
+      await postgresClient.query(
+        `UPDATE crm_fields SET ${ setParts.join(', ') } WHERE id = $1 AND tenant_id = $2`,
+        params,
+      );
+
+      const undoToken = await CrmSchemaService.writeAudit(postgresClient, {
+        op: 'updateField', entityType: 'field', entityId: fieldId,
+        before, after: { ...before, ...updates }, tenantId,
+      });
+      return { ok: true, id: fieldId, undoToken };
+    } catch (err: any) {
+      return { ok: false, error: String(err?.message ?? err) };
+    }
+  }
+
+  static async listViews(
+    recordTypeId: string,
+    tenantId = DEFAULT_TENANT_ID,
+  ): Promise<Array<{ id: string; name: string; kind: string; config: unknown; position: number }>> {
+    return postgresClient.query(
+      `SELECT id, name, kind, config, position
+       FROM crm_views WHERE record_type_id = $1 AND tenant_id = $2 AND archived = false
+       ORDER BY position ASC`,
+      [recordTypeId, tenantId],
+    );
+  }
+
+  static async listDashboards(
+    tenantId = DEFAULT_TENANT_ID,
+  ): Promise<Array<{ id: string; key: string; name: string; icon: string | null; widget_count: number }>> {
+    return postgresClient.query(
+      `SELECT d.id, d.key, d.name, d.icon, COUNT(w.id)::int AS widget_count
+       FROM crm_dashboards d
+       LEFT JOIN crm_widgets w ON w.dashboard_id = d.id
+       WHERE d.tenant_id = $1 AND d.archived = false
+       GROUP BY d.id, d.key, d.name, d.icon
+       ORDER BY d.name ASC`,
+      [tenantId],
+    );
+  }
 }

--- a/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
+++ b/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
@@ -1219,6 +1219,48 @@ export class CrmSchemaService {
     );
   }
 
+  /**
+   * One-shot CRM state overview — all types with field + relationship counts,
+   * plus dashboard counts. Lets the agent orient itself without looping over
+   * list_record_types + describe_record_type for every type.
+   */
+  static async getSchemaSummary(tenantId = DEFAULT_TENANT_ID): Promise<{
+    types: Array<{ id: string; key: string; label: string; field_count: number; relationship_count: number }>;
+    dashboards: Array<{ id: string; key: string; name: string; widget_count: number }>;
+  }> {
+    const [types, relCounts, dashboards] = await Promise.all([
+      postgresClient.query(
+        `SELECT rt.id, rt.key, rt.label, COUNT(f.id)::int AS field_count
+         FROM crm_record_types rt
+         LEFT JOIN crm_fields f ON f.record_type_id = rt.id AND f.archived = false
+         WHERE rt.tenant_id = $1 AND rt.archived = false
+         GROUP BY rt.id, rt.key, rt.label ORDER BY rt.label ASC`,
+        [tenantId],
+      ),
+      postgresClient.query(
+        `SELECT unnest(ARRAY[from_type_id, to_type_id]) AS type_id, COUNT(*)::int AS cnt
+         FROM crm_relationships WHERE tenant_id = $1 AND archived = false
+         GROUP BY type_id`,
+        [tenantId],
+      ),
+      CrmSchemaService.listDashboards(tenantId),
+    ]);
+
+    const relByType = new Map<string, number>();
+    for (const r of relCounts) {
+      relByType.set(r.type_id, (relByType.get(r.type_id) ?? 0) + r.cnt);
+    }
+
+    return {
+      types: types.map((t: any) => ({
+        id: t.id, key: t.key, label: t.label,
+        field_count: t.field_count,
+        relationship_count: relByType.get(t.id) ?? 0,
+      })),
+      dashboards,
+    };
+  }
+
   static async listViews(
     recordTypeId: string,
     tenantId = DEFAULT_TENANT_ID,

--- a/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
+++ b/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
@@ -865,6 +865,31 @@ export class CrmSchemaService {
     }
   }
 
+  /**
+   * Create multiple records of the same type in one call. Each item in `items`
+   * is a field-values map (same shape as createRecord `values`). Returns the
+   * count of successful inserts and an error list for failed items — never
+   * aborts the whole batch on a single failure.
+   */
+  static async bulkCreateRecords(
+    recordTypeId: string,
+    items: Array<Record<string, unknown>>,
+    tenantId = DEFAULT_TENANT_ID,
+    createdBy?: string,
+  ): Promise<{ created: number; errors: Array<{ index: number; error: string }> }> {
+    let created = 0;
+    const errors: Array<{ index: number; error: string }> = [];
+    for (let i = 0; i < items.length; i++) {
+      const result = await CrmSchemaService.createRecord(recordTypeId, items[i], tenantId, createdBy);
+      if (result.ok) {
+        created++;
+      } else {
+        errors.push({ index: i, error: result.error ?? 'unknown error' });
+      }
+    }
+    return { created, errors };
+  }
+
   // ── Read / discovery ──────────────────────────────────────────────────────
 
   /**

--- a/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
+++ b/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
@@ -1161,6 +1161,39 @@ export class CrmSchemaService {
     }
   }
 
+  /**
+   * Fetch recent audit rows. Filterable by entity_id (a specific record/field/
+   * etc.) and entity_type. Useful for recovering lost undo tokens or reviewing
+   * what the agent has changed.
+   */
+  static async getAuditLog(
+    opts: {
+      entityId?: string;
+      entityType?: AuditEntityType;
+      limit?: number;
+      tenantId?: string;
+    } = {},
+  ): Promise<Array<{
+    id: string; op: string; entity_type: string; entity_id: string | null;
+    undo_token: string; undone: boolean; created_at: string;
+  }>> {
+    const tenantId = opts.tenantId ?? DEFAULT_TENANT_ID;
+    const params: any[] = [tenantId];
+    const where: string[] = ['tenant_id = $1'];
+    const push = (v: any): string => { params.push(v); return `$${ params.length }`; };
+
+    if (opts.entityId) where.push(`entity_id = ${ push(opts.entityId) }`);
+    if (opts.entityType) where.push(`entity_type = ${ push(opts.entityType) }`);
+
+    const limitPh = push(opts.limit ?? 20);
+    return postgresClient.query(
+      `SELECT id, op, entity_type, entity_id, undo_token, undone, created_at
+       FROM crm_audit WHERE ${ where.join(' AND ') }
+       ORDER BY created_at DESC LIMIT ${ limitPh }`,
+      params,
+    );
+  }
+
   static async listViews(
     recordTypeId: string,
     tenantId = DEFAULT_TENANT_ID,

--- a/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
+++ b/pkg/rancher-desktop/agent/services/CrmSchemaService.ts
@@ -867,6 +867,49 @@ export class CrmSchemaService {
 
   // ── Read / discovery ──────────────────────────────────────────────────────
 
+  /**
+   * Full-text search across records of a type using the denormalized
+   * `search_text` column (all text field values concatenated on write).
+   * Returns hydrated records in the same shape as queryRecords.
+   */
+  static async searchRecords(
+    recordTypeId: string,
+    q: string,
+    opts: { limit?: number; tenantId?: string } = {},
+  ): Promise<Array<Record<string, unknown>>> {
+    const tenantId = opts.tenantId ?? DEFAULT_TENANT_ID;
+    const limit = opts.limit ?? 50;
+
+    const records = await postgresClient.query(
+      `SELECT r.id, r.title, r.created_at FROM crm_records r
+       WHERE r.tenant_id = $1 AND r.record_type_id = $2 AND r.archived = false
+         AND r.search_text ILIKE $3
+       ORDER BY r.created_at DESC LIMIT $4`,
+      [tenantId, recordTypeId, `%${ q }%`, limit],
+    );
+    if (!records.length) return [];
+
+    const ids = records.map((r: any) => r.id);
+    const values = await postgresClient.query(
+      `SELECT fv.record_id, f.key, f.data_type,
+              fv.value_text, fv.value_number, fv.value_bool, fv.value_datetime, fv.value_json
+       FROM crm_field_values fv
+       JOIN crm_fields f ON f.id = fv.field_id
+       WHERE fv.record_id = ANY($1)`,
+      [ids],
+    );
+
+    const byRecord = new Map<string, Record<string, unknown>>();
+    for (const r of records) byRecord.set(r.id, { id: r.id, title: r.title, created_at: r.created_at });
+    for (const v of values) {
+      const target = byRecord.get(v.record_id);
+      if (!target) continue;
+      const col = valueColumnFor(v.data_type);
+      target[v.key] = col ? (v as any)[col] : null;
+    }
+    return records.map((r: any) => byRecord.get(r.id)!);
+  }
+
   static async describeRecordType(
     keyOrId: string,
     tenantId = DEFAULT_TENANT_ID,

--- a/pkg/rancher-desktop/agent/tools/crm/aggregate_records.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/aggregate_records.ts
@@ -1,0 +1,57 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail, resolveRecordTypeId } from './_shared';
+
+const VALID_METRICS = new Set(['count', 'sum', 'avg', 'min', 'max']);
+
+export class CrmAggregateRecordsWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const keyOrId = input?.record_type ?? input?.record_type_id;
+    if (!keyOrId) return fail('crm/aggregate_records needs { record_type }.');
+
+    const metric: string = input?.metric ?? 'count';
+    if (!VALID_METRICS.has(metric)) return fail(`metric must be one of: ${ [...VALID_METRICS].join('|') }.`);
+    if (metric !== 'count' && !input?.field) {
+      return fail(`metric "${ metric }" requires a { field } key to aggregate on.`);
+    }
+
+    try {
+      const recordTypeId = await resolveRecordTypeId(String(keyOrId));
+      const rows = await CrmSchemaService.aggregateRecords(recordTypeId, {
+        metric: metric as any,
+        field: input?.field,
+        groupBy: input?.group_by ?? input?.groupBy,
+        filter: input?.filter,
+        limit: typeof input?.limit === 'number' ? Math.min(500, input.limit) : 100,
+      });
+
+      if (!rows.length) {
+        return { successBoolean: true, responseString: 'No matching records.' };
+      }
+
+      const hasGroup = 'group_value' in rows[0];
+      if (hasGroup) {
+        const lines = rows.map((r: any) =>
+          `  ${ r.group_value ?? '(null)' }: count=${ r.count }, ${ metric }=${ r.metric ?? 'null' }`,
+        );
+        return {
+          successBoolean: true,
+          responseString: `${ rows.length } group(s):\n${ lines.join('\n') }`,
+        };
+      }
+
+      const r = rows[0];
+      return {
+        successBoolean: true,
+        responseString: metric === 'count'
+          ? `count: ${ r.count }`
+          : `count: ${ r.count }, ${ metric }: ${ r.metric ?? 'null' }`,
+      };
+    } catch (err) {
+      return fail(`crm/aggregate_records failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/crm/bulk_create_records.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/bulk_create_records.ts
@@ -1,0 +1,36 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail, resolveRecordTypeId } from './_shared';
+
+export class CrmBulkCreateRecordsWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const keyOrId = input?.record_type ?? input?.record_type_id;
+    if (!keyOrId) return fail('crm/bulk_create_records needs { record_type }.');
+    if (!Array.isArray(input?.items) || !input.items.length) {
+      return fail('crm/bulk_create_records needs { items: [...] } — a non-empty array of field-value maps.');
+    }
+    if (input.items.length > 200) {
+      return fail('crm/bulk_create_records: items array exceeds max of 200 per call.');
+    }
+    try {
+      const recordTypeId = await resolveRecordTypeId(String(keyOrId));
+      const { created, errors } = await CrmSchemaService.bulkCreateRecords(
+        recordTypeId,
+        input.items,
+        undefined,
+        input?.created_by,
+      );
+      const parts: string[] = [`Created ${ created }/${ input.items.length } ${ keyOrId } record(s).`];
+      if (errors.length) {
+        parts.push(`${ errors.length } error(s):`);
+        errors.forEach(e => parts.push(`  index ${ e.index }: ${ e.error }`));
+      }
+      return { successBoolean: errors.length === 0, responseString: parts.join('\n') };
+    } catch (err) {
+      return fail(`crm/bulk_create_records failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/crm/describe_record_type.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/describe_record_type.ts
@@ -1,0 +1,41 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail, resolveRecordTypeId } from './_shared';
+
+export class CrmDescribeRecordTypeWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const keyOrId = input?.record_type ?? input?.record_type_id ?? input?.key ?? input?.id;
+    if (!keyOrId) return fail('crm/describe_record_type needs { record_type }.');
+    try {
+      const desc = await CrmSchemaService.describeRecordType(String(keyOrId));
+      if (!desc) return fail(`Record type "${ keyOrId }" not found.`);
+
+      const fields = desc.fields.map((f: any) =>
+        `  • ${ f.key } (${ f.data_type })${ f.is_title ? ' [title]' : '' }${ f.is_required ? ' [required]' : '' }${ f.is_system ? ' [system]' : '' }`,
+      ).join('\n');
+
+      const rels = desc.relationships.length
+        ? desc.relationships.map((r: any) =>
+          `  • ${ r.key } (${ r.cardinality }): ${ r.from_type_key } → ${ r.to_type_key }`,
+        ).join('\n')
+        : '  (none)';
+
+      const lines = [
+        `Type: ${ desc.label } (key:${ desc.key }, id:${ desc.id })`,
+        desc.label_plural ? `Plural: ${ desc.label_plural }` : null,
+        desc.description ? `Description: ${ desc.description }` : null,
+        `\nFields (${ desc.fields.length }):`,
+        fields || '  (none)',
+        `\nRelationships (${ desc.relationships.length }):`,
+        rels,
+      ].filter(Boolean);
+
+      return { successBoolean: true, responseString: lines.join('\n') };
+    } catch (err) {
+      return fail(`crm/describe_record_type failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/crm/get_audit_log.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/get_audit_log.ts
@@ -1,0 +1,41 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail } from './_shared';
+import type { AuditEntityType } from '../../services/CrmSchemaService';
+
+const ENTITY_TYPES = new Set<string>([
+  'record_type', 'field', 'relationship', 'view', 'dashboard', 'widget', 'record', 'link',
+]);
+
+export class CrmGetAuditLogWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    try {
+      const entityType = input?.entity_type;
+      if (entityType && !ENTITY_TYPES.has(entityType)) {
+        return fail(`entity_type must be one of: ${ [...ENTITY_TYPES].join('|') }.`);
+      }
+      const limit = typeof input?.limit === 'number' ? Math.min(100, input.limit) : 20;
+      const rows = await CrmSchemaService.getAuditLog({
+        entityId: input?.entity_id,
+        entityType: entityType as AuditEntityType | undefined,
+        limit,
+      });
+      if (!rows.length) {
+        return { successBoolean: true, responseString: 'No audit entries found.' };
+      }
+      const lines = rows.map((r: any) => {
+        const undone = r.undone ? ' [undone]' : '';
+        return `  ${ r.created_at } | ${ r.op } | ${ r.entity_type }:${ r.entity_id ?? '—' }${ undone } | undo:${ r.undo_token }`;
+      });
+      return {
+        successBoolean: true,
+        responseString: `${ rows.length } audit entry/entries (newest first):\n${ lines.join('\n') }`,
+      };
+    } catch (err) {
+      return fail(`crm/get_audit_log failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/crm/get_linked_records.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/get_linked_records.ts
@@ -1,0 +1,37 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail } from './_shared';
+
+export class CrmGetLinkedRecordsWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const recordId = input?.record_id ?? input?.id;
+    if (!recordId) return fail('crm/get_linked_records needs { record_id }.');
+    try {
+      const direction = input?.direction ?? 'both';
+      if (!['from', 'to', 'both'].includes(direction)) {
+        return fail('direction must be "from", "to", or "both".');
+      }
+      const limit = typeof input?.limit === 'number' ? Math.min(200, input.limit) : 50;
+      const rows = await CrmSchemaService.getLinkedRecords(String(recordId), {
+        relationshipId: input?.relationship_id,
+        direction,
+        limit,
+      });
+      if (!rows.length) {
+        return { successBoolean: true, responseString: `No linked records found for ${ recordId }.` };
+      }
+      const lines = rows.map((r: any) =>
+        `  [${ r.direction }] ${ r.record_type_label } — ${ r.title ?? r.id } (id:${ r.id }, rel:${ r.relationship_key })`,
+      );
+      return {
+        successBoolean: true,
+        responseString: `${ rows.length } linked record(s):\n${ lines.join('\n') }`,
+      };
+    } catch (err) {
+      return fail(`crm/get_linked_records failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/crm/get_record.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/get_record.ts
@@ -1,0 +1,23 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail } from './_shared';
+
+export class CrmGetRecordWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const recordId = input?.record_id ?? input?.id;
+    if (!recordId) return fail('crm/get_record needs { record_id }.');
+    try {
+      const record = await CrmSchemaService.getRecord(String(recordId));
+      if (!record) return { successBoolean: true, responseString: `Record ${ recordId } not found.` };
+      return {
+        successBoolean: true,
+        responseString: `Record:\n${ JSON.stringify(record, null, 2) }`,
+      };
+    } catch (err) {
+      return fail(`crm/get_record failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/crm/get_schema_summary.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/get_schema_summary.ts
@@ -1,0 +1,41 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail } from './_shared';
+
+export class CrmGetSchemaSummaryWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(): Promise<ToolResponse> {
+    try {
+      const { types, dashboards } = await CrmSchemaService.getSchemaSummary();
+      if (!types.length && !dashboards.length) {
+        return {
+          successBoolean: true,
+          responseString: 'CRM is empty. Use crm/create_record_type to get started.',
+        };
+      }
+
+      const typeLines = types.map((t: any) =>
+        `  • ${ t.label } (key:${ t.key }, id:${ t.id }) — ${ t.field_count } field(s), ${ t.relationship_count } relationship(s)`,
+      );
+      const dashLines = dashboards.map((d: any) =>
+        `  • ${ d.name } (key:${ d.key }, id:${ d.id }, ${ d.widget_count } widget(s))`,
+      );
+
+      const parts: string[] = [];
+      if (types.length) {
+        parts.push(`${ types.length } record type(s):`);
+        parts.push(...typeLines);
+      }
+      if (dashboards.length) {
+        parts.push(`\n${ dashboards.length } dashboard(s):`);
+        parts.push(...dashLines);
+      }
+
+      return { successBoolean: true, responseString: parts.join('\n') };
+    } catch (err) {
+      return fail(`crm/get_schema_summary failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/crm/list_dashboards.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/list_dashboards.ts
@@ -1,0 +1,26 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail } from './_shared';
+
+export class CrmListDashboardsWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(): Promise<ToolResponse> {
+    try {
+      const dashboards = await CrmSchemaService.listDashboards();
+      if (!dashboards.length) {
+        return { successBoolean: true, responseString: 'No dashboards yet. Use crm/create_dashboard to add one.' };
+      }
+      const lines = dashboards.map((d: any) =>
+        `  • ${ d.name } (key:${ d.key }, id:${ d.id }, widgets:${ d.widget_count })`,
+      );
+      return {
+        successBoolean: true,
+        responseString: `${ dashboards.length } dashboard(s):\n${ lines.join('\n') }`,
+      };
+    } catch (err) {
+      return fail(`crm/list_dashboards failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/crm/list_views.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/list_views.ts
@@ -1,0 +1,27 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail, resolveRecordTypeId } from './_shared';
+
+export class CrmListViewsWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const keyOrId = input?.record_type ?? input?.record_type_id;
+    if (!keyOrId) return fail('crm/list_views needs { record_type }.');
+    try {
+      const recordTypeId = await resolveRecordTypeId(String(keyOrId));
+      const views = await CrmSchemaService.listViews(recordTypeId);
+      if (!views.length) {
+        return { successBoolean: true, responseString: `No views for ${ keyOrId }. Use crm/create_view to add one.` };
+      }
+      const lines = views.map((v: any) => `  • ${ v.name } (kind:${ v.kind }, id:${ v.id })`);
+      return {
+        successBoolean: true,
+        responseString: `${ views.length } view(s) for ${ keyOrId }:\n${ lines.join('\n') }`,
+      };
+    } catch (err) {
+      return fail(`crm/list_views failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/crm/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/manifests.ts
@@ -156,6 +156,18 @@ export const crmToolManifests: ToolManifest[] = [
     loader:         () => import('./query_records'),
   },
   {
+    name:        'search_records',
+    description: 'Full-text search over records of a type using the denormalized search_text index (all text-type field values concatenated). Returns hydrated records. Use when you know a keyword but not the exact field value.',
+    category:    'crm',
+    schemaDef:   {
+      record_type: { type: 'string', description: 'Record type key or id.' },
+      q:           { type: 'string', description: 'Search query (min 2 chars). Matched with ILIKE against all text fields.' },
+      limit:       { type: 'number', optional: true, description: 'Max results (default 50, cap 200).' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./search_records'),
+  },
+  {
     name:        'get_record',
     description: 'Get a single record by id with all field values hydrated. Use after get_linked_records returns an id and you need the full details.',
     category:    'crm',

--- a/pkg/rancher-desktop/agent/tools/crm/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/manifests.ts
@@ -80,6 +80,33 @@ export const crmToolManifests: ToolManifest[] = [
     operationTypes: ['delete'],
     loader:         () => import('./archive_record_type'),
   },
+  {
+    name:        'describe_record_type',
+    description: 'Return a record type\'s full field schema + all relationships. Call this before add_field, create_record, or query_records to see what already exists.',
+    category:    'crm',
+    schemaDef:   {
+      record_type: { type: 'string', description: 'Record type key or id.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./describe_record_type'),
+  },
+  {
+    name:        'update_field',
+    description: 'Patch a field\'s label, config (e.g. select options), is_required, is_unique, or is_title. Accepts field_id directly OR { record_type, field_key } for lookup. Cannot modify system fields, key, or data_type.',
+    category:    'crm',
+    schemaDef:   {
+      field_id:    { type: 'string', optional: true, description: 'Field id to update (preferred).' },
+      record_type: { type: 'string', optional: true, description: 'Record type key or id (used with field_key).' },
+      field_key:   { type: 'string', optional: true, description: 'Field key to look up within the record type.' },
+      label:       { type: 'string', optional: true },
+      config:      { type: 'object', optional: true, description: 'Type-specific config, e.g. select options.' },
+      is_required: { type: 'boolean', optional: true },
+      is_unique:   { type: 'boolean', optional: true },
+      is_title:    { type: 'boolean', optional: true, description: 'Make this the title field; auto-unsets previous title.' },
+    },
+    operationTypes: ['update'],
+    loader:         () => import('./update_field'),
+  },
 
   // ── Data (records) ───────────────────────────────────────────────────────
   {
@@ -129,6 +156,31 @@ export const crmToolManifests: ToolManifest[] = [
     loader:         () => import('./query_records'),
   },
   {
+    name:        'get_record',
+    description: 'Get a single record by id with all field values hydrated. Use after get_linked_records returns an id and you need the full details.',
+    category:    'crm',
+    schemaDef:   {
+      record_id: { type: 'string', description: 'Record id to fetch.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./get_record'),
+  },
+  {
+    name:        'aggregate_records',
+    description: 'Run COUNT / SUM / AVG / MIN / MAX over records of a type. Supports optional groupBy (returns one row per distinct value) and the same filter DSL as query_records. metric ∈ count|sum|avg|min|max (default count). sum/avg/min/max require a { field } key.',
+    category:    'crm',
+    schemaDef:   {
+      record_type: { type: 'string', description: 'Record type key or id.' },
+      metric:      { type: 'enum', enum: ['count', 'sum', 'avg', 'min', 'max'], optional: true, description: 'Aggregation function (default count).' },
+      field:       { type: 'string', optional: true, description: 'Field key to aggregate (required for sum/avg/min/max).' },
+      group_by:    { type: 'string', optional: true, description: 'Field key to group results by.' },
+      filter:      { type: 'object', optional: true, description: 'Same filter DSL as query_records.' },
+      limit:       { type: 'number', optional: true, description: 'Max groups to return (default 100).' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./aggregate_records'),
+  },
+  {
     name:        'undo',
     description: 'Revert a previous CRM mutation by its undo token (from an earlier op\'s [undo:...] tag). Reverses create/update/archive/link ops; idempotent.',
     category:    'crm',
@@ -163,7 +215,40 @@ export const crmToolManifests: ToolManifest[] = [
     loader:         () => import('./unlink_records'),
   },
 
+  // ── Relationships ────────────────────────────────────────────────────────
+  {
+    name:        'get_linked_records',
+    description: 'Traverse crm_record_links from/to a record. Returns linked record id/title/type/relationship/direction. Optional: filter by relationship_id or direction ("from"|"to"|"both", default "both").',
+    category:    'crm',
+    schemaDef:   {
+      record_id:       { type: 'string', description: 'Record id whose links to traverse.' },
+      relationship_id: { type: 'string', optional: true, description: 'Restrict to one relationship type.' },
+      direction:       { type: 'enum', enum: ['from', 'to', 'both'], optional: true, description: 'Link direction (default "both").' },
+      limit:           { type: 'number', optional: true, description: 'Max links to return (default 50).' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./get_linked_records'),
+  },
+
   // ── Presentation (views / dashboards / widgets) ──────────────────────────
+  {
+    name:        'list_views',
+    description: 'List saved views for a record type (id, name, kind). Call before create_view to avoid duplicates.',
+    category:    'crm',
+    schemaDef:   {
+      record_type: { type: 'string', description: 'Record type key or id.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./list_views'),
+  },
+  {
+    name:        'list_dashboards',
+    description: 'List dashboards for the tenant with widget counts. Call before create_dashboard to avoid duplicates.',
+    category:    'crm',
+    schemaDef:   {},
+    operationTypes: ['read'],
+    loader:         () => import('./list_dashboards'),
+  },
   {
     name:        'create_view',
     description: 'Create a saved view for a record type. kind ∈ table|kanban|calendar|list|gallery. config carries view options (groupBy, fields, etc.).',

--- a/pkg/rancher-desktop/agent/tools/crm/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/manifests.ts
@@ -193,6 +193,18 @@ export const crmToolManifests: ToolManifest[] = [
     loader:         () => import('./aggregate_records'),
   },
   {
+    name:        'get_audit_log',
+    description: 'Return recent CRM audit entries (op, entity, undo_token, undone flag). Use to recover lost undo tokens or inspect what the agent changed. Filter by entity_id and/or entity_type.',
+    category:    'crm',
+    schemaDef:   {
+      entity_id:   { type: 'string', optional: true, description: 'Filter to a specific record/field/type/etc id.' },
+      entity_type: { type: 'enum', enum: ['record_type', 'field', 'relationship', 'view', 'dashboard', 'widget', 'record', 'link'], optional: true },
+      limit:       { type: 'number', optional: true, description: 'Max rows (default 20, cap 100).' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./get_audit_log'),
+  },
+  {
     name:        'undo',
     description: 'Revert a previous CRM mutation by its undo token (from an earlier op\'s [undo:...] tag). Reverses create/update/archive/link ops; idempotent.',
     category:    'crm',

--- a/pkg/rancher-desktop/agent/tools/crm/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/manifests.ts
@@ -81,6 +81,14 @@ export const crmToolManifests: ToolManifest[] = [
     loader:         () => import('./archive_record_type'),
   },
   {
+    name:        'get_schema_summary',
+    description: 'One-shot CRM orientation: all record types with field + relationship counts, plus all dashboards. Call this at the start of any CRM session to understand what already exists.',
+    category:    'crm',
+    schemaDef:   {},
+    operationTypes: ['read'],
+    loader:         () => import('./get_schema_summary'),
+  },
+  {
     name:        'describe_record_type',
     description: 'Return a record type\'s full field schema + all relationships. Call this before add_field, create_record, or query_records to see what already exists.',
     category:    'crm',

--- a/pkg/rancher-desktop/agent/tools/crm/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/manifests.ts
@@ -168,6 +168,18 @@ export const crmToolManifests: ToolManifest[] = [
     loader:         () => import('./search_records'),
   },
   {
+    name:        'bulk_create_records',
+    description: 'Create multiple records of the same type in one call. Accepts { items: [{ field: value, ... }, ...] } — up to 200 items. Fails per-item without aborting the batch; returns created count + error list.',
+    category:    'crm',
+    schemaDef:   {
+      record_type: { type: 'string', description: 'Record type key or id.' },
+      items:       { type: 'array', description: 'Array of field-value maps, one per record (max 200).', items: { type: 'object' } },
+      created_by:  { type: 'string', optional: true, description: 'Optional creator attribution.' },
+    },
+    operationTypes: ['create'],
+    loader:         () => import('./bulk_create_records'),
+  },
+  {
     name:        'get_record',
     description: 'Get a single record by id with all field values hydrated. Use after get_linked_records returns an id and you need the full details.',
     category:    'crm',

--- a/pkg/rancher-desktop/agent/tools/crm/search_records.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/search_records.ts
@@ -1,0 +1,29 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail, resolveRecordTypeId } from './_shared';
+
+export class CrmSearchRecordsWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const keyOrId = input?.record_type ?? input?.record_type_id;
+    if (!keyOrId) return fail('crm/search_records needs { record_type }.');
+    const q = input?.q ?? input?.query;
+    if (!q || String(q).trim().length < 2) return fail('crm/search_records needs { q } with at least 2 characters.');
+    try {
+      const recordTypeId = await resolveRecordTypeId(String(keyOrId));
+      const limit = typeof input?.limit === 'number' ? Math.min(200, input.limit) : 50;
+      const rows = await CrmSchemaService.searchRecords(recordTypeId, String(q), { limit });
+      if (!rows.length) {
+        return { successBoolean: true, responseString: `No ${ keyOrId } records match "${ q }".` };
+      }
+      return {
+        successBoolean: true,
+        responseString: `${ rows.length } ${ keyOrId } record(s) matching "${ q }":\n${ JSON.stringify(rows, null, 2) }`,
+      };
+    } catch (err) {
+      return fail(`crm/search_records failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/crm/update_field.ts
+++ b/pkg/rancher-desktop/agent/tools/crm/update_field.ts
@@ -1,0 +1,40 @@
+import { BaseTool, ToolResponse } from '../base';
+import { CrmSchemaService } from '../../services/CrmSchemaService';
+import { fail, fromOp, resolveRecordTypeId } from './_shared';
+
+export class CrmUpdateFieldWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    try {
+      let fieldId: string | undefined = input?.field_id;
+
+      if (!fieldId) {
+        const typeKeyOrId = input?.record_type ?? input?.record_type_id;
+        const fieldKey = input?.field_key ?? input?.key;
+        if (!typeKeyOrId || !fieldKey) {
+          return fail('crm/update_field needs { field_id } OR { record_type, field_key }.');
+        }
+        const recordTypeId = await resolveRecordTypeId(String(typeKeyOrId));
+        const found = await CrmSchemaService.getFieldByKey(recordTypeId, String(fieldKey));
+        if (!found) return fail(`Field "${ fieldKey }" not found on record type "${ typeKeyOrId }".`);
+        fieldId = found.id;
+      }
+
+      const updates: Record<string, unknown> = {};
+      if (input?.label !== undefined) updates.label = String(input.label);
+      if (input?.config !== undefined && typeof input.config === 'object') updates.config = input.config;
+      if (input?.is_required !== undefined) updates.is_required = Boolean(input.is_required);
+      if (input?.is_unique !== undefined) updates.is_unique = Boolean(input.is_unique);
+      if (input?.is_title !== undefined) updates.is_title = Boolean(input.is_title);
+
+      if (!Object.keys(updates).length) return fail('No updatable properties provided.');
+
+      const result = await CrmSchemaService.updateField(fieldId, updates as any);
+      return fromOp(result, `Field ${ fieldId } updated.`);
+    } catch (err) {
+      return fail(`crm/update_field failed: ${ (err as Error).message }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/meta/exechost.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/exechost.ts
@@ -1,0 +1,75 @@
+import { BaseTool, ToolResponse } from '../base';
+import { runCommand } from '../util/CommandRunner';
+import { HOST_ACCESS_DISABLED_MESSAGE, isHostAccessEnabled } from '../util/hostAccess';
+
+/**
+ * ExecHost — runs a shell command directly on the host macOS machine,
+ * NOT inside the Lima VM. Uses the user's login shell so that PATH
+ * includes Homebrew, nvm, rbenv, etc. — any tool the user has installed.
+ *
+ * Gated by application.hostAccess (Preferences → Application →
+ * Administrative Access → "Allow access to the host machine"). Fails
+ * closed if that setting is off.
+ *
+ * Use this instead of the AppleScript→Terminal bridge whenever you need
+ * to run host commands silently — no Terminal window pops up, output is
+ * returned directly to the agent.
+ */
+export class ExecHostWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const command = String(input.command ?? input.cmd ?? '').trim();
+    if (!command) {
+      return { successBoolean: false, responseString: 'Missing required field: command (or cmd).' };
+    }
+
+    if (!isHostAccessEnabled()) {
+      return { successBoolean: false, responseString: HOST_ACCESS_DISABLED_MESSAGE };
+    }
+
+    const cwd       = input.cwd ? String(input.cwd).trim() : undefined;
+    const timeoutMs = input.timeout ? Number(input.timeout) : 60_000;
+    const stdin     = input.stdin ? String(input.stdin) : undefined;
+
+    // Use the user's configured login shell so PATH includes Homebrew, nvm, etc.
+    // Require an absolute path — process.env.SHELL is always /bin/zsh or /bin/bash
+    // on macOS. Fall back to /bin/bash if SHELL is unset or a bare name.
+    const shell = (process.env.SHELL ?? '').startsWith('/') ? process.env.SHELL! : '/bin/bash';
+
+    // Prefix with cd when a working directory is requested.
+    const script = cwd ? `cd ${ singleQuote(cwd) } && ${ command }` : command;
+
+    try {
+      // Passing the full path (e.g. /bin/zsh) bypasses CommandRunner's
+      // special-case rewrite for bare "bash"/"zsh" names, so spawn receives
+      // the args exactly as given: ['-lc', script].
+      const res = await runCommand(shell, ['-lc', script], {
+        timeoutMs,
+        maxOutputChars: 160_000,
+        stdin,
+        // runInLimaShell is false by default → executes on the host process
+      });
+
+      if (res.exitCode !== 0) {
+        return {
+          successBoolean: false,
+          responseString: `Command exited ${ res.exitCode }:\n${ res.stderr || res.stdout }`,
+        };
+      }
+
+      return {
+        successBoolean: true,
+        responseString: res.stdout || res.stderr || '(no output)',
+      };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `exechost failed: ${ err.message }` };
+    }
+  }
+}
+
+/** Wrap a string in single quotes, escaping any embedded single quotes. */
+function singleQuote(s: string): string {
+  return `'${ s.replace(/'/g, `'"'"'`) }'`;
+}

--- a/pkg/rancher-desktop/agent/tools/meta/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/manifests.ts
@@ -29,6 +29,20 @@ export const metaToolManifests: ToolManifest[] = [
     loader:         () => import('./exec'),
   },
   {
+    name:        'exechost',
+    description: 'Run a shell command directly on the HOST macOS machine — NOT inside the Lima VM. Uses the user\'s login shell (/bin/zsh or /bin/bash) so PATH includes Homebrew, nvm, rbenv, and any other user-installed tools. Output is returned directly to the agent — no Terminal window opens. Requires "Allow access to the host machine" to be enabled in Preferences → Application → Administrative Access. Use this instead of the AppleScript→Terminal bridge whenever you need silent host execution.',
+    category:    'meta',
+    schemaDef:   {
+      command: { type: 'string', optional: true, description: 'The exact shell command to run on the host' },
+      cmd:     { type: 'string', optional: true, description: 'Alias for command' },
+      cwd:     { type: 'string', optional: true, description: 'Working directory on the host to run the command in (absolute path)' },
+      timeout: { type: 'number', optional: true, description: 'Timeout in milliseconds (default 60000)' },
+      stdin:   { type: 'string', optional: true, description: 'Optional stdin data to pipe into the command' },
+    },
+    operationTypes: ['execute'],
+    loader:         () => import('./exechost'),
+  },
+  {
     name:        'remove_observational_memory',
     description: 'Archive (soft-delete) a specific observational memory by its ID. The record is never hard-deleted — it is marked archived=true so the history is always recoverable.',
     category:    'observation',


### PR DESCRIPTION
## Summary

- Adds `exechost` tool to the `meta` category
- Runs commands directly on the host macOS machine via the users login shell (`/bin/zsh` or `/bin/bash`) — no Terminal window opens
- Gated by `application.hostAccess` (same Preferences toggle as before) — fails closed if disabled
- Output returned inline; replaces `applescript_execute` + Terminal which pops visible windows

## How it works

`runCommand` without `runInLimaShell` already executes via `child_process.spawn` in the Electron main process, which is on the host. `exechost` calls this with the full-path login shell (`/bin/zsh`) and `-lc` flag so Homebrew, nvm, etc. are on PATH.

## Test plan

- [ ] `sulla meta/exechost {"command":"echo $SHELL && which git"}` — returns host shell path + git location
- [ ] `sulla meta/exechost {"command":"ls","cwd":"/Users/jonathonbyrdziak/Sites"}` — lists Sites directory
- [ ] Disable host access → `sulla meta/exechost {"command":"ls"}` — returns HOST_ACCESS_DISABLED_MESSAGE
- [ ] Verify no Terminal window opens during any of the above

🤖 Generated with Claude Code