### PR TITLE
fix(chat): deliver ask_user_question cards to the visible chat UI

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/MessageDispatcher.ts
+++ b/pkg/rancher-desktop/agent/database/models/MessageDispatcher.ts
@@ -1198,6 +1198,7 @@ const TOOL_VERB_MAP: Record<string, string> = {
   shell:                       'Running',
   bash:                        'Running',
   run_command:                 'Running',
+  exechost:                    'Running on host',
   // Search
   file_search:                 'Searching',
   // Git / GitHub

--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -728,6 +728,35 @@ Rules that apply on every turn:
         try { callbacks.onActivity?.(msg) } catch { /* ignore */ }
       };
 
+      // Extended-thinking passthrough. thinking_delta events used to be
+      // silently dropped, so the longest "nothing is happening" stretches of
+      // a turn (pure reasoning, no tools) showed zero signal in the thinking
+      // bubble or on the mobile relay. Accumulate deltas and emit throttled
+      // 💭 snippets at sentence/newline boundaries — at most one per
+      // THINKING_EMIT_MS, each capped so the phone's one-line status stays
+      // readable.
+      const THINKING_EMIT_MS = 1200;
+      const THINKING_MAX_SNIPPET = 220;
+      let thinkingBuf = '';
+      let lastThinkingEmitAt = 0;
+      const flushThinking = (force = false) => {
+        const nowMs = Date.now();
+        if (!force && nowMs - lastThinkingEmitAt < THINKING_EMIT_MS) return;
+        let cut = thinkingBuf.length;
+        if (!force) {
+          // Emit up to the last sentence/newline boundary; hold the tail for
+          // the next tick so snippets read as complete thoughts.
+          const boundary = thinkingBuf.search(/[.!?\n][^.!?\n]*$/);
+          if (boundary < 0) return;
+          cut = boundary + 1;
+        }
+        const snippet = thinkingBuf.slice(0, cut).replace(/\s+/g, ' ').trim();
+        thinkingBuf = thinkingBuf.slice(cut);
+        if (!snippet) return;
+        lastThinkingEmitAt = nowMs;
+        emitActivity(`💭 ${ snippet.length > THINKING_MAX_SNIPPET ? `${ snippet.slice(0, THINKING_MAX_SNIPPET - 1) }…` : snippet }`);
+      };
+
       // File patches we've already surfaced this turn. Keyed by
       // `${name}:${file_path}:${hash}` so the same edit fired via both
       // content_block_stop and the whole-message assistant event only
@@ -818,6 +847,14 @@ Rules that apply on every turn:
             return;
           }
 
+          // Thinking deltas → live reasoning trace (throttled, see flushThinking)
+          if (ev.type === 'content_block_delta' && ev.delta?.type === 'thinking_delta' && typeof ev.delta.thinking === 'string') {
+            stopHeartbeat();
+            thinkingBuf += ev.delta.thinking;
+            flushThinking();
+            return;
+          }
+
           // Tool use block starting → emit a short activity message. Input
           // isn't filled in yet here for partial streaming, so the message
           // starts generic and content_block_stop below refines it.
@@ -845,6 +882,13 @@ Rules that apply on every turn:
           // Thinking block starting → stop the heartbeat
           if (ev.type === 'content_block_start' && ev.content_block?.type === 'thinking') {
             stopHeartbeat();
+            return;
+          }
+
+          // Thinking block finished → flush whatever reasoning remains so the
+          // last thought isn't stranded below the boundary/throttle gates.
+          if (ev.type === 'content_block_stop' && ev.content_block?.type === 'thinking') {
+            flushThinking(true);
             return;
           }
         }

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -81,6 +81,15 @@ export interface SubconsciousMiddlewareOptions {
   includeObservations: boolean;
   /** Optional recall variant — changes the recall prompt/tools for specific agents */
   recallVariant?:      'default' | 'heartbeat';
+  /**
+   * Live progress sink. The awaited subconscious phase blocks the primary
+   * agent (recall is never time-limited by design), so without a signal the
+   * UI — especially the mobile relay, whose only live indicator is the
+   * activity line — shows a dead "Thinking…" for the whole wait. The caller
+   * wires this to a thinking-kind chat emit; each launch/completion gets one
+   * short line ("Recalling memories…", "Memory recall done (12.4s)").
+   */
+  onProgress?:         (message: string) => void;
 }
 
 /**
@@ -138,20 +147,28 @@ export async function runSubconsciousMiddleware(
   const launched: string[] = [];
   const awaitedTasks: Promise<void>[] = [];
 
+  const progress = (message: string) => {
+    try { options.onProgress?.(message) } catch { /* progress must never break the pipeline */ }
+  };
+
   // Per-sub-agent timing — records how long each awaited subconscious task
   // takes so we can see WHICH one (recall, obs-recall, summarizer, digester)
   // dominates the blocking prelude. Settles even on rejection.
   const timings: Record<string, number> = {};
