### PR TITLE
feat(audio): add Grok Voice (xAI TTS) as a third voice provider

### DIFF
--- a/pkg/rancher-desktop/agent/services/TextToSpeechService.ts
+++ b/pkg/rancher-desktop/agent/services/TextToSpeechService.ts
@@ -1,8 +1,12 @@
 /**
- * TextToSpeechService – sends text to ElevenLabs Text-to-Speech API
- * and returns audio bytes (mp3).
+ * TextToSpeechService – converts text to speech audio bytes (mp3).
  *
- * Uses the streaming endpoint and flash model for lowest latency.
+ * Provider-aware: routes to the cloud TTS provider selected in Audio Settings
+ * (`audioTtsProvider`). Supported providers:
+ *   - `elevenlabs` — ElevenLabs streaming endpoint, eleven_flash_v2_5 (lowest latency).
+ *   - `grok`       — xAI Grok Text-to-Speech (`POST https://api.x.ai/v1/tts`).
+ * (The keyless `system` / native-OS voice is handled entirely in the renderer by
+ * TTSPlayerService and never reaches this main-process service.)
  * Includes retry with exponential backoff and request timeouts.
  */
 
@@ -21,6 +25,10 @@ export function getTextToSpeechService(): TextToSpeechService {
 // Jessica — ElevenLabs default voice
 const DEFAULT_VOICE_ID = 'cgSgspJ2msm6clMCkdW9';
 
+// Grok TTS — https://api.x.ai/v1/tts. `eve` is xAI's default voice.
+const GROK_TTS_URL = 'https://api.x.ai/v1/tts';
+const GROK_DEFAULT_VOICE = 'eve';
+
 const MAX_RETRIES = 3;
 const INITIAL_BACKOFF_MS = 500;
 const REQUEST_TIMEOUT_MS = 15_000;
@@ -32,13 +40,25 @@ export class TextToSpeechService {
   private readonly baseUrl = 'https://api.elevenlabs.io/v1';
 
   /**
-   * Convert text to speech audio using ElevenLabs TTS streaming endpoint.
-   * Uses eleven_flash_v2_5 for lowest latency.
+   * Convert text to speech audio using the provider selected in Audio Settings.
    * @param text     The text to speak
-   * @param voiceId  ElevenLabs voice ID (falls back to settings if not provided)
+   * @param voiceId  Provider-specific voice id (falls back to the saved setting)
    * @returns Audio buffer (mp3) and MIME type
    */
   async speak(text: string, voiceId?: string): Promise<{ audio: Buffer; mimeType: string }> {
+    const provider = await this.getProvider();
+
+    if (provider === 'grok') {
+      return this.speakGrok(text, voiceId);
+    }
+
+    return this.speakElevenLabs(text, voiceId);
+  }
+
+  /**
+   * ElevenLabs TTS via the streaming endpoint (eleven_flash_v2_5).
+   */
+  private async speakElevenLabs(text: string, voiceId?: string): Promise<{ audio: Buffer; mimeType: string }> {
     const apiKey = await this.getApiKey();
 
     if (!apiKey) {
@@ -132,6 +152,113 @@ export class TextToSpeechService {
       }
 
       return null;
+    } catch {
+      return null;
+    }
+  }
+
+  // ─── Grok TTS ─────────────────────────────────────────────────
+
+  /**
+   * xAI Grok Text-to-Speech (`POST https://api.x.ai/v1/tts`). Returns mp3 bytes.
+   * Uses the metered xAI API key (Bearer) — the Grok OAuth subscription token is
+   * rejected by api.x.ai, so TTS specifically needs the pasted api_key.
+   */
+  private async speakGrok(text: string, voiceId?: string): Promise<{ audio: Buffer; mimeType: string }> {
+    const apiKey = await this.getGrokApiKey();
+
+    if (!apiKey) {
+      throw new Error('Grok API key is not configured. Add your xAI API key in Integrations → Grok.');
+    }
+
+    const voice = voiceId || await this.getConfiguredVoiceRaw() || GROK_DEFAULT_VOICE;
+
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        const delay = INITIAL_BACKOFF_MS * Math.pow(2, attempt - 1);
+        await new Promise(r => setTimeout(r, delay));
+      }
+
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+        const response = await fetch(GROK_TTS_URL, {
+          method:  'POST',
+          signal:  controller.signal,
+          headers: {
+            Authorization:  `Bearer ${ apiKey }`,
+            'Content-Type': 'application/json',
+          },
+          // Default output is MP3 24kHz/128kbps; `auto` lets Grok detect the language.
+          body: JSON.stringify({
+            text,
+            voice_id: voice,
+            language: 'auto',
+          }),
+        });
+
+        clearTimeout(timeout);
+
+        if (!response.ok) {
+          const errorBody = await response.text().catch(() => '');
+          lastError = new Error(`Grok TTS failed (${ response.status }): ${ errorBody }`);
+
+          if (RETRYABLE_STATUS_CODES.has(response.status)) {
+            continue; // retry
+          }
+          throw lastError; // non-retryable (e.g. 401, 400)
+        }
+
+        const arrayBuffer = await response.arrayBuffer();
+
+        return {
+          audio:    Buffer.from(arrayBuffer),
+          mimeType: 'audio/mpeg',
+        };
+      } catch (err: any) {
+        lastError = err;
+        if (err.name === 'AbortError') {
+          lastError = new Error(`Grok TTS request timed out after ${ REQUEST_TIMEOUT_MS }ms`);
+          continue;
+        }
+        if (err.message?.includes('fetch failed') || err.code === 'ECONNREFUSED' || err.code === 'ENOTFOUND') {
+          continue; // network error, retry
+        }
+        throw err; // non-retryable
+      }
+    }
+
+    throw lastError || new Error('Grok TTS failed after retries');
+  }
+
+  private async getGrokApiKey(): Promise<string | null> {
+    const integrationService = getIntegrationService();
+    const value = await integrationService.getIntegrationValue('grok', 'api_key');
+
+    return value?.value ?? null;
+  }
+
+  // ─── Provider / voice resolution ──────────────────────────────
+
+  private async getProvider(): Promise<string> {
+    try {
+      const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');
+
+      return (await SullaSettingsModel.get('audioTtsProvider', 'elevenlabs')) || 'elevenlabs';
+    } catch {
+      return 'elevenlabs';
+    }
+  }
+
+  /** Raw saved voice id, no provider-specific validation (Grok voice ids are short words). */
+  private async getConfiguredVoiceRaw(): Promise<string | null> {
+    try {
+      const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');
+
+      return (await SullaSettingsModel.get('audioTtsVoice', '')) || null;
     } catch {
       return null;
     }

--- a/pkg/rancher-desktop/pages/AudioSettings.vue
+++ b/pkg/rancher-desktop/pages/AudioSettings.vue
@@ -1044,6 +1044,8 @@ const ttsProviders = ref<TtsProviderInfo[]>([
   // Native macOS voices via the OS speech engine — always available, no API key. Mirrors Sulla Mobile's default.
   { id: 'system', name: 'System Default (macOS)', connected: true },
   { id: 'elevenlabs', name: 'ElevenLabs', connected: false, vaultKey: { integrationId: 'elevenlabs', property: 'api_key' } },
+  // xAI Grok Text-to-Speech. Uses the metered xAI API key (Grok integration → api_key).
+  { id: 'grok', name: 'Grok Voice', connected: false, vaultKey: { integrationId: 'grok', property: 'api_key' } },
 ]);
 
 const ttsProvider = ref('system');
@@ -1887,10 +1889,61 @@ async function fetchVoices(): Promise<void> {
       await fetchSystemVoices();
     } else if (ttsProvider.value === 'elevenlabs') {
       await fetchElevenLabsVoices();
+    } else if (ttsProvider.value === 'grok') {
+      await fetchGrokVoices();
     }
   } finally {
     loadingVoices.value = false;
   }
