### PR TITLE
fix(lima): pin GitHub SSH host keys in guest known_hosts (#94)

### DIFF
--- a/pkg/rancher-desktop/assets/lima-config.yaml
+++ b/pkg/rancher-desktop/assets/lima-config.yaml
@@ -303,6 +303,32 @@ provision:
     else
       echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] [dns-pivot] WARN: Quad9 resolution failed" >> "$LOG"
     fi
+- # GitHub SSH host keys — fixes "Host key verification failed" for exec git over SSH.
+  # The guest has no known_hosts entry for github.com, so `git fetch/pull/push` (and any
+  # `ssh git@github.com`) run via the exec tool die with "Host key verification failed".
+  # We pin GitHub's PUBLISHED host keys into the system-wide known_hosts rather than
+  # ssh-keyscan-at-boot: pinning is MITM-safe (no trust-on-first-use over the network) and
+  # needs no connectivity during provisioning. Keys are GitHub's official published values
+  # (https://docs.github.com/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints);
+  # if GitHub rotates a key, ssh-keyscan on a live host will still work as before — this only
+  # seeds the offline baseline. Idempotent: skips if github.com is already present.
+  mode: system
+  script: |
+    #!/bin/sh
+    LOG=/var/log/boot-perf.log
+    KH=/etc/ssh/ssh_known_hosts
+    touch "$KH"
+    if grep -q '^github.com ' "$KH" 2>/dev/null; then
+      echo "[boot-perf] github-known-hosts: already present" >> "$LOG"
+    else
+      cat >> "$KH" <<'EOF'
+    github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+    github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+    github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=
+    EOF
+      chmod 644 "$KH"
+      echo "[boot-perf] github-known-hosts: pinned github.com host keys into $KH" >> "$LOG"
+    fi
 - # Final boot timing — captures end-of-provisioning state
   mode: system
   script: |


### PR DESCRIPTION
Closes #94.

## Problem
Running git over SSH inside the Lima guest via the `exec` tool (`git fetch/pull/push`, or any `ssh git@github.com`) fails with:
```
No ED25519 host key is known for github.com and you have requested strict checking.
Host key verification failed.
```
The guest has no `known_hosts` entry for github.com. Native host git tools work because they run on the host, not in Lima — so this only bites `exec`-driven git.

## Fix
Add a `provision.system` script to `lima-config.yaml` that pins GitHub's **published** host keys (ed25519 / ecdsa / rsa) into the system-wide `/etc/ssh/ssh_known_hosts`.

Why pin published keys instead of `ssh-keyscan` at boot:
- **MITM-safe** — no trust-on-first-use over the network.
- **No connectivity dependency** during provisioning.
- Keys are GitHub's official published values ([docs](https://docs.github.com/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)); if GitHub ever rotates a key, `ssh-keyscan` on a live host still works — this only seeds the offline baseline.
- **Idempotent** — skips when `github.com` is already present, so it's safe on every boot.

## Verification (in-guest)
- Reproduced the failure with an empty `known_hosts`.
- Parsed the actual YAML and ran the extracted provision script against a temp `known_hosts`.
- Confirmed the pinned keys are **byte-identical** to live `ssh-keyscan github.com`.
- With the keys present, `ssh -T git@github.com` gets **past host-key verification** to the auth stage (`Permission denied (publickey)`, expected without a deploy key) — the barrier is gone.
- Re-ran the script: `known_hosts` unchanged (idempotent).

Scope is intentionally minimal (GitHub only, matching the issue). Extending to other git hosts is a trivial follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)