### PR TITLE
feat(alibaba): live-fetch model catalog from DashScope /models

### DIFF
--- a/pkg/rancher-desktop/agent/integrations/select_box/AlibabaModels.ts
+++ b/pkg/rancher-desktop/agent/integrations/select_box/AlibabaModels.ts
@@ -1,18 +1,65 @@
 import { SelectBoxProvider, type SelectBoxContext, type SelectOption } from './SelectBoxProvider';
 
+const DEFAULT_BASE_URL = 'https://coding-intl.dashscope.aliyuncs.com/v1';
+
+// Friendly labels/descriptions for known model ids. Unknown ids (e.g. models
+// Alibaba adds later) still surface — they just show their raw id as the label.
+const KNOWN: Record<string, { label: string; description?: string }> = {
+  'qwen3.5-plus':         { label: 'Qwen 3.5 Plus', description: 'Balanced performance' },
+  'qwen3.6-plus':         { label: 'Qwen 3.6 Plus', description: 'Newer Qwen generation' },
+  'qwen3.7-plus':         { label: 'Qwen 3.7 Plus', description: 'Newest Qwen generation' },
+  'qwen3-max-2026-01-23': { label: 'Qwen 3 Max', description: 'Most capable Qwen 3 model' },
+  'qwen3-coder-plus':     { label: 'Qwen 3 Coder Plus', description: 'Optimized for code generation' },
+  'qwen3-coder-next':     { label: 'Qwen 3 Coder Next', description: 'Next-gen code model' },
+  'kimi-k2.5':            { label: 'Kimi K2.5', description: '256K context, long-context reasoning' },
+  'glm-5':                { label: 'GLM 5', description: 'Zhipu GLM flagship model' },
+  'glm-4.7':              { label: 'GLM 4.7', description: 'Zhipu GLM 4.7' },
+  'MiniMax-M2.5':         { label: 'MiniMax M2.5', description: '200K context, advanced reasoning' },
+};
+
 export class AlibabaModels extends SelectBoxProvider {
   readonly id = 'alibaba_models';
 
-  async getOptions(_context: SelectBoxContext): Promise<SelectOption[]> {
-    return [
-      { value: 'qwen3.5-plus', label: 'Qwen 3.5 Plus', description: 'Latest Qwen, balanced performance' },
-      { value: 'MiniMax-M2.5', label: 'MiniMax M2.5', description: '200K context, advanced reasoning' },
-      { value: 'kimi-k2.5', label: 'Kimi K2.5', description: '256K context, long-context reasoning' },
-      { value: 'glm-5', label: 'GLM 5', description: 'Zhipu GLM flagship model' },
-      { value: 'qwen3-coder-plus', label: 'Qwen 3 Coder Plus', description: 'Optimized for code generation' },
-      { value: 'qwen3-coder-next', label: 'Qwen 3 Coder Next', description: 'Next-gen code model' },
-      { value: 'qwen3-max-2026-01-23', label: 'Qwen 3 Max', description: 'Most capable Qwen 3 model' },
-      { value: 'glm-4.7', label: 'GLM 4.7', description: 'Zhipu GLM 4.7' },
-    ];
+  async getOptions(context: SelectBoxContext): Promise<SelectOption[]> {
+    const apiKey  = context.formValues.api_key;
+    const baseUrl = (context.formValues.base_url || DEFAULT_BASE_URL).replace(/\/$/, '');
+
+    try {
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      // The DashScope Coding Plan /models route is readable without auth, but send the
+      // key when we have it so the catalog reflects the account's entitlements.
+      if (apiKey) {
+        headers.Authorization = `Bearer ${ apiKey }`;
+      }
+
+      const response = await fetch(`${ baseUrl }/models`, {
+        method:  'GET',
+        headers,
+        signal:  AbortSignal.timeout(10000),
+      });
+
+      if (response.ok) {
+        const body = await response.json() as { data?: { id: string }[] };
+        if (body.data && body.data.length > 0) {
+          return body.data.map(m => this.toOption(m.id));
+        }
+      }
+    } catch {
+      // Fall back to static list
+    }
+
+    return this.getStaticModels();
+  }
+
+  private toOption(id: string): SelectOption {
+    const known = KNOWN[id];
+    return known
+      ? { value: id, label: known.label, description: known.description }
+      : { value: id, label: id };
+  }
+
+  // Last-resort fallback shown when the DashScope /models endpoint is unreachable.
+  private getStaticModels(): SelectOption[] {
+    return Object.keys(KNOWN).map(id => this.toOption(id));
   }
 }

--- a/pkg/rancher-desktop/agent/languagemodels/ModelDiscoveryService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ModelDiscoveryService.ts
@@ -25,6 +25,7 @@ interface ProviderConfig {
   authHeader:     string;
   parseResponse:  (data: any) => ModelInfo[];
   staticModels?:  ModelInfo[]; // Use static list when /models endpoint isn't supported
+  preferLive?:    boolean;     // When true, fetch /models live and only use staticModels as a fallback
 }
 
 export class ModelDiscoveryService {
@@ -129,9 +130,14 @@ export class ModelDiscoveryService {
         name:     model.id,
         provider: 'alibaba',
       })) || [],
