### PR TITLE
feat(agents): per-agent-definition model/provider override

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/index.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/index.ts
@@ -235,6 +235,40 @@ class LLMRegistryImpl {
     return this.getPrimaryService();
   }
 
+  /**
+   * Agent-definition model override. When an agent's config.yaml declares
+   * `model:` (explicit model ID or tier name 'fast'|'balanced'|'powerful')
+   * and/or `provider:`, resolve a dedicated service instance for that agent.
+   *
+   * Returns null when the agent declares no override — callers fall back to
+   * the role slots (primary / subconscious). Resolution failures also return
+   * null rather than throwing so a bad agent config degrades to slot routing.
+   */
+  async getAgentOverrideService(agentCfg?: { model?: string; provider?: string }): Promise<BaseLanguageModel | null> {
+    const model = typeof agentCfg?.model === 'string' ? agentCfg.model.trim() : '';
+    const provider = typeof agentCfg?.provider === 'string' ? agentCfg.provider.trim() : '';
+
+    if (!model && !provider) return null;
+
+    try {
+      const mps = tryGetModelProviderService();
+      const effectiveProvider = provider || (mps
+        ? mps.getPrimaryProvider()
+        : await SullaSettingsModel.get('primaryProvider', 'grok'));
+
+      const modelOverride = model
+        ? (isTierName(model)
+          ? await resolveTierToModelId(effectiveProvider, model as ModelTier)
+          : model)
+        : undefined;
+
+      return await this.getServiceByProvider(effectiveProvider, modelOverride);
+    } catch (err) {
+      console.warn(`[LLMRegistry] Agent model override failed (provider="${ provider }", model="${ model }") — falling back to slot routing:`, err);
+      return null;
+    }
+  }
+
   async getRemoteModel(): Promise<string> {
     const svc = await this.getRemoteService();
     return svc.getModel();
@@ -405,6 +439,7 @@ export const getCurrentModel = async() => await LLMRegistry.getCurrentModel();
 // Primary / Secondary / Heartbeat provider exports
 export const getPrimaryService = async() => await LLMRegistry.getPrimaryService();
 export const getSecondaryService = async() => await LLMRegistry.getSecondaryService();
+export const getAgentOverrideService = async(agentCfg?: { model?: string; provider?: string }) => await LLMRegistry.getAgentOverrideService(agentCfg);
 export const getHeartbeatService = async() => await LLMRegistry.getHeartbeatLLM();
 export const getSubconsciousService = async() => await LLMRegistry.getSubconsciousLLM();
 

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -4,7 +4,7 @@ import path from 'node:path'; // used by enrichPrompt for active_projects_file
 import { ChatController, type ChatMode } from '../controllers/ChatController';
 import { ToolExecutor } from '../controllers/ToolExecutor';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
-import { getPrimaryService, getSecondaryService, getSubconsciousService } from '../languagemodels';
+import { getAgentOverrideService, getPrimaryService, getSecondaryService, getSubconsciousService } from '../languagemodels';
 import { BaseLanguageModel, ChatMessage, NormalizedResponse, FinishReason, type StreamCallbacks } from '../languagemodels/BaseLanguageModel';
 import { throwIfAborted } from '../services/AbortService';
 import { parseJson } from '../services/JsonParseService';
@@ -671,9 +671,10 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     // so the system prompt's provider-conditional sections (e.g. Anthropic
     // cache blocks vs OpenAI response format) match the model we'll invoke.
     const isSubAgentForPrompt = !!(state.metadata as any).isSubAgent;
-    const llm = isSubAgentForPrompt
+    const overrideLLMForPrompt = await getAgentOverrideService((state.metadata as any).agent);
+    const llm = overrideLLMForPrompt ?? (isSubAgentForPrompt
       ? await getSubconsciousService()
-      : await getPrimaryService();
+      : await getPrimaryService());
     const providerName = llm?.getProviderName?.() || 'anthropic';
 
     const mode = options.promptMode || 'full';
@@ -908,14 +909,17 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     systemPrompt: string,
     options: LLMCallOptions = {},
   ): Promise<NormalizedResponse | null> {
-    // Subconscious agents (memory-recall, observation, unstuck-research) need
-    // a fast tool-emitting chat peer, not the autonomous Claude-Code-style
-    // primary. Route them to the dedicated subconscious provider (falls back
-    // to secondary, then primary).
+    // Agent-definition override first: an agent whose config.yaml declares
+    // model/provider gets its own service instance regardless of role slot.
+    // Otherwise: subconscious agents (memory-recall, observation,
+    // unstuck-research) need a fast tool-emitting chat peer, not the
+    // autonomous Claude-Code-style primary. Route them to the dedicated
+    // subconscious provider (falls back to secondary, then primary).
     const isSubAgent = !!(state.metadata as any).isSubAgent;
-    this.llm = isSubAgent
+    const agentOverrideLLM = await getAgentOverrideService((state.metadata as any).agent);
+    this.llm = agentOverrideLLM ?? (isSubAgent
       ? await getSubconsciousService()
-      : await getPrimaryService();
+      : await getPrimaryService());
 
     const nodeRunContext = this.createNodeRunContext(state, {
       systemPrompt,

--- a/pkg/rancher-desktop/agent/nodes/Graph.ts
+++ b/pkg/rancher-desktop/agent/nodes/Graph.ts
@@ -182,6 +182,8 @@ export interface AgentGraphState extends BaseThreadState {
       integrations?: string[];  // allowlist of integration slugs (empty = none, ["*"] = all)
       prompt?:       string;          // compiled .md files, no variable substitution
       excludeSoul?:  boolean;         // if true, skip the global soul prompt from settings
+      model?:        string;          // per-agent model override: explicit model ID or tier name ('fast'|'balanced'|'powerful')
+      provider?:     string;          // per-agent provider override (defaults to primary provider when only model is set)
 
       // Execution outcomes (set during runtime)
       status?:               'done' | 'blocked' | 'continue' | 'in_progress';

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -1347,6 +1347,8 @@ async function loadAgentConfig(agentId: string): Promise<AgentGraphState['metada
       integrations: parsed.integrations || [],
       prompt:       sections.length > 0 ? sections.join('\n\n') : undefined,
       excludeSoul:  parsed.excludeSoul === true,
+      model:        typeof parsed.model === 'string' && parsed.model.trim() ? parsed.model.trim() : undefined,
+      provider:     typeof parsed.provider === 'string' && parsed.provider.trim() ? parsed.provider.trim() : undefined,
     };
   } catch (err) {
     console.error(`[GraphRegistry] Failed to load agent config for ${ agentId }:`, err);


### PR DESCRIPTION
Agent definitions (config.yaml) can now declare `model:` (explicit model ID or tier name fast|balanced|powerful) and `provider:`. `loadAgentConfig` parses the fields and `BaseNode` routes through the new `LLMRegistry.getAgentOverrideService()` ahead of the primary/subconscious slot routing.

- No override declared → existing slot behavior, byte-for-byte unchanged
- Bad/unresolvable override → warn + graceful fallback to slot routing
- Tier names resolve via the existing ModelTierResolver; explicit IDs pass through (incl. per-model ClaudeCodeService instances)

Re-introduces the paved-over apron-config capability on the current slot plumbing. Unblocks multi-model planning-mode panels (planning agents + routines shipped separately in sulla-resources @5c40951).

Typecheck clean — only pre-existing errors in scripts/ remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)