### PR TITLE
fix(chat): deliver ask_user_question cards to the visible chat UI

### DIFF
--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -1083,6 +1083,39 @@ export const GraphRegistry = {
 
     return updatedCount;
   },
+
+  /**
+   * Best-effort lookup of the live sulla-desktop chat the user is looking
+   * at. Used by interactive tools (`ask_user_question`, `request_user_input`)
+   * when they are invoked outside a ToolExecutor context (CLI / HTTP) and
+   * need a channel + thread to render their card into.
+   *
+   * Prefers graphs whose wsChannel is `sulla-desktop` and that still look
+   * "alive" (not waitingForUser with a completed cycle). Falls back to the
+   * most recently registered sulla-desktop entry, then any agent graph.
+   */
+  findActiveChat(): { wsChannel: string; threadId: string; state: BaseThreadState } | null {
+    const preferred: Array<{ wsChannel: string; threadId: string; state: BaseThreadState; score: number }> = [];
+    for (const [key, record] of registry.entries()) {
+      const state = record.state;
+      const wsChannel = String(state?.metadata?.wsChannel || '').trim();
+      const threadId = String(state?.metadata?.threadId || key || '').trim();
+      if (!wsChannel || !threadId) continue;
+      // Skip pure subconscious / heartbeat-only graphs — they are not the chat UI.
+      if (wsChannel === 'heartbeat' || wsChannel.startsWith('subconscious')) continue;
+      let score = 0;
+      if (wsChannel === 'sulla-desktop') score += 100;
+      if (!(state.metadata as any)?.cycleComplete) score += 10;
+      if ((state.metadata as any)?.hadUserMessages) score += 5;
+      // Prefer non-sub-agent primary graphs.
+      if (!(state.metadata as any)?.isSubAgent) score += 20;
+      preferred.push({ wsChannel, threadId, state, score });
+    }
+    if (preferred.length === 0) return null;
+    preferred.sort((a, b) => b.score - a.score);
+    const best = preferred[0];
+    return { wsChannel: best.wsChannel, threadId: best.threadId, state: best.state };
+  },
 };
 
 const DEFAULT_AGENT_FALLBACK = 'chat-controller';

--- a/pkg/rancher-desktop/agent/tools/meta/askUserQuestionShared.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/askUserQuestionShared.ts
@@ -26,7 +26,7 @@ export const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000;
 export const MIN_TIMEOUT_MS = 5 * 1000;
 export const MAX_TIMEOUT_MS = 30 * 60 * 1000;
 
-const DEFAULT_WS_CHANNEL = 'heartbeat';
+const DEFAULT_WS_CHANNEL = 'sulla-desktop';
 
 /** Clamp a caller-supplied timeout into the allowed band, falling back to
  *  the default when absent or non-numeric. */
