### PR TITLE
fix(workflow): validator accepts the schedule trigger shape the scheduler actually arms (#493)

### DIFF
--- a/pkg/rancher-desktop/agent/services/WorkflowSchedulerService.ts
+++ b/pkg/rancher-desktop/agent/services/WorkflowSchedulerService.ts
@@ -10,6 +10,8 @@
 
 import schedule from 'node-schedule';
 
+import { SCHEDULE_TRIGGER } from '@pkg/pages/editor/workflow/types';
+
 // ── Types ──
 
 interface ScheduleNode {
@@ -172,7 +174,7 @@ export class WorkflowSchedulerService {
       const nodes = Array.isArray((definition as any).nodes) ? (definition as any).nodes as ScheduleNode[] : [];
 
       for (const node of nodes) {
-        if (node?.data?.category !== 'trigger' || node?.data?.subtype !== 'schedule') continue;
+        if (node?.data?.category !== SCHEDULE_TRIGGER.category || node?.data?.subtype !== SCHEDULE_TRIGGER.subtype) continue;
         if (this.registerScheduleNode(id, name, node)) count++;
       }
     }

--- a/pkg/rancher-desktop/agent/tools/workflow/__tests__/validate_sulla_workflow.spec.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/__tests__/validate_sulla_workflow.spec.ts
@@ -1,0 +1,136 @@
+import { validateWorkflowDefinition } from '../validate_sulla_workflow';
+
+import { getWorkflowSchedulerService } from '@pkg/agent/services/WorkflowSchedulerService';
+import { SCHEDULE_TRIGGER } from '@pkg/pages/editor/workflow/types';
+
+function makeDefinition(triggerNode: any) {
+  return {
+    id:    'workflow-test',
+    name:  'Test Workflow',
+    nodes: [
+      triggerNode,
+      {
+        id:       'node-2',
+        type:     'workflow',
+        position: { x: 0, y: 120 },
+        data:     {
+          category: 'agent',
+          subtype:  'orchestrator-prompt',
+          label:    'Do the thing',
+          config:   { prompt: 'do it' },
+        },
+      },
+    ],
+    edges: [{ id: 'edge-1', source: 'node-1', target: 'node-2' }],
+  };
+}
+
+function errors(def: any) {
+  return validateWorkflowDefinition(def).filter(i => i.severity === 'error');
+}
+
+describe('validateWorkflowDefinition', () => {
+  it('accepts the schedule trigger shape the runtime scheduler arms (#493)', () => {
+    // Exact shape of a production routine's weekly schedule trigger —
+    // category/subtype from the constant WorkflowSchedulerService filters on.
+    const def = makeDefinition({
+      id:       'node-1',
+      type:     'workflow',
+      position: { x: 0, y: 0 },
+      data:     {
+        category: SCHEDULE_TRIGGER.category,
+        subtype:  SCHEDULE_TRIGGER.subtype,
+        label:    'Weekly Sunday 6pm Trigger',
+        config:   {
+          triggerType:        'schedule',
+          triggerDescription: 'Weekly audit, Sundays 18:00 PT.',
+          frequency:          'weekly',
+          hour:               18,
+          minute:             0,
+          dayOfWeek:          0,
+          timezone:           'America/Los_Angeles',
+        },
+      },
+    });
+
+    expect(errors(def)).toEqual([]);
+  });
+
+  it('accepts a manual trigger', () => {
+    const def = makeDefinition({
+      id:       'node-1',
+      type:     'workflow',
+      position: { x: 0, y: 0 },
+      data:     {
+        category: 'trigger',
+        subtype:  'manual',
+        label:    'Manual Trigger',
+        config:   { triggerType: 'manual', triggerDescription: 'Run on demand' },
+      },
+    });
+
+    expect(errors(def)).toEqual([]);
+  });
+
+  it('still rejects a bogus subtype', () => {
+    const def = makeDefinition({
+      id:       'node-1',
+      type:     'workflow',
+      position: { x: 0, y: 0 },
+      data:     {
+        category: 'trigger',
+        subtype:  'cron',
+        label:    'Bad Trigger',
+        config:   { triggerType: 'cron', triggerDescription: 'nope' },
+      },
+    });
+
+    expect(errors(def).some(e => e.message.includes('Invalid subtype "cron"'))).toBe(true);
+  });
+
+  it('still rejects unknown config fields on a schedule trigger', () => {
+    const def = makeDefinition({
+      id:       'node-1',
+      type:     'workflow',
+      position: { x: 0, y: 0 },
+      data:     {
+        category: 'trigger',
+        subtype:  'schedule',
+        label:    'Schedule Trigger',
+        config:   {
+          triggerType:        'schedule',
+          triggerDescription: 'desc',
+          cronExpression:     '0 18 * * 0',
+        },
+      },
+    });
+
+    expect(errors(def).some(e => e.path.endsWith('/config/cronExpression'))).toBe(true);
+  });
+
+  it('validates the same trigger shape the scheduler service arms', () => {
+    // Importing the service here also makes ts-jest type-check
+    // WorkflowSchedulerService.ts, which consumes SCHEDULE_TRIGGER.
+    expect(typeof getWorkflowSchedulerService).toBe('function');
+    expect(SCHEDULE_TRIGGER).toEqual({ category: 'trigger', subtype: 'schedule' });
+  });
+
+  it('requires triggerType/triggerDescription on schedule triggers', () => {
+    const def = makeDefinition({
+      id:       'node-1',
+      type:     'workflow',
+      position: { x: 0, y: 0 },
+      data:     {
+        category: 'trigger',
+        subtype:  'schedule',
+        label:    'Schedule Trigger',
+        config:   { frequency: 'daily' },
+      },
+    });
+
+    const errs = errors(def);
+
+    expect(errs.some(e => e.path.endsWith('/config/triggerType'))).toBe(true);
+    expect(errs.some(e => e.path.endsWith('/config/triggerDescription'))).toBe(true);
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/workflow/validate_sulla_workflow.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/validate_sulla_workflow.ts
@@ -5,9 +5,16 @@ import yaml from 'yaml';
 
 import { BaseTool, ToolResponse } from '../base';
 
-// ── Valid subtypes and their required categories ──
+import type { WorkflowNodeCategory, WorkflowNodeSubtype } from '@pkg/pages/editor/workflow/types';
 
-const SUBTYPE_CATEGORY_MAP: Record<string, string> = {
+// ── Valid subtypes and their required categories ──
+// Keyed exhaustively on WorkflowNodeSubtype so a subtype added to (or
+// removed from) the editor type union is a compile error here until the
+// validator learns about it — the drift that caused #493.
+
+const SUBTYPE_CATEGORY_MAP: Record<WorkflowNodeSubtype, WorkflowNodeCategory> = {
+  manual:                'trigger',
+  schedule:              'trigger',
   calendar:              'trigger',
   'chat-app':            'trigger',
   heartbeat:             'trigger',
@@ -18,6 +25,7 @@ const SUBTYPE_CATEGORY_MAP: Record<string, string> = {
   'tool-call':           'agent',
   'integration-call':    'agent',
   'orchestrator-prompt': 'agent',
+  function:              'agent',
   router:                'routing',
   condition:             'routing',
   wait:                  'flow-control',
@@ -28,11 +36,14 @@ const SUBTYPE_CATEGORY_MAP: Record<string, string> = {
   'user-input':          'io',
   response:              'io',
   transfer:              'io',
+  'desktop-notification': 'io',
 };
 
 // ── Required config fields per subtype ──
 
-const REQUIRED_CONFIG_FIELDS: Record<string, string[]> = {
+const REQUIRED_CONFIG_FIELDS: Record<WorkflowNodeSubtype, string[]> = {
+  manual:                ['triggerType', 'triggerDescription'],
+  schedule:              ['triggerType', 'triggerDescription'],
   calendar:              ['triggerType', 'triggerDescription'],
   'chat-app':            ['triggerType', 'triggerDescription'],
   heartbeat:             ['triggerType', 'triggerDescription'],
@@ -43,6 +54,7 @@ const REQUIRED_CONFIG_FIELDS: Record<string, string[]> = {
   'tool-call':           ['toolName', 'defaults'],
   'integration-call':    ['integrationSlug', 'endpointName', 'accountId', 'defaults', 'preCallDescription'],
   'orchestrator-prompt': ['prompt'],
+  function:              ['functionRef'],
   router:                ['classificationPrompt', 'routes'],
   condition:             ['rules', 'combinator'],
   wait:                  ['delayAmount', 'delayUnit'],
@@ -53,11 +65,14 @@ const REQUIRED_CONFIG_FIELDS: Record<string, string[]> = {
   'user-input':          ['promptText'],
   response:              ['responseTemplate'],
   transfer:              ['targetWorkflowId'],
+  'desktop-notification': ['toolName', 'defaults'],
 };
 
 // ── Optional config fields per subtype (allowed but not required) ──
 
-const OPTIONAL_CONFIG_FIELDS: Record<string, string[]> = {
+const OPTIONAL_CONFIG_FIELDS: Partial<Record<WorkflowNodeSubtype, string[]>> = {
+  schedule:       ['frequency', 'intervalMinutes', 'hour', 'minute', 'dayOfWeek', 'dayOfMonth', 'timezone'],
+  function:       ['inputs', 'integrationAccounts', 'timeoutOverride'],
   'sub-workflow': ['agentId', 'orchestratorPrompt'],
   loop:           ['loopMode', 'orchestratorPrompt'],
 };
@@ -79,7 +94,7 @@ interface ValidationIssue {
   message:  string;
 }
 
-function validateWorkflowDefinition(def: any, filePath?: string): ValidationIssue[] {
+export function validateWorkflowDefinition(def: any, filePath?: string): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
 
   if (!def || typeof def !== 'object') {
@@ -157,9 +172,10 @@ function validateWorkflowDefinition(def: any, filePath?: string): ValidationIssu
       continue;
     }
 
-    const { subtype, category, label, config } = node.data;
+    const { category, label, config } = node.data;
 
-    // subtype
+    // subtype — unvalidated YAML input; the map lookup below IS the validation
+    const subtype = node.data.subtype as WorkflowNodeSubtype;
     if (!subtype || !SUBTYPE_CATEGORY_MAP[subtype]) {
       issues.push({ severity: 'error', path: `${ np }/data/subtype`, message: `Invalid subtype "${ subtype }". Valid: ${ Object.keys(SUBTYPE_CATEGORY_MAP).join(', ') }` });
       continue;
@@ -263,7 +279,7 @@ function validateWorkflowDefinition(def: any, filePath?: string): ValidationIssu
   const targetSet = new Set(edges.map((e: any) => e?.target).filter(Boolean));
   for (const node of def.nodes) {
     if (!node?.data || !node.id) continue;
-    const cat = SUBTYPE_CATEGORY_MAP[node.data.subtype];
+    const cat = SUBTYPE_CATEGORY_MAP[node.data.subtype as WorkflowNodeSubtype];
     if (cat === 'trigger') continue;
     if (!targetSet.has(node.id)) {
       issues.push({ severity: 'warning', path: `/nodes[id=${ node.id }]`, message: `Node "${ node.data.label || node.id }" is not the target of any edge (unreachable)` });

--- a/pkg/rancher-desktop/pages/editor/workflow/types.ts
+++ b/pkg/rancher-desktop/pages/editor/workflow/types.ts
@@ -18,6 +18,17 @@ export type WorkflowNodeSubtype =
   | FlowControlNodeSubtype
   | IONodeSubtype;
 
+/**
+ * The one trigger shape WorkflowSchedulerService actually arms —
+ * scanAndSchedule filters on exactly this category/subtype pair. Shared
+ * by the scheduler and the workflow validator so the armable shape and
+ * the validated shape cannot drift apart (#493).
+ */
+export const SCHEDULE_TRIGGER = {
+  category: 'trigger',
+  subtype:  'schedule',
+} as const satisfies { category: WorkflowNodeCategory; subtype: TriggerNodeSubtype };
+
 // ── Per-node config types ──
 
 export interface TriggerNodeConfig {


### PR DESCRIPTION
## Bug (#493)

The workflow validator's trigger-subtype allowlist was missing `schedule` and `manual` — yet `WorkflowSchedulerService.scanAndSchedule` arms **only** nodes with `category: trigger` / `subtype: schedule`. The one trigger shape that works at runtime failed validation, and legacy shapes the validator passed never fire. Surfaced 2026-07-19 while authoring the goals-cascade-refresh and routine-health-critic production routines.

## Fix

- **validate_sulla_workflow.ts** — `SUBTYPE_CATEGORY_MAP` is now keyed `Record<WorkflowNodeSubtype, WorkflowNodeCategory>` (the editor type union), so a subtype added to or removed from the union is a **compile error** in the validator until it learns about it — the anti-drift mechanism #493 asked for. Adds the four subtypes the union had that the map didn't: `manual`, `schedule` (triggers, per the nodeRegistry palette), `function` (agent), `desktop-notification` (io). Required/optional config fields taken from `nodeRegistry.defaultConfig` and the scheduler's `buildCronExpression` reads (`frequency`/`intervalMinutes`/`hour`/`minute`/`dayOfWeek`/`dayOfMonth`/`timezone` optional on `schedule`). `validateWorkflowDefinition` is now exported for tests.
- **pages/editor/workflow/types.ts** — new runtime `SCHEDULE_TRIGGER` constant (`{ category: 'trigger', subtype: 'schedule' }`, `satisfies`-checked against the unions), shared by the scheduler and the validator spec.
- **WorkflowSchedulerService.ts** — the arming filter now compares against `SCHEDULE_TRIGGER` instead of string literals, closing the remaining drift path (renaming the subtype in the union now breaks the scheduler at compile time too).

## Verification (VM, fresh clone @ 90f5aae)

- New spec `__tests__/validate_sulla_workflow.spec.ts`: **6/6 pass** — the exact weekly-schedule trigger shape of the live `routine-health-critic` routine validates error-free; manual trigger passes; bogus subtype still rejected; unknown config field still rejected; required trigger fields still enforced; scheduler module imports cleanly + constant shape matches.
- ts-jest fully type-checks all four files under the repo's strict tsconfig during the spec run (it caught two intermediate TS7053s — fixed with narrowing casts at the untrusted-YAML lookup sites).
- Full `tsc --noEmit` and full jest suite were **not** run here: repo-wide tsc OOMs on this VM (kernel-killed at 4 GB heap) and no other spec imports the touched modules (grepped). Note for later: both `package-lock.json` and `yarn.lock` on main are out of sync with `package.json` (`npm ci` and `yarn --frozen-lockfile` both refuse) — separate issue worth filing.
- Host-side `sulla workflow/validate` against `~/sulla/routines/routine-health-critic/` after the next rebuild is the remaining end-to-end check (issue #493 verification sketch).

Closes #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)