### PR TITLE
feat(workflow): catch_up_schedules — detect and recover missed scheduled fires

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "better-sqlite3": "12.6.2",
         "cookie-universal": "2.2.2",
         "cors": "2.8.6",
+        "cron-parser": "^4.2.0",
         "cross-spawn": "7.0.6",
         "dayjs": "1.11.19",
         "ddgs": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "better-sqlite3": "12.6.2",
     "cookie-universal": "2.2.2",
     "cors": "2.8.6",
+    "cron-parser": "^4.2.0",
     "cross-spawn": "7.0.6",
     "dayjs": "1.11.19",
     "ddgs": "1.0.4",

--- a/pkg/rancher-desktop/agent/database/models/WorkflowExecutionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkflowExecutionModel.ts
@@ -122,6 +122,23 @@ export class WorkflowExecutionModel extends BaseModel<WorkflowExecutionAttribute
   }
 
   /**
+   * Find the most recent execution for a workflow, regardless of status.
+   * Used by catch_up_schedules to decide whether a scheduled fire was missed.
+   */
+  static async findLatestByWorkflow(workflowId: string): Promise<WorkflowExecutionModel | null> {
+    const row = await postgresClient.queryOne(
+      `SELECT * FROM workflow_executions
+       WHERE workflow_id = $1
+       ORDER BY started_at DESC LIMIT 1`,
+      [workflowId],
+    );
+    if (!row) return null;
+    const m = new WorkflowExecutionModel();
+    m.databaseFill(row as any);
+    return m;
+  }
+
+  /**
    * Find any active (running or suspended) execution for a workflow.
    * Used for concurrent-run guard.
    */