+}
+
+// Fetch Grok's built-in voices from GET /v1/tts/voices, falling back to the known
+// built-ins when no key is set or the endpoint is unreachable.
+async function fetchGrokVoices(): Promise<void> {
+  try {
+    const result = await ipcRenderer.invoke('integration-get-value', 'grok', 'api_key');
+    const apiKey = result?.value;
+
+    if (!apiKey) {
+      voices.value = getGrokStaticVoices();
+      return;
+    }
+
+    const response = await fetch('https://api.x.ai/v1/tts/voices', {
+      headers: { Authorization: `Bearer ${ apiKey }` },
+    });
+
+    if (!response.ok) {
+      voices.value = getGrokStaticVoices();
+      return;
+    }
+
+    // Response shape: either a bare array or { voices: [...] } of { voice_id, name }.
+    const body = await response.json() as { voices?: { voice_id: string; name?: string }[] } | { voice_id: string; name?: string }[];
+    const list = Array.isArray(body) ? body : (body.voices ?? []);
+
+    if (list.length > 0) {
+      voices.value = list.map(v => ({
+        value: v.voice_id,
+        label: v.name || v.voice_id,
+      }));
+    } else {
+      voices.value = getGrokStaticVoices();
+    }
+  } catch {
+    voices.value = getGrokStaticVoices();
+  }
+}
+
+// Grok's five built-in voices (docs.x.ai). `eve` is the API default.
+function getGrokStaticVoices(): { value: string; label: string; description?: string }[] {
+  return [
+    { value: 'eve', label: 'Eve', description: 'default' },
+    { value: 'ara', label: 'Ara' },
+    { value: 'leo', label: 'Leo' },
+    { value: 'rex', label: 'Rex' },
+    { value: 'sal', label: 'Sal' },
+  ];
 }
 
 // Enumerate the OS speech-engine voices exposed through the browser SpeechSynthesis API.


