### PR TITLE
fix(relay): survive sleep/net-loss — un-killable reconnect loop + powerMonitor hooks

### DIFF
--- a/pkg/rancher-desktop/main/__tests__/desktopRelay.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/desktopRelay.spec.ts
@@ -1,0 +1,169 @@
+/** @jest-environment node */
+
+/**
+ * DesktopRelayClient durability tests.
+ *
+ * Covers the sleep/net-loss recovery paths behind the "desktop relay never
+ * comes back until logout/login" bug:
+ *   1. The reconnect loop must survive openSocket() throwing (e.g. the VM's
+ *      Postgres still waking when the auth token is read after resume).
+ *   2. powerMonitor suspend closes the socket and gates reconnects;
+ *      resume reconnects immediately with fresh backoff.
+ */
+
+import { jest } from '@jest/globals';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+const mockSullaSettingsModel = {
+  SullaSettingsModel: {
+    get: jest.fn<() => Promise<any>>().mockResolvedValue(''),
+    set: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  },
+};
+
+const mockAuth = {
+  getCurrentAccessToken: jest.fn<() => Promise<string>>().mockResolvedValue('test-token'),
+};
+
+const mockWsService = {
+  connect:   jest.fn(),
+  send:      jest.fn(),
+  onMessage: jest.fn(),
+};
+
+mockModules({
+  '@pkg/agent/database/models/SullaSettingsModel': mockSullaSettingsModel,
+  '@pkg/agent/services/WebSocketClientService':    { getWebSocketClientService: () => mockWsService },
+  '@pkg/main/ipcMain':                             { getIpcMainProxy: jest.fn() },
+  '@pkg/main/sullaCloudAuth':                      mockAuth,
+  '@pkg/main/deviceIdentity':                      { getDesktopDeviceId: jest.fn<() => Promise<string>>().mockResolvedValue('desktop-1') },
+  '@pkg/main/sync/syncMirror':                     {
+    claudeMessageExists: jest.fn<() => Promise<boolean>>().mockResolvedValue(false),
+    deriveMessageId:     jest.fn(() => 'msg-id'),
+    scribeRelayTurn:     jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  },
+  '@pkg/utils/logging': undefined,
+});
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static OPEN = 1;
+  static CLOSED = 3;
+
+  url: string;
+  readyState = 0;
+  closed = false;
+  private listeners = new Map<string, Array<(ev: any) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: (ev: any) => void) {
+    const arr = this.listeners.get(type) ?? [];
+    arr.push(cb);
+    this.listeners.set(type, arr);
+  }
+
+  emit(type: string, ev: any = {}) {
+    for (const cb of this.listeners.get(type) ?? []) cb(ev);
+  }
+
+  open() {
+    this.readyState = MockWebSocket.OPEN;
+    this.emit('open');
+  }
+
+  send(_data: string) {}
+
+  close() {
+    this.closed = true;
+    this.readyState = MockWebSocket.CLOSED;
+    this.emit('close');
+  }
+}
+
+(globalThis as any).WebSocket = MockWebSocket;
+
+const { DesktopRelayClient } = await import('@pkg/main/desktopRelay');
+
+describe('DesktopRelayClient durability', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    MockWebSocket.instances = [];
+    mockAuth.getCurrentAccessToken.mockResolvedValue('test-token');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('keeps retrying when openSocket throws mid-backoff (loop must not die)', async() => {
+    // Every token read throws, as when the VM's Postgres is still waking
+    // after system resume.
+    mockAuth.getCurrentAccessToken.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const client = new DesktopRelayClient();
+    await client.setPairedUserId('user-1');
+    await jest.advanceTimersByTimeAsync(0);
+
+    const callsAfterConnect = mockAuth.getCurrentAccessToken.mock.calls.length;
+    expect(callsAfterConnect).toBeGreaterThanOrEqual(1);
+
+    // Walk through several backoff cycles (1s, 2s, 4s, 8s...). Before the
+    // fix, the first throw inside the retry timer killed the loop and the
+    // call count froze.
+    await jest.advanceTimersByTimeAsync(60_000);
+    expect(mockAuth.getCurrentAccessToken.mock.calls.length).toBeGreaterThan(callsAfterConnect + 2);
+
+    // Once the token read recovers, a socket gets opened again.
+    mockAuth.getCurrentAccessToken.mockResolvedValue('test-token');
+    await jest.advanceTimersByTimeAsync(60_000);
+    expect(MockWebSocket.instances.length).toBeGreaterThan(0);
+  });
+
+  it('suspend closes the socket and blocks reconnects; resume reconnects promptly', async() => {
+    const client = new DesktopRelayClient();
+    await client.setPairedUserId('user-1');
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(MockWebSocket.instances.length).toBe(1);
+    const ws = MockWebSocket.instances[0];
+    ws.open();
+
+    client.handleSuspend();
+    expect(ws.closed).toBe(true);
+    expect(client.getStatus().connected).toBe(false);
+
+    // While suspended, no reconnect attempts happen no matter how long we wait.
+    await jest.advanceTimersByTimeAsync(120_000);
+    expect(MockWebSocket.instances.length).toBe(1);
+
+    // Resume: a fresh socket appears within the base backoff (~1s), not
+    // after the stale-socket watchdog window.
+    client.handleResume();
+    await jest.advanceTimersByTimeAsync(1_500);
+    expect(MockWebSocket.instances.length).toBe(2);
+  });
+
+  it('does not open a socket when suspend lands during the token read', async() => {
+    let releaseToken: (v: string) => void = () => {};
+
+    mockAuth.getCurrentAccessToken.mockReturnValue(new Promise<string>((resolve) => {
+      releaseToken = resolve;
+    }));
+
+    const client = new DesktopRelayClient();
+    const pairing = client.setPairedUserId('user-1');
+
+    client.handleSuspend();
+    releaseToken('test-token');
+    await pairing;
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(MockWebSocket.instances.length).toBe(0);
+  });
+});

