### PR TITLE
fix(test): polyfill TextEncoder/TextDecoder for jsdom so pg-importing suites load

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,9 @@ export default {
     '^@pkg/(.*)$':   '<rootDir>/pkg/rancher-desktop/$1',
   },
   setupFiles: [
+    // Must run first: polyfills TextEncoder/TextDecoder onto the jsdom
+    // global so suites that import `pg` can load (jsdom omits them).
+    '<rootDir>/pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts',
     '<rootDir>/pkg/rancher-desktop/utils/testUtils/setupVue.ts',
   ],
   testEnvironment:        'jsdom',

--- a/pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts
+++ b/pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts
@@ -1,0 +1,22 @@
+/**
+ * Preloaded into all Jest tests (see jest.config.js `setupFiles`, listed
+ * BEFORE setupVue so it runs first).
+ *
+ * The `jsdom` test environment does not expose `TextEncoder`/`TextDecoder`
+ * as globals, but Node does. Modules that pull in `pg` (and its
+ * dependencies) reference them at import time, so any suite that loads a
+ * database model crashes with `ReferenceError: TextEncoder is not defined`
+ * before a single test runs. Bridge Node's implementation onto the jsdom
+ * global so those suites can load.
+ */
+
+import { TextEncoder, TextDecoder } from 'node:util';
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder;
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  // Node's TextDecoder is structurally compatible; the DOM lib typing is
+  // stricter than the runtime contract these tests rely on.
+  globalThis.TextDecoder = TextDecoder as unknown as typeof globalThis.TextDecoder;
+}


### PR DESCRIPTION
## What
Adds a Jest `setupFiles` polyfill that bridges Node`s `TextEncoder`/`TextDecoder` onto the jsdom global, so test suites that import a database model (which transitively imports `pg`) can load.

## Why
The `testEnvironment: jsdom` config does not expose `TextEncoder`/`TextDecoder` as globals, but `pg` and its dependencies reference them at **import time**. Any suite that loads a model crashed before a single test ran:

```
ReferenceError: TextEncoder is not defined
```

`SullaSettingsModel.simple.test.ts` also surfaced a misleading `Cannot access BaseModel before initialization` — a side-effect of the aborted module load, not a real circular-import bug.

## Fix
- New `pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts` — assigns Nodes `TextEncoder`/`TextDecoder` from `node:util` onto `globalThis` if absent (guarded, no-op where already defined).
- Registered **first** in `jest.config.js` `setupFiles`, before `setupVue`, so it runs before any test module imports `pg`.

## Verification
- `SullaSettingsModel.simple.test.ts`: **0 → 2 passing**.
- Full main-tree run (`--testPathIgnorePatterns node_modules /.claude/ sudo-prompt`): **`TextEncoder is not defined` occurrences 3 → 0**, no regressions to existing passing suites (45 passed).
- `tsc` clean on the new file.

## Scope
Only the TextEncoder crash. The other pre-existing failures on this ARM64/musl VM (missing `@napi-rs/xattr-linux-arm64-musl` native binding, missing kubectl/integration fixtures, and a few TS2339 test-registration drifts) are unrelated and out of scope — they pass on real x64 CI.

+25 / -0, two files.

Generated during an autonomous heartbeat cycle.
