### PR TITLE
fix(projects): kebab-case project slugs & directories (#43)

### DIFF
--- a/pkg/rancher-desktop/agent/database/registry/ProjectRegistry.ts
+++ b/pkg/rancher-desktop/agent/database/registry/ProjectRegistry.ts
@@ -9,6 +9,7 @@ import {
 } from '../../services/ProjectService';
 import { resolveSullaProjectsDir } from '../../utils/sullaPaths';
 import { redisClient } from '../RedisClient';
+import { slugify } from './projectSlug';
 
 export interface ProjectRegistryInitOptions {
   filesystemProjectDirs?: string[];
@@ -234,10 +235,13 @@ export class ProjectRegistry {
     const name = String(projectName || '').trim();
     if (!name) return 'Project name is required.';
 
-    const baseDir = customDir ? String(customDir).trim() : path.join(this.getUserProjectsDir(), name);
+    // Directory + slug are kebab-case and path-safe; the human-friendly name
+    // is preserved as the frontmatter title (issue #43).
+    const slug = slugify(name);
+    const baseDir = customDir ? String(customDir).trim() : path.join(this.getUserProjectsDir(), slug);
     const projectDir = baseDir;
     const projectFile = path.join(projectDir, 'PROJECT.md');
-    const projectContent = this.normalizeCreateProjectContent(name, content);
+    const projectContent = this.normalizeCreateProjectContent(name, slug, content);
 
     try {
       await mkdir(projectDir, { recursive: true });
@@ -246,13 +250,13 @@ export class ProjectRegistry {
       // Scaffold README.md if it doesn't exist
       const readmeFile = path.join(projectDir, 'README.md');
       if (!fs.existsSync(readmeFile)) {
-        const service = ProjectService.fromRaw('filesystem', name, projectContent);
+        const service = ProjectService.fromRaw('filesystem', slug, projectContent);
         const readmeContent = this.scaffoldReadme(service);
         await writeFile(readmeFile, readmeContent, 'utf8');
       }
 
       // Reload from the new file so the registry picks it up immediately
-      const service = ProjectService.fromRaw('filesystem', name, projectContent);
+      const service = ProjectService.fromRaw('filesystem', slug, projectContent);
       if (service) {
         this.projectsBySlug.set(service.slug, service);
         this.cachedSummaries = this.buildSummariesFromCurrentMap();
@@ -521,20 +525,26 @@ ${ description }
 `;
   }
 
-  private normalizeCreateProjectContent(projectName: string, content?: string): string {
+  private normalizeCreateProjectContent(displayName: string, slug: string, content?: string): string {
     const provided = String(content || '').trim();
     if (provided) return provided;
 
-    const title = projectName
-      .split('-')
-      .filter(Boolean)
-      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(' ') || projectName;
+    // Preserve the human-readable name verbatim when it already carries
+    // spaces/capitalization; otherwise prettify the kebab slug (e.g. a
+    // `my-cool-project` input becomes the "My Cool Project" title).
+    const looksHuman = /[A-Z]/.test(displayName) || /\s/.test(displayName);
+    const title = looksHuman
+      ? displayName
+      : slug
+        .split('-')
+        .filter(Boolean)
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ') || displayName;
     const now = new Date().toISOString();
 
     return `---
 schemaversion: 1
-slug: ${ projectName }
+slug: ${ slug }
 title: "${ title }"
 section: Projects
 status: active

--- a/pkg/rancher-desktop/agent/database/registry/__tests__/projectSlug.test.ts
+++ b/pkg/rancher-desktop/agent/database/registry/__tests__/projectSlug.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @jest-environment node
+ *
+ * Pure function under test — no DB, fs, or bridge deps, so the slug logic
+ * (issue #43) is verified in isolation without mocking ProjectRegistry.
+ */
+import { describe, expect, it } from '@jest/globals';
+
+import { slugify } from '../projectSlug';
+
+describe('slugify (project slugs — issue #43)', () => {
+  it('converts a spaced human name to kebab-case', () => {
+    expect(slugify('Test Demo Alpha')).toBe('test-demo-alpha');
+  });
+
+  it('leaves an already-kebab name unchanged', () => {
+    expect(slugify('my-cool-project')).toBe('my-cool-project');
+  });
+
+  it('collapses runs of whitespace and punctuation into single hyphens', () => {
+    expect(slugify('Foo   Bar & Baz!!')).toBe('foo-bar-baz');
+  });
+
+  it('strips leading and trailing separators', () => {
+    expect(slugify('  --Hello World--  ')).toBe('hello-world');
+  });
+
+  it('drops characters that are unsafe in file paths and URLs', () => {
+    expect(slugify('Q1/2026 Report: v2')).toBe('q1-2026-report-v2');
+  });
+
+  it('falls back to a stable default when nothing usable remains', () => {
+    expect(slugify('!!!')).toBe('project');
+    expect(slugify('')).toBe('project');
+  });
+
+  it('tolerates non-string input without throwing', () => {
+    expect(slugify(undefined as unknown as string)).toBe('project');
+    expect(slugify(null as unknown as string)).toBe('project');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/registry/projectSlug.ts
+++ b/pkg/rancher-desktop/agent/database/registry/projectSlug.ts
@@ -1,0 +1,18 @@
+/**
+ * Derive a URL/path-safe kebab-case slug from a human project name.
+ *
+ * Keeps directories, slugs, and URLs free of spaces and punctuation that
+ * break shell scripts, file paths, and CI pipelines (see issue #43). The
+ * human-friendly name is preserved separately as the project `title`.
+ *
+ * Mirrors the routine-export slugify convention used elsewhere in the app.
+ */
+export function slugify(input: string): string {
+  const slug = String(input || '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return slug || 'project';
+}


### PR DESCRIPTION
## Summary
Closes #43.

`create_project` used the raw project name (with spaces/punctuation) as **both** the on-disk directory and the frontmatter `slug`, producing paths like `.../Test Demo Alpha/` — literal spaces that break shell scripts, URLs, and CI pipelines.

This derives a URL/path-safe **kebab-case** slug (`test-demo-alpha`) for the directory and slug, while preserving the human-friendly name as the frontmatter `title` (exactly the fix the issue proposed).

### Changes
- New `projectSlug.ts` — a small `slugify()` helper mirroring the existing routine-export slugify convention (`toLowerCase → collapse non-alphanumerics to \`-\` → trim edges`), with a stable `project` fallback.
- `ProjectRegistry.createProject` now uses the slug for the directory, the `fromRaw` identifier, and the frontmatter `slug`; the display name is kept verbatim as the `title`.
- `normalizeCreateProjectContent(displayName, slug, content?)` — writes `slug: <kebab>` + `title: <human name>`. Preserves the name verbatim when it already looks human (has spaces/caps); otherwise prettifies the slug (so a `my-cool-project` input still yields a `My Cool Project` title — no regression).

### Backward compatibility
Existing projects are unaffected: they keep their stored frontmatter `slug`, and `ProjectRegistry.loadProject` still resolves them by name via its fuzzy `project.name` match. Only newly created projects get kebab-case directories.

### Tests
New `__tests__/projectSlug.test.ts` — 7 focused cases (spaced names, already-kebab, punctuation collapse, edge trimming, path-unsafe chars, empty/`!!!` fallback, non-string input). All green via jest.

```
Test Suites: 1 passed  |  Tests: 7 passed
```

Note: repo eslint could not run in the build env (native `oxc-resolver` binding is macOS-only on this Linux VM); CI lints on the supported platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)