### PR TITLE
fix: run integration OAuth in main process so embedded auth windows work (Codex/Grok)

### DIFF
--- a/pkg/rancher-desktop/main/integrationOAuth.ts
+++ b/pkg/rancher-desktop/main/integrationOAuth.ts
@@ -1,0 +1,67 @@
+/**
+ * Generic integration OAuth handler.
+ *
+ * Runs the full OAuth flow in the MAIN process so providers that render their
+ * sign-in page in an embedded Electron window (openInEmbeddedWindow: true —
+ * e.g. OpenAI Codex and Grok) can actually construct it. `BrowserWindow` is a
+ * main-process-only API: the renderer previously called
+ * IntegrationService.startOAuthFlow() directly, which tried to
+ * `new BrowserWindow()` inside the renderer and threw
+ * "BrowserWindow is not a constructor".
+ *
+ * The dedicated claude-oauth / openai-oauth handlers already dodge this by
+ * going over IPC to main; this is the same bridge for every other
+ * YAML/OAuth-manifest provider.
+ */
+
+import { getIntegrationService } from '@pkg/agent/services/IntegrationService';
+import { getIpcMainProxy } from '@pkg/main/ipcMain';
+import Logging from '@pkg/utils/logging';
+
+const console = Logging.background;
+
+const LOG_PREFIX = '[IntegrationOAuth]';
+
+export function initIntegrationOAuthEvents(): void {
+  const ipcMainProxy = getIpcMainProxy(console);
+
+  /**
+   * Start a generic integration OAuth flow in the main process. Delegates to
+   * IntegrationService.startOAuthFlow → OAuthService.startFlow, which owns the
+   * callback server, the embedded auth window, token exchange, and marking the
+   * integration connected.
+   */
+  ipcMainProxy.handle('integration-oauth:start', async(
+    _event: unknown,
+    payload: {
+      integrationId: string;
+      providerId:    string;
+      clientId?:     string;
+      clientSecret?: string;
+      accountId?:    string;
+      extraScopes?:  string[];
+    },
+  ): Promise<{ success: boolean; error?: string }> => {
+    try {
+      const integrationService = getIntegrationService();
+
+      await integrationService.startOAuthFlow(
+        payload.integrationId,
+        payload.providerId,
+        payload.clientId || '',
+        payload.clientSecret || '',
+        payload.accountId,
+        payload.extraScopes,
+      );
+
+      console.log(`${ LOG_PREFIX } OAuth flow completed for ${ payload.integrationId }`);
+
+      return { success: true };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      console.error(`${ LOG_PREFIX } OAuth failed for ${ payload?.integrationId }:`, errMsg);
+
+      return { success: false, error: errMsg };
+    }
+  });
+}

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -10,6 +10,7 @@ import { initTabsIpc } from './browserTabs/tabsIpc';
 import { initClaudeCodeTestEvents } from './claudeCodeTest';
 import { initClaudeOAuthEvents } from './claudeOAuth';
 import { initOpenAIOAuthEvents } from './openaiOAuth';
+import { initIntegrationOAuthEvents } from './integrationOAuth';
 import { initDesktopRelayEvents } from './desktopRelay';
 import { initSullaCloudAuthEvents } from './sullaCloudAuth';
 import { initConversationHistoryIpc } from './conversationHistoryIpc';
@@ -71,6 +72,7 @@ export function initSullaEvents(): void {
   initChatMessagesIpc();
   initClaudeOAuthEvents();
   initOpenAIOAuthEvents();
+  initIntegrationOAuthEvents();
   initClaudeCodeTestEvents();
   initDesktopRelayEvents();
   initSullaCloudAuthEvents();

--- a/pkg/rancher-desktop/pages/AccountEditor.vue
+++ b/pkg/rancher-desktop/pages/AccountEditor.vue
@@ -866,9 +866,18 @@ async function handleOAuthConnect() {
       }
     }
     await integrationService.setAccountLabel(props.integrationId, targetAccountId, integration.value.name + ' OAuth');
