### PR TITLE
feat(audio): selectable STT provider — local Whisper (default) or Grok

### DIFF
--- a/pkg/rancher-desktop/main/audio-driver/init.ts
+++ b/pkg/rancher-desktop/main/audio-driver/init.ts
@@ -506,7 +506,29 @@ function registerIpcHandlers(): void {
   }) => {
     log.info('IPC', 'transcribe-start', opts);
 
-    if (!whisper.isAvailable()) {
+    // Resolve the selected STT provider. Defaults to local whisper; when the user
+    // picks Grok, fetch the metered xAI api key (OAuth tokens are rejected by api.x.ai).
+    let sttProvider: 'whisper' | 'grok' = 'whisper';
+    let grokApiKey: string | null = null;
+    try {
+      const { SullaSettingsModel } = await import('@pkg/agent/database/models/SullaSettingsModel');
+      sttProvider = (await SullaSettingsModel.get('audioSttProvider', 'whisper')) === 'grok' ? 'grok' : 'whisper';
+    } catch { /* default to whisper */ }
+
+    if (sttProvider === 'grok') {
+      try {
+        const { getIntegrationService } = await import('@pkg/agent/services/IntegrationService');
+        grokApiKey = (await getIntegrationService().getIntegrationValue('grok', 'api_key'))?.value || null;
+      } catch { /* no key — fall back to whisper below */ }
+
+      if (!grokApiKey) {
+        log.warn('IPC', 'transcribe-start: Grok STT selected but no xAI api key — falling back to whisper');
+        sttProvider = 'whisper';
+      }
+    }
+
+    // Local whisper needs the binary present; Grok does not.
+    if (sttProvider === 'whisper' && !whisper.isAvailable()) {
       await whisper.detect();
     }
 
@@ -517,6 +539,8 @@ function registerIpcHandlers(): void {
       mode:         opts.mode,
       language:     opts.language,
       model:        opts.model,
+      provider:     sttProvider,
+      grokApiKey,
       onTranscript: (event) => {
         broadcast('gateway-transcript', event);
         // Feed the main-process teleprompter tracker (no-ops if not tracking)
@@ -524,7 +548,7 @@ function registerIpcHandlers(): void {
       },
     });
 
-    return { ok };
+    return { ok, provider: sttProvider };
   });
 
   ipcMain.handle('audio-driver:transcribe-stop', () => {

--- a/pkg/rancher-desktop/main/audio-driver/service/whisper-transcribe.ts
+++ b/pkg/rancher-desktop/main/audio-driver/service/whisper-transcribe.ts
@@ -1,10 +1,16 @@
 /**
- * Service — local whisper.cpp transcription.
+ * Service — speech-to-text transcription.
  *
  * Sits on top of the audio driver. Consumes PCM audio from the existing
  * capture pipeline and produces transcript events in the same format as
  * the gateway (transcript_turn / transcript_partial), so existing UI
  * code (SecretaryModeController, ChatInterface) works unchanged.
+ *
+ * The buffering / VAD-gated segmentation / 2s flush cadence is provider-
+ * agnostic; only the per-segment engine differs:
+ *   - `whisper` (default) — local whisper.cpp, fully offline.
+ *   - `grok`             — xAI Grok STT (`POST https://api.x.ai/v1/stt`).
+ * The provider (and Grok api key) are chosen per-session in start().
  *
  * Two modes:
  *   - conversation: mic channel only → transcript sent to Sulla chat
@@ -22,6 +28,11 @@ import * as whisperModel from '../model/whisper';
 // ─── Types ──────────────────────────────────────────────────
 
 export type TranscribeMode = 'conversation' | 'secretary';
+
+/** STT engine. `whisper` = local whisper.cpp; `grok` = xAI Grok STT. */
+export type SttProvider = 'whisper' | 'grok';
+
+const GROK_STT_URL = 'https://api.x.ai/v1/stt';
 
 export interface TranscriptEvent {
   event_type: 'transcript_turn' | 'transcript_partial';
@@ -48,6 +59,11 @@ let onTranscript: TranscriptCallback | null = null;
 let language = 'en';
 let modelName = 'base.en';
 
+// STT engine for this session. Defaults to local whisper; the transcribe-start
+// IPC handler passes `grok` + the api key when the user selects Grok STT.
+let provider: SttProvider = 'whisper';
+let grokApiKey: string | null = null;
+
 // Per-channel PCM accumulators (raw s16le, 16kHz, mono)
 const micBuffer: Buffer[] = [];
 const speakerBuffer: Buffer[] = [];
@@ -65,8 +81,18 @@ export function start(opts: {
   onTranscript: TranscriptCallback;
   language?:    string;
   model?:       string;
+  provider?:    SttProvider;
+  grokApiKey?:  string | null;
 }): boolean {
-  if (!whisperModel.isAvailable()) {
+  const useGrok = opts.provider === 'grok';
+
+  // Grok STT needs an api key; local whisper needs the binary + a model.
+  if (useGrok) {
+    if (!opts.grokApiKey) {
+      log.error('WhisperTranscribe', 'Cannot start — Grok STT selected but no xAI api key');
+      return false;
+    }
+  } else if (!whisperModel.isAvailable()) {
     log.error('WhisperTranscribe', 'Cannot start — whisper.cpp not installed');
     return false;
   }
@@ -75,7 +101,7 @@ export function start(opts: {
   const models = status?.models ?? [];
   const requestedModel = opts.model || modelName;
 
-  if (models.length === 0) {
+  if (!useGrok && models.length === 0) {
     log.error('WhisperTranscribe', 'Cannot start — no whisper models downloaded');
     return false;
   }
@@ -89,8 +115,11 @@ export function start(opts: {
     return true;
   }
 
-  // Use requested model if available, otherwise first available model
-  modelName = models.includes(requestedModel) ? requestedModel : models[0];
+  provider = opts.provider || 'whisper';
+  grokApiKey = opts.grokApiKey || null;
+
+  // Use requested model if available, otherwise first available model (whisper only)
+  modelName = models.includes(requestedModel) ? requestedModel : (models[0] || modelName);
   mode = opts.mode;
   onTranscript = opts.onTranscript;
   language = opts.language || 'en';
@@ -119,6 +148,8 @@ export function stop(): void {
 
   mode = null;
   onTranscript = null;
+  provider = 'whisper';
+  grokApiKey = null;
   resetBuffers();
   log.info('WhisperTranscribe', 'Stopped');
 }
@@ -229,6 +260,12 @@ function transcribeChunk(pcm: Buffer, channel: number, speakerLabel: string): vo
     return;
   }
 
+  // Cloud engine: transcribe the segment via Grok STT instead of local whisper.
+  if (provider === 'grok' && grokApiKey) {
+    transcribeChunkGrok(pcm, channel, speakerLabel);
+    return;
+  }
+
   const wavPath = path.join(tmpDir, `ch${ channel }-${ Date.now() }.wav`);
 
   writeWav(wavPath, pcm);
@@ -306,9 +343,9 @@ function transcribeChunk(pcm: Buffer, channel: number, speakerLabel: string): vo
 }
 
 /**
- * Write raw PCM data as a valid WAV file (RIFF header + data).
+ * Build a valid WAV (RIFF header + PCM data) in memory.
  */
-function writeWav(filePath: string, pcm: Buffer): void {
+function buildWav(pcm: Buffer): Buffer {
   const dataSize = pcm.length;
   const header = Buffer.alloc(44);
 
@@ -331,7 +368,75 @@ function writeWav(filePath: string, pcm: Buffer): void {
   header.write('data', 36);
   header.writeUInt32LE(dataSize, 40);
 
-  fs.writeFileSync(filePath, Buffer.concat([header, pcm]));
+  return Buffer.concat([header, pcm]);
+}
+
+/**
+ * Write raw PCM data as a valid WAV file (RIFF header + data).
+ */
+function writeWav(filePath: string, pcm: Buffer): void {
+  fs.writeFileSync(filePath, buildWav(pcm));
+}
+
+/**
+ * Grok STT engine — transcribe a PCM segment via `POST https://api.x.ai/v1/stt`.
+ * Wraps the segment as WAV and uploads it as multipart/form-data (the `file`
+ * field must come after the other fields per the xAI API). Emits the same
+ * transcript_turn event whisper does, so all downstream UI is unchanged.
+ */
+function transcribeChunkGrok(pcm: Buffer, channel: number, speakerLabel: string): void {
+  const wav = buildWav(pcm);
+
+  transcribing = true;
+
+  const form = new FormData();
+
+  form.append('language', language);
+  // `file` must be appended last (xAI multipart requirement).
+  form.append('file', new Blob([new Uint8Array(wav)], { type: 'audio/wav' }), `ch${ channel }.wav`);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+
+  fetch(GROK_STT_URL, {
+    method:  'POST',
+    signal:  controller.signal,
+    headers: { Authorization: `Bearer ${ grokApiKey }` },
+    body:    form,
+  })
+    .then(async(response) => {
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        log.warn('WhisperTranscribe', 'Grok STT failed', { status: response.status, body: body.slice(0, 200) });
+        return;
+      }
+
+      const data = await response.json() as { text?: string };
+      const text = (data.text || '').trim();
+
+      if (!text || text.length < 2) {
+        log.debug('WhisperTranscribe', 'Grok STT blank/empty — skipping', { channel });
+        return;
+      }
+
+      log.info('WhisperTranscribe', 'Grok transcript', { channel, speaker: speakerLabel, text: text.substring(0, 80) });
+
+      if (onTranscript) {
+        onTranscript({
+          event_type: 'transcript_turn',
+          text,
+          speaker:    speakerLabel,
+          channel,
+        });
+      }
+    })
+    .catch((err) => {
+      log.warn('WhisperTranscribe', 'Grok STT request error', { error: err?.message });
+    })
+    .finally(() => {
+      clearTimeout(timeout);
+      transcribing = false;
+    });
 }
 
 function cleanupFile(filePath: string): void {

--- a/pkg/rancher-desktop/pages/AudioSettings.vue
+++ b/pkg/rancher-desktop/pages/AudioSettings.vue
@@ -667,9 +667,36 @@
         >
           <h2>Transcription</h2>
           <p class="description">
-            Local speech-to-text powered by whisper.cpp. Runs entirely on your
-            machine &mdash; no network, no API keys, no data sent anywhere.
+            Speech-to-text for voice chat and Secretary Mode. Use local
+            whisper.cpp (private, offline, no API key) or a cloud provider.
           </p>
+
+          <!-- ── STT Provider selection ── -->
+          <div class="setting-section">
+            <h3>Provider</h3>
+            <div class="voice-select-row">
+              <select
+                v-model="sttProvider"
+                class="setting-select"
+                @change="onSttProviderChange"
+              >
+                <option value="whisper">
+                  Whisper (Local &mdash; default)
+                </option>
+                <option value="grok">
+                  Grok (xAI)
+                </option>
+              </select>
+            </div>
+            <p
+              v-if="sttProvider === 'grok'"
+              class="description"
+              :class="grokSttConnected ? 'banner-success' : 'banner-info'"
+            >
+              <span v-if="grokSttConnected">Grok speech-to-text is connected. Audio is sent to xAI for transcription.</span>
+              <span v-else>Grok speech-to-text needs your xAI API key in Integrations &rarr; Grok. Until then, transcription falls back to local Whisper.</span>
+            </p>
+          </div>
 
           <!-- ── Progress / Activity Log ── -->
           <div
@@ -713,8 +740,11 @@
             </div>
           </div>
 
-          <!-- ── Engine Status ── -->
-          <div class="setting-section">
+          <!-- ── Engine Status (whisper only) ── -->
+          <div
+            v-if="sttProvider === 'whisper'"
+            class="setting-section"
+          >
             <h3>whisper.cpp Engine</h3>
             <div
               v-if="whisperVersion"
@@ -734,7 +764,7 @@
 
           <!-- ── Model Management (only when installed) ── -->
           <div
-            v-if="whisperInstalled"
+            v-if="sttProvider === 'whisper' && whisperInstalled"
             class="setting-section"
           >
             <h3>Models</h3>
@@ -827,7 +857,7 @@
 
           <!-- ── Test Transcription (only when installed + has models) ── -->
           <div
-            v-if="whisperInstalled && whisperModels.length > 0"
+            v-if="sttProvider === 'whisper' && whisperInstalled && whisperModels.length > 0"
             class="setting-section"
           >
             <h3>Test</h3>
@@ -1090,6 +1120,10 @@ const audioInputDeviceId = ref('');
 const audioInputDevices = ref<{ value: string; label: string }[]>([]);
 const loadingDevices = ref(false);
 const sttLanguage = ref('en-US');
+
+// STT provider — 'whisper' (local, default) or 'grok' (xAI cloud STT).
+const sttProvider = ref('whisper');
+const grokSttConnected = ref(false);
 
 // ─── Speaker tab ────────────────────────────────────────────────
 
@@ -1815,6 +1849,21 @@ function onMicDeviceChange() {
   saveSettings();
 }
 
+function onSttProviderChange() {
+  saveSettings();
+  checkGrokSttConnection();
+}
+
+// Grok STT uses the same metered xAI api_key as Grok TTS (OAuth tokens are rejected by api.x.ai).
+async function checkGrokSttConnection(): Promise<void> {
+  try {
+    const result = await ipcRenderer.invoke('integration-get-value', 'grok', 'api_key');
+    grokSttConnected.value = !!(result?.value);
+  } catch {
+    grokSttConnected.value = false;
+  }
+}
+
 // ─── Settings persistence ───────────────────────────────────────
 
 async function loadSettings(): Promise<void> {
@@ -1824,6 +1873,7 @@ async function loadSettings(): Promise<void> {
     ttsVoiceName.value = await ipcRenderer.invoke('sulla-settings-get', 'audioTtsVoiceName', '');
     transcriptionMode.value = await ipcRenderer.invoke('sulla-settings-get', 'audioTranscriptionMode', 'browser');
     sttLanguage.value = await ipcRenderer.invoke('sulla-settings-get', 'audioSttLanguage', 'en-US');
+    sttProvider.value = await ipcRenderer.invoke('sulla-settings-get', 'audioSttProvider', 'whisper');
     audioInputDeviceId.value = await ipcRenderer.invoke('sulla-settings-get', 'audioInputDeviceId', '');
     activeWhisperModel.value = await ipcRenderer.invoke('sulla-settings-get', 'audioWhisperModel', '');
   } catch (err) {
@@ -1838,6 +1888,7 @@ async function saveSettings(): Promise<void> {
     await ipcRenderer.invoke('sulla-settings-set', 'audioTtsVoiceName', ttsVoiceName.value);
     await ipcRenderer.invoke('sulla-settings-set', 'audioTranscriptionMode', transcriptionMode.value);
     await ipcRenderer.invoke('sulla-settings-set', 'audioSttLanguage', sttLanguage.value);
+    await ipcRenderer.invoke('sulla-settings-set', 'audioSttProvider', sttProvider.value);
     await ipcRenderer.invoke('sulla-settings-set', 'audioInputDeviceId', audioInputDeviceId.value);
   } catch (err) {
     console.error('[AudioSettings] Failed to save settings:', err);
@@ -2095,6 +2146,7 @@ onMounted(async() => {
   await loadSettings();
   await checkProviders();
   await checkGateway();
+  await checkGrokSttConnection();
   await fetchVoices();
   await fetchAudioDevices();
 


### PR DESCRIPTION
## What

Decouples **speech-to-text** from **text-to-speech** so each side of the voice chain is chosen independently, per Jonathon: *"text-to-speech I can pick any provider… and separately I could change the speech-to-text to any provider I want, including the local default."*

STT gets its own **Provider** selector on the Transcription tab:
- **Whisper (local, default)** — private, offline, no API key. Unchanged behavior.
- **Grok (xAI)** — cloud STT via `POST https://api.x.ai/v1/stt`.

TTS keeps its separate System / ElevenLabs / Grok picker (#510/#512). The two are fully independent.

## How

The existing STT pipeline (mic capture → VAD → 2s segmentation → flush → transcript broadcast) is **provider-agnostic**; only the per-segment engine differs, so all mic capture and downstream transcript UI (voice chat + Secretary Mode) is untouched.

- **`whisper-transcribe.ts`** — adds a `grok` engine beside local whisper. Each 2s PCM segment is WAV-wrapped and POSTed to `/v1/stt` (multipart; `file` field last per xAI), parsed to `{text}`, and emitted as the same `transcript_turn` event. `start()` now takes `provider` + `grokApiKey`; whisper model checks are skipped when Grok is active.
- **`init.ts` (`transcribe-start` handler)** — resolves `audioSttProvider` from settings + the **metered** grok `api_key` from the vault, passes them down. **Falls back to whisper** if Grok is selected without a key. Zero changes to the three renderer STT call sites — routing is centralized here.
- **`AudioSettings.vue`** — STT Provider selector + `audioSttProvider` setting (default `whisper`); whisper Engine/Models/Test sections hide when Grok is selected; Grok connection status shown.

## Notes

- **Auth:** Grok STT uses the same **metered xAI api_key** as Grok TTS (the SuperGrok OAuth token is rejected by `api.x.ai`).
- **Default unchanged:** whisper stays the default, so nothing changes unless you deliberately switch — fully reversible.
- Verified against **docs.x.ai** (`POST /v1/stt`, multipart, Bearer, response `{text, language, duration, words}`). There is also a realtime `wss://api.x.ai/v1/stt` variant — a future latency optimization; this first cut mirrors whispers existing per-segment cadence.

## Verification

- Main-process files (`whisper-transcribe.ts`, `init.ts`) scoped-typecheck clean; `.vue` isnt tsc-checked without vue-tsc.
- **Not yet run against a live key / in a built app** — needs a real xAI key + rebuild to confirm transcripts flow. Flagging that as the remaining step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)