### PR TITLE
perf(claude-code): cache stable <sulla_context> across fresh sessions

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -59,6 +59,20 @@ export class ClaudeCodeService extends BaseLanguageModel {
   private readonly SESSION_KEY_PREFIX = 'claude_code_session:';
   private readonly SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
 
+  /**
+   * Redis key holding the hash of the stable <sulla_context> tier last stamped
+   * into ANY conversation on this install. The stable tier (platform rules +
+   * top-priority memory) is install-global, and it is ALSO carried by the
+   * byte-stable system prompt (soul/tooling + the observational_memory
+   * section), which is sent on every session — fresh or resumed. So a
+   * brand-new session already has this content via the system prompt; we use
+   * this persisted hash to skip re-stamping the ~6k tier into the first
+   * message of every fresh session (e.g. the heartbeat's per-cycle
+   * conversations). It only needs to ride the message when its content
+   * actually changes — see buildUserMessageContextPrefix.
+   */
+  private readonly STABLE_CTX_KEY = 'claude_code_stable_ctx_hash';
+
   private async getSession(convId: string): Promise<string | undefined> {
     const cached = this.sessions.get(convId);
     if (cached) return cached;
@@ -375,14 +389,40 @@ Rules that apply on every turn:
 
     const parts: string[] = [];
 
-    // Only send the stable tier when it's new to this session or has changed
-    // since it was last sent.
+    // Decide whether to stamp the stable tier into this message.
+    //
+    // The stable tier is redundant with the byte-stable system prompt (which
+    // carries the same platform rules + top-priority memory and is sent on
+    // EVERY session, fresh or resumed). So it only needs to ride the message
+    // when its content has CHANGED since a conversation last saw it — repeating
+    // it verbatim otherwise just multiplies token cost in the permanent history.
+    //
+    //   - Resumed session: compare against the per-conversation hash we recorded
+    //     earlier this session. Unchanged → skip (existing dedup). Changed →
+    //     re-send, because a resumed session never re-receives the system prompt.
+    //   - Fresh session (new convId, empty per-conv hash): the system prompt has
+    //     ALREADY delivered the current stable content, so seed this
+    //     conversation's baseline from the install-global hash instead of
+    //     force-sending. Only send if the global hash is missing/stale (first
+    //     call, Redis down, or the content genuinely changed) — a safe fallback.
     const stableText = stableParts.join('\n\n');
     const stableHash = crypto.createHash('sha1').update(stableText).digest('hex');
-    if (opts.isNewSession || this.lastStableContextHash.get(opts.convId) !== stableHash) {
+
+    let lastHash = this.lastStableContextHash.get(opts.convId);
+    if (lastHash === undefined && opts.isNewSession) {
+      try {
+        lastHash = (await redisClient.get(this.STABLE_CTX_KEY)) ?? undefined;
+      } catch { /* Redis unavailable → lastHash stays undefined → we send (safe) */ }
+    }
+    if (lastHash !== stableHash) {
       parts.push(stableText);
     }
     this.lastStableContextHash.set(opts.convId, stableHash);
+    // Keep the install-global "current stable hash" fresh so subsequent new
+    // sessions can dedup against it.
+    try {
+      await redisClient.set(this.STABLE_CTX_KEY, stableHash, this.SESSION_TTL_SECONDS);
+    } catch { /* Redis unavailable — non-fatal, we simply re-send next new session */ }
 
     // Recall context from subconscious middleware (may be null on first turn)
     const recallContext = (state?.metadata as any)?.recallContext;


### PR DESCRIPTION
## Problem
The stable `<sulla_context>` tier (platform rules + top-priority observational memory, ~6k) was re-stamped into the **first message of every fresh session**. Now that the heartbeat mints a new conversation per cycle (`heartbeat_<ts>`), the per-conversation dedup map is always empty for it and the `isNewSession` short-circuit forced a full re-send **every ~15-min cycle** — the exact `~212 → ~10k` promptLen jump visible in `background.log` on fresh beats vs. resumed turns.

## Why it is safe to skip
The stable tier is **redundant with the byte-stable system prompt**, which already carries:
- the same platform rules — `soul.ts` + `tooling.ts` sections
- top-N observational memory — the `observational_memory` section (table-based, `semi-stable`)

…and is sent on **every** session, fresh or resumed. So a fresh session already has this content via the system prompt. Duplicating it in the message just bloats the (uncacheable) message body and works against prompt caching, which wants stable content in the cached system-prompt prefix — not the variable turn.

## Fix
Persist an install-global stable-context hash in Redis (`claude_code_stable_ctx_hash`). On a fresh session, seed the conversation baseline from that hash **instead of force-sending** — the system prompt already delivered it. Send only when the content genuinely changed (or the global hash is missing / Redis down — safe fallback).

**Per-conversation change-detection is unchanged**, so long-lived *resumed* sessions still get memory updates mid-session (they never re-receive the system prompt). Degrades safely: any Redis hiccup → send (current behavior).

## Trace
| case | before | after |
|---|---|---|
| resumed turn, unchanged | skip | skip |
| resumed turn, memory changed | send | send |
| **fresh beat, unchanged** | **send ~6k** | **skip** ✅ |
| fresh beat, first-ever / Redis down | send | send (safe) |
| fresh beat, memory changed since last | send | send once, re-persist |

## Net
Heartbeat fresh-cycle prompts drop back toward the ~212 floor instead of ~10k every cycle. Diff is `ClaudeCodeService.ts` only, **+35/-4**. Full-project `tsc` shows **no new errors in this file** (the repo has a pre-existing baseline of unrelated e2e/Playwright type errors).

## Follow-up (not in this PR)
The message tier reads observational memory from the **legacy** `SullaSettingsModel` blob while the system prompt reads the **observations table** — post-migration these can differ. Relying on the system prompt (table) is the more-correct source; worth removing the legacy read from the message tier in a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)