### PR TITLE
fix(test): exclude .claude/ from jest scanning (kills ~163 phantom worktree suites + OOM)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,7 @@ export default {
     '<rootDir>/dist',
     '<rootDir>/pkg/rancher-desktop/dist',
     '<rootDir>/.git',
+    '<rootDir>/.claude',
     '<rootDir>/e2e',
     '<rootDir>/screenshots',
   ],
@@ -42,6 +43,7 @@ export default {
   },
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
+    '<rootDir>/.claude/',
     '<rootDir>/pkg/rancher-desktop/sudo-prompt/',
   ],
 };


### PR DESCRIPTION
## Problem

`yarn test:unit:jest` on a clean `main` checkout is slow, non-deterministic, and noisy. Root cause: **jest walks into `.claude/worktrees/agent-*`** — stale registered git worktrees left behind by Claude Code agents (April/June snapshots, on old branches `feat/token-ws3-slim-tool-catalog` and `worktree-agent-ac361fc4`). Each is a full copy of the repo tree, so jest discovers and runs their test files as if they were part of the working tree.

Measured impact on this machine (`node --experimental-vm-modules .../jest.js`, no filters):

| | before | after |
|---|---|---|
| total suites scanned | **231** | 68 |
| runtime | **59 s + a jest worker OOM-killed (SIGKILL)** | 18 s |
| phantom `.claude/worktrees` suites | ~163 | 0 |

The SIGKILL made runs non-deterministic (a worker dies mid-run) and the ~163 duplicate suites buried the real failures.

## Fix

Add `<rootDir>/.claude` to both ignore lists in `jest.config.js`:
- `modulePathIgnorePatterns` — stops haste-map module/mock collisions from the duplicated trees
- `testPathIgnorePatterns` — stops test discovery inside them

`.claude/` is already gitignored (it's the Claude Code convention dir), so this only affects local runs — but every agent/dev who has ever created a worktree hits it. Two-line, additive, no behavior change to real tests.

## Scope / not included

This is hygiene only. After the fix, 24 real-tree suites still fail — all **pre-existing and environment-specific**, not touched here:
- `@napi-rs/xattr-linux-arm64-musl` native binding missing (arm64/musl box; fine on x64 CI)
- missing kubectl/integration fixtures + `readlink ENOENT` under `/tmp`
- `ReferenceError: TextEncoder is not defined` when `pg` is imported under the `jsdom` test environment (3 suites — a genuine cross-env bug worth a follow-up, but out of scope for this PR)

Note for whoever's chasing the "jest fails on clean branch" report: the earlier "missing `babel-preset-expo`" theory is a red herring — this repo has no Expo/`babel-preset-expo` dependency at all (Electron/Vue/Babel toolchain); `grep babel-preset-expo` over the whole jest log returns 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