--- a/pkg/rancher-desktop/agent/services/WorkflowSchedulerService.ts
+++ b/pkg/rancher-desktop/agent/services/WorkflowSchedulerService.ts
@@ -51,8 +51,11 @@ interface ProductionRow {
  *   daily         → M H * * *
  *   weekly        → M H * * D
  *   monthly       → M H D * *
+ *
+ * Exported so tools that reason about schedules (e.g. catch_up_schedules)
+ * derive the exact same cron the scheduler arms — one source of truth.
  */
-function buildCronExpression(config: Record<string, unknown>): string | null {
+export function buildCronExpression(config: Record<string, unknown>): string | null {
   const freq = (config.frequency as string) || 'daily';
   const minute = Number(config.minute ?? 0);
   const hour = Number(config.hour ?? 9);

--- a/pkg/rancher-desktop/agent/tools/workflow/catch_up_schedules.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/catch_up_schedules.ts
@@ -1,0 +1,150 @@
+import parser from 'cron-parser';
+
+import { BaseTool, ToolResponse } from '../base';
+import { SCHEDULE_TRIGGER } from '@pkg/pages/editor/workflow/types';
+
+/**
+ * catch_up_schedules — detect and recover missed scheduled fires.
+ *
+ * The scheduler only fires crons while the app is running with the schedule
+ * armed. If the app was off (or the scheduler dormant) when a cron time
+ * passed, the fire is silently skipped until the next occurrence — for a
+ * weekly routine that's a whole week of drift.
+ *
+ * For every enabled production workflow with a schedule trigger, this tool
+ * computes the previous expected fire time from the exact same cron the
+ * scheduler arms, checks workflow_executions for a run since then, and
+ * dispatches missed ones through the same executeRoutine path the cron
+ * callback uses. Dispatch is fire-and-forget (routine runs can take
+ * minutes); verify completion via the workflow_executions table.
+ */
+export class CatchUpSchedulesWorker extends BaseTool {
+  name = 'catch_up_schedules';
+  description = 'Detect scheduled workflow fires that were missed (app off or scheduler dormant when the cron time passed) and dispatch them through the real executor. Compares each armed schedule\'s previous expected fire time against workflow_executions. Use dryRun to report without firing.';
+
+  schemaDef = {
+    dryRun: {
+      type:        'boolean' as const,
+      optional:    true,
+      description: 'Report missed fires without dispatching them. Default: false.',
+    },
+    lookbackDays: {
+      type:        'number' as const,
+      optional:    true,
+      description: 'Only treat fires missed within this many days as recoverable. Default 7, max 31.',
+    },
+  };
+
+  protected async _validatedCall(input: { dryRun?: boolean; lookbackDays?: number }): Promise<ToolResponse> {
+    const dryRun = input.dryRun === true;
+    const lookbackDays = Math.min(Math.max(Number(input.lookbackDays ?? 7), 1), 31);
+    const lookbackMs = lookbackDays * 24 * 60 * 60 * 1000;
+    const now = new Date();
+
+    const { WorkflowModel } = await import('../../database/models/WorkflowModel');
+    const { WorkflowExecutionModel } = await import('../../database/models/WorkflowExecutionModel');
+    const { buildCronExpression } = await import('../../services/WorkflowSchedulerService');
+
+    let rows: any[];
+    try {
+      rows = await WorkflowModel.listByStatus('production');
+    } catch (err) {
+      return {
+        successBoolean: false,
+        responseString: `Failed to load production workflows: ${ (err as Error).message }`,
+      };
+    }
+
+    const lines: string[] = [];
+    let missedCount = 0;
+    let dispatchedCount = 0;
+
+    for (const row of rows) {
+      if (row.attributes.enabled === false) continue;
+
+      const { id, name } = row.attributes;
+      const definition = row.attributes.definition || {};
+      const nodes = Array.isArray((definition as any).nodes) ? (definition as any).nodes : [];
+
+      for (const node of nodes) {
+        if (node?.data?.category !== SCHEDULE_TRIGGER.category || node?.data?.subtype !== SCHEDULE_TRIGGER.subtype) continue;
+
+        const config = node.data?.config || {};
+        const cron = buildCronExpression(config);
+        if (!cron) {
+          lines.push(`  • ${ name } — SKIP: could not build cron from schedule config`);
+          continue;
+        }
+        const tz = (config.timezone as string || '').trim() || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+        let prevFire: Date;
+        try {
+          prevFire = parser.parseExpression(cron, { tz, currentDate: now }).prev().toDate();
+        } catch (err) {
+          lines.push(`  • ${ name } — SKIP: cron "${ cron }" unparsable (${ (err as Error).message })`);
+          continue;
+        }
+
+        if (now.getTime() - prevFire.getTime() > lookbackMs) {
+          lines.push(`  • ${ name } — ok: last expected fire ${ prevFire.toISOString() } is outside the ${ lookbackDays }d lookback`);
+          continue;
+        }
+
+        const latest = await WorkflowExecutionModel.findLatestByWorkflow(id);
+        const latestStartRaw = latest?.attributes.started_at;
+        const latestStart = latestStartRaw ? new Date(latestStartRaw) : null;
+
+        if (latestStart && latestStart.getTime() >= prevFire.getTime()) {
+          lines.push(`  • ${ name } — ok: fired ${ latestStart.toISOString() } (expected ${ prevFire.toISOString() })`);
+          continue;
+        }
+
+        missedCount++;
+
+        const active = await WorkflowExecutionModel.findActiveByWorkflow(id);
+        if (active) {
+          lines.push(`  • ${ name } — MISSED ${ prevFire.toISOString() } but an execution is already active (${ (active.attributes as any).execution_id }) — skipped`);
+          continue;
+        }
+
+        if (dryRun) {
+          lines.push(`  • ${ name } — MISSED: expected ${ prevFire.toISOString() }, last run ${ latestStart?.toISOString() ?? 'never' } (dry-run, not dispatched)`);
+          continue;
+        }
+
+        try {
+          // Same entry point the cron callback uses. Fire-and-forget: routine
+          // runs can take minutes and this tool must return promptly.
+          const { executeRoutine } = await import('@pkg/main/sullaRoutineTemplateEvents');
+
+          void executeRoutine(
+            id,
+            `Catch-up: the scheduled run of "${ name }" expected at ${ prevFire.toISOString() } was missed (app offline or scheduler dormant). Run it now.`,
+          ).catch((err: unknown) => {
+            console.error(`[CatchUpSchedules] Dispatched catch-up for "${ name }" failed:`, err);
+          });
+          dispatchedCount++;
+          lines.push(`  • ${ name } — MISSED ${ prevFire.toISOString() } → DISPATCHED (verify via workflow_executions)`);
+        } catch (err) {
+          lines.push(`  • ${ name } — MISSED ${ prevFire.toISOString() } but dispatch failed: ${ (err as Error).message }`);
+        }
+      }
+    }
+
+    if (lines.length === 0) {
+      return {
+        successBoolean: true,
+        responseString: 'No enabled production workflows with schedule triggers found — nothing to catch up.',
+      };
+    }
+
+    const header = dryRun
+      ? `Catch-up scan (dry-run): ${ missedCount } missed fire(s) found.`
+      : `Catch-up scan: ${ missedCount } missed fire(s) found, ${ dispatchedCount } dispatched.`;
+
+    return {
+      successBoolean: true,
+      responseString: [header, ...lines].join('\n'),
+    };
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/workflow/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/manifests.ts
@@ -44,6 +44,17 @@ export const workflowToolManifests: ToolManifest[] = [
     loader:         () => import('./refresh_schedules'),
   },
   {
+    name:        'catch_up_schedules',
+    description: 'Detect scheduled workflow fires that were missed (app off or scheduler dormant when the cron time passed) and dispatch them through the real executor. Compares each armed schedule\'s previous expected fire time against workflow_executions. Use after a restart or whenever a routine may have missed its window; dryRun reports without firing.',
+    category:    'workflow',
+    schemaDef:   {
+      dryRun:       { type: 'boolean', optional: true, description: 'Report missed fires without dispatching them. Default: false.' },
+      lookbackDays: { type: 'number', optional: true, description: 'Only treat fires missed within this many days as recoverable. Default 7, max 31.' },
+    },
+    operationTypes: ['execute'],
+    loader:         () => import('./catch_up_schedules'),
+  },
+  {
     name:        'set_workflow_status',
     description: 'Enable/disable a workflow or change its status (draft | production | archive) by id or exact name, then re-arm the scheduler so the change takes effect immediately without an app restart. Reports the workflow\'s armed cron state after the change.',
     category:    'workflow',


### PR DESCRIPTION
## The gap this closes
The scheduler only fires crons while the app is running with schedules armed. A fire that passes while the app is off (or the scheduler dormant) is **silently skipped until the next occurrence** — for a weekly routine, a week of drift. Today's 18:00 `routine-health-critic` miss is exactly this failure mode; the heartbeat had to hand-run the routine outside the executor.

With #491 (arm on import), #492 (`refresh_schedules` + `set_workflow_status`), #494 (validator), and this tool, the heartbeat can now manage the full routine lifecycle itself: author → validate → import (auto-arms) → verify armed state → enable/disable → **recover missed fires** — no UI re-save, no restart, no log-grepping.

## How it works
For each enabled production workflow with a schedule trigger:
1. Derive the previous expected fire time via `cron-parser` from the **same cron the scheduler arms** (`buildCronExpression` now exported — one source of truth).
2. Compare against the latest `workflow_executions` row (`findLatestByWorkflow`, new).
3. Missed + inside lookback (default 7d, max 31) → dispatch through the **same `executeRoutine` path the cron callback uses** (fire-and-forget; routine runs can take minutes — verify via `workflow_executions`).

Guards: `dryRun` report mode, active-execution skip, unparsable-cron skip with reason.

## Deps
`cron-parser` promoted from transitive (node-schedule pins `^4.2.0`) to declared, per the declare-what-you-import rule from #483. package-lock root-deps entry added via `npm install --package-lock-only` on macOS; **yarn.lock untouched** — it already contains the matching `cron-parser@^4.2.0` entry (never-regen-on-linux rule respected).

## Verification
- Full-project `tsc --noEmit` on host: **no errors contributed by these files** (pre-existing 394-error baseline unchanged; the one new error found mid-development was fixed — `started_at` is Partial-typed).
- Diff: +34/-1 across 4 code files + 2 dep files; new tool file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)