@@ -102,10 +102,13 @@ export async function emitQuestionCardViaWs(
   questionId: string,
   questions:  UserQuestion[],
 ): Promise<boolean> {
-  const connectionId = wsChannel || DEFAULT_WS_CHANNEL;
+  // Prefer the caller's channel, then sulla-desktop (the chat the user is
+  // looking at). Never fall back to "heartbeat" — that channel is invisible
+  // in the chat UI and is the classic "question never showed up" failure.
+  const connectionId = (wsChannel && wsChannel.trim()) || DEFAULT_WS_CHANNEL;
   try {
     const ws = getWebSocketClientService();
-    return await ws.send(connectionId, {
+    const sent = await ws.send(connectionId, {
       type: 'assistant_message',
       data: {
         content:   '',
@@ -116,7 +119,18 @@ export async function emitQuestionCardViaWs(
         toolQuestion: { questionId, questions },
       },
     });
-  } catch {
+    if (!sent) {
+      console.warn(
+        `[ask_user_question] emitQuestionCardViaWs failed — channel="${ connectionId }", thread="${ threadId || '(none)' }", questionId="${ questionId }"`,
+      );
+    } else {
+      console.log(
+        `[ask_user_question] question card emitted → channel="${ connectionId }", thread="${ threadId || '(none)' }", questionId="${ questionId }", questions=${ questions.length }`,
+      );
+    }
+    return sent;
+  } catch (err) {
+    console.warn('[ask_user_question] emitQuestionCardViaWs threw:', err);
     return false;
   }
 }

--- a/pkg/rancher-desktop/assets/styles/themes/protocol-light.css
+++ b/pkg/rancher-desktop/assets/styles/themes/protocol-light.css
@@ -1782,3 +1782,152 @@
   background: #b91c1c !important;
   box-shadow: 0 0 8px rgba(185, 28, 28, 0.6) !important;
 }
+
+/* ═════════════════════════════════════════════════════════════════
+   ToolQuestion / ToolApproval cards — Light Mode
+   Scoped component styles use translucent dark-theme rgba fills
+   (e.g. rgba(0,0,0,0.18) inputs, faint steel tints) that wash out
+   on the light canvas. Force solid high-contrast surfaces so the
+   cards remain readable when protocol-light is active.
+   ═════════════════════════════════════════════════════════════════ */
+
+/* ToolQuestion */
+.theme-protocol-light .question {
+  background: #ffffff !important;
+  border-color: rgba(80, 150, 179, 0.35) !important;
+  box-shadow: 0 1px 3px rgba(26, 35, 50, 0.06), 0 0 0 1px rgba(80, 150, 179, 0.08) !important;
+}
+
+.theme-protocol-light .question .head {
+  color: #3a7fa0 !important;
+}
+
+.theme-protocol-light .question .head::before {
+  background: #5096b3 !important;
+  color: #ffffff !important;
+}
+
+.theme-protocol-light .question .chip {
+  color: #3a7fa0 !important;
+  border-color: rgba(80, 150, 179, 0.35) !important;
+  background: rgba(80, 150, 179, 0.08) !important;
+}
+
+.theme-protocol-light .question .qtext {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .question .opt {
+  background: #eef2f8 !important;
+  border-color: rgba(168, 188, 207, 0.45) !important;
+}
+
+.theme-protocol-light .question .opt:hover:not(:disabled) {
+  background: rgba(80, 150, 179, 0.12) !important;
+  border-color: #5096b3 !important;
+}
+
+.theme-protocol-light .question .opt.picked {
+  background: rgba(80, 150, 179, 0.18) !important;
+  border-color: #5096b3 !important;
+  box-shadow: 0 0 0 1px rgba(80, 150, 179, 0.25) !important;
+}
+
+.theme-protocol-light .question .opt-label {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .question .opt-desc {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .question .other {
+  background: #ffffff !important;
+  border-color: rgba(168, 188, 207, 0.5) !important;
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .question .other:focus {
+  border-color: #5096b3 !important;
+  box-shadow: 0 0 0 2px rgba(80, 150, 179, 0.2) !important;
+}
+
+.theme-protocol-light .question .other::placeholder {
+  color: #94a8bc !important;
+}
+
+.theme-protocol-light .question .submit {
+  background: #5096b3 !important;
+  border-color: #3a7fa0 !important;
+  color: #ffffff !important;
+}
+
+.theme-protocol-light .question .submit:hover:not(:disabled) {
+  background: #3a7fa0 !important;
+  box-shadow: 0 0 14px rgba(80, 150, 179, 0.35) !important;
+}
+
+.theme-protocol-light .question .answer-q {
+  color: #6a7d94 !important;
+}
+
+.theme-protocol-light .question .answer-v {
+  color: #16803c !important;
+}
+
+/* ToolApproval */
+.theme-protocol-light .approval {
+  background: #fffbeb !important;
+  border-color: rgba(180, 83, 9, 0.4) !important;
+  box-shadow: 0 1px 3px rgba(26, 35, 50, 0.06), 0 0 0 1px rgba(180, 83, 9, 0.08) !important;
+}
+
+.theme-protocol-light .approval .head {
+  color: #b45309 !important;
+}
+
+.theme-protocol-light .approval .head::before {
+  background: #b45309 !important;
+  color: #ffffff !important;
+}
+
+.theme-protocol-light .approval .what {
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .approval .cmd {
+  background: #ffffff !important;
+  border-color: rgba(180, 83, 9, 0.3) !important;
+  color: #1a2332 !important;
+}
+
+.theme-protocol-light .approval .actions .approve {
+  background: #5096b3 !important;
+  border-color: #3a7fa0 !important;
+  color: #ffffff !important;
+}
+
+.theme-protocol-light .approval .actions .approve:hover {
+  background: #3a7fa0 !important;
+  box-shadow: 0 0 14px rgba(80, 150, 179, 0.35) !important;
+}
+
+.theme-protocol-light .approval .actions .deny {
+  background: #ffffff !important;
+  color: #6a7d94 !important;
+  border-color: rgba(168, 188, 207, 0.5) !important;
+}
+
+.theme-protocol-light .approval .actions .deny:hover {
+  color: #b91c1c !important;
+  border-color: #b91c1c !important;
+  background: rgba(185, 28, 28, 0.06) !important;
+}
+
+.theme-protocol-light .approval.approved::after {
+  color: #16803c !important;
+}
+
+.theme-protocol-light .approval.denied::after {
+  color: #b91c1c !important;
+}

--- a/pkg/rancher-desktop/main/chatCompletionsServer.ts
+++ b/pkg/rancher-desktop/main/chatCompletionsServer.ts
@@ -1144,6 +1144,52 @@ export class ChatCompletionsServer {
         // Accept both { params: { ... } } and flat { action: "upsert", ... } formats
         const body = req.body || {};
         const params = body.params && typeof body.params === 'object' ? body.params : body;
+
+        // Interactive tools (ask_user_question / request_user_input) need a
+        // live chat channel to render their card. ToolExecutor injects
+        // sendChatMessage for in-process agent turns, but the CLI path
+        // (`sulla meta/ask_user_question`) hits this HTTP handler with a
+        // bare tool instance — without injection emitMessage() returns
+        // false and the card never appears in the UI. Wire a best-effort
+        // emitter that targets the active sulla-desktop chat.
+        const interactiveNames = new Set(['ask_user_question', 'request_user_input']);
+        const toolName = String((tool as any)?.name || endpoint || '').trim();
+        if (interactiveNames.has(toolName) && typeof (tool as any).sendChatMessage !== 'function') {
+          try {
+            const { GraphRegistry } = await import('@pkg/agent/services/GraphRegistry');
+            const { getWebSocketClientService } = await import('@pkg/agent/services/WebSocketClientService');
+            const active = GraphRegistry.findActiveChat?.() ?? null;
+            const channel = active?.wsChannel || 'sulla-desktop';
+            const threadId = active?.threadId;
+            const ws = getWebSocketClientService();
+            (tool as any).sendChatMessage = async(
+              content: string,
+              kind = 'progress',
+              extras?: Record<string, unknown>,
+            ): Promise<boolean> => {
+              console.log(
+                `[ChatCompletionsAPI] CLI interactive tool emit — tool="${ toolName }", channel="${ channel }", thread="${ threadId || '(none)' }", kind="${ kind }"`,
+              );
+              return ws.send(channel, {
+                type: 'assistant_message',
+                data: {
+                  content,
+                  role:      'assistant',
+                  kind,
+                  thread_id: threadId,
+                  timestamp: Date.now(),
+                  ...(extras ?? {}),
+                },
+              });
+            };
+            if (active?.state) {
+              try { (tool as any).setState?.(active.state); } catch { /* best-effort */ }
+            }
+          } catch (err) {
+            console.warn('[ChatCompletionsAPI] failed to wire interactive tool chat emit:', err);
+          }
+        }
+
         const result = await tool.call(params);
         return res.json({ success: true, result });
       }

--- a/pkg/rancher-desktop/pages/chat/controller/ChatController.ts
+++ b/pkg/rancher-desktop/pages/chat/controller/ChatController.ts
@@ -298,6 +298,18 @@ export class ChatController {
   /** Drains the first queued message if no run is active. */
   drainQueueIfIdle(): void {
     if (isRunning(this.runState.value)) return;
+    // Never drain while a tool_question / tool_approval card is still
+    // waiting on the user. The backend is parked on ApprovalService and
+    // the card is the only surface that can unblock it — kicking off a
+    // new user turn here races the pending card and makes it look like
+    // "ask_user_question never showed up" (the card is scrolled off /
+    // overwritten by the next turn).
+    const hasPendingGate = this.thread.value.messages.some((m) => {
+      if (m.kind === 'tool_question') return (m as ToolQuestionMessage).status === 'pending';
+      if (m.kind === 'tool_approval') return (m as ToolApprovalMessage).decision === 'pending';
+      return false;
+    });
+    if (hasPendingGate) return;
     const [first, ...rest] = this.queue.value;
     if (!first) return;
     this.queue.value = rest;

--- a/pkg/rancher-desktop/pages/chat/models/RunState.ts
+++ b/pkg/rancher-desktop/pages/chat/models/RunState.ts
@@ -14,7 +14,7 @@ export type RunState =
   | { phase: 'error'; message: string; at: number };
 
 export const isRunning = (r: RunState): boolean =>
-  r.phase === 'thinking' || r.phase === 'tool' || r.phase === 'streaming';
+  r.phase === 'thinking' || r.phase === 'tool' || r.phase === 'streaming' || r.phase === 'awaiting_approval';
 
 export const canContinue = (r: RunState): boolean =>
   r.phase === 'paused' && r.reason === 'limit';


### PR DESCRIPTION
## Summary
`ask_user_question` / `request_user_input` cards were frequently invisible in the chat UI. Five independent causes stacked:

1. **Wrong default WS channel** — `DEFAULT_WS_CHANNEL` was `heartbeat`, which never renders in the chat transcript.
2. **CLI path had no `sendChatMessage`** — `sulla meta/ask_user_question` hits `chatCompletionsServer` with a bare tool instance; without injection, `emitMessage()` returns false and no card is emitted.
3. **Queue drain race** — `drainQueueIfIdle()` could start a new turn while a pending `tool_question` / `tool_approval` card was still on screen, scrolling/overwriting it.
4. **`awaiting_approval` treated as idle** — `isRunning()` omitted that phase, so drain logic fired while the backend was parked on the user.
5. **Light-mode washout** — ToolQuestion / ToolApproval used hard-coded dark translucent rgba that disappears on the protocol-light canvas.

## Fixes
- `askUserQuestionShared.ts` — default channel `sulla-desktop`; emit success/failure logging
- `GraphRegistry.findActiveChat()` — scores live non-heartbeat graphs (prefers sulla-desktop, non-subagent, non-cycleComplete)
- `chatCompletionsServer.ts` — injects `sendChatMessage` for interactive CLI tools via `findActiveChat`
- `ChatController.drainQueueIfIdle()` — early-return while a gate card is pending
- `RunState.isRunning` — includes `awaiting_approval`
- `protocol-light.css` — solid high-contrast overrides for ToolQuestion / ToolApproval

## Test plan
- [ ] From chat: agent calls `ask_user_question` → card appears in the same thread
- [ ] From CLI: `sulla meta/ask_user_question` with a sample question → card appears in the active sulla-desktop chat
- [ ] While a question card is pending, queued messages do not auto-drain over it
- [ ] Toggle protocol-light theme → question + approval cards remain readable
- [ ] Approve/deny + answer flows still resolve the blocked tool