### PR TITLE
fix(deps): declare @modelcontextprotocol/sdk + zod, pin zod 3.25.76

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@langchain/openai": "1.2.9",
     "@mantine/core": "8.3.16",
     "@mantine/hooks": "8.3.16",
+    "@modelcontextprotocol/sdk": "1.27.1",
     "@mozilla/readability": "0.6.0",
     "@napi-rs/xattr": "1.0.3",
     "@octokit/rest": "22.0.1",
@@ -149,6 +150,7 @@
     "ws": "^8.20.0",
     "yaml": "2.8.2",
     "yazl": "^3.3.1",
+    "zod": "3.25.76",
     "zod-to-json-schema": "3.23.5"
   },
   "devDependencies": {
@@ -253,7 +255,8 @@
     "merge-deep": "npm:deepmerge@^4.3.1",
     "string-width": "^4",
     "sqlite-vec-win32-x64": "npm:sqlite-vec-windows-x64@0.1.7-alpha.2",
-    "better-sqlite3": "12.6.2"
+    "better-sqlite3": "12.6.2",
+    "zod": "3.25.76"
   },
   "optionalDependencies": {
     "dmg-license": "1.0.11",


### PR DESCRIPTION
Declares previously-phantom dependencies (mcp-sdk, zod) and pins zod to 3.25.76. Requires a yarn install on the host after merge.

🤖 Generated with Sulla