### PR TITLE
fix(lima): parse multi-word lima_shell commands via guest shell (#78)

### DIFF
--- a/pkg/rancher-desktop/agent/tools/lima/__tests__/lima_shell.test.ts
+++ b/pkg/rancher-desktop/agent/tools/lima/__tests__/lima_shell.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+const runCommandMock: any = jest.fn();
+
+jest.unstable_mockModule('../../util/CommandRunner', () => ({
+  runCommand: runCommandMock,
+}));
+
+async function loadModule() {
+  return import('../lima_shell');
+}
+
+describe('lima_shell command construction (issue #78)', () => {
+  afterEach(() => {
+    runCommandMock.mockReset();
+  });
+
+  it('wraps a multi-word command in `sh -lc` so the guest shell parses it', async() => {
+    runCommandMock.mockResolvedValue({ stdout: 'Linux lima-test 6.8.0', stderr: '', exitCode: 0 });
+
+    const { LimaShellWorker } = await loadModule();
+    const worker = new LimaShellWorker() as any;
+
+    const res = await worker._validatedCall({ instance: 'test-vm', command: 'uname -a' });
+
+    expect(runCommandMock).toHaveBeenCalledTimes(1);
+    const [cmd, args] = runCommandMock.mock.calls[0];
+
+    expect(cmd).toBe('limactl');
+    // The command must be handed to the guest shell as its own argv element,
+    // NOT concatenated into a single `-- "uname -a"` token (the pre-fix bug
+    // that produced `uname -a: command not found`).
+    expect(args).toEqual(['shell', 'test-vm', '--', 'sh', '-lc', 'uname -a']);
+    expect(res.successBoolean).toBe(true);
+    expect(res.responseString).toContain('Linux lima-test');
+  });
+
+  it('preserves pipes, arguments and redirects inside the wrapped command', async() => {
+    runCommandMock.mockResolvedValue({ stdout: '3', stderr: '', exitCode: 0 });
+
+    const { LimaShellWorker } = await loadModule();
+    const worker = new LimaShellWorker() as any;
+
+    const script = 'ls -la /tmp | grep foo | wc -l';
+    await worker._validatedCall({ instance: 'test-vm', command: script });
+
+    const [, args] = runCommandMock.mock.calls[0];
+
+    // The full script stays a single argv element after `sh -lc`, so the guest
+    // shell — not limactl's argv splitter — interprets the pipeline.
+    expect(args).toEqual(['shell', 'test-vm', '--', 'sh', '-lc', script]);
+  });
+
+  it('opens an interactive shell (no `--` command) when command is omitted', async() => {
+    runCommandMock.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+    const { LimaShellWorker } = await loadModule();
+    const worker = new LimaShellWorker() as any;
+
+    await worker._validatedCall({ instance: 'test-vm' });
+
+    const [, args] = runCommandMock.mock.calls[0];
+
+    expect(args).toEqual(['shell', 'test-vm']);
+  });
+
+  it('surfaces a non-zero exit as a failure response', async() => {
+    runCommandMock.mockResolvedValue({ stdout: '', stderr: 'boom', exitCode: 1 });
+
+    const { LimaShellWorker } = await loadModule();
+    const worker = new LimaShellWorker() as any;
+
+    const res = await worker._validatedCall({ instance: 'test-vm', command: 'false' });
+
+    expect(res.successBoolean).toBe(false);
+    expect(res.responseString).toContain('boom');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/lima/lima_shell.ts
+++ b/pkg/rancher-desktop/agent/tools/lima/lima_shell.ts
@@ -13,7 +13,14 @@ export class LimaShellWorker extends BaseTool {
     const args = ['shell', instance];
 
     if (command) {
-      args.push('--', command);
+      // Pass the command through the guest shell so multi-word commands,
+      // arguments, pipes and redirects are parsed by `sh` rather than exec'd as
+      // a single literal token. Without this, `limactl shell <vm> -- "uname -a"`
+      // reaches the guest as one argv element and fails with
+      // `uname -a: command not found` (issue #78). Mirrors the canonical lima
+      // invocation used by CommandRunner's runInLimaShell path
+      // (`['shell', instance, '--', 'sh', '-lc', script]`).
+      args.push('--', 'sh', '-lc', command);
     }
 
     try {


### PR DESCRIPTION
## Closes #78 — `lima_shell` fails with multi-word commands

### Bug
`lima_shell("test-vm", "uname -a")` failed with:
```
Error executing command in Lima VM: /bin/bash: line 1: uname -a: command not found
```
Single-word commands (`whoami`, `uname`, `hostname`) worked; anything with a space failed.

### Root cause
`lima_shell.ts` built the invocation as:
```ts
const args = ['shell', instance];
if (command) { args.push('--', command); }   // command = "uname -a"
runCommand('limactl', args, ...)
```
Since `runCommand` spawns with `shell: false`, the whole `"uname -a"` string reached the guest as a **single argv element** after `--`, so the guest tried to exec a program literally named `uname -a` → `command not found`.

### Fix
Wrap the command in the guest shell so `sh` — not limactl's argv splitter — parses it:
```ts
if (command) { args.push('--', 'sh', '-lc', command); }
```
This is the **canonical lima invocation the codebase already uses** — see `CommandRunner.ts` `runInLimaShell` path:
```ts
const limactlArgs = ['shell', limaInstance, '--', 'sh', '-lc', script];
```
Multi-word commands, arguments, pipes and redirects are now all parsed by the guest shell. Single-word and interactive (no-command) invocations are unchanged.

### Verification
New standalone unit test `lima_shell.test.ts` (mocks `CommandRunner`, same proven pattern as `exec.test.ts`) — **4/4 green**:
- multi-word command → `['shell','test-vm','--','sh','-lc','uname -a']`
- pipeline (`ls -la /tmp | grep foo | wc -l`) preserved as one argv element
- interactive shell (no command) → no `--` appended
- non-zero exit surfaced as failure

```
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
