### PR TITLE
fix(test): exclude .claude/ from jest + polyfill TextEncoder for jsdom (#488, #489)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,7 @@ export default {
     '<rootDir>/dist',
     '<rootDir>/pkg/rancher-desktop/dist',
     '<rootDir>/.git',
+    '<rootDir>/.claude',
     '<rootDir>/e2e',
     '<rootDir>/screenshots',
   ],
@@ -31,6 +32,7 @@ export default {
     '^@pkg/(.*)$':   '<rootDir>/pkg/rancher-desktop/$1',
   },
   setupFiles: [
+    '<rootDir>/pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts',
     '<rootDir>/pkg/rancher-desktop/utils/testUtils/setupVue.ts',
   ],
   testEnvironment:        'jsdom',
@@ -42,6 +44,7 @@ export default {
   },
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
+    '<rootDir>/.claude/',
     '<rootDir>/pkg/rancher-desktop/sudo-prompt/',
   ],
 };

--- a/pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts
+++ b/pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts
@@ -1,0 +1,19 @@
+// Jest setup: bridge Node's TextEncoder/TextDecoder onto the jsdom global.
+//
+// The `jsdom` test environment does not expose `TextEncoder`/`TextDecoder` as
+// globals, but `pg` (and its dependencies) reference them at *import time*. Any
+// test suite that loads a database model transitively imports `pg` and crashes
+// with `ReferenceError: TextEncoder is not defined` before a single test runs.
+//
+// Registered first in jest.config.js `setupFiles`, ahead of setupVue, so it
+// runs before any test module imports `pg`. Guarded so it is a no-op in any
+// environment that already defines these globals.
+import { TextEncoder, TextDecoder } from 'node:util';
+
+if (typeof (globalThis as { TextEncoder?: unknown }).TextEncoder === 'undefined') {
+  (globalThis as { TextEncoder: unknown }).TextEncoder = TextEncoder;
+}
+
+if (typeof (globalThis as { TextDecoder?: unknown }).TextDecoder === 'undefined') {
+  (globalThis as { TextDecoder: unknown }).TextDecoder = TextDecoder;
+}


### PR DESCRIPTION
Turns two fully-specced but never-shipped autonomous-cycle issues (#488, #489) into a PR. Both are additive test-health fixes with **no behavior change to real suites**.

## #488 — exclude `.claude/` from jest
`yarn test:unit:jest` on clean `main` was slow, non-deterministic, and noisy because jest walks into `.claude/worktrees/agent-*` — stale registered git worktrees left behind by Claude Code agents. Each is a full repo copy, so jest discovered and ran ~163 phantom duplicate suites and **OOM-killed a worker (SIGKILL)**, burying real failures.

Fix: add `<rootDir>/.claude` to both `modulePathIgnorePatterns` (haste-map module/mock collisions) and `testPathIgnorePatterns` (test discovery). `.claude/` is already gitignored → local-run-only impact, but every agent/dev who ever created a worktree hits it.

## #489 — polyfill TextEncoder/TextDecoder for jsdom
The `jsdom` testEnvironment doesn't expose `TextEncoder`/`TextDecoder` as globals, but `pg` references them at **import time**. Any suite loading a DB model crashed with `ReferenceError: TextEncoder is not defined` before a single test ran.

Fix: new guarded `setupTextEncoder.ts` assigns them from `node:util` onto `globalThis` (no-op where already defined), registered **first** in `setupFiles` (before `setupVue`) so it runs before any `pg` import.

## Verification (this PR, in an isolated worktree off `main`)
- `SullaSettingsModel.simple.test.ts`: **0 → 2 passing**.
- `jest --listTests` config valid (70 suites); a planted `.claude/worktrees/agent-decoy` test is **correctly ignored** (0 discovered though present on disk).
- `tsc --noEmit --isolatedModules` clean on the new file.

Diff: 2 files, +22 −0.

Closes #488
Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code) during an autonomous heartbeat cycle.