### PR DESCRIPTION
## What

Adds **xAI Grok Text-to-Speech** as a third selectable voice provider, alongside **System Default (macOS)** (#510) and **ElevenLabs**. Requested by Jonathon: *"add another option for the voice — Grok Voice API."*

## Which Grok voice API — and why

Grok has **two** voice offerings:
1. **Realtime Voice Agent** — `wss://api.x.ai/v1/realtime`, a bidirectional conversational WebSocket (STT+LLM+TTS in one session, server VAD). Great for a live two-way voice *mode*, but it is **not** a text→audio call.
2. **Standalone Grok TTS** — `POST https://api.x.ai/v1/tts`, returns audio bytes for a text string.

For a **voice-provider dropdown** ("speak this reply"), #2 is the correct fit — it maps 1:1 onto the existing ElevenLabs `text → mp3 bytes` pipeline. (The realtime agent would belong in a future conversational *voice mode*, not the TTS provider list.)

Verified against **docs.x.ai**: `POST /v1/tts`, `Authorization: Bearer`, body `{ text, voice_id, language }`, default output MP3 24kHz/128kbps, voices `eve`(default)/`ara`/`leo`/`rex`/`sal`, voices listed at `GET /v1/tts/voices`.

## Changes

**`TextToSpeechService.ts` (main)** — now **provider-aware**: reads `audioTtsProvider` and routes to `speakGrok()` or `speakElevenLabs()`.
- `speakGrok()` posts to `/v1/tts` with the **metered xAI `api_key`** (Bearer) — the Grok OAuth *subscription* token is rejected by `api.x.ai` (per `GrokService`), so TTS specifically needs the pasted key. Same retry/backoff/timeout as the ElevenLabs path.
- Provider-agnostic raw voice resolver so short Grok ids (`eve`…`sal`) aren't rejected by ElevenLabs' 15-char-id guard.

**`AudioSettings.vue` (renderer)** — new `grok` provider (`vaultKey` → `grok`/`api_key`); `fetchGrokVoices()` pulls `GET /v1/tts/voices` with a static fallback to the five built-ins. Preview + runtime already route non-`system` providers through the `audio-speak` IPC, so both work unchanged.

## Setup / auth note

Grok TTS is **metered** (~$4.20 / 1M chars) and needs a pasted **xAI API key** in Integrations → Grok (`api_key`) — *not* the SuperGrok/X-Premium OAuth login. If only OAuth-connected, the provider shows "Not configured" (by design).

## Verification

- TS scoped-typecheck clean (full project `tsc` OOMs in the sandbox VM; `.vue` isn't tsc-checked without vue-tsc).
- API shape verified against docs.x.ai. **Not yet exercised against a live key / in a built app** — needs a real xAI key + rebuild to hear it. Flagging that as the remaining step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)