### PR TITLE
fix(workflow): arm scheduler after CLI routine import

### DIFF
--- a/pkg/rancher-desktop/agent/tools/workflow/import_workflow.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/import_workflow.ts
@@ -86,6 +86,16 @@ export class ImportWorkflowWorker extends BaseTool {
       };
     }
 
+    // The scheduler only scans the DB at boot and on UI save/promote events —
+    // without this, CLI-imported routines stay unarmed until the next restart.
+    try {
+      const { getWorkflowSchedulerService } = await import('@pkg/agent/services/WorkflowSchedulerService');
+
+      await getWorkflowSchedulerService().refresh();
+    } catch (err) {
+      console.warn('[import_workflow] Failed to refresh workflow schedules:', err);
+    }
+
     return {
       successBoolean: true,
       responseString: [


### PR DESCRIPTION
## Problem

`sulla workflow/import_workflow` upserts a routine into the `workflows` table but never notifies `WorkflowSchedulerService`. The scheduler only scans the DB at boot (`sulla.ts` lifecycle init) and on UI save/promote IPC events (`sullaWorkflowEvents.refreshWorkflowSchedules`). Result: any routine imported via the CLI with a `schedule` trigger sits in Postgres **unarmed** until the next app restart.

Found live today: `workflow-goals-cascade-refresh` (Mon 04:00 PT) and `workflow-routine-health-critic` (Sun 18:00 PT) were imported to production at 12:41 PM PT, both enabled with valid `category:trigger`/`subtype:schedule` nodes, zero cron registrations and zero executions — the scheduler last scanned at boot, before they existed.

## Fix

After a successful upsert, dynamically import `WorkflowSchedulerService` and call `refresh()` — the exact pattern `sullaWorkflowEvents.ts` already uses. Wrapped in try/catch so a refresh failure never fails the import itself.

One file, +11 lines. `refresh()` wipes and re-registers all jobs, so re-imports and status downgrades (production→draft/archive) are handled too.

## Verification

- Trigger-node shape confirmed against live PG rows (both routines match the scheduler filter).
- Syntax-checked with tsc; mirrors the existing dynamic-import refresh pattern.
- Note: running binary predates this fix — the two routines above still need a one-time arm (app restart or UI re-save) until the next rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)