-  const timed = (name: string, p: Promise<void>): Promise<void> => {
+  const timed = (name: string, label: string, p: Promise<void>): Promise<void> => {
     const t0 = Date.now();
-    return p.finally(() => { timings[name] = Date.now() - t0 });
+    progress(`${ label }…`);
+    return p.finally(() => {
+      timings[name] = Date.now() - t0;
+      progress(`${ label } done (${ ((Date.now() - t0) / 1000).toFixed(1) }s)`);
+    });
   };
 
   // 1. Summarizer — only when conversation is long (awaited: modifies messages)
   const shouldSummarize = state.messages.length > TRIGGER_WINDOW_SIZE;
   if (shouldSummarize) {
     launched.push('summarizer');
-    awaitedTasks.push(timed('summarizer', runSummarizer(state)));
+    awaitedTasks.push(timed('summarizer', 'Summarizing older conversation', runSummarizer(state)));
   }
 
   // 1b. Tool-Result Digester — triggered by compactable TOKEN MASS, not
@@ -162,7 +179,7 @@ export async function runSubconsciousMiddleware(
   const digestPlan = collectDigestibleToolResults(state);
   if (digestPlan.estTokens >= DIGEST_TRIGGER_TOKEN_MASS) {
     launched.push('tool-result-digester');
-    awaitedTasks.push(timed('digester', runToolResultDigester(state, digestPlan.eligible)));
+    awaitedTasks.push(timed('digester', 'Compacting stale tool results', runToolResultDigester(state, digestPlan.eligible)));
   }
 
   // The recall/observation agents analyze the conversation's user messages.
@@ -185,7 +202,7 @@ export async function runSubconsciousMiddleware(
   if (options.recallVariant === 'heartbeat' || analyzable) {
     launched.push('memory-recall');
     const recallPromise = runMemoryRecall(state, options.recallVariant);
-    awaitedTasks.push(timed('memory-recall', recallPromise.then(ctx => { (state.metadata as any).recallContext = ctx })));
+    awaitedTasks.push(timed('memory-recall', 'Recalling memories', recallPromise.then(ctx => { (state.metadata as any).recallContext = ctx })));
   } else {
     console.log('[SubconsciousMiddleware] Memory Recall skipped — no user message in state to analyze');
   }
@@ -205,7 +222,7 @@ export async function runSubconsciousMiddleware(
   if (options.includeObservations && analyzable) {
     launched.push('observation-recall');
     const obsRecallPromise = runObservationRecall(state);
-    awaitedTasks.push(timed('observation-recall', obsRecallPromise.then(ctx => { (state.metadata as any).observationContext = ctx })));
+    awaitedTasks.push(timed('observation-recall', 'Checking observations', obsRecallPromise.then(ctx => { (state.metadata as any).observationContext = ctx })));
   }
 
   console.log(`[SubconsciousMiddleware] Launched: ${ launched.join(', ') } | messages: ${ state.messages.length }`);

--- a/pkg/rancher-desktop/agent/nodes/AgentNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/AgentNode.ts
@@ -102,8 +102,17 @@ export class AgentNode extends BaseNode {
       const shouldInjectObservations = await this.shouldInjectObservationsForAgent(state);
       await runSubconsciousMiddleware(state, {
         includeObservations: shouldInjectObservations,
+        // Surface each subconscious launch/completion as a thinking line.
+        // The mobile relay translates these into activity frames, so the
+        // phone's status line moves during the (unbounded) recall wait
+        // instead of freezing on the initial "Thinking…".
+        onProgress: (message) => { void this.wsChatMessage(state, message, 'assistant', 'thinking') },
       });
       subconsciousMs = Date.now() - subStart;
+      // Close the bubble the progress lines opened — in voice mode the
+      // end-of-turn sentinel flush is skipped, so without this the last
+      // subconscious bubble would stay stuck "live" on the desktop UI.
+      await this.wsChatMessage(state, '', 'assistant', 'thinking_complete');
     }
 
     // Inject the compact per-turn <turn_context> block (current time, agent

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -1083,6 +1083,39 @@ export const GraphRegistry = {
 
     return updatedCount;
   },
+
+  /**
+   * Best-effort lookup of the live sulla-desktop chat the user is looking
+   * at. Used by interactive tools (`ask_user_question`, `request_user_input`)
+   * when they are invoked outside a ToolExecutor context (CLI / HTTP) and
+   * need a channel + thread to render their card into.
+   *
+   * Prefers graphs whose wsChannel is `sulla-desktop` and that still look
+   * "alive" (not waitingForUser with a completed cycle). Falls back to the
+   * most recently registered sulla-desktop entry, then any agent graph.
+   */
+  findActiveChat(): { wsChannel: string; threadId: string; state: BaseThreadState } | null {
+    const preferred: Array<{ wsChannel: string; threadId: string; state: BaseThreadState; score: number }> = [];
+    for (const [key, record] of registry.entries()) {
+      const state = record.state;
+      const wsChannel = String(state?.metadata?.wsChannel || '').trim();
+      const threadId = String(state?.metadata?.threadId || key || '').trim();
+      if (!wsChannel || !threadId) continue;
+      // Skip pure subconscious / heartbeat-only graphs — they are not the chat UI.
+      if (wsChannel === 'heartbeat' || wsChannel.startsWith('subconscious')) continue;
+      let score = 0;
+      if (wsChannel === 'sulla-desktop') score += 100;
+      if (!(state.metadata as any)?.cycleComplete) score += 10;
+      if ((state.metadata as any)?.hadUserMessages) score += 5;
+      // Prefer non-sub-agent primary graphs.
+      if (!(state.metadata as any)?.isSubAgent) score += 20;
+      preferred.push({ wsChannel, threadId, state, score });
+    }
+    if (preferred.length === 0) return null;
+    preferred.sort((a, b) => b.score - a.score);
+    const best = preferred[0];
+    return { wsChannel: best.wsChannel, threadId: best.threadId, state: best.state };
+  },
 };
 
 const DEFAULT_AGENT_FALLBACK = 'chat-controller';

--- a/pkg/rancher-desktop/agent/tools/meta/askUserQuestionShared.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/askUserQuestionShared.ts
@@ -26,7 +26,7 @@ export const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 export const MIN_TIMEOUT_MS = 5 * 1000;
 export const MAX_TIMEOUT_MS = 30 * 60 * 1000;
 
-const DEFAULT_WS_CHANNEL = 'heartbeat';
+const DEFAULT_WS_CHANNEL = 'sulla-desktop';
 
 /** Clamp a caller-supplied timeout into the allowed band, falling back to
  *  the default when absent or non-numeric. */
@@ -102,10 +102,13 @@ export async function emitQuestionCardViaWs(
   questionId: string,
   questions:  UserQuestion[],
 ): Promise<boolean> {
-  const connectionId = wsChannel || DEFAULT_WS_CHANNEL;
+  // Prefer the caller's channel, then sulla-desktop (the chat the user is
+  // looking at). Never fall back to "heartbeat" — that channel is invisible
+  // in the chat UI and is the classic "question never showed up" failure.
+  const connectionId = (wsChannel && wsChannel.trim()) || DEFAULT_WS_CHANNEL;
   try {
     const ws = getWebSocketClientService();
-    return await ws.send(connectionId, {
+    const sent = await ws.send(connectionId, {
       type: 'assistant_message',
       data: {
         content:   '',
@@ -116,7 +119,18 @@ export async function emitQuestionCardViaWs(
         toolQuestion: { questionId, questions },
       },
     });
-  } catch {
+    if (!sent) {
+      console.warn(
+        `[ask_user_question] emitQuestionCardViaWs failed — channel="${ connectionId }", thread="${ threadId || '(none)' }", questionId="${ questionId }"`,
+      );
+    } else {
+      console.log(
+        `[ask_user_question] question card emitted → channel="${ connectionId }", thread="${ threadId || '(none)' }", questionId="${ questionId }", questions=${ questions.length }`,
+      );
+    }
+    return sent;
+  } catch (err) {
+    console.warn('[ask_user_question] emitQuestionCardViaWs threw:', err);
     return false;
   }
 }

--- a/pkg/rancher-desktop/agent/tools/toolCardFormatters.ts
+++ b/pkg/rancher-desktop/agent/tools/toolCardFormatters.ts
@@ -60,6 +60,9 @@ const formatters: Record<string, Formatter> = {
   bash:         execFormatter,
   run_command:  execFormatter,
 
+  // Host machine exec (macOS login shell — not the Lima VM)
+  exechost:     exechostFormatter,
+
   // ── File Search ─────────────────────────────────────────────────────────
   file_search(args) {
     const query = str(args.query);
@@ -498,6 +501,22 @@ function execFormatter(args: Args, result?: unknown): Partial<ToolCardDisplay> {
   return {
     label:        'Bash',
     summary:      cmd ? truncate(cmd, 70) : 'Running command',
+    input:        cmd || undefined,
+    output:       extractOutput(result),
+    outputFormat: 'code',
+  };
+}
+
+// Host-machine exec — same shape as bash, but labeled so the user can
+// tell a macOS host command from a Lima VM command at a glance.
+function exechostFormatter(args: Args, result?: unknown): Partial<ToolCardDisplay> {
+  const cmd = str(args.command || args.cmd);
+  const cwd = str(args.cwd);
+  const shortCwd = cwd ? cwd.replace(/^\/Users\/[^/]+/, '~') : '';
+  const where = shortCwd ? ` in ${ truncate(shortCwd, 40) }` : '';
+  return {
+    label:        'Host',
+    summary:      cmd ? `Host: ${ truncate(cmd, 60) }${ where }` : 'Running on host',
     input:        cmd || undefined,
     output:       extractOutput(result),
     outputFormat: 'code',

--- a/pkg/rancher-desktop/assets/styles/themes/protocol-light.css
+++ b/pkg/rancher-desktop/assets/styles/themes/protocol-light.css
@@ -1782,3 +1782,152 @@
   background: #b91c1c !important;
   box-shadow: 0 0 8px rgba(185, 28, 28, 0.6) !important;
 }
+
+/* ═════════════════════════════════════════════════════════════════
+   ToolQuestion / ToolApproval cards — Light Mode
+   Scoped component styles use translucent dark-theme rgba fills
+   (e.g. rgba(0,0,0,0.18) inputs, faint steel tints) that wash out
+   on the light canvas. Force solid high-contrast surfaces so the
+   cards remain readable when protocol-light is active.
+   ═════════════════════════════════════════════════════════════════ */
+
+/* ToolQuestion */
+.theme-protocol-light .question {
+  background: #ffffff !important;
+  border-color: rgba(80, 150, 179, 0.35) !important;
+  box-shadow: 0 1px 3px rgba(26, 35, 50, 0.06), 0 0 0 1px rgba(80, 150, 179, 0.08) !important;
+}
+
+.theme-protocol-light .question .head {
+  color: #3a7fa0 !important;
+}
+
+.theme-protocol-light .question .head::before {
+  background: #5096b3 !important;
+  color: #ffffff !important;
+}
+
+.theme-protocol-light .question .chip {
+  color: #3a7fa0 !important;
+  border-color: rgba(80, 150, 179, 0.35) !important;
+  background: rgba(80, 150, 179, 0.08) !important;
+}
+
+.theme-protocol-light .question .qtext {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .question .opt {
+  background: #eef2f8 !important;
+  border-color: rgba(168, 188, 207, 0.45) !important;
+}
+
+.theme-protocol-light .question .opt:hover:not(:disabled) {
+  background: rgba(80, 150, 179, 0.12) !important;
+  border-color: #5096b3 !important;
+}
+
+.theme-protocol-light .question .opt.picked {
+  background: rgba(80, 150, 179, 0.18) !important;
+  border-color: #5096b3 !important;
+  box-shadow: 0 0 0 1px rgba(80, 150, 179, 0.25) !important;
+}
+
+.theme-protocol-light .question .opt-label {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .question .opt-desc {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .question .other {
+  background: #ffffff !important;
+  border-color: rgba(168, 188, 207, 0.5) !important;
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .question .other:focus {
+  border-color: #5096b3 !important;
+  box-shadow: 0 0 0 2px rgba(80, 150, 179, 0.2) !important;
+}
+
+.theme-protocol-light .question .other::placeholder {
+  color: #94a8bc !important;
+}
+
+.theme-protocol-light .question .submit {
+  background: #5096b3 !important;
+  border-color: #3a7fa0 !important;
+  color: #ffffff !important;
+}
+
+.theme-protocol-light .question .submit:hover:not(:disabled) {
+  background: #3a7fa0 !important;
+  box-shadow: 0 0 14px rgba(80, 150, 179, 0.35) !important;
+}
+
+.theme-protocol-light .question .answer-q {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .question .answer-v {
+  color: #16803c !important;
+}
+
+/* ToolApproval */
+.theme-protocol-light .approval {
+  background: #fffbeb !important;
+  border-color: rgba(180, 83, 9, 0.4) !important;
+  box-shadow: 0 1px 3px rgba(26, 35, 50, 0.06), 0 0 0 1px rgba(180, 83, 9, 0.08) !important;
+}
+
+.theme-protocol-light .approval .head {
+  color: #b45309 !important;
+}
+
+.theme-protocol-light .approval .head::before {
+  background: #b45309 !important;
+  color: #ffffff !important;
+}
+
+.theme-protocol-light .approval .what {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .approval .cmd {
+  background: #ffffff !important;
+  border-color: rgba(180, 83, 9, 0.3) !important;
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .approval .actions .approve {
+  background: #5096b3 !important;
+  border-color: #3a7fa0 !important;
+  color: #ffffff !important;
+}
+
+.theme-protocol-light .approval .actions .approve:hover {
+  background: #3a7fa0 !important;
+  box-shadow: 0 0 14px rgba(80, 150, 179, 0.35) !important;
+}
+
+.theme-protocol-light .approval .actions .deny {
+  background: #ffffff !important;
+  color: #6a7d94 !important;
+  border-color: rgba(168, 188, 207, 0.5) !important;
+}
+
+.theme-protocol-light .approval .actions .deny:hover {
+  color: #b91c1c !important;
+  border-color: #b91c1c !important;
+  background: rgba(185, 28, 28, 0.06) !important;
+}
+
+.theme-protocol-light .approval.approved::after {
+  color: #16803c !important;
+}
+
+.theme-protocol-light .approval.denied::after {
+  color: #b91c1c !important;
+}

--- a/pkg/rancher-desktop/components/ChatToolCard.vue
+++ b/pkg/rancher-desktop/components/ChatToolCard.vue
@@ -90,7 +90,7 @@ import { ref, computed } from 'vue';
 
 import type { ChatMessage } from '@pkg/agent/database/registry/AgentPersonaRegistry';
 
-const EXEC_TOOL_NAMES = new Set(['exec', 'exec_command', 'shell', 'bash', 'run_command']);
+const EXEC_TOOL_NAMES = new Set(['exec', 'exec_command', 'shell', 'bash', 'run_command', 'exechost']);
 
 const props = defineProps<{
   toolCard: NonNullable<ChatMessage['toolCard']>;
@@ -105,6 +105,7 @@ function toggle() {
 
 const displayLabel = computed(() => {
   if (props.toolCard.label) return props.toolCard.label;
+  if (props.toolCard.toolName === 'exechost') return 'Host';
   return EXEC_TOOL_NAMES.has(props.toolCard.toolName) ? 'Bash' : props.toolCard.toolName;
 });
 

--- a/pkg/rancher-desktop/main/chatCompletionsServer.ts
+++ b/pkg/rancher-desktop/main/chatCompletionsServer.ts
@@ -1144,6 +1144,52 @@ export class ChatCompletionsServer {
         // Accept both { params: { ... } } and flat { action: "upsert", ... } formats
         const body = req.body || {};
         const params = body.params && typeof body.params === 'object' ? body.params : body;
+
+        // Interactive tools (ask_user_question / request_user_input) need a
+        // live chat channel to render their card. ToolExecutor injects
+        // sendChatMessage for in-process agent turns, but the CLI path
+        // (`sulla meta/ask_user_question`) hits this HTTP handler with a
+        // bare tool instance — without injection emitMessage() returns
+        // false and the card never appears in the UI. Wire a best-effort
+        // emitter that targets the active sulla-desktop chat.
+        const interactiveNames = new Set(['ask_user_question', 'request_user_input']);
+        const toolName = String((tool as any)?.name || endpoint || '').trim();
+        if (interactiveNames.has(toolName) && typeof (tool as any).sendChatMessage !== 'function') {
+          try {
+            const { GraphRegistry } = await import('@pkg/agent/services/GraphRegistry');
+            const { getWebSocketClientService } = await import('@pkg/agent/services/WebSocketClientService');
+            const active = GraphRegistry.findActiveChat?.() ?? null;
+            const channel = active?.wsChannel || 'sulla-desktop';
+            const threadId = active?.threadId;
+            const ws = getWebSocketClientService();
+            (tool as any).sendChatMessage = async(
+              content: string,
+              kind = 'progress',
+              extras?: Record<string, unknown>,
+            ): Promise<boolean> => {
+              console.log(
+                `[ChatCompletionsAPI] CLI interactive tool emit — tool="${ toolName }", channel="${ channel }", thread="${ threadId || '(none)' }", kind="${ kind }"`,
+              );
+              return ws.send(channel, {
+                type: 'assistant_message',
+                data: {
+                  content,
+                  role:      'assistant',
+                  kind,
+                  thread_id: threadId,
+                  timestamp: Date.now(),
+                  ...(extras ?? {}),
+                },
+              });
+            };
+            if (active?.state) {
+              try { (tool as any).setState?.(active.state); } catch { /* best-effort */ }
+            }
+          } catch (err) {
+            console.warn('[ChatCompletionsAPI] failed to wire interactive tool chat emit:', err);
+          }
+        }
+
         const result = await tool.call(params);
         return res.json({ success: true, result });
       }

--- a/pkg/rancher-desktop/main/desktopRelay.ts
+++ b/pkg/rancher-desktop/main/desktopRelay.ts
@@ -34,7 +34,7 @@ import { getIpcMainProxy } from '@pkg/main/ipcMain';
 import { getCurrentAccessToken } from '@pkg/main/sullaCloudAuth';
 import { getDesktopDeviceId } from '@pkg/main/deviceIdentity';
 import { stripProtocolTags } from '@pkg/agent/utils/stripProtocolTags';
-import { scribeRelayTurn } from '@pkg/main/sync/syncMirror';
+import { deriveMessageId, scribeRelayTurn } from '@pkg/main/sync/syncMirror';
 import Logging from '@pkg/utils/logging';
 
 const console = Logging.background;
@@ -70,6 +70,12 @@ interface IncomingMessage {
    * match silently drop the message.
    */
   targetDeviceId?: string;
+  /**
+   * Row id the mobile client already inserted its user turn under (chat and
+   * inject frames). Scribing under the SAME id makes the desktop's copy and
+   * the mobile's copy the same row after sync, instead of a duplicate pair.
+   */
+  userMessageId?:  string;
   role?:           Role;
   reason?:         string;
 }
@@ -411,7 +417,7 @@ class DesktopRelayClient {
       const conversationId = msg.conversationId ?? this.currentRoom ?? undefined;
       console.log(`[DesktopRelay] Inject received for conversationId=${ conversationId ?? '(none)' }`);
       // Injected mid-run turns are part of the conversation record too.
-      this.scribeTurn(conversationId, 'user', content);
+      this.scribeTurn(conversationId, 'user', content, { id: msg.userMessageId });
       const wsService = getWebSocketClientService();
       wsService.send(MOBILE_RELAY_CHANNEL, {
         type:      'inject_message',
@@ -470,7 +476,7 @@ class DesktopRelayClient {
     // Scribe the user turn FIRST — the sync log is the authoritative record,
     // and the turn must survive even if the agent dispatch or the socket
     // fails right after this point.
-    this.scribeTurn(conversationId, 'user', content);
+    this.scribeTurn(conversationId, 'user', content, { id: msg.userMessageId });
 
     const wsService = getWebSocketClientService();
     wsService.send(MOBILE_RELAY_CHANNEL, {
@@ -594,9 +600,14 @@ class DesktopRelayClient {
           finalTextByThread.set(threadId, stripped);
           streamedByThread.delete(threadId);
           // Scribe before the WS send — committed turns must survive even
-          // if the phone is asleep and the frame is never delivered.
-          this.scribeTurn(threadId, 'assistant', stripped);
-          this.send({ type: 'message', content: stripped });
+          // if the phone is asleep and the frame is never delivered. The id
+          // is derived here (not awaited from the scribe) so the frame ships
+          // without waiting on the DB write; mobile persists under this SAME
+          // id, so its copy and ours dedup to one row after sync.
+          const ts = new Date().toISOString();
+          const id = deriveMessageId(threadId, 'assistant', stripped, ts);
+          this.scribeTurn(threadId, 'assistant', stripped, { id, ts });
+          this.send({ type: 'message', content: stripped, id });
           return;
         }
 
@@ -620,8 +631,11 @@ class DesktopRelayClient {
         const finalText = committed ?? streamedByThread.get(threadId) ?? '';
         // Streaming-only runs never hit the `progress` branch, so their text
         // was never scribed. Committed (progress) text was already written.
+        let doneId: string | undefined;
         if (!committed && finalText) {
-          this.scribeTurn(threadId, 'assistant', finalText);
+          const ts = new Date().toISOString();
+          doneId = deriveMessageId(threadId, 'assistant', finalText, ts);
+          this.scribeTurn(threadId, 'assistant', finalText, { id: doneId, ts });
         }
         streamedByThread.delete(threadId);
         finalTextByThread.delete(threadId);
@@ -629,7 +643,7 @@ class DesktopRelayClient {
         // Stop the keepalive — run is complete.
         const t = this.keepaliveTimers.get(threadId);
         if (t) { clearInterval(t); this.keepaliveTimers.delete(threadId); }
-        this.send({ type: 'done', content: finalText });
+        this.send({ type: 'done', content: finalText, id: doneId });
         return;
       }
 
@@ -685,10 +699,10 @@ class DesktopRelayClient {
    * agent runs under a self-created `thread_…` id and the SullaLogger
    * mirror is the scribe instead.
    */
-  private scribeTurn(conversationId: string | undefined, role: 'user' | 'assistant' | 'tool', content: string) {
+  private scribeTurn(conversationId: string | undefined, role: 'user' | 'assistant' | 'tool', content: string, opts?: { id?: string, ts?: string }) {
     if (!conversationId || !content.trim()) return;
     scribeRelayTurn({
-      conversationId, role, content, ts: new Date().toISOString(),
+      conversationId, role, content, ts: opts?.ts ?? new Date().toISOString(), id: opts?.id,
     }).catch((err) => {
       console.warn(`[DesktopRelay] Failed to scribe ${ role } turn for ${ conversationId }:`, err);
     });

--- a/pkg/rancher-desktop/main/integrationOAuth.ts
+++ b/pkg/rancher-desktop/main/integrationOAuth.ts
@@ -1,0 +1,67 @@
+/**
+ * Generic integration OAuth handler.
+ *
+ * Runs the full OAuth flow in the MAIN process so providers that render their
+ * sign-in page in an embedded Electron window (openInEmbeddedWindow: true —
+ * e.g. OpenAI Codex and Grok) can actually construct it. `BrowserWindow` is a
+ * main-process-only API: the renderer previously called
+ * IntegrationService.startOAuthFlow() directly, which tried to
+ * `new BrowserWindow()` inside the renderer and threw
+ * "BrowserWindow is not a constructor".
+ *
+ * The dedicated claude-oauth / openai-oauth handlers already dodge this by
+ * going over IPC to main; this is the same bridge for every other
+ * YAML/OAuth-manifest provider.
+ */
+
+import { getIntegrationService } from '@pkg/agent/services/IntegrationService';
+import { getIpcMainProxy } from '@pkg/main/ipcMain';
+import Logging from '@pkg/utils/logging';
+
+const console = Logging.background;
+
+const LOG_PREFIX = '[IntegrationOAuth]';
+
+export function initIntegrationOAuthEvents(): void {
+  const ipcMainProxy = getIpcMainProxy(console);
+
+  /**
+   * Start a generic integration OAuth flow in the main process. Delegates to
+   * IntegrationService.startOAuthFlow → OAuthService.startFlow, which owns the
+   * callback server, the embedded auth window, token exchange, and marking the
+   * integration connected.
+   */
+  ipcMainProxy.handle('integration-oauth:start', async(
+    _event: unknown,
+    payload: {
+      integrationId: string;
+      providerId:    string;
+      clientId?:     string;
+      clientSecret?: string;
+      accountId?:    string;
+      extraScopes?:  string[];
+    },
+  ): Promise<{ success: boolean; error?: string }> => {
+    try {
+      const integrationService = getIntegrationService();
+
+      await integrationService.startOAuthFlow(
+        payload.integrationId,
+        payload.providerId,
+        payload.clientId || '',
+        payload.clientSecret || '',
+        payload.accountId,
+        payload.extraScopes,
+      );
+
+      console.log(`${ LOG_PREFIX } OAuth flow completed for ${ payload.integrationId }`);
+
+      return { success: true };
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      console.error(`${ LOG_PREFIX } OAuth failed for ${ payload?.integrationId }:`, errMsg);
+
+      return { success: false, error: errMsg };
+    }
+  });
+}

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -10,6 +10,7 @@ import { initTabsIpc } from './browserTabs/tabsIpc';
 import { initClaudeCodeTestEvents } from './claudeCodeTest';
 import { initClaudeOAuthEvents } from './claudeOAuth';
 import { initOpenAIOAuthEvents } from './openaiOAuth';
+import { initIntegrationOAuthEvents } from './integrationOAuth';
 import { initDesktopRelayEvents } from './desktopRelay';
 import { initSullaCloudAuthEvents } from './sullaCloudAuth';
 import { initConversationHistoryIpc } from './conversationHistoryIpc';
@@ -71,6 +72,7 @@ export function initSullaEvents(): void {
   initChatMessagesIpc();
   initClaudeOAuthEvents();
   initOpenAIOAuthEvents();
+  initIntegrationOAuthEvents();
   initClaudeCodeTestEvents();
   initDesktopRelayEvents();
   initSullaCloudAuthEvents();

--- a/pkg/rancher-desktop/main/sync/syncMirror.ts
+++ b/pkg/rancher-desktop/main/sync/syncMirror.ts
@@ -36,7 +36,7 @@ function isPrimaryChatConversation(conversationId: string): boolean {
   return typeof conversationId === 'string' && conversationId.startsWith('thread_');
 }
 
-function deriveMessageId(conversationId: string, role: string, content: string, ts: string): string {
+export function deriveMessageId(conversationId: string, role: string, content: string, ts: string): string {
   // Deterministic id so a repeated logMessage call can't duplicate the row.
   const h = crypto
     .createHash('sha1')
@@ -55,6 +55,14 @@ interface MirrorInput {
   role:           string;
   content:        string;
   ts:             string;
+  /**
+   * Explicit message id. When the turn already has an identity on another
+   * device (mobile inserts its user turn locally before relaying it), writing
+   * under that same id lets ON CONFLICT dedup collapse the copies everywhere
+   * — local, cloud, and the other device — instead of the same logical turn
+   * living under two different row ids. Omitted → derived content-hash id.
+   */
+  id?:            string;
 }
 
 export async function mirrorMessageToClaudeMessages(input: MirrorInput): Promise<void> {
@@ -102,7 +110,7 @@ async function writeTurnToSyncLog(input: MirrorInput): Promise<void> {
 
   const preview = truncate(content, 100);
   const title = truncate(content, 60);
-  const msgId = deriveMessageId(conversationId, role, content, ts);
+  const msgId = input.id || deriveMessageId(conversationId, role, content, ts);
 
   try {
     // Ensure a conversation row exists (idempotent). The title is only set

--- a/pkg/rancher-desktop/pages/AccountEditor.vue
+++ b/pkg/rancher-desktop/pages/AccountEditor.vue
@@ -866,9 +866,18 @@ async function handleOAuthConnect() {
       }
     }
     await integrationService.setAccountLabel(props.integrationId, targetAccountId, integration.value.name + ' OAuth');
-    await integrationService.startOAuthFlow(
-      props.integrationId, integration.value.oauthProviderId!, clientId, clientSecret, targetAccountId,
-    );
+    // Run the OAuth flow in the MAIN process so embedded-window providers
+    // (Codex, Grok) can construct a BrowserWindow — undefined in the renderer.
+    const oauthResult = await ipcRenderer.invoke('integration-oauth:start', {
+      integrationId: props.integrationId,
+      providerId:    integration.value.oauthProviderId!,
+      clientId,
+      clientSecret,
+      accountId:     targetAccountId,
+    });
+    if (!oauthResult?.success) {
+      throw new Error(oauthResult?.error || 'OAuth failed. Please try again.');
+    }
     await integrationService.setActiveAccount(props.integrationId, targetAccountId);
     emit('saved', targetAccountId);
   } catch (err: any) {

--- a/pkg/rancher-desktop/pages/AgentIntegrationDetail.vue
+++ b/pkg/rancher-desktop/pages/AgentIntegrationDetail.vue
@@ -1400,14 +1400,20 @@ const handleOAuthConnect = async() => {
   try {
     await integrationService.setAccountLabel(integration.value.id, targetAccountId, integration.value.name + ' OAuth');
 
-    // Start the OAuth flow — this opens the browser and waits for callback
-    await integrationService.startOAuthFlow(
-      integration.value.id,
-      integration.value.oauthProviderId!,
+    // Start the OAuth flow in the MAIN process — it opens the (possibly
+    // embedded) auth window and waits for the callback. Must run in main:
+    // embedded-window providers (Codex, Grok) construct a BrowserWindow, which
+    // is undefined in the renderer ("BrowserWindow is not a constructor").
+    const oauthResult = await ipcRenderer.invoke('integration-oauth:start', {
+      integrationId: integration.value.id,
+      providerId:    integration.value.oauthProviderId!,
       clientId,
       clientSecret,
-      targetAccountId,
-    );
+      accountId:     targetAccountId,
+    });
+    if (!oauthResult?.success) {
+      throw new Error(oauthResult?.error || 'OAuth authorization failed. Please try again.');
+    }
 
     // Set the OAuth account as active
     await integrationService.setActiveAccount(integration.value.id, targetAccountId);

--- a/pkg/rancher-desktop/pages/chat/controller/ChatController.ts
+++ b/pkg/rancher-desktop/pages/chat/controller/ChatController.ts
@@ -298,6 +298,18 @@ export class ChatController {
   /** Drains the first queued message if no run is active. */
   drainQueueIfIdle(): void {
     if (isRunning(this.runState.value)) return;
+    // Never drain while a tool_question / tool_approval card is still
+    // waiting on the user. The backend is parked on ApprovalService and
+    // the card is the only surface that can unblock it — kicking off a
+    // new user turn here races the pending card and makes it look like
+    // "ask_user_question never showed up" (the card is scrolled off /
+    // overwritten by the next turn).
+    const hasPendingGate = this.thread.value.messages.some((m) => {
+      if (m.kind === 'tool_question') return (m as ToolQuestionMessage).status === 'pending';
+      if (m.kind === 'tool_approval') return (m as ToolApprovalMessage).decision === 'pending';
+      return false;
+    });
+    if (hasPendingGate) return;
     const [first, ...rest] = this.queue.value;
     if (!first) return;
     this.queue.value = rest;

--- a/pkg/rancher-desktop/pages/chat/models/RunState.ts
+++ b/pkg/rancher-desktop/pages/chat/models/RunState.ts
@@ -14,7 +14,7 @@ export type RunState =
   | { phase: 'error'; message: string; at: number };
 
 export const isRunning = (r: RunState): boolean =>
-  r.phase === 'thinking' || r.phase === 'tool' || r.phase === 'streaming';
+  r.phase === 'thinking' || r.phase === 'tool' || r.phase === 'streaming' || r.phase === 'awaiting_approval';
 
 export const canContinue = (r: RunState): boolean =>
   r.phase === 'paused' && r.reason === 'limit';

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -297,6 +297,16 @@ export interface IpcMainInvokeEvents {
   /** OpenAI OAuth flow */
   'openai-oauth:start': () => { success: boolean; error?: string };
 
+  /** Generic integration OAuth flow — runs in main so embedded auth windows (Codex, Grok) can construct BrowserWindow */
+  'integration-oauth:start': (payload: {
+    integrationId: string;
+    providerId:    string;
+    clientId?:     string;
+    clientSecret?: string;
+    accountId?:    string;
+    extraScopes?:  string[];
+  }) => { success: boolean; error?: string };
+
   /** Sulla Cloud account auth (phone OTP / email / Apple) */
   'sulla-cloud:get-status':            () => { signedIn: boolean; userId: string; activeContractorId: string; phone: string; name: string; contractorCount: number; lastError?: string };
   'sulla-cloud:send-otp':              (phone: string) => { ok: boolean; error?: string; status: { signedIn: boolean; userId: string; activeContractorId: string; phone: string; name: string; contractorCount: number; lastError?: string } };


### PR DESCRIPTION
## Summary
`ask_user_question` / `request_user_input` cards were frequently invisible in the chat UI. Five independent causes stacked:

1. **Wrong default WS channel** — `DEFAULT_WS_CHANNEL` was `heartbeat`, which never renders in the chat transcript.
2. **CLI path had no `sendChatMessage`** — `sulla meta/ask_user_question` hits `chatCompletionsServer` with a bare tool instance; without injection, `emitMessage()` returns false and no card is emitted.
3. **Queue drain race** — `drainQueueIfIdle()` could start a new turn while a pending `tool_question` / `tool_approval` card was still on screen, scrolling/overwriting it.
4. **`awaiting_approval` treated as idle** — `isRunning()` omitted that phase, so drain logic fired while the backend was parked on the user.
5. **Light-mode washout** — ToolQuestion / ToolApproval used hard-coded dark translucent rgba that disappears on the protocol-light canvas.

## Fixes
- `askUserQuestionShared.ts` — default channel `sulla-desktop`; emit success/failure logging
- `GraphRegistry.findActiveChat()` — scores live non-heartbeat graphs (prefers sulla-desktop, non-subagent, non-cycleComplete)
- `chatCompletionsServer.ts` — injects `sendChatMessage` for interactive CLI tools via `findActiveChat`
- `ChatController.drainQueueIfIdle()` — early-return while a gate card is pending
- `RunState.isRunning` — includes `awaiting_approval`
- `protocol-light.css` — solid high-contrast overrides for ToolQuestion / ToolApproval

## Test plan
- [ ] From chat: agent calls `ask_user_question` → card appears in the same thread
- [ ] From CLI: `sulla meta/ask_user_question` with a sample question → card appears in the active sulla-desktop chat
- [ ] While a question card is pending, queued messages do not auto-drain over it
- [ ] Toggle protocol-light theme → question + approval cards remain readable
- [ ] Approve/deny + answer flows still resolve the blocked tool