### PR TITLE
fix(slack): strip internal agent-protocol wrappers before sending (#96)

### DIFF
--- a/pkg/rancher-desktop/agent/tools/slack/__tests__/slack_send_message.test.ts
+++ b/pkg/rancher-desktop/agent/tools/slack/__tests__/slack_send_message.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
+import { slackToolManifests } from '../manifests';
+
 const mockGet: any = jest.fn();
 
 jest.unstable_mockModule('../../../integrations', () => ({
@@ -8,9 +10,28 @@ jest.unstable_mockModule('../../../integrations', () => ({
   },
 }));
 
+// slack_send_message imports the slackClient singleton directly; mock it so the
+// real module (which eagerly pulls in the Postgres/DB layer) never loads.
+jest.unstable_mockModule('../../../integrations/slack/SlackClient', () => ({
+  slackClient: {
+    isConnected: () => true,
+  },
+  SlackClient: class {},
+}));
+
+// Cut the transitive DB import chain (integrations → IntegrationService →
+// Postgres models) that would otherwise load under jsdom.
+jest.unstable_mockModule('../../../services/IntegrationService', () => ({
+  getIntegrationService: () => ({}),
+}));
+
 async function loadSlackSendMessageTool() {
   return import('../slack_send_message');
 }
+
+// Source the registration from the canonical tool manifest (single source of
+// truth) rather than a bespoke per-tool export.
+const slackSendMessageRegistration = slackToolManifests.find(m => m.name === 'slack_send_message')!;
 
 function configureWorker(worker: any, registration: any) {
   worker.name = registration.name;
@@ -25,7 +46,7 @@ describe('slack_send_message tool', () => {
   });
 
   it('returns success when Slack API confirms message post', async() => {
-    const { SlackSendMessageWorker, slackSendMessageRegistration } = await loadSlackSendMessageTool();
+    const { SlackSendMessageWorker } = await loadSlackSendMessageTool();
 
     mockGet.mockResolvedValueOnce({
       sendMessage: jest.fn(async() => ({ ok: true, ts: '1234.5678' })),
@@ -40,7 +61,7 @@ describe('slack_send_message tool', () => {
   });
 
   it('returns failure when Slack API returns ok=false', async() => {
-    const { SlackSendMessageWorker, slackSendMessageRegistration } = await loadSlackSendMessageTool();
+    const { SlackSendMessageWorker } = await loadSlackSendMessageTool();
 
     mockGet.mockResolvedValueOnce({
       sendMessage: jest.fn(async() => ({ ok: false, error: 'channel_not_found' })),
@@ -52,5 +73,42 @@ describe('slack_send_message tool', () => {
     expect(result.success).toBe(false);
     expect(result.result).toContain('Failed to send Slack message');
     expect(result.result).toContain('channel_not_found');
+  });
+
+  it('strips internal protocol wrappers before sending to Slack (#96)', async() => {
+    const { SlackSendMessageWorker } = await loadSlackSendMessageTool();
+
+    const sendMessage: any = jest.fn(async() => ({ ok: true, ts: '1.2' }));
+    mockGet.mockResolvedValueOnce({ sendMessage });
+
+    const worker = configureWorker(new SlackSendMessageWorker(), slackSendMessageRegistration);
+    const dirty = 'Here is your answer.\n\n<AGENT_DONE>\n<KEY_RESULT>did the thing</KEY_RESULT>\n</AGENT_DONE>';
+    const result = await worker.invoke({ channel: 'C123', text: dirty });
+
+    expect(result.success).toBe(true);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    const sentText = sendMessage.mock.calls[0][1];
+
+    expect(sentText).toBe('Here is your answer.');
+    expect(sentText).not.toContain('AGENT_DONE');
+    expect(sentText).not.toContain('KEY_RESULT');
+  });
+
+  it('refuses to send when the message is entirely protocol wrappers (#96)', async() => {
+    const { SlackSendMessageWorker } = await loadSlackSendMessageTool();
+
+    const sendMessage: any = jest.fn(async() => ({ ok: true, ts: '1.2' }));
+    mockGet.mockResolvedValueOnce({ sendMessage });
+
+    const worker = configureWorker(new SlackSendMessageWorker(), slackSendMessageRegistration);
+    const result = await worker.invoke({
+      channel: 'C123',
+      text:    '<AGENT_DONE><KEY_RESULT>internal only</KEY_RESULT></AGENT_DONE>',
+    });
+
+    expect(result.success).toBe(false);
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.result).toContain('internal protocol');
   });
 });

--- a/pkg/rancher-desktop/agent/tools/slack/slack_send_message.ts
+++ b/pkg/rancher-desktop/agent/tools/slack/slack_send_message.ts
@@ -1,6 +1,7 @@
 import { registry } from '../../integrations';
 import { slackClient } from '../../integrations/slack/SlackClient';
 import { BaseTool, ToolResponse } from '../base';
+import { stripProtocolTags } from '../../utils/stripProtocolTags';
 
 import type { SlackClient } from '../../integrations/slack/SlackClient';
 
@@ -23,6 +24,11 @@ export class SlackSendMessageWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { channel, text } = input;
+    // Strip internal agent-protocol wrappers (AGENT_DONE / AGENT_BLOCKED /
+    // AGENT_CONTINUE, etc.) so they never leak into user-visible Slack messages
+    // (issue #96). stripProtocolTags is the single source of truth for these
+    // regexes.
+    const cleanText = stripProtocolTags(text);
     const invocationId = `send-${ Date.now() }-${ Math.random().toString(36).slice(2, 8) }`;
     const startedAt = Date.now();
 
@@ -57,12 +63,25 @@ export class SlackSendMessageWorker extends BaseTool {
         };
       }
 
+      // Guard: if the message was made up entirely of protocol wrappers,
+      // refuse rather than post an empty message (Slack rejects empty text).
+      if (typeof text === 'string' && text.trim().length > 0 && cleanText.length === 0) {
+        console.warn('[slack_send_message] Message was entirely internal protocol content — not sending', {
+          invocationId,
+          durationMs: Date.now() - startedAt,
+        });
+        return {
+          successBoolean: false,
+          responseString: `Not sending Slack message to channel ${ channel }: content was entirely internal protocol wrappers after stripping`,
+        };
+      }
+
       console.log('[slack_send_message] Calling slack.sendMessage', {
         invocationId,
         channel,
-        textPreview: typeof text === 'string' ? text.slice(0, 80) : null,
+        textPreview: cleanText.slice(0, 80),
       });
-      const res = await slack.sendMessage(channel, text);
+      const res = await slack.sendMessage(channel, cleanText);
       console.log('[slack_send_message] sendMessage response', {
         invocationId,
         ok:         !!res?.ok,

--- a/pkg/rancher-desktop/agent/utils/__tests__/stripProtocolTags.test.ts
+++ b/pkg/rancher-desktop/agent/utils/__tests__/stripProtocolTags.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { stripProtocolTags, stripProtocolTagsStreaming } from '../stripProtocolTags';
+
+describe('stripProtocolTags', () => {
+  it('strips a trailing AGENT_DONE wrapper, leaving only user content (issue #96)', () => {
+    const dirty = 'Here is your answer.\n\n<AGENT_DONE>\n<KEY_RESULT>did the thing</KEY_RESULT>\n</AGENT_DONE>';
+
+    expect(stripProtocolTags(dirty)).toBe('Here is your answer.');
+  });
+
+  it('strips AGENT_BLOCKED and AGENT_CONTINUE wrappers', () => {
+    expect(stripProtocolTags('msg <AGENT_BLOCKED><BLOCKER_REASON>x</BLOCKER_REASON></AGENT_BLOCKED>')).toBe('msg');
+    expect(stripProtocolTags('msg <AGENT_CONTINUE>keep going</AGENT_CONTINUE>')).toBe('msg');
+  });
+
+  it('removes standalone inner tags if they leak without their wrapper', () => {
+    expect(stripProtocolTags('answer <KEY_RESULT>')).toBe('answer');
+    expect(stripProtocolTags('answer </STATUS_MESSAGE>')).toBe('answer');
+  });
+
+  it('returns empty string when the content is entirely protocol wrappers', () => {
+    expect(stripProtocolTags('<AGENT_DONE><KEY_RESULT>internal only</KEY_RESULT></AGENT_DONE>')).toBe('');
+  });
+
+  it('leaves clean text untouched', () => {
+    expect(stripProtocolTags('just a normal message')).toBe('just a normal message');
+  });
+
+  it('handles null/undefined input', () => {
+    expect(stripProtocolTags(null)).toBe('');
+    expect(stripProtocolTags(undefined)).toBe('');
+  });
+
+  it('streaming variant truncates at a half-arrived opening wrapper', () => {
+    expect(stripProtocolTagsStreaming('partial answer\n<AGENT_DONE>\nsummary not yet closed')).toBe('partial answer');
+  });
+});


### PR DESCRIPTION
@/tmp/pr96-body.md