### PR TITLE
release v1.4.1: eval_js silent-failure fix + subconscious unfence/parallelism

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sulla-desktop",
   "productName": "Sulla Desktop",
   "license": "Apache-2.0 WITH Commons-Clause",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "Jonathon Byrdziak",
     "email": "jonathonbyrd@gmail.com"

--- a/pkg/rancher-desktop/agent/controllers/ToolExecutor.ts
+++ b/pkg/rancher-desktop/agent/controllers/ToolExecutor.ts
@@ -80,6 +80,12 @@ export interface ToolExecutorContext {
   /** Current node run context (null when not inside an LLM call) */
   currentNodeRunContext: NodeRunContext | null;
 
+  /** When true, all tool calls in one LLM reply are invoked concurrently and
+   *  their results appended in the original call order. Enabled for
+   *  subconscious agents (read-only search tools) where batch latency should
+   *  be max(tool) rather than sum(tools). */
+  parallelToolCalls?: boolean;
+
   /** Send a chat message over WebSocket. `extras` is merged into the WS
    *  event `data` alongside content/role/kind — used to ride structured
    *  payloads (citations, workflow documents) on the same event. */
@@ -136,6 +142,10 @@ export class ToolExecutor {
     }
 
     throwIfAborted(state, 'Tool execution aborted');
+
+    if (this.ctx.parallelToolCalls && toolCalls.length > 1) {
+      return this.executeToolCallsParallel(state, toolCalls, allowedTools);
+    }
 
     const results: { toolName: string; success: boolean; result?: unknown; error?: string }[] = [];
 
@@ -307,6 +317,175 @@ export class ToolExecutor {
         results.push({ toolName, success: false, error: 'Unknown tool' });
         this.pushToTranscript(toolName, false, 'Unknown tool');
         continue;
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Parallel variant of executeToolCalls: every invocation in the batch starts
+   * together and results are appended in the original call order, so the
+   * message stream and transcript look identical to the sequential path while
+   * batch latency drops from sum(tools) to max(tools). Only reached when
+   * ctx.parallelToolCalls is set (subconscious agents — their tools are
+   * independent read-only searches; ordering between them carries no meaning).
+   */
+  private async executeToolCallsParallel(
+    state: BaseThreadState,
+    toolCalls: { name: string; id?: string; args: any }[],
+    allowedTools?: string[],
+  ): Promise<{ toolName: string; success: boolean; result?: unknown; error?: string }[]> {
+    type Launched = {
+      toolRunId: string;
+      toolName:  string;
+      args:      any;
+      // Pre-flight rejections (loop/policy/allowlist/unknown-tool) settle
+      // immediately; real invocations settle when the tool returns.
+      outcome:   Promise<{ result?: ToolResult; error?: string; loopBlock?: boolean }>;
+      started:   number;
+    };
+    const launched: Launched[] = [];
+
+    // Phase 1 — pre-flight checks in call order, then fire every invocation
+    // without awaiting it. Checks stay sequential: they're cheap, and loop
+    // detection reads __toolRuns which phase 2 appends to.
+    for (const call of toolCalls) {
+      const toolRunId = call.id || `${ call.name }_${ Date.now() }_${ Math.random().toString(36).substr(2, 9) }`;
+      const toolName = call.name;
+      const args = call.args;
+
+      await this.emitToolCallEvent(state, toolRunId, toolName, args);
+
+      // Loop detection — same rule as the sequential path.
+      const LOOP_THRESHOLD = 7;
+      const dedupeKey = this.buildToolRunDedupeKey(toolName, args);
+      const toolRuns = (state.metadata as any).__toolRuns as { dedupeKey: string }[] | undefined;
+      let consecutiveCount = 0;
+      if (toolRuns?.length) {
+        for (let i = toolRuns.length - 1; i >= 0; i--) {
+          if (toolRuns[i].dedupeKey === dedupeKey) consecutiveCount++;
+          else break;
+        }
+      }
+      if (consecutiveCount >= LOOP_THRESHOLD) {
+        const loopMsg = `Loop detected: this exact tool call ("${ toolName }" with the same arguments) was executed ${ consecutiveCount } times consecutively. Use the previous result instead of calling it again.`;
+        launched.push({ toolRunId, toolName, args, outcome: Promise.resolve({ error: loopMsg, loopBlock: true }), started: Date.now() });
+        continue;
+      }
+
+      const policyBlockReason = await this.getToolPolicyBlockReason(state, toolName);
+      if (policyBlockReason) {
+        launched.push({ toolRunId, toolName, args, outcome: Promise.resolve({ error: policyBlockReason }), started: Date.now() });
+        continue;
+      }
+
+      if (allowedTools?.length && !allowedTools.includes(toolName)) {
+        launched.push({ toolRunId, toolName, args, outcome: Promise.resolve({ error: `Tool not allowed in this node: ${ toolName }` }), started: Date.now() });
+        continue;
+      }
+
+      let tool: any;
+      try {
+        tool = await toolRegistry.getTool(toolName);
+      } catch {
+        launched.push({ toolRunId, toolName, args, outcome: Promise.resolve({ error: `Unknown tool: ${ toolName }` }), started: Date.now() });
+        continue;
+      }
+
+      if (tool instanceof BaseTool) {
+        tool.setState(state);
+        tool.sendChatMessage = (content: string, kind = 'progress', extras?: Record<string, unknown>) =>
+          this.ctx.wsChatMessage(state, content, 'assistant', kind, extras);
+        tool.emitProgress = async(data: any) => {
+          await this.dispatchToWebSocket(state.metadata.wsChannel || DEFAULT_WS_CHANNEL, {
+            type:      'progress_update',
+            data:      { ...data, kind: 'progress', thread_id: state.metadata.threadId },
+            timestamp: Date.now(),
+          });
+        };
+      }
+
+      const started = Date.now();
+      launched.push({
+        toolRunId,
+        toolName,
+        args,
+        started,
+        outcome: Promise.resolve(tool.invoke(args))
+          .then((result: ToolResult) => ({ result }))
+          .catch((err: any) => ({ error: err?.message || String(err) })),
+      });
+    }
+
+    // Phase 2 — settle in call order and run the exact plumbing the
+    // sequential path runs: emit result, append message, persist, transcript.
+    const results: { toolName: string; success: boolean; result?: unknown; error?: string }[] = [];
+
+    for (const entry of launched) {
+      const { toolRunId, toolName, args } = entry;
+      const settled = await entry.outcome;
+      const invokeMs = Date.now() - entry.started;
+
+      if (settled.result !== undefined) {
+        const result = settled.result;
+        let argHint = '';
+        try {
+          const a = args as any;
+          const raw = a?.query ?? a?.pattern ?? a?.path ?? a?.file_path ?? a?.slug ?? '';
+          argHint = String(raw).slice(0, 80);
+        } catch { /* best-effort */ }
+        perf.log(`[InProcToolTiming] node=${ this.ctx.nodeName } tool=${ toolName } ms=${ invokeMs } success=${ result?.success === true } parallel=true arg="${ argHint }"`);
+        state.metadata.lastActivityMs = Date.now();
+
+        const toolSuccess = result?.success === true;
+        const toolError = typeof result?.error === 'string'
+          ? result.error
+          : (!toolSuccess && typeof result?.result === 'string' ? result.result : undefined);
+
+        await this.emitToolResultEvent(state, toolRunId, toolSuccess, toolError, result);
+        await this.appendToolResultMessage(state, toolName, {
+          toolName, success: toolSuccess, result, error: toolError, toolCallId: toolRunId,
+        });
+        this.persistStructuredToolRunRecord(state, {
+          toolName, toolRunId, args, success: toolSuccess, result, error: toolError,
+        });
+        results.push({ toolName, success: toolSuccess, result, error: toolError });
+        this.pushToTranscript(toolName, toolSuccess, toolError, result);
+        this.trackFailureSignature(state, toolName, toolSuccess, toolError, result);
+
+        const convId = (state.metadata as any).conversationId;
+        if (convId) {
+          try {
+            const { getConversationLogger: getLogger } = require('../services/ConversationLogger');
+            getLogger().logToolCall(convId, toolName, args, result);
+          } catch { /* best-effort */ }
+        }
+      } else {
+        const error = settled.error || 'Tool execution failed';
+
+        await this.emitToolResultEvent(state, toolRunId, false, error);
+        await this.appendToolResultMessage(state, toolName, {
+          toolName, success: false, error, toolCallId: toolRunId,
+        });
+        // Mirror the sequential path: loop blocks are not persisted as
+        // structured run records (a blocked call shouldn't extend the streak).
+        if (!settled.loopBlock) {
+          this.persistStructuredToolRunRecord(state, {
+            toolName, toolRunId, args, success: false, error,
+          });
+          this.trackFailureSignature(state, toolName, false, error, null);
+        }
+        results.push({ toolName, success: false, error });
+        this.pushToTranscript(toolName, false, error);
+
+        const convId = (state.metadata as any).conversationId;
+        if (convId && !settled.loopBlock) {
+          try {
+            const { getConversationLogger: getLogger } = require('../services/ConversationLogger');
+            getLogger().logToolCall(convId, toolName, args, { error });
+          } catch { /* best-effort */ }
+        }
       }
     }
 

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -536,6 +536,10 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
   private _chatController:       ChatController | null = null;
   private _toolExecutor:         ToolExecutor | null = null;
 
+  /** Subclasses set true to run batched tool calls concurrently (results are
+   *  still appended in call order). See ToolExecutorContext.parallelToolCalls. */
+  protected parallelToolCalls = false;
+
   constructor(id: string, name: string) {
     this.id = id;
     this.name = name;
@@ -547,6 +551,7 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
       this._toolExecutor = new ToolExecutor({
         nodeId:                this.id,
         nodeName:              this.name,
+        parallelToolCalls:     this.parallelToolCalls,
         get currentNodeRunContext() { return null }, // overridden below
         wsChatMessage:         (state, content, role, kind) => this.wsChatMessage(state, content, role, kind),
         bumpStateVersion:      (state) => this.bumpStateVersion(state),

--- a/pkg/rancher-desktop/agent/nodes/SubconsciousAgentNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/SubconsciousAgentNode.ts
@@ -109,6 +109,9 @@ function extractOutcome(text: string, hadToolCalls: boolean): SubconsciousOutcom
 export class SubconsciousAgentNode extends BaseNode {
   constructor() {
     super('subconscious', 'Subconscious');
+    // Subconscious tools are independent read-only searches — run a batch of
+    // tool calls concurrently so batch latency is max(tool), not sum(tools).
+    this.parallelToolCalls = true;
   }
 
   async execute(state: BaseThreadState): Promise<NodeResult<BaseThreadState>> {

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -84,6 +84,19 @@ only the categories that relate to it. For example:
 
 Never search all categories by default. Be selective.
 
+## Speed — the human is waiting
+
+Time is of the essence: the primary agent (and the human) BLOCK until you
+finish. Tool calls you issue in the SAME response execute in PARALLEL; calls
+spread across separate responses each cost a full model round-trip. So:
+- Decide up front everything you plausibly need and issue ALL of those tool
+  calls in ONE response — one parallel batch beats a chain of single calls.
+- Combine related terms into one query instead of near-duplicate searches.
+- Aim for at most 2-3 rounds total: index lookup + broad parallel sweep →
+  targeted follow-up reads → store digests and answer.
+- Returning nothing quickly is a GOOD outcome when nothing is relevant —
+  never keep searching just to have something to show.
+
 ## STEP 0 — Check the citation index FIRST
 
 Before any file_search or read_file call, call \`recall_index_lookup\` with the
@@ -241,7 +254,10 @@ const HEARTBEAT_RECALL_PROMPT = `You are a READ-ONLY recall process for the hear
 
 ## Your checklist
 
-Complete these steps in order, then finish:
+Complete these steps in order, then finish. Speed matters: tool calls issued
+in the SAME response run in PARALLEL — batch independent reads/calls together
+(e.g. all PROJECT.md reads at once; presence + jobs in the same round) instead
+of one call per response.
 
 ### 0. Citation Index
 Call \`recall_index_lookup\` with topic \`heartbeat-projects\` plus the
@@ -485,6 +501,11 @@ Rules:
 - Format each result as: \`[id] priority date — content\`
 - If nothing is relevant, return an empty string — do NOT pad with filler.
 - Do NOT narrate your process. Output only the filtered observation lines.
+
+Speed: the primary agent BLOCKS until you finish. Tool calls in the SAME
+response run in PARALLEL — issue every search you need (different phrasings,
+plus list_observations) as ONE batch in your first response, then answer.
+Do not search one term at a time across multiple rounds.
 
 Be selective: a 5-entry relevant subset is better than 30 entries dumped verbatim.`;
 

--- a/pkg/rancher-desktop/agent/tools/browser/__tests__/exec.test.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/__tests__/exec.test.ts
@@ -1,0 +1,245 @@
+/**
+ * @jest-environment node
+ *
+ * Node environment on purpose: nothing here touches the DOM (the tab bridge
+ * is mocked, classifyCode/buildWrapper are pure), and base.ts transitively
+ * reaches the pg client, which needs Node globals (TextEncoder) that the
+ * default jsdom environment doesn't provide.
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+// ESM tests in this repo mock via unstable_mockModule + dynamic import
+// (see meta/__tests__/browser_tab.test.ts) — plain jest.mock does not
+// intercept under --experimental-vm-modules.
+const mockResolveBridge = jest.fn<() => Promise<unknown>>();
+
+jest.unstable_mockModule('../resolve_bridge', () => ({
+  resolveBridge:    mockResolveBridge,
+  isBridgeResolved: (r: any) => !!r?.bridge,
+}));
+jest.unstable_mockModule('../screenshot_store', () => ({ saveScreenshot: jest.fn() }));
+// GuestBridge and friends import electron, which doesn't exist under jest.
+jest.unstable_mockModule('electron', () => ({
+  app:           {},
+  ipcMain:       { on: jest.fn(), handle: jest.fn() },
+  nativeImage:   { createFromBuffer: jest.fn(), createFromDataURL: jest.fn() },
+  BrowserWindow: class {},
+  WebContentsView: class {},
+}));
+
+async function loadModule() {
+  return import('../exec');
+}
+
+function makeCaller(bridge: Record<string, unknown>) {
+  mockResolveBridge.mockResolvedValue({ bridge, assetId: 'tab-1' });
+
+  return async(input: Record<string, unknown>) => {
+    const { ExecInPageWorker } = await loadModule();
+    const worker = new ExecInPageWorker();
+
+    // _validatedCall is protected; tests drive it directly.
+    return (worker as any)._validatedCall(input);
+  };
+}
+
+/** A well-formed diagnostic envelope, as the in-page wrapper produces. */
+function envelope(overrides: Record<string, unknown> = {}) {
+  return {
+    result:     undefined,
+    resultNote: null,
+    error:      undefined,
+    errorStack: undefined,
+    logs:       [],
+    sullaLog:   [],
+    timing:     1.5,
+    mutations:  0,
+    navigated:  false,
+    url:        'about:blank',
+    title:      't',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockResolveBridge.mockReset();
+});
+
+describe('classifyCode', () => {
+  it('classifies single expressions (devtools semantics)', async() => {
+    const { classifyCode } = await loadModule();
+
+    expect(classifyCode('1 + 1').form).toBe('expression');
+    expect(classifyCode('document.title').form).toBe('expression');
+    expect(classifyCode('fetch("/x")').form).toBe('expression');
+    expect(classifyCode('(async () => { return 1; })()').form).toBe('expression');
+  });
+
+  it('classifies expressions using top-level await', async() => {
+    const { classifyCode } = await loadModule();
+
+    expect(classifyCode('await fetch("/x")').form).toBe('expression');
+  });
+
+  it('classifies statement lists as body', async() => {
+    const { classifyCode } = await loadModule();
+
+    expect(classifyCode('const x = 1; return x + 1;').form).toBe('body');
+    expect(classifyCode('let a = 2;\nreturn a;').form).toBe('body');
+    // Trailing semicolon defeats the expression parse — falls back to body.
+    expect(classifyCode('1 + 1;').form).toBe('body');
+  });
+
+  it('classifies syntax errors as invalid with a parse error', async() => {
+    const { classifyCode } = await loadModule();
+    const res = classifyCode('const = 5;');
+
+    expect(res.form).toBe('invalid');
+    expect(res.parseError).toBeTruthy();
+  });
+
+  it('is not fooled by trailing line comments on expressions', async() => {
+    const { classifyCode } = await loadModule();
+
+    expect(classifyCode('document.title // read the title').form).toBe('expression');
+  });
+});
+
+describe('buildWrapper', () => {
+  it('auto-returns expression-form code', async() => {
+    const { buildWrapper } = await loadModule();
+    const w = buildWrapper('1 + 1', 'expression');
+
+    expect(w).toContain('return (\n1 + 1\n);');
+  });
+
+  it('embeds body-form code without an implicit return', async() => {
+    const { buildWrapper } = await loadModule();
+    const w = buildWrapper('const x = 1; return x;', 'body');
+
+    expect(w).toContain('const x = 1; return x;');
+    expect(w).not.toContain('return (\nconst');
+  });
+
+  it('guards MutationObserver against a null document.body', async() => {
+    const { buildWrapper } = await loadModule();
+
+    expect(buildWrapper('1', 'expression')).toContain('if (document.body)');
+  });
+
+  it('captures console with a circular-safe stringifier', async() => {
+    const { buildWrapper } = await loadModule();
+
+    expect(buildWrapper('1', 'expression')).toContain('catch (e) { return String(a); }');
+  });
+});
+
+describe('ExecInPageWorker._validatedCall', () => {
+  it('reports syntax errors without a page round-trip (was: silent Result: undefined)', async() => {
+    const execInPageStrict = jest.fn();
+    const call = makeCaller({ execInPageStrict });
+
+    const res = await call({ code: 'const = 5;' });
+
+    expect(res.successBoolean).toBe(false);
+    expect(res.responseString).toContain('Syntax error');
+    expect(execInPageStrict).not.toHaveBeenCalled();
+  });
+
+  it('surfaces bridge rejections as errors (was: swallowed to undefined)', async() => {
+    const call = makeCaller({
+      execInPageStrict: jest.fn<() => Promise<unknown>>().mockRejectedValue(new Error('An object could not be cloned')),
+    });
+
+    const res = await call({ code: 'return window' });
+
+    expect(res.successBoolean).toBe(false);
+    expect(res.responseString).toContain('Execution failed');
+    expect(res.responseString).toContain('could not be cloned');
+  });
+
+  it('enforces the timeout param (was: accepted and ignored — hung forever)', async() => {
+    const call = makeCaller({
+      execInPageStrict: jest.fn<() => Promise<unknown>>().mockReturnValue(new Promise(() => { /* never settles */ })),
+    });
+
+    const res = await call({ code: 'await new Promise(() => {})', timeout: 50 });
+
+    expect(res.successBoolean).toBe(false);
+    expect(res.responseString).toContain('timed out after 50ms');
+  });
+
+  it('returns the value from a successful expression', async() => {
+    const call = makeCaller({
+      execInPageStrict: jest.fn<() => Promise<unknown>>().mockResolvedValue(envelope({ result: 2 })),
+    });
+
+    const res = await call({ code: '1 + 1' });
+
+    expect(res.successBoolean).toBe(true);
+    expect(res.responseString).toContain('Result: 2');
+  });
+
+  it('hints when body-form code returns nothing and has no return statement', async() => {
+    const call = makeCaller({
+      execInPageStrict: jest.fn<() => Promise<unknown>>().mockResolvedValue(envelope()),
+    });
+
+    const res = await call({ code: 'const x = 1; console.log(x);' });
+
+    expect(res.successBoolean).toBe(true);
+    expect(res.responseString).toContain('ran as a function body and returned nothing');
+  });
+
+  it('does not hint when body-form code explicitly returns a value', async() => {
+    const call = makeCaller({
+      execInPageStrict: jest.fn<() => Promise<unknown>>().mockResolvedValue(envelope({ result: 'ok' })),
+    });
+
+    const res = await call({ code: 'const x = "ok"; return x;' });
+
+    expect(res.successBoolean).toBe(true);
+    expect(res.responseString).toContain('Result: ok');
+    expect(res.responseString).not.toContain('returned nothing');
+  });
+
+  it('passes through the in-page serialization note for unserializable results', async() => {
+    const call = makeCaller({
+      execInPageStrict: jest.fn<() => Promise<unknown>>().mockResolvedValue(envelope({
+        result:     '[object HTMLDivElement]',
+        resultNote: 'Result was not JSON-serializable (circular) — returning String(result).',
+      })),
+    });
+
+    const res = await call({ code: 'return document.createElement("div")' });
+
+    expect(res.successBoolean).toBe(true);
+    expect(res.responseString).toContain('Note: Result was not JSON-serializable');
+  });
+
+  it('reports a lost diagnostic envelope instead of faking Result: undefined', async() => {
+    const call = makeCaller({
+      execInPageStrict: jest.fn<() => Promise<unknown>>().mockResolvedValue(undefined),
+    });
+
+    const res = await call({ code: '1 + 1' });
+
+    expect(res.successBoolean).toBe(false);
+    expect(res.responseString).toContain('no diagnostic envelope');
+  });
+
+  it('reports in-page runtime errors with stack', async() => {
+    const call = makeCaller({
+      execInPageStrict: jest.fn<() => Promise<unknown>>().mockResolvedValue(envelope({
+        error:      'boom',
+        errorStack: 'Error: boom\n  at <anonymous>',
+      })),
+    });
+
+    const res = await call({ code: 'throw new Error("boom")' });
+
+    expect(res.successBoolean).toBe(false);
+    expect(res.responseString).toContain('Error: boom');
+    expect(res.responseString).toContain('Stack:');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/browser/exec.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/exec.ts
@@ -11,44 +11,90 @@ import { resolveBridge, isBridgeResolved } from './resolve_bridge';
  * Enhanced with __sulla log capture, timing, mutation counting,
  * navigation detection, optional waitFor/waitForIdle/screenshot,
  * and full error stack traces.
+ *
+ * Silent-failure hardening (fix/eval-js-silent-failures):
+ *  - Single expressions are auto-returned (devtools-console semantics) —
+ *    models routinely send `document.title` and expect a value back.
+ *  - Syntax errors are caught by pre-validation in the main process and
+ *    reported as errors; they used to come back `Result: undefined` with
+ *    success=true because the bridge swallowed the compile rejection.
+ *  - The `timeout` param is actually enforced (it was accepted and
+ *    silently ignored — code awaiting a never-settling promise hung the
+ *    tool call forever).
+ *  - Results and console args are serialized defensively in-page so
+ *    circular structures / DOM nodes can't crash the response path or
+ *    the user's own console.log calls.
  */
-export class ExecInPageWorker extends BaseTool {
-  name = '';
-  description = '';
 
-  protected async _validatedCall(input: any): Promise<ToolResponse> {
-    const { code, screenshot, waitFor, waitForIdle, timeout = 30000 } = input;
-    if (!code || typeof code !== 'string') {
-      return { successBoolean: false, responseString: 'code parameter is required.' };
-    }
+/** How the user code must be wrapped to produce a value. */
+export type CodeForm = 'expression' | 'body' | 'invalid';
 
-    const result = await resolveBridge(input.assetId);
-    if (!isBridgeResolved(result)) return result;
+/**
+ * Classify user code: a single expression gets auto-returned (console
+ * semantics); anything that only parses as a statement list runs as a
+ * function body (explicit `return` sends the value); code that parses as
+ * neither is a syntax error we can report without a page round-trip.
+ *
+ * Both probes compile inside an async arrow so top-level `await` is legal
+ * exactly like it will be in the page wrapper. `new Function` compiles
+ * without executing, and main-process V8 matches the renderer's parser.
+ */
+export function classifyCode(code: string): { form: CodeForm; parseError?: string } {
+  try {
+    // eslint-disable-next-line no-new-func
+    new Function(`"use strict"; return (async () => (\n${ code }\n));`);
 
-    try {
-      // Wrap code to capture console output, __sulla logs, timing,
-      // mutations, navigation, errors with stacks, and page state.
-      const wrapped = `
+    return { form: 'expression' };
+  } catch { /* not a single expression — try statement-list form */ }
+
+  try {
+    // eslint-disable-next-line no-new-func
+    new Function(`"use strict"; return (async () => {\n${ code }\n});`);
+
+    return { form: 'body' };
+  } catch (e) {
+    return { form: 'invalid', parseError: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Build the in-page diagnostic wrapper around the user code. Exported for tests. */
+export function buildWrapper(code: string, form: 'expression' | 'body'): string {
+  const invocation = form === 'expression'
+    ? `__result = await (async function() { return (\n${ code }\n); })();`
+    : `__result = await (async function() {\n${ code }\n})();`;
+
+  return `
 (async function() {
   const __logs = [];
+  // Circular-safe stringifier — console.log of a circular object used to
+  // throw inside the USER'S code because the capture called bare
+  // JSON.stringify on every argument.
+  const __str = function(a) {
+    if (typeof a === 'string') return a;
+    try { return JSON.stringify(a); } catch (e) { return String(a); }
+  };
   const __origLog = console.log;
   const __origWarn = console.warn;
   const __origError = console.error;
-  console.log = function() { __logs.push('[log] ' + Array.from(arguments).map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ')); __origLog.apply(console, arguments); };
-  console.warn = function() { __logs.push('[warn] ' + Array.from(arguments).map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ')); __origWarn.apply(console, arguments); };
-  console.error = function() { __logs.push('[error] ' + Array.from(arguments).map(a => typeof a === 'string' ? a : JSON.stringify(a)).join(' ')); __origError.apply(console, arguments); };
+  console.log = function() { __logs.push('[log] ' + Array.from(arguments).map(__str).join(' ')); __origLog.apply(console, arguments); };
+  console.warn = function() { __logs.push('[warn] ' + Array.from(arguments).map(__str).join(' ')); __origWarn.apply(console, arguments); };
+  console.error = function() { __logs.push('[error] ' + Array.from(arguments).map(__str).join(' ')); __origError.apply(console, arguments); };
 
   // Clear __sulla.__log before execution
   if (window.__sulla && Array.isArray(window.__sulla.__log)) {
     window.__sulla.__log.length = 0;
   }
 
-  // Track mutations
+  // Track mutations. document.body can legitimately be null (about:blank,
+  // document-start timing) — observing null threw before the user code
+  // even ran, and the bridge turned that into a silent undefined.
   let __mutationCount = 0;
   const __observer = new MutationObserver(function(mutations) {
     __mutationCount += mutations.length;
   });
-  __observer.observe(document.body, { childList: true, subtree: true, attributes: true, characterData: true });
+  if (document.body) {
+    __observer.observe(document.body, { childList: true, subtree: true, attributes: true, characterData: true });
+  }
 
   // Track navigation
   const __startUrl = location.href;
@@ -56,7 +102,7 @@ export class ExecInPageWorker extends BaseTool {
   let __result, __error, __errorStack;
   const __t0 = performance.now();
   try {
-    __result = await (async function() { ${ code } })();
+    ${ invocation }
   } catch(e) {
     __error = e.message || String(e);
     __errorStack = e.stack || null;
@@ -76,8 +122,23 @@ export class ExecInPageWorker extends BaseTool {
     ? window.__sulla.__log.slice()
     : [];
 
+  // Serialize the result defensively IN PAGE. executeJavaScript clones the
+  // whole return envelope; a circular / non-cloneable __result used to
+  // reject the clone and lose every diagnostic with it.
+  let __safeResult = __result;
+  let __resultNote = null;
+  if (__result !== null && (typeof __result === 'object' || typeof __result === 'function')) {
+    try {
+      __safeResult = JSON.parse(JSON.stringify(__result));
+    } catch (e) {
+      __safeResult = String(__result);
+      __resultNote = 'Result was not JSON-serializable (' + (e.message || String(e)) + ') — returning String(result). Return plain data (objects/arrays/primitives), not DOM nodes or circular structures.';
+    }
+  }
+
   return {
-    result: __result,
+    result: __safeResult,
+    resultNote: __resultNote,
     error: __error,
     errorStack: __errorStack,
     logs: __logs,
@@ -89,8 +150,73 @@ export class ExecInPageWorker extends BaseTool {
     title: document.title,
   };
 })()`;
+}
 
-      const returnValue = await result.bridge.execInPage(wrapped) as any;
+export class ExecInPageWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const { code, screenshot, waitFor, waitForIdle, timeout = 30000 } = input;
+    if (!code || typeof code !== 'string') {
+      return { successBoolean: false, responseString: 'code parameter is required.' };
+    }
+
+    const result = await resolveBridge(input.assetId);
+    if (!isBridgeResolved(result)) return result;
+
+    // Pre-validate syntax in the main process. A compile error in the page
+    // used to be swallowed by the bridge and surface as a silent
+    // `Result: undefined` with success=true.
+    const classified = classifyCode(code);
+    if (classified.form === 'invalid') {
+      return {
+        successBoolean: false,
+        responseString: `[${ result.assetId }] Syntax error in code: ${ classified.parseError }\n`
+          + 'The code never reached the page. Fix the syntax and retry. '
+          + 'Single expressions are auto-returned; multi-statement code needs an explicit `return` to send a value back.',
+      };
+    }
+
+    try {
+      const wrapped = buildWrapper(code, classified.form);
+
+      // Enforce the documented timeout — it was accepted and ignored, so
+      // code awaiting a never-settling promise hung the tool call forever.
+      // On timeout the page script may keep running; we just stop waiting.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(
+            `eval_js timed out after ${ timeout }ms — the code is likely awaiting a promise that never settles. `
+            + 'The page script may still be running. Prefer polling with short evals over long in-page waits.',
+          )),
+          timeout,
+        );
+      });
+
+      const execPromise = result.bridge.execInPageStrict(wrapped);
+      // If the timeout wins the race, the exec promise may reject later —
+      // pre-attach a handler so that never becomes an unhandled rejection.
+      execPromise.catch(() => { /* reported via the race or irrelevant after timeout */ });
+
+      let returnValue: any;
+      try {
+        returnValue = await Promise.race([execPromise, timeoutPromise]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+
+      // The strict bridge propagates rejections, so a missing envelope here
+      // means something exotic (e.g. the page overrode Promise). Report it
+      // rather than printing a fake `Result: undefined`.
+      if (!returnValue || typeof returnValue !== 'object') {
+        return {
+          successBoolean: false,
+          responseString: `[${ result.assetId }] Execution returned no diagnostic envelope (got ${ typeof returnValue }). `
+            + 'The page may have navigated mid-execution or interfered with the wrapper. Retry, or use browser/snapshot to check page state.',
+        };
+      }
 
       // Post-execution: waitFor
       if (waitFor && typeof waitFor === 'string') {
@@ -135,15 +261,34 @@ export class ExecInPageWorker extends BaseTool {
       }
 
       const val = returnValue?.result;
-      const serialized = val === undefined
-        ? 'undefined'
-        : val === null
-          ? 'null'
-          : typeof val === 'string'
-            ? val
-            : JSON.stringify(val, null, 2);
+      let serialized: string;
+      if (val === undefined) {
+        serialized = 'undefined';
+      } else if (val === null) {
+        serialized = 'null';
+      } else if (typeof val === 'string') {
+        serialized = val;
+      } else {
+        // In-page serialization already JSON-round-tripped objects, but stay
+        // defensive — a crash here used to destroy a successful result.
+        try {
+          serialized = JSON.stringify(val, null, 2);
+        } catch (e) {
+          serialized = `${ String(val) } (unserializable: ${ e instanceof Error ? e.message : String(e) })`;
+        }
+      }
 
       parts.push(`Result: ${ serialized }`);
+      if (returnValue?.resultNote) {
+        parts.push(`Note: ${ returnValue.resultNote }`);
+      }
+
+      // The #1 confusion with this tool: statement-form code that never
+      // returns. Say so explicitly instead of leaving a bare `undefined`.
+      if (!returnValue?.error && val === undefined && classified.form === 'body' && !/\breturn\b/.test(code)) {
+        parts.push('Note: the code ran as a function body and returned nothing. Add an explicit `return <value>` to send a value back (single expressions are auto-returned).');
+      }
+
       parts.push(`Timing: ${ returnValue?.timing?.toFixed(1) ?? '?' }ms`);
       parts.push(`Mutations: ${ returnValue?.mutations ?? 0 }`);
       parts.push(`Navigated: ${ returnValue?.navigated ?? false }`);

--- a/pkg/rancher-desktop/agent/tools/browser/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/manifests.ts
@@ -196,10 +196,10 @@ export const browserToolManifests: ToolManifest[] = [
 
   {
     name:        'eval_js',
-    description: 'Evaluate arbitrary JavaScript in the active browser tab with enhanced diagnostics. Returns result, console logs, timing, DOM mutation count, navigation detection, and page state. Captures window.__sulla.__log entries (cleared before execution). Use window.__sulla.waitFor(selector) and window.__sulla.waitForIdle() helpers for post-execution synchronization. Optionally capture a screenshot after. Use for anything the other browser tools cannot do.',
+    description: 'Evaluate arbitrary JavaScript in the active browser tab with enhanced diagnostics. A single expression is auto-returned like a devtools console (`document.title` works as-is); multi-statement code must use an explicit `return` to send a value back. Top-level await is supported and returned promises are awaited. Syntax errors and runtime errors are reported with stacks; non-JSON-serializable results (DOM nodes, circular structures) are stringified with a note. Also returns console logs, timing, DOM mutation count, navigation detection, and page state. Captures window.__sulla.__log entries (cleared before execution). Use window.__sulla.waitFor(selector) and window.__sulla.waitForIdle() helpers for post-execution synchronization. Optionally capture a screenshot after. Use for anything the other browser tools cannot do.',
     category:    'browser',
     schemaDef:   {
-      code:        { type: 'string', description: 'JavaScript code to execute in the page. The return value is sent back.' },
+      code:        { type: 'string', description: 'JavaScript code to execute in the page. A single expression is auto-returned (devtools semantics); multi-statement code needs an explicit `return <value>`. Top-level await works; returned promises are awaited. Return plain data (objects/arrays/primitives) — DOM nodes and circular structures are stringified.' },
       screenshot:  { type: 'boolean', optional: true, description: 'Capture a screenshot after execution. Returns a compact reference under `screenshot` — image saved to disk, never inline base64.' },
       waitFor:     { type: 'string', optional: true, description: 'CSS selector to wait for after code execution (uses window.__sulla.waitFor if available).' },
       waitForIdle: { type: 'boolean', optional: true, description: 'Wait for the page to become idle after execution (uses window.__sulla.waitForIdle if available).' },

--- a/pkg/rancher-desktop/agent/tools/meta/meta_search.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/meta_search.ts
@@ -4,7 +4,7 @@ import { BaseTool, ToolResponse } from '../base';
 
 import { resolveSullaDocsDir } from '@pkg/agent/utils/sullaPaths';
 import {
-  indexDirectory, search, getLastCoverage, SearchTimeoutError, SearchTooManyFilesError, type FileSearchResult,
+  indexDirectory, search, getLastCoverage, SearchTooManyFilesError, type FileSearchResult,
 } from '@pkg/main/fileSearchService';
 
 /**
@@ -80,19 +80,13 @@ export class MetaSearchWorker extends BaseTool {
 
       if (primary.length === 0 && docsHits.length === 0) {
         // Try indexing the primary dir and searching again before giving up.
-        // safeIndex returns a sentinel on guardrail/timeout so we surface a
+        // safeIndex returns a sentinel on the size guardrail so we surface a
         // useful error to the LLM instead of pretending the search succeeded.
         const indexOutcome = await safeIndex(dirPath);
         if (indexOutcome.kind === 'tooManyFiles') {
           return {
             successBoolean: false,
             responseString: `Search not run: ${ indexOutcome.message } Pass a more specific dirPath (e.g. a single repo or subdirectory).`,
-          };
-        }
-        if (indexOutcome.kind === 'timeout') {
-          return {
-            successBoolean: false,
-            responseString: `Search not run: indexing ${ dirPath } timed out. Narrow the dirPath to a smaller subtree.`,
           };
         }
 
@@ -123,12 +117,6 @@ export class MetaSearchWorker extends BaseTool {
           responseString: `Search not run: ${ error.message } Pass a more specific dirPath (e.g. a single repo or subdirectory).`,
         };
       }
-      if (error instanceof SearchTimeoutError) {
-        return {
-          successBoolean: false,
-          responseString: `Search timed out: ${ error.message }. Narrow the dirPath or simplify the query.`,
-        };
-      }
       return {
         successBoolean: false,
         responseString: `Search failed: ${ error instanceof Error ? error.message : String(error) }`,
@@ -139,11 +127,10 @@ export class MetaSearchWorker extends BaseTool {
 
 type IndexOutcome =
   | { kind: 'ok'; result: { indexed: number; updated: number; removed: number } }
-  | { kind: 'tooManyFiles'; message: string }
-  | { kind: 'timeout'; message: string };
+  | { kind: 'tooManyFiles'; message: string };
 
-// Wrap indexDirectory so the caller can react to guardrail / timeout errors
-// without nesting another try/catch. Other errors propagate.
+// Wrap indexDirectory so the caller can react to the size guardrail without
+// nesting another try/catch. Other errors propagate.
 async function safeIndex(dirPath: string): Promise<IndexOutcome> {
   try {
     const result = await indexDirectory(dirPath);
@@ -151,9 +138,6 @@ async function safeIndex(dirPath: string): Promise<IndexOutcome> {
   } catch (err) {
     if (err instanceof SearchTooManyFilesError) {
       return { kind: 'tooManyFiles', message: err.message };
-    }
-    if (err instanceof SearchTimeoutError) {
-      return { kind: 'timeout', message: err.message };
     }
     throw err;
   }

--- a/pkg/rancher-desktop/main/browserTabs/GuestBridge.ts
+++ b/pkg/rancher-desktop/main/browserTabs/GuestBridge.ts
@@ -54,6 +54,18 @@ export class GuestBridge {
     return this.exec(code);
   }
 
+  /**
+   * Like execInPage() but PROPAGATES rejections instead of mapping them to
+   * undefined. eval_js uses this so compile errors, mid-exec navigations,
+   * and unserializable results surface as real errors — the swallowing
+   * exec() made all of them come back as a silent `Result: undefined`
+   * with success=true, which the model can't distinguish from a legitimate
+   * undefined return.
+   */
+  execInPageStrict(code: string): Promise<unknown> {
+    return this.wc.executeJavaScript(code, true);
+  }
+
   // ── Guest bridge methods (DOM helpers from window.sullaBridge) ────
   async getActionableMarkdown(): Promise<string> {
     return String((await this.call('getActionableMarkdown')) || '');

--- a/pkg/rancher-desktop/main/fileSearchService.ts
+++ b/pkg/rancher-desktop/main/fileSearchService.ts
@@ -3,11 +3,16 @@
  *
  * Replaces the qmd/worker_threads implementation. All heavy work (SQLite FTS5,
  * enumeration, file reads) runs in an Electron utilityProcess sidecar so the
- * main process never blocks — and, unlike a worker_thread, a stuck sidecar can
- * simply be kill()ed. Terminating a worker parked inside a synchronous
- * better-sqlite3 native call segfaulted the whole app (SIGSEGV in
- * v8::Isolate::Dispose()), which forced an abandon-don't-terminate mitigation
- * that leaked stuck threads until OOM. Process isolation removes that hazard.
+ * main process never blocks. Process isolation exists for crash containment:
+ * a worker_thread parked inside a synchronous better-sqlite3 native call
+ * segfaulted the whole app (SIGSEGV in v8::Isolate::Dispose()) when
+ * terminated, while a sidecar crash only costs a respawn on the next request.
+ *
+ * There are NO request timeouts and NO kill-on-slow behavior here by design:
+ * subconscious agents are never fenced (Jonathon's rule). A slow search waits
+ * as long as it takes; latency is managed by making the engine fast (warm
+ * index, exact-term FTS queries) and by chunking background index passes so
+ * live searches are never stuck behind long maintenance work.
  *
  * Storage is a contentless FTS5 index (~/.cache/sulla-search/index.sqlite):
  * tokens only, never file bodies — the old qmd store kept full bodies and grew
@@ -50,8 +55,6 @@ export interface SearchCoverage {
 
 // ── Budgets and limits ──────────────────────────────────────────
 
-const SEARCH_TIMEOUT_MS = 15_000;
-const INDEX_TIMEOUT_MS = 120_000;
 // Skip files larger than this in both tiers. Minified bundles / vendored blobs
 // (one observed at 27 MB) add almost no search value but bloat the FTS index
 // and make every query slower. ~1 MB covers all real source/docs.
@@ -66,24 +69,15 @@ const MAX_INDEX_FILES = 500_000;
 // bodies. Unread files simply aren't in the files table yet, so the next pass
 // resumes where this one stopped — passes converge monotonically.
 const INDEX_BYTE_BUDGET = 512 * 1024 * 1024;
-
-// Upper bound on how long a request may sit in the sidecar's queue before it
-// is actually picked up (the sidecar serializes work). Must comfortably exceed
-// the longest op that could be ahead of it — an in-flight index. Until the
-// sidecar acks that it has started a given request, only this cap applies, so
-// a search never times out merely because an index is running ahead of it.
-const QUEUE_TIMEOUT_MS = INDEX_TIMEOUT_MS + 30_000;
-
-// Crash breaker: more than CRASH_LIMIT abnormal exits (crash or killed for
-// timeout) within CRASH_WINDOW_MS puts the service in degraded mode for
-// DEGRADED_MS — no respawn loops, no wedged app.
-const CRASH_LIMIT = 3;
-const CRASH_WINDOW_MS = 10 * 60_000;
-const DEGRADED_MS = 10 * 60_000;
+// Work-chunking (NOT a timeout): a single index pass also stops cleanly after
+// this much wall time, alongside the byte budget above. The sidecar serializes
+// work, so bounding one pass keeps a live search from sitting behind hours of
+// maintenance; the next pass resumes exactly where this one stopped. No
+// request is ever failed or killed because of this value.
+const INDEX_PASS_TIME_BUDGET_MS = 120_000;
 
 // ── Candidate-file rules ────────────────────────────────────────
-// Defined once here and injected into the sidecar source at spawn time so the
-// sidecar and the parent's degraded-mode direct scanner can never drift apart.
+// Defined once here and injected into the sidecar source at spawn time.
 
 const TEXT_EXTENSIONS = [
   'md', 'txt', 'ts', 'js', 'vue', 'json', 'yaml', 'yml', 'jsx', 'tsx',
@@ -108,13 +102,6 @@ const SENSITIVE_DIR_NAMES = ['.ssh', '.gnupg', '.aws', '.azure', '.password-stor
 
 // ── Errors ──────────────────────────────────────────────────────
 
-export class SearchTimeoutError extends Error {
-  constructor(action: string, ms: number) {
-    super(`file search ${ action } timed out after ${ ms }ms`);
-    this.name = 'SearchTimeoutError';
-  }
-}
-
 export class SearchTooManyFilesError extends Error {
   constructor(public count: number, public limit: number, public dirPath: string) {
     super(`file search index aborted: ${ count } files in ${ dirPath } exceeds limit of ${ limit }. Narrow the dirPath.`);
@@ -127,18 +114,11 @@ export class SearchTooManyFilesError extends Error {
 interface Pending {
   resolve: (v: any) => void;
   reject:  (e: Error) => void;
-  timer:   NodeJS.Timeout;
-  onAck:   () => void;
 }
 
 let _child: Electron.UtilityProcess | null = null;
 let _requestId = 0;
 const _pending = new Map<number, Pending>();
-// Set before an intentional kill (timeout or shutdown) so the exit handler
-// doesn't double-count the resulting non-zero exit as a fresh crash.
-let _expectedExit = false;
-let _crashTimes: number[] = [];
-let _degradedUntil = 0;
 const _lastCoverage = new Map<string, SearchCoverage | null>();
 
 /**
@@ -225,23 +205,6 @@ function cleanupLegacyIndex(): void {
   }
 }
 
-function isDegraded(): boolean {
-  return Date.now() < _degradedUntil;
-}
-
-function recordCrash(reason: string): void {
-  const now = Date.now();
-
-  _crashTimes.push(now);
-  _crashTimes = _crashTimes.filter(t => t > now - CRASH_WINDOW_MS);
-  console.warn(`[file_search] sidecar abnormal exit (${ _crashTimes.length } in last 10m): ${ reason }`);
-  if (_crashTimes.length > CRASH_LIMIT) {
-    _degradedUntil = now + DEGRADED_MS;
-    console.error(`[file_search] CRASH BREAKER OPEN: ${ _crashTimes.length } sidecar failures within ${ CRASH_WINDOW_MS / 60_000 }m — ` +
-      `degraded mode (direct scan for small dirs only) until ${ new Date(_degradedUntil).toISOString() }`);
-  }
-}
-
 function getChild(): Electron.UtilityProcess {
   if (_child) {
     return _child;
@@ -251,7 +214,7 @@ function getChild(): Electron.UtilityProcess {
 
   const { utilityProcess } = require('electron') as typeof import('electron');
   const constants = JSON.stringify({
-    SMALL_TIER_MAX, MAX_INDEX_FILES, MAX_FILE_BYTES, INDEX_BYTE_BUDGET, INDEX_TIMEOUT_MS,
+    SMALL_TIER_MAX, MAX_INDEX_FILES, MAX_FILE_BYTES, INDEX_BYTE_BUDGET, INDEX_PASS_TIME_BUDGET_MS,
   });
   // Config rides in env, not argv — utilityProcess argv layout is not part of
   // the stable contract, and a misread argv[3] means JSON.parse throws before
@@ -286,7 +249,7 @@ function getChild(): Electron.UtilityProcess {
 
   child.on('message', (msg: any) => {
     // A sidecar that dies at boot reports the root cause before exiting so
-    // the crash breaker log line is actionable, not just "exit code 1".
+    // the exit log line is actionable, not just "exit code 1".
     if (msg?.bootError) {
       console.error(`[file_search] sidecar BOOT FAILURE: ${ msg.bootError }`);
 
@@ -297,14 +260,6 @@ function getChild(): Electron.UtilityProcess {
     if (!pending) {
       return;
     }
-    // Sidecar signals it has dequeued and started this request: swap the queue
-    // cap for the real per-request processing timeout.
-    if (msg.ack) {
-      pending.onAck();
-
-      return;
-    }
-    clearTimeout(pending.timer);
     _pending.delete(msg.id);
     if (msg.error) {
       if (msg.errorName === 'SearchTooManyFilesError' && msg.errorCount && msg.errorLimit && msg.errorDirPath) {
@@ -321,13 +276,9 @@ function getChild(): Electron.UtilityProcess {
     if (_child === child) {
       _child = null;
     }
-    if (_expectedExit) {
-      _expectedExit = false;
-    } else if (code !== 0) {
-      recordCrash(`exit code ${ code }`);
-    }
+    // Crash recovery, not a gate: reject what was in flight so callers see a
+    // real error, and let the next request respawn a fresh sidecar.
     for (const [id, pending] of _pending) {
-      clearTimeout(pending.timer);
       pending.reject(new Error(`file search sidecar exited with code ${ code }`));
       _pending.delete(id);
     }
@@ -336,70 +287,15 @@ function getChild(): Electron.UtilityProcess {
   return child;
 }
 
-// Kill the sidecar. Used when a request times out — the sidecar serializes
-// work, so a stuck operation would block every subsequent call. Unlike the old
-// worker_threads implementation (where terminate() mid-native-call segfaulted
-// the whole app), killing a separate process is unconditionally safe — that is
-// the point of the utilityProcess isolation. Next request respawns.
-function killChild(reason: string): void {
-  if (!_child) {
-    return;
-  }
-  console.warn(`[file_search] killing sidecar: ${ reason }`);
-  const child = _child;
-
-  _child = null;
-
-  for (const [id, pending] of _pending) {
-    clearTimeout(pending.timer);
-    pending.reject(new Error(`file search sidecar killed: ${ reason }`));
-    _pending.delete(id);
-  }
-
-  _expectedExit = true;
-  recordCrash(reason);
-  try {
-    child.kill();
-  } catch { /* already gone */ }
-}
-
-function postRequest(action: string, params: any, timeoutMs: number): Promise<any> {
+// No timeout, no watchdog: the request settles when the sidecar answers (or
+// dies, which the exit handler above turns into a rejection). Subconscious
+// agents wait as long as the work takes.
+function postRequest(action: string, params: any): Promise<any> {
   const id = ++_requestId;
   const child = getChild();
 
   return new Promise((resolve, reject) => {
-    const fail = (ms: number, why: string) => {
-      if (!_pending.has(id)) {
-        return;
-      }
-      _pending.delete(id);
-      killChild(`${ action } request ${ id } ${ why }`);
-      reject(new SearchTimeoutError(action, ms));
-    };
-
-    const arm = (ms: number, why: string): NodeJS.Timeout => {
-      const t = setTimeout(() => fail(ms, why), ms);
-
-      // Don't keep the event loop alive on this timer.
-      if (typeof t.unref === 'function') t.unref();
-
-      return t;
-    };
-
-    // Phase 1: queue-wait cap. Phase 2 (on ack): real processing timeout. This
-    // split is what stops a search from timing out while it's still queued
-    // behind a long-running index in the sidecar.
-    const entry: Pending = {
-      resolve,
-      reject,
-      timer: arm(QUEUE_TIMEOUT_MS, `stuck in queue > ${ QUEUE_TIMEOUT_MS }ms`),
-      onAck: () => {
-        clearTimeout(entry.timer);
-        entry.timer = arm(timeoutMs, `exceeded ${ timeoutMs }ms`);
-      },
-    };
-
-    _pending.set(id, entry);
+    _pending.set(id, { resolve, reject });
     child.postMessage({ id, action, ...params });
   });
 }
@@ -411,13 +307,11 @@ export function closeFileSearch(): void {
     const child = _child;
 
     _child = null;
-    _expectedExit = true;
     try {
       child.kill();
     } catch { /* shutting down */ }
   }
   for (const [id, pending] of _pending) {
-    clearTimeout(pending.timer);
     pending.reject(new Error('file search service closed'));
     _pending.delete(id);
   }
@@ -436,11 +330,8 @@ export async function indexDirectory(
   dirPath: string,
   glob?: string,
 ): Promise<{ indexed: number; updated: number; removed: number; candidateCount?: number; truncated?: boolean }> {
-  if (isDegraded()) {
-    throw new Error('file search engine unavailable (sidecar crash breaker open), retry shortly');
-  }
   const t0 = Date.now();
-  const result = await postRequest('index', { dirPath, glob }, INDEX_TIMEOUT_MS);
+  const result = await postRequest('index', { dirPath, glob });
 
   console.log(`[file_search] index root=${ path.resolve(dirPath) } indexed=${ result.indexed } updated=${ result.updated } ` +
     `removed=${ result.removed } candidates=${ result.candidateCount ?? 'n/a' } truncated=${ result.truncated === true } totalMs=${ Date.now() - t0 }`);
@@ -456,11 +347,7 @@ export async function search(
   const root = path.resolve(dirPath);
   const t0 = Date.now();
 
-  if (isDegraded()) {
-    return degradedDirectScan(query, root, limit, t0);
-  }
-
-  const res = await postRequest('search', { query, dirPath: root, limit }, SEARCH_TIMEOUT_MS);
+  const res = await postRequest('search', { query, dirPath: root, limit });
   const coverage: SearchCoverage | null = res.coverage ?? null;
 
   _lastCoverage.set(root, coverage);
@@ -502,8 +389,8 @@ const WARMUP_PASS_GAP_MS = 5_000;
 // reads at most INDEX_BYTE_BUDGET of new file bodies.
 const WARMUP_MAX_PASSES = 24;
 const MAINTENANCE_INTERVAL_MS = 30 * 60_000;
-// When the sidecar is busy with live work (or the crash breaker is open),
-// retry shortly instead of skipping a whole interval.
+// When the sidecar is busy with live work, retry shortly instead of skipping
+// a whole interval.
 const MAINTENANCE_BUSY_RETRY_MS = 60_000;
 
 let _maintenanceTimer: NodeJS.Timeout | null = null;
@@ -535,7 +422,7 @@ async function maintenancePass(root: string): Promise<void> {
   if (_maintenanceStopped) {
     return;
   }
-  if (isDegraded() || _pending.size > 0) {
+  if (_pending.size > 0) {
     scheduleMaintenance(root, MAINTENANCE_BUSY_RETRY_MS);
 
     return;
@@ -561,7 +448,7 @@ async function warmupLoop(root: string): Promise<void> {
   let deferrals = 0;
 
   while (!_maintenanceStopped && pass < WARMUP_MAX_PASSES) {
-    if (isDegraded() || _pending.size > 0) {
+    if (_pending.size > 0) {
       if (++deferrals > 30) {
         break;
       }
@@ -622,163 +509,11 @@ export function stopFileSearchMaintenance(): void {
   }
 }
 
-// ── Degraded-mode direct scan ───────────────────────────────────
-// Fallback while the crash breaker is open: a bounded scan in the main process
-// (async fs, no sidecar). Only viable for small-tier roots; anything larger is
-// refused rather than blocking the main process on an unbounded read.
-
-function isSensitiveDirName(name: string): boolean {
-  return SENSITIVE_DIR_NAMES.includes(name) || name.startsWith('.keychain');
-}
-
-async function degradedDirectScan(query: string, root: string, limit: number, t0: number): Promise<FileSearchResult[]> {
-  const candidates: { abs: string; rel: string; size: number }[] = [];
-  const queue = [root];
-  let exceeded = false;
-
-  while (queue.length > 0 && !exceeded) {
-    const dir = queue.shift() as string;
-    let entries: fs.Dirent[];
-
-    try {
-      entries = await fs.promises.readdir(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const ent of entries) {
-      const name = ent.name;
-
-      if (ent.isSymbolicLink()) {
-        continue;
-      }
-      if (ent.isDirectory()) {
-        if (!name.startsWith('.') && !EXCLUDE_DIRS.includes(name) && !isSensitiveDirName(name)) {
-          queue.push(path.join(dir, name));
-        }
-        continue;
-      }
-      if (!ent.isFile() || name.startsWith('.')) {
-        continue;
-      }
-      const dot = name.lastIndexOf('.');
-
-      if (dot <= 0 || !TEXT_EXTENSIONS.includes(name.slice(dot + 1).toLowerCase())) {
-        continue;
-      }
-      const abs = path.join(dir, name);
-      let st: fs.Stats;
-
-      try {
-        st = await fs.promises.stat(abs);
-      } catch {
-        continue;
-      }
-      // Cloud placeholders: zero blocks but non-zero size means online-only;
-      // reading would trigger a network download. blocks is undefined on Windows.
-      if (name.endsWith('.icloud') || (typeof st.blocks === 'number' && st.blocks === 0 && st.size > 0)) {
-        continue;
-      }
-      candidates.push({ abs, rel: path.relative(root, abs), size: st.size });
-      if (candidates.length > SMALL_TIER_MAX) {
-        exceeded = true;
-        break;
-      }
-    }
-  }
-
-  if (exceeded) {
-    throw new Error(`file search engine unavailable (sidecar crash breaker open) and ${ root } is too large for a direct scan — retry shortly or narrow the dirPath`);
-  }
-
-  const terms = query.toLowerCase().split(/\s+/).filter(t => t.length > 1);
-  const results: FileSearchResult[] = [];
-
-  if (terms.length > 0) {
-    for (const c of candidates) {
-      if (c.size > MAX_FILE_BYTES) {
-        continue;
-      }
-      let body: string;
-
-      try {
-        body = await fs.promises.readFile(c.abs, 'utf-8');
-      } catch {
-        continue;
-      }
-      const lowerBody = body.toLowerCase();
-      const lowerRel = c.rel.toLowerCase();
-      let hits = 0;
-      let nameHit = false;
-      let all = true;
-
-      for (const term of terms) {
-        let count = 0;
-        let idx = lowerBody.indexOf(term);
-
-        while (idx !== -1 && count < 100) {
-          count++;
-          idx = lowerBody.indexOf(term, idx + term.length);
-        }
-        if (lowerRel.includes(term)) {
-          nameHit = true;
-        } else if (count === 0) {
-          all = false;
-          break;
-        }
-        hits += count;
-      }
-      if (!all) {
-        continue;
-      }
-      let density = hits / Math.max(1, body.length / 1000);
-
-      if (nameHit) {
-        density += 2;
-      }
-      const lineHit = firstMatchingLine(body, terms);
-
-      results.push({
-        path:    c.abs,
-        name:    path.basename(c.abs),
-        line:    lineHit?.line ?? 0,
-        preview: lineHit?.snippet ?? c.rel,
-        score:   density / (1 + density),
-        source:  nameHit && hits === 0 ? 'filename' : 'scan',
-      });
-    }
-    results.sort((a, b) => b.score - a.score);
-  }
-
-  const top = results.slice(0, limit);
-
-  // A completed direct scan is full coverage by construction — don't let a
-  // stale FTS coverage entry from before the breaker opened linger.
-  _lastCoverage.set(root, null);
-  logSearchTiming(root, top.length, { tier: 'degraded-scan', scanMs: Date.now() - t0 }, null, Date.now() - t0);
-
-  return top;
-}
-
-function firstMatchingLine(body: string, terms: string[]): { line: number; snippet: string } | null {
-  const searchable = body.length > 50_000 ? body.slice(0, 50_000) : body;
-  const lines = searchable.split('\n');
-
-  for (let i = 0; i < lines.length; i++) {
-    const lower = lines[i].toLowerCase();
-
-    if (terms.some(t => lower.includes(t))) {
-      return { line: i + 1, snippet: lines[i].trim().slice(0, 200) };
-    }
-  }
-
-  return null;
-}
-
 // ── Inline sidecar source ───────────────────────────────────────
 // Plain CommonJS, written to ~/.cache/sulla-search/sidecar.cjs at spawn time
 // and run as an Electron utilityProcess. It owns the SQLite handle and all
-// filesystem enumeration, keeping the main process responsive and making a
-// hard kill() safe. NOTE: this is a template literal — backslashes in the
+// filesystem enumeration, keeping the main process responsive and containing
+// any crash. NOTE: this is a template literal — backslashes in the
 // regexes below are doubled so the generated file gets single ones, and the
 // only ${ } interpolations are the deliberate constant injections.
 
@@ -918,7 +653,8 @@ function getDb() {
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
   // Retry on SQLITE_BUSY instead of throwing immediately — a previous sidecar
-  // killed mid-write can hold the WAL lock briefly while its OS handles close.
+  // that died mid-write (crash or app shutdown) can hold the WAL lock briefly
+  // while its OS handles close.
   db.pragma('busy_timeout = 5000');
   // Bounded page cache (~16 MB) keeps this sidecar's memory footprint flat.
   db.pragma('cache_size = -16000');
@@ -958,8 +694,7 @@ function buildFTS5Query(query) {
   // Exact terms, never prefix ('"t"*'): without prefix indexes, FTS5 answers
   // a prefix query by range-scanning the whole term b-tree and merging every
   // matching doclist. Over a code corpus (huge vocabulary) that measured 66s
-  // vs 2.7s exact for the same two-term query on an 86k-doc index — and the
-  // slow form is what tripped the parent's SEARCH_TIMEOUT sidecar kill.
+  // vs 2.7s exact for the same two-term query on an 86k-doc index.
   return terms.map(t => '"' + t + '"').join(' AND ');
 }
 
@@ -1140,9 +875,10 @@ async function handleIndex(msg) {
   const deleteFts = db.prepare('DELETE FROM files_fts WHERE rowid = ?');
   const insertFts = db.prepare('INSERT INTO files_fts (rowid, name, body) VALUES (?, ?, ?)');
 
-  // Stop cleanly before the caller's INDEX_TIMEOUT would kill us mid-run.
-  // WAL + per-batch transactions mean even a hard kill can't corrupt.
-  const deadline = t0 + CONST.INDEX_TIMEOUT_MS - 10000;
+  // Work-chunking, not a timeout: one pass stops cleanly at this deadline (or
+  // the byte budget below) and the next pass resumes exactly where it stopped.
+  // Bounding a pass keeps live searches from queuing behind hours of indexing.
+  const deadline = t0 + CONST.INDEX_PASS_TIME_BUDGET_MS;
   let indexed = 0;
   let updated = 0;
   let bytesRead = 0;
@@ -1216,9 +952,6 @@ async function handleIndex(msg) {
 process.parentPort.on('message', async (e) => {
   const msg = e.data;
   if (!msg || typeof msg.id !== 'number') return;
-  // Ack tells the parent we've dequeued and started work, so it can swap the
-  // queue-wait cap for the real per-request processing timeout.
-  try { process.parentPort.postMessage({ id: msg.id, ack: true }); } catch { /* parent gone */ }
   try {
     let result;
     if (msg.action === 'search') result = handleSearch(msg);


### PR DESCRIPTION
## Summary

Carries local main (verified working in Jonathon's running binary) up to origin for the v1.4.1 release.

### fix/eval-js-silent-failures (verified live 2026-07-07)
- Syntax errors are pre-validated and reported (no more success=true / Result: undefined)
- Single expressions auto-return devtools-style; top-level await supported
- `timeout` param actually enforced via Promise.race (was destructured and ignored)
- Circular/non-JSON results serialize with String fallback + note instead of crashing the response path
- Null-body/early-page runs no longer crash; 18-test jest suite

### perf/unfence-subconscious-parallel-recall
- fileSearchService: SEARCH_TIMEOUT_MS, QUEUE_TIMEOUT_MS, killChild, SearchTimeoutError, crash breaker + degraded direct-scan ALL removed — subconscious agents are never fenced (jJ76); sidecar crash = reject in-flight + respawn on next request
- ToolExecutor: opt-in parallel batch mode — subconscious agents run all tool calls in one LLM reply concurrently, results append in call order (batch latency = max(tool), not sum)
- Recall prompts (memory/observation/heartbeat): batch-all-searches-in-one-response directive, 2-3 rounds max

- chore: version 1.4.0 → 1.4.1

Typecheck: 0 errors in changed files. After merge: tag v1.4.1 to trigger the Package workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)