### PR TITLE
feat(audio): native macOS TTS as default keyless voice provider

### DIFF
--- a/pkg/rancher-desktop/composables/voice/TTSPlayerService.ts
+++ b/pkg/rancher-desktop/composables/voice/TTSPlayerService.ts
@@ -16,6 +16,13 @@
 import { TypedEventEmitter } from './TypedEventEmitter';
 import { logTTSEnqueue, logTTSPlayStart, logTTSPlayEnd, logTTSStop, logTTSDedup, logTTSFallback, timingFirstAudio } from './VoiceLogger';
 
+// Speaking-rate multipliers for the native OS voice, mirroring Sulla Mobile's TtsService.
+const RATE_MAP: Record<string, number> = {
+  slow:   0.85,
+  normal: 1.0,
+  fast:   1.2,
+};
+
 // ─── Types ──────────────────────────────────────────────────────
 
 export interface TTSPlayerEvents {
@@ -55,6 +62,11 @@ export class TTSPlayerService extends TypedEventEmitter<TTSPlayerEvents> {
   private prefetchedAudio: { text: string; result: any } | null = null;
   private prefetchAbort:   AbortController | null = null;
   private prefetchingText: string | null = null;
+
+  // ── TTS provider config ──
+  // Cached provider selection. Loaded lazily from settings and cleared on stop() so a
+  // provider/voice change in Audio Settings takes effect on the next spoken turn.
+  private ttsConfig: { provider: string; voiceURI: string; rate: number } | null = null;
 
   constructor(config: TTSPlayerConfig) {
     super();
@@ -118,6 +130,9 @@ export class TTSPlayerService extends TypedEventEmitter<TTSPlayerEvents> {
     this.prefetchedAudio = null;
     this.prefetchingText = null;
 
+    // Re-read provider/voice config next turn (may have changed in Audio Settings)
+    this.ttsConfig = null;
+
     // Cancel browser speechSynthesis fallback if active
     if (typeof window !== 'undefined' && window.speechSynthesis) {
       window.speechSynthesis.cancel();
@@ -157,6 +172,22 @@ export class TTSPlayerService extends TypedEventEmitter<TTSPlayerEvents> {
     this.emit('playbackStart', undefined as any);
 
     try {
+      const cfg = await this.getTtsConfig();
+
+      // Native OS voice: speak in-renderer via SpeechSynthesis — no IPC, no prefetch, no audio blob.
+      if (cfg.provider === 'system') {
+        if (seq !== this.sequence) {
+          this.playing = false;
+
+          return;
+        }
+        await this.speakNative(text, cfg.voiceURI, cfg.rate);
+        logTTSPlayEnd(text, Date.now() - playStartTime);
+        this.emit('playbackEnd', undefined as any);
+
+        return;
+      }
+
       let result: any;
       let source: string;
 
@@ -261,6 +292,8 @@ export class TTSPlayerService extends TypedEventEmitter<TTSPlayerEvents> {
    */
   private async prefetch(): Promise<void> {
     if (this.queue.length === 0 || this.prefetchedAudio) return;
+    // Native OS voice is synthesized locally on demand — nothing to prefetch over IPC.
+    if ((await this.getTtsConfig()).provider === 'system') return;
     const nextText = this.queue[0]; // peek, don't shift
     if (this.prefetchingText === nextText) return;
 
@@ -287,6 +320,71 @@ export class TTSPlayerService extends TypedEventEmitter<TTSPlayerEvents> {
       this.prefetchAbort = null;
       this.prefetchingText = null;
     }
+  }
+
+  // ─── Provider config ──────────────────────────────────────────
+
+  /**
+   * Reads the selected TTS provider, voice, and rate from settings (cached until
+   * stop() clears it). Defaults to the keyless native OS voice so speech works
+   * out of the box without an ElevenLabs key.
+   */
+  private async getTtsConfig(): Promise<{ provider: string; voiceURI: string; rate: number }> {
+    if (this.ttsConfig) return this.ttsConfig;
+    try {
+      const [provider, voiceURI, rateKey] = await Promise.all([
+        this.ipcInvoke('sulla-settings-get', 'audioTtsProvider', 'system'),
+        this.ipcInvoke('sulla-settings-get', 'audioTtsVoice', ''),
+        this.ipcInvoke('sulla-settings-get', 'audioTtsRate', 'normal'),
+      ]);
+      this.ttsConfig = {
+        provider: provider || 'system',
+        voiceURI: voiceURI || '',
+        rate:     RATE_MAP[rateKey as string] ?? 1.0,
+      };
+    } catch {
+      this.ttsConfig = { provider: 'system', voiceURI: '', rate: 1.0 };
+    }
+
+    return this.ttsConfig;
+  }
+
+  // ─── Native (OS) Voice ────────────────────────────────────────
+
+  /**
+   * Speaks text through the OS speech engine via SpeechSynthesis. In Electron on
+   * macOS these are the native system voices. Honors the selected voiceURI (or an
+   * auto pick of the default English voice) and speaking rate.
+   */
+  private speakNative(text: string, voiceURI: string, rate: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const synth = typeof window !== 'undefined' ? window.speechSynthesis : undefined;
+      if (!synth) {
+        console.warn('[TTSPlayer:native] speechSynthesis not available');
+        resolve();
+
+        return;
+      }
+
+      const utterance = new SpeechSynthesisUtterance(text);
+      const allVoices = synth.getVoices();
+
+      if (voiceURI && voiceURI !== 'auto') {
+        const match = allVoices.find(v => v.voiceURI === voiceURI);
+        if (match) utterance.voice = match;
+      } else {
+        // Auto: prefer the OS default English voice, else the first English voice.
+        const english = allVoices.filter(v => v.lang?.toLowerCase().startsWith('en'));
+        const pick = english.find(v => v.default) || english[0];
+        if (pick) utterance.voice = pick;
+      }
+
+      utterance.rate = rate;
+      utterance.onstart = () => timingFirstAudio();
+      utterance.onend = () => resolve();
+      utterance.onerror = () => resolve();
+      synth.speak(utterance);
+    });
   }
 
   // ─── Browser Fallback ─────────────────────────────────────────

--- a/pkg/rancher-desktop/pages/AudioSettings.vue
+++ b/pkg/rancher-desktop/pages/AudioSettings.vue
@@ -1036,14 +1036,17 @@ interface TtsProviderInfo {
   id:        string;
   name:      string;
   connected: boolean;
-  vaultKey:  { integrationId: string; property: string };
+  /** Vault credential this provider needs. Absent for keyless providers (e.g. the native OS voice). */
+  vaultKey?: { integrationId: string; property: string };
 }
 
 const ttsProviders = ref<TtsProviderInfo[]>([
+  // Native macOS voices via the OS speech engine — always available, no API key. Mirrors Sulla Mobile's default.
+  { id: 'system', name: 'System Default (macOS)', connected: true },
   { id: 'elevenlabs', name: 'ElevenLabs', connected: false, vaultKey: { integrationId: 'elevenlabs', property: 'api_key' } },
 ]);
 
-const ttsProvider = ref('elevenlabs');
+const ttsProvider = ref('system');
 const ttsVoice = ref('');
 const ttsVoiceName = ref('');
 const voices = ref<{ value: string; label: string; description?: string }[]>([]);
@@ -1051,7 +1054,8 @@ const loadingVoices = ref(false);
 const previewPlaying = ref(false);
 
 const hasAnyTtsProvider = computed(() => ttsProviders.value.some(p => p.connected));
-const ttsFullyConfigured = computed(() => hasAnyTtsProvider.value && !!ttsVoice.value);
+// The system voice speaks with the OS default even when no specific voice is picked, so it counts as configured.
+const ttsFullyConfigured = computed(() => hasAnyTtsProvider.value && (ttsProvider.value === 'system' || !!ttsVoice.value));
 
 function selectTtsProvider(id: string) {
   ttsProvider.value = id;
@@ -1813,7 +1817,7 @@ function onMicDeviceChange() {
 
 async function loadSettings(): Promise<void> {
   try {
-    ttsProvider.value = await ipcRenderer.invoke('sulla-settings-get', 'audioTtsProvider', 'elevenlabs');
+    ttsProvider.value = await ipcRenderer.invoke('sulla-settings-get', 'audioTtsProvider', 'system');
     ttsVoice.value = await ipcRenderer.invoke('sulla-settings-get', 'audioTtsVoice', '');
     ttsVoiceName.value = await ipcRenderer.invoke('sulla-settings-get', 'audioTtsVoiceName', '');
     transcriptionMode.value = await ipcRenderer.invoke('sulla-settings-get', 'audioTranscriptionMode', 'browser');
@@ -1842,6 +1846,11 @@ async function saveSettings(): Promise<void> {
 
 async function checkProviders(): Promise<void> {
   for (const provider of ttsProviders.value) {
+    // Keyless providers (e.g. the native OS voice) are always available — no vault lookup.
+    if (!provider.vaultKey) {
+      provider.connected = true;
+      continue;
+    }
     try {
       const result = await ipcRenderer.invoke(
         'integration-get-value',
@@ -1874,12 +1883,46 @@ async function fetchVoices(): Promise<void> {
   loadingVoices.value = true;
 
   try {
-    if (ttsProvider.value === 'elevenlabs') {
+    if (ttsProvider.value === 'system') {
+      await fetchSystemVoices();
+    } else if (ttsProvider.value === 'elevenlabs') {
       await fetchElevenLabsVoices();
     }
   } finally {
     loadingVoices.value = false;
   }
+}
+
+// Enumerate the OS speech-engine voices exposed through the browser SpeechSynthesis API.
+// In Electron/Chromium on macOS these are the native system voices (Samantha, Alex, the Siri voices, …).
+async function fetchSystemVoices(): Promise<void> {
+  const synth = typeof window !== 'undefined' ? window.speechSynthesis : undefined;
+  if (!synth) {
+    voices.value = [{ value: 'auto', label: 'Automatic (system default)' }];
+    return;
+  }
+
+  // Chromium loads voices lazily — the first getVoices() call can return []. Wait briefly for voiceschanged.
+  let list = synth.getVoices();
+  if (list.length === 0) {
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, 1000);
+      synth.addEventListener('voiceschanged', () => { clearTimeout(timer); resolve(); }, { once: true });
+    });
+    list = synth.getVoices();
+  }
+
+  const english = list.filter(v => v.lang?.toLowerCase().startsWith('en'));
+  const pool = english.length > 0 ? english : list;
+
+  voices.value = [
+    { value: 'auto', label: 'Automatic (system default)' },
+    ...pool.map(v => ({
+      value:       v.voiceURI,
+      label:       v.name,
+      description: v.lang,
+    })),
+  ];
 }
 
 async function fetchElevenLabsVoices(): Promise<void> {
@@ -1949,10 +1992,32 @@ async function fetchAudioDevices(): Promise<void> {
 
 // ─── Voice preview ──────────────────────────────────────────────
 
+// Speak a sample through the OS speech engine using the currently-selected system voice.
+function previewSystemVoice(text: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const synth = typeof window !== 'undefined' ? window.speechSynthesis : undefined;
+    if (!synth) { resolve(); return; }
+    synth.cancel();
+    const utterance = new SpeechSynthesisUtterance(text);
+    if (ttsVoice.value && ttsVoice.value !== 'auto') {
+      const match = synth.getVoices().find(v => v.voiceURI === ttsVoice.value);
+      if (match) utterance.voice = match;
+    }
+    utterance.onend = () => resolve();
+    utterance.onerror = () => resolve();
+    synth.speak(utterance);
+  });
+}
+
 async function previewVoice(): Promise<void> {
   if (previewPlaying.value) return;
   previewPlaying.value = true;
   try {
+    // System provider speaks natively in the renderer — no ElevenLabs round-trip.
+    if (ttsProvider.value === 'system') {
+      await previewSystemVoice('Hello, this is how I sound.');
+      return;
+    }
     const result = await ipcRenderer.invoke('audio-speak', { text: 'Hello, this is how I sound.' });
     if (result?.audio) {
       const blob = new Blob([result.audio], { type: result.mimeType || 'audio/mpeg' });


### PR DESCRIPTION
## What

Adds a **System Default (macOS)** TTS provider alongside ElevenLabs, mirroring Sulla Mobile's native-voice default. It speaks through the OS speech engine (`window.speechSynthesis` → native macOS voices like Samantha, Alex, the Siri voices) with **no API key required**, and is now the out-of-the-box default so two-way voice works before any ElevenLabs key is added.

Requested by Jonathon: *"we should also have the default TTS like the sulla-mobile app does — mac supports TTS natively."*

## Why

Today desktop TTS is hardcoded to ElevenLabs, which needs a paid API key. Native speech already existed in the codebase but only as an **error fallback** (`browserFallback` in `TTSPlayerService`, fired only when the ElevenLabs `audio-speak` IPC throws). This promotes it to a first-class, selectable provider — the same model Sulla Mobile uses with `expo-speech`.

## Changes

**`AudioSettings.vue`**
- Keyless `system` provider (always `connected: true`), now the default provider.
- `fetchSystemVoices()` enumerates native voices via `speechSynthesis.getVoices()` (waits for the lazy `voiceschanged` event), with an **Automatic** option.
- `checkProviders` guards providers with no `vaultKey`.
- Native in-renderer preview path (no ElevenLabs round-trip).
- `ttsFullyConfigured` treats `system` as configured even without an explicit voice (OS default always speaks).

**`TTSPlayerService.ts`**
- Provider-aware playback: when provider is `system`, speak in-renderer via `SpeechSynthesis` (selected `voiceURI` or auto-pick of the default English voice + rate map) instead of the `audio-speak` IPC; prefetch skipped.
- ElevenLabs path and the existing error-fallback are unchanged.

## Verification

- TS logic scoped-typecheck clean (full project `tsc` OOMs in the sandbox VM; `.vue` isn't tsc-checked without vue-tsc).
- **Not yet run in a built app** — needs a rebuild + a listen test to confirm a Mac voice speaks and the provider switch persists. Flagging that as the remaining step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)