-    await integrationService.startOAuthFlow(
-      props.integrationId, integration.value.oauthProviderId!, clientId, clientSecret, targetAccountId,
-    );
+    // Run the OAuth flow in the MAIN process so embedded-window providers
+    // (Codex, Grok) can construct a BrowserWindow — undefined in the renderer.
+    const oauthResult = await ipcRenderer.invoke('integration-oauth:start', {
+      integrationId: props.integrationId,
+      providerId:    integration.value.oauthProviderId!,
+      clientId,
+      clientSecret,
+      accountId:     targetAccountId,
+    });
+    if (!oauthResult?.success) {
+      throw new Error(oauthResult?.error || 'OAuth failed. Please try again.');
+    }
     await integrationService.setActiveAccount(props.integrationId, targetAccountId);
     emit('saved', targetAccountId);
   } catch (err: any) {

--- a/pkg/rancher-desktop/pages/AgentIntegrationDetail.vue
+++ b/pkg/rancher-desktop/pages/AgentIntegrationDetail.vue
@@ -1400,14 +1400,20 @@ const handleOAuthConnect = async() => {
   try {
     await integrationService.setAccountLabel(integration.value.id, targetAccountId, integration.value.name + ' OAuth');
 
-    // Start the OAuth flow — this opens the browser and waits for callback
-    await integrationService.startOAuthFlow(
-      integration.value.id,
-      integration.value.oauthProviderId!,
+    // Start the OAuth flow in the MAIN process — it opens the (possibly
+    // embedded) auth window and waits for the callback. Must run in main:
+    // embedded-window providers (Codex, Grok) construct a BrowserWindow, which
+    // is undefined in the renderer ("BrowserWindow is not a constructor").
+    const oauthResult = await ipcRenderer.invoke('integration-oauth:start', {
+      integrationId: integration.value.id,
+      providerId:    integration.value.oauthProviderId!,
       clientId,
       clientSecret,
-      targetAccountId,
-    );
+      accountId:     targetAccountId,
+    });
+    if (!oauthResult?.success) {
+      throw new Error(oauthResult?.error || 'OAuth authorization failed. Please try again.');
+    }
 
     // Set the OAuth account as active
     await integrationService.setActiveAccount(integration.value.id, targetAccountId);

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -297,6 +297,16 @@ export interface IpcMainInvokeEvents {
   /** OpenAI OAuth flow */
   'openai-oauth:start': () => { success: boolean; error?: string };
 
+  /** Generic integration OAuth flow — runs in main so embedded auth windows (Codex, Grok) can construct BrowserWindow */
+  'integration-oauth:start': (payload: {
+    integrationId: string;
+    providerId:    string;
+    clientId?:     string;
+    clientSecret?: string;
+    accountId?:    string;
+    extraScopes?:  string[];
+  }) => { success: boolean; error?: string };
+
   /** Sulla Cloud account auth (phone OTP / email / Apple) */
   'sulla-cloud:get-status':            () => { signedIn: boolean; userId: string; activeContractorId: string; phone: string; name: string; contractorCount: number; lastError?: string };
   'sulla-cloud:send-otp':              (phone: string) => { ok: boolean; error?: string; status: { signedIn: boolean; userId: string; activeContractorId: string; phone: string; name: string; contractorCount: number; lastError?: string } };


### PR DESCRIPTION
## Problem

Clicking **Connect** on the OpenAI Codex and Grok integrations fails with:

```
i.BrowserWindow is not a constructor
```

## Root cause

The generic OAuth path called `IntegrationService.startOAuthFlow()` **directly from the renderer** (`AgentIntegrationDetail.vue`, `AccountEditor.vue`). That chains into `OAuthService.openEmbeddedAuthWindow()` → `new BrowserWindow(...)` — but `BrowserWindow` is a **main-process-only** API. With nodeIntegration on, the renderer's `require('electron')` exposes `shell` (so `shell.openExternal` providers work) but **not** `BrowserWindow`, so it's `undefined`.

Codex and Grok are the only two providers with `openInEmbeddedWindow: true`, so they're the only ones that hit `new BrowserWindow`. The dedicated `claude-oauth:start` / `openai-oauth:start` flows already dodge this by going over IPC to main; the generic path never got that bridge.

## Fix

- **New** `main/integrationOAuth.ts` — a generic `integration-oauth:start` IPC handler that runs `startOAuthFlow` in the **main process**.
- Registered in `main/sullaEvents.ts`; typed in `typings/electron-ipc.d.ts`.
- Both renderer call sites now `ipcRenderer.invoke('integration-oauth:start', …)` instead of calling the service directly.

The embedded `BrowserWindow` is now constructed in main. One path fixes **both Codex and Grok**.

## Verification

- `tsc --noEmit`: zero errors in any touched file (pre-existing node_modules/e2e/discord.js errors are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)