### PR TITLE
fix(db): make earliest migrations idempotent (0002/0011/0012)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0002_create_agent_awareness_table.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0002_create_agent_awareness_table.ts
@@ -1,5 +1,5 @@
 export const up = `
-  CREATE TABLE agent_awareness (
+  CREATE TABLE IF NOT EXISTS agent_awareness (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     data JSONB NOT NULL DEFAULT '{}',
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/pkg/rancher-desktop/agent/database/migrations/0011_create_settings_table.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0011_create_settings_table.ts
@@ -1,8 +1,8 @@
 export const up = `
-  CREATE TABLE sulla_settings (
+  CREATE TABLE IF NOT EXISTS sulla_settings (
     property TEXT PRIMARY KEY,
-    value TEXT 
+    value TEXT
   );
 `;
 
-export const down = `DROP TABLE IF EXISTS settings;`;
+export const down = `DROP TABLE IF EXISTS sulla_settings;`;

--- a/pkg/rancher-desktop/agent/database/migrations/0012_add_cast_column_to_sulla_settings.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0012_add_cast_column_to_sulla_settings.ts
@@ -1,7 +1,7 @@
 export const up = `
-  ALTER TABLE sulla_settings ADD COLUMN "cast" TEXT;
+  ALTER TABLE sulla_settings ADD COLUMN IF NOT EXISTS "cast" TEXT;
 `;
 
 export const down = `
-  ALTER TABLE sulla_settings DROP COLUMN "cast";
+  ALTER TABLE sulla_settings DROP COLUMN IF EXISTS "cast";
 `;


### PR DESCRIPTION
Turns fully-specced but never-shipped autonomous-cycle issue #486 into a PR.

## Problem
`DatabaseManager.runMigrations` **fails fast** — any error in a migration's `up` SQL is rethrown and aborts DB init (`DatabaseManager.ts:138`). Migrations **0002, 0011, 0012** are the earliest and predate the `IF NOT EXISTS` convention that every migration from **0009 onward** already follows.

On any install where the tables/columns already exist but aren't recorded in `sulla_migrations` (pre-tracking installs, restored DBs, a manually seeded migration table), these three re-run their `up` and throw `42P07` (duplicate table) / duplicate column — **bricking boot**.

## Fix
- **0002** — `CREATE TABLE agent_awareness` → `CREATE TABLE IF NOT EXISTS`
- **0011** — `CREATE TABLE sulla_settings` → `CREATE TABLE IF NOT EXISTS`; also fixes a latent **down-migration bug** — it dropped `settings` instead of `sulla_settings`
- **0012** — `ADD COLUMN "cast"` → `ADD COLUMN IF NOT EXISTS`; down → `DROP COLUMN IF EXISTS`

## Audit
Swept all 22 registered migrations: these three are the **only** non-idempotent DDL. 0009/0014/0024 already use `ADD COLUMN IF NOT EXISTS`; 0010 indexes use `CREATE INDEX IF NOT EXISTS`; no `CREATE TYPE`/enum. Schema-only, no user data (complies with the no-user-data-in-migrations rule).

## Verification (this PR)
- `tsc --noEmit --isolatedModules` exit 0 — template literals balanced.
- Confirmed against the **live DB** that `agent_awareness`, `sulla_settings`, and the `sulla_settings."cast"` column all already exist (the exact bricking precondition).
- Ran all three fixed `up` statements against that live DB → **all succeed as no-ops** (0 rows affected). Pre-fix these would have thrown. Idempotency proven.

Diff: 3 files, +6 −6.

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code) during an autonomous heartbeat cycle.