-      // Coding Plan endpoint doesn't support /models — use static list
+      // The Coding Plan /models endpoint DOES return a live catalog (verified 2026-07-20).
+      // Fetch it live so new models (e.g. qwen3.6-plus, qwen3.7-plus) appear automatically;
+      // fall back to the list below only if the endpoint is unreachable.
+      preferLive: true,
       staticModels: [
         { id: 'qwen3.5-plus', name: 'Qwen 3.5 Plus', provider: 'alibaba' },
+        { id: 'qwen3.6-plus', name: 'Qwen 3.6 Plus', provider: 'alibaba' },
+        { id: 'qwen3.7-plus', name: 'Qwen 3.7 Plus', provider: 'alibaba' },
         { id: 'MiniMax-M2.5', name: 'MiniMax M2.5', provider: 'alibaba' },
         { id: 'kimi-k2.5', name: 'Kimi K2.5', provider: 'alibaba' },
         { id: 'glm-5', name: 'GLM 5', provider: 'alibaba' },
@@ -345,8 +351,9 @@ export class ModelDiscoveryService {
       throw new Error(`Unsupported provider: ${ providerId }`);
     }
 
-    // If provider has a static model list (e.g. endpoint doesn't support /models), use it
-    if (provider.staticModels?.length) {
+    // If provider has a static model list (e.g. endpoint doesn't support /models), use it —
+    // unless it opts into live discovery, in which case the static list is only a fallback.
+    if (provider.staticModels?.length && !provider.preferLive) {
       this.cache.set(cacheKey, { models: provider.staticModels, timestamp: Date.now() });
       return provider.staticModels;
     }
@@ -399,6 +406,11 @@ export class ModelDiscoveryService {
       // Return cached results if available, even if expired
       if (cached) {
         return cached.models;
+      }
+
+      // Fall back to a static list when the live fetch fails (keeps the picker populated)
+      if (provider.staticModels?.length) {
+        return provider.staticModels;
       }
 
       // Return empty array on complete failure


### PR DESCRIPTION
## What

The Alibaba/DashScope Coding Plan **model picker was hardcoded** in two places, so paid models Alibaba added later (`qwen3.6-plus`, `qwen3.7-plus`) never showed up in the dropdown. Turns out the `/models` endpoint **does** return a live catalog (verified 2026-07-20) — the old `"endpoint doesn't support /models"` comment was simply wrong.

This makes the catalog self-updating so new Alibaba models appear automatically, with the hardcoded list kept only as an offline fallback.

## Changes

**`AlibabaModels.ts` (select-box provider)**
- Fetches `${baseUrl}/models` live (sends `Authorization` when an API key is present so the catalog reflects account entitlements; the DashScope route is also readable without auth).
- Maps known ids → friendly labels/descriptions via a `KNOWN` table; unknown/new ids still surface with their raw id as the label.
- Falls back to the static list only when the endpoint is unreachable (10s timeout).

**`ModelDiscoveryService.ts`**
- Adds a `preferLive` flag: a provider that has a `staticModels` list can still discover live, using the static list purely as a fallback.
- Enables `preferLive` for `alibaba` and refreshes the static seed with `qwen3.6-plus` / `qwen3.7-plus`.
- Adds a static-list fallback on live-fetch failure so the picker stays populated.

## Verification

- TS scoped-typecheck clean (full project `tsc` OOMs in the sandbox VM).
- Behavior-verified earlier that DashScope `/models` returns 200 with a live catalog. Live in-app confirmation (dropdown shows qwen3.6/3.7-plus) still wants a rebuild.

These were uncommitted working-tree changes on `main` — putting them up as a PR so they don't get lost. Separate from the native-TTS work in #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)