--- a/pkg/rancher-desktop/main/desktopRelay.ts
+++ b/pkg/rancher-desktop/main/desktopRelay.ts
@@ -86,7 +86,8 @@ interface Status {
   lastError?:   string;
 }
 
-class DesktopRelayClient {
+// Exported for tests only — production code must go through getDesktopRelayClient().
+export class DesktopRelayClient {
   private ws: WebSocket | null = null;
   private currentRoom: string | null = null;
   private reconnectDelay = RECONNECT_BASE_MS;
@@ -132,6 +133,10 @@ class DesktopRelayClient {
   // with undeliverable frames during a mobile reconnect.
   private activeConversations = new Set<string>();
   private mobilePeerOnline = true;
+  // System-sleep gate. While the machine is suspended we close the socket on
+  // purpose and must not schedule reconnects that can't succeed. Set on
+  // powerMonitor 'suspend', cleared on 'resume' (see sullaEvents.ts).
+  private suspended = false;
 
   async start(): Promise<void> {
     const paired = (await SullaSettingsModel.get('pairedMobileUserId', '')) ?? '';
@@ -164,6 +169,41 @@ class DesktopRelayClient {
     return () => {
       this.statusListeners = this.statusListeners.filter(l => l !== listener);
     };
+  }
+
+  /**
+   * powerMonitor 'suspend': close the socket proactively so the relay DO
+   * drops this peer immediately — mobile sees the desktop go offline right
+   * away instead of after the server-side stale timeout. No reconnects are
+   * scheduled while suspended.
+   */
+  handleSuspend(): void {
+    if (this.suspended) return;
+    this.suspended = true;
+    if (!this.currentRoom) return;
+    console.log('[DesktopRelay] System suspending — closing relay socket');
+    if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
+    this.teardownLiveness();
+    if (this.ws) {
+      try { this.ws.close(); } catch { /* ignore */ }
+      this.ws = null;
+    }
+    this.connected = false;
+    this.broadcastStatus();
+  }
+
+  /**
+   * powerMonitor 'resume': reconnect immediately with fresh backoff instead
+   * of waiting for the stale-socket watchdog to notice (which could take
+   * up to STALE_SOCKET_MS plus the accumulated backoff after wake).
+   */
+  handleResume(): void {
+    this.suspended = false;
+    if (!this.currentRoom || this.intentionallyClosed) return;
+    console.log('[DesktopRelay] System resumed — reconnecting relay socket');
+    this.reconnectDelay = RECONNECT_BASE_MS;
+    this.failedAttempts = 0;
+    this.forceReconnect('system resumed');
   }
 
   // ── Internal ────────────────────────────────────────────
@@ -230,10 +270,13 @@ class DesktopRelayClient {
   }
 
   private async openSocket() {
-    if (!this.currentRoom) return;
+    if (!this.currentRoom || this.suspended) return;
     const room = this.currentRoom;
 
     const token = await getCurrentAccessToken();
+    // The machine may have gone to sleep (or the user unpaired) while we
+    // were awaiting the token read — don't open a socket nobody wants.
+    if (this.suspended || this.intentionallyClosed) return;
     if (!token) {
       this.lastError = 'Not signed in — relay cannot authenticate';
       console.warn('[DesktopRelay] No access token — skipping connect. Sign in first.');
@@ -330,7 +373,7 @@ class DesktopRelayClient {
   }
 
   private scheduleReconnect() {
-    if (this.reconnectTimer || !this.currentRoom) return;
+    if (this.reconnectTimer || !this.currentRoom || this.suspended) return;
     const delay = this.reconnectDelay;
     this.reconnectDelay = Math.min(this.reconnectDelay * 2, RECONNECT_MAX_MS);
     // During a long outage the 30s-capped backoff retries ~120×/hour and each
@@ -344,6 +387,12 @@ class DesktopRelayClient {
       this.reconnectTimer = null;
       this.openSocket().catch((err) => {
         console.warn('[DesktopRelay] openSocket failed:', err);
+        // Without rescheduling here, a single throw (e.g. the VM's Postgres
+        // still waking when getCurrentAccessToken reads the session) killed
+        // the reconnect loop permanently — the relay then stayed dead until
+        // logout/login. Same fix connect() already has: hand the failure
+        // back to the backoff machinery.
+        this.scheduleReconnect();
       });
     }, delay);
   }

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -844,8 +844,40 @@ export function initSullaEvents(): void {
 
   const { powerMonitor, BrowserWindow } = require('electron') as typeof import('electron');
 
+  powerMonitor.on('suspend', () => {
+    console.log('[Power] System suspending');
+
+    // Close the mobile-relay socket cleanly so the relay DO drops this peer
+    // now — mobile then sees the desktop offline immediately instead of
+    // after the server-side stale timeout.
+    try {
+      const { getDesktopRelayClient } = require('@pkg/main/desktopRelay');
+      getDesktopRelayClient().handleSuspend();
+    } catch (err) {
+      console.warn('[Power] Failed to suspend desktop relay:', err);
+    }
+  });
+
   powerMonitor.on('resume', () => {
     console.log('[Power] System resumed');
+
+    // Reconnect the mobile relay right away with fresh backoff — otherwise
+    // recovery waits on the stale-socket watchdog plus accumulated backoff.
+    try {
+      const { getDesktopRelayClient } = require('@pkg/main/desktopRelay');
+      getDesktopRelayClient().handleResume();
+    } catch (err) {
+      console.warn('[Power] Failed to resume desktop relay:', err);
+    }
+
+    // Refresh device presence immediately so mobile's device list shows this
+    // desktop online within seconds of wake instead of at the next 45s tick.
+    try {
+      const { DevicesCloudApi } = require('@pkg/main/devicesCloudApi');
+      void DevicesCloudApi.heartbeat();
+    } catch (err) {
+      console.warn('[Power] Failed to send wake device heartbeat:', err);
+    }
 
     // Re-initialize the backend graph executor so it re-subscribes its
     // message handlers after wake.


### PR DESCRIPTION
## Problem
After Mac sleep or network loss, the desktop relay WebSocket to sulla-workers never recovered — Jonathon had to log out/in before Sulla Mobile saw the desktop online (ACTIVE_PROJECTS §4, Heartbeat-owned).

## Root cause
`scheduleReconnect()`'s retry callback caught `openSocket()` failures but never re-scheduled. One throw mid-backoff — typically `getCurrentAccessToken()` hitting the VM's still-waking Postgres right after resume — permanently killed the reconnect loop. `connect()` had this exact fix already; the retry path did not. Logout/login "worked" because `setPairedUserId()` restarts the loop from scratch.

## Changes
- **Loop can no longer die**: failed `openSocket()` in the retry path funnels back into the backoff machinery.
- **powerMonitor suspend**: proactively close the socket (relay DO drops the peer → mobile sees desktop offline promptly); reconnects gated while asleep.
- **powerMonitor resume**: reconnect with fresh backoff ~1s after wake instead of waiting for the 45s stale-socket watchdog; immediate device heartbeat so the cloud device list flips online right away.
- **Race guard**: `openSocket()` aborts if suspend/unpair landed during the token read.

## Verification
- New `desktopRelay.spec.ts`: 3/3 green.
- Mutation-verified: the loop-death test **fails** with the one-line fix removed.
- Repo-wide tsc/eslint not runnable in the arm64-musl VM (OOM / native binding) — CI is the judge.
- Real sleep/wake verification needs the Mac to actually sleep — checklist in comments.

Server-side sibling (stale-socket/presence cleanup) is on sulla-workers `feat/relay-reliability-rollup` — prod deploy stays Jonathon-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)