### PR TITLE
Draft: implement #516 episodic knowledge graph schema

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0029_create_knowledge_graph.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0029_create_knowledge_graph.ts
@@ -1,0 +1,45 @@
+export const up = `
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS unaccent;
+CREATE OR REPLACE FUNCTION norm_alias(x text) RETURNS text
+ LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+$$ SELECT regexp_replace(lower(unaccent('unaccent', x)), '[^a-z0-9#]+', '', 'g') $$;
+
+CREATE TABLE IF NOT EXISTS knowledge_nodes (
+ id TEXT PRIMARY KEY,
+ node_type TEXT NOT NULL DEFAULT 'entity',
+ title TEXT NOT NULL, summary TEXT NOT NULL DEFAULT '', detail TEXT,
+ link_count INTEGER NOT NULL DEFAULT 0, recall_count INTEGER NOT NULL DEFAULT 0,
+ last_recalled_at TIMESTAMPTZ, archived BOOLEAN NOT NULL DEFAULT false,
+ merged_into TEXT REFERENCES knowledge_nodes(id), source TEXT,
+ created_at TIMESTAMPTZ NOT NULL DEFAULT now(), updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+ search_tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', title || ' ' || summary)) STORED
+);
+CREATE TABLE IF NOT EXISTS node_aliases (
+ alias TEXT NOT NULL, alias_norm TEXT NOT NULL,
+ node_id TEXT NOT NULL REFERENCES knowledge_nodes(id) ON DELETE CASCADE,
+ PRIMARY KEY (alias_norm, node_id)
+);
+CREATE TABLE IF NOT EXISTS node_links (
+ src_id TEXT NOT NULL REFERENCES knowledge_nodes(id) ON DELETE CASCADE,
+ dst_id TEXT NOT NULL REFERENCES knowledge_nodes(id) ON DELETE CASCADE,
+ relation_type TEXT NOT NULL DEFAULT 'related_to',
+ strength REAL NOT NULL DEFAULT 0.3, fire_count INTEGER NOT NULL DEFAULT 0,
+ last_fired_at TIMESTAMPTZ, confirmed BOOLEAN NOT NULL DEFAULT false,
+ created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+ PRIMARY KEY (src_id, dst_id, relation_type), CHECK (src_id <> dst_id)
+);
+CREATE INDEX IF NOT EXISTS idx_node_aliases_norm ON node_aliases (alias_norm);
+CREATE INDEX IF NOT EXISTS idx_node_aliases_trgm ON node_aliases USING gin (alias_norm gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_knowledge_nodes_tsv ON knowledge_nodes USING gin (search_tsv);
+CREATE INDEX IF NOT EXISTS idx_node_links_src ON node_links (src_id) INCLUDE (dst_id, relation_type, strength, confirmed, last_fired_at, created_at);
+CREATE INDEX IF NOT EXISTS idx_node_links_dst ON node_links (dst_id) INCLUDE (src_id, relation_type, strength, confirmed, last_fired_at, created_at);
+CREATE INDEX IF NOT EXISTS idx_knowledge_nodes_hub ON knowledge_nodes (link_count DESC) WHERE archived = false;
+`;
+
+export const down = `
+DROP TABLE IF EXISTS node_links CASCADE;
+DROP TABLE IF EXISTS node_aliases CASCADE;
+DROP TABLE IF EXISTS knowledge_nodes CASCADE;
+DROP FUNCTION IF EXISTS norm_alias(text);
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -24,6 +24,7 @@ import { up as up_0028, down as down_0028 } from './0028_create_observations_tab
 // NOTE: numbered 0037+ (not 0029-0032) to sit AFTER the CRM dynamic-schema
 // migrations 0029-0036 that production has already executed. See commit message /
 // docs/MIGRATION_NOTES.md §7 for the collision-resolution rationale.
+import { up as up_0029, down as down_0029 } from './0029_create_knowledge_graph';
 import { up as up_0037, down as down_0037 } from './0037_create_routine_stewardship_views';
 import { up as up_0038, down as down_0038 } from './0038_create_routine_digest_views';
 import { up as up_0039, down as down_0039 } from './0039_create_routine_promotion_candidates_view';
@@ -52,8 +53,9 @@ export const migrationsRegistry = [
   { name: '0026_create_workflow_executions_table', up: up_0026, down: down_0026 },
   { name: '0027_create_audit_history_tables', up: up_0027, down: down_0027 },
   { name: '0028_create_observations_table',   up: up_0028, down: down_0028 },
-  { name: '0037_create_routine_stewardship_views', up: up_0037, down: down_0037 },
-  { name: '0038_create_routine_digest_views', up: up_0038, down: down_0038 },
-  { name: '0039_create_routine_promotion_candidates_view', up: up_0039, down: down_0039 },
-  { name: '0040_create_heartbeat_seen_issues_table', up: up_0040, down: down_0040 },
+  { name: '0029_create_knowledge_graph',               up: up_0029, down: down_0029 },
+  { name: '0037_create_routine_stewardship_views',          up: up_0037, down: down_0037 },
+  { name: '0038_create_routine_digest_views',               up: up_0038, down: down_0038 },
+  { name: '0039_create_routine_promotion_candidates_view',  up: up_0039, down: down_0039 },
+  { name: '0040_create_heartbeat_seen_issues_table',        up: up_0040, down: down_0040 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/KnowledgeGraphModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/KnowledgeGraphModel.ts
@@ -1,0 +1,267 @@
+import { postgresClient } from '../PostgresClient';
+
+export interface KnowledgeNodeRecord {
+  id:               string;
+  node_type:        string;
+  title:            string;
+  summary:          string;
+  detail:           string | null;
+  link_count:       number;
+  recall_count:     number;
+  last_recalled_at: string | null;
+  archived:         boolean;
+  merged_into:      string | null;
+  source:           string | null;
+  created_at:       string;
+  updated_at:       string;
+}
+
+export interface NodeAliasRecord {
+  alias:      string;
+  alias_norm: string;
+  node_id:    string;
+}
+
+export interface NodeLinkRecord {
+  src_id:        string;
+  dst_id:        string;
+  relation_type: string;
+  strength:      number;
+  fire_count:    number;
+  last_fired_at: string | null;
+  confirmed:     boolean;
+  created_at:    string;
+}
+
+export interface UpsertKnowledgeNodeInput {
+  id:           string;
+  node_type?:   string;
+  title:        string;
+  summary?:     string;
+  detail?:      string | null;
+  source?:      string | null;
+  archived?:    boolean;
+  merged_into?: string | null;
+}
+
+export interface AliasResolutionRecord {
+  node_id:   string;
+  title:     string;
+  node_type: string;
+  alias:     string;
+  match:     'exact' | 'fuzzy';
+  sim:       number;
+}
+
+export class KnowledgeGraphModel {
+  static readonly NODES_TABLE = 'knowledge_nodes';
+  static readonly ALIASES_TABLE = 'node_aliases';
+  static readonly LINKS_TABLE = 'node_links';
+
+  static async ensureSchema(): Promise<void> {
+    await postgresClient.query(`
+      CREATE EXTENSION IF NOT EXISTS pg_trgm;
+      CREATE EXTENSION IF NOT EXISTS unaccent;
+      CREATE OR REPLACE FUNCTION norm_alias(x text) RETURNS text
+       LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+      $$ SELECT regexp_replace(lower(unaccent('unaccent', x)), '[^a-z0-9#]+', '', 'g') $$;
+
+      CREATE TABLE IF NOT EXISTS ${ KnowledgeGraphModel.NODES_TABLE } (
+       id TEXT PRIMARY KEY,
+       node_type TEXT NOT NULL DEFAULT 'entity',
+       title TEXT NOT NULL, summary TEXT NOT NULL DEFAULT '', detail TEXT,
+       link_count INTEGER NOT NULL DEFAULT 0, recall_count INTEGER NOT NULL DEFAULT 0,
+       last_recalled_at TIMESTAMPTZ, archived BOOLEAN NOT NULL DEFAULT false,
+       merged_into TEXT REFERENCES ${ KnowledgeGraphModel.NODES_TABLE }(id), source TEXT,
+       created_at TIMESTAMPTZ NOT NULL DEFAULT now(), updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+       search_tsv tsvector GENERATED ALWAYS AS (to_tsvector('english', title || ' ' || summary)) STORED
+      );
+      CREATE TABLE IF NOT EXISTS ${ KnowledgeGraphModel.ALIASES_TABLE } (
+       alias TEXT NOT NULL, alias_norm TEXT NOT NULL,
+       node_id TEXT NOT NULL REFERENCES ${ KnowledgeGraphModel.NODES_TABLE }(id) ON DELETE CASCADE,
+       PRIMARY KEY (alias_norm, node_id)
+      );
+      CREATE TABLE IF NOT EXISTS ${ KnowledgeGraphModel.LINKS_TABLE } (
+       src_id TEXT NOT NULL REFERENCES ${ KnowledgeGraphModel.NODES_TABLE }(id) ON DELETE CASCADE,
+       dst_id TEXT NOT NULL REFERENCES ${ KnowledgeGraphModel.NODES_TABLE }(id) ON DELETE CASCADE,
+       relation_type TEXT NOT NULL DEFAULT 'related_to',
+       strength REAL NOT NULL DEFAULT 0.3, fire_count INTEGER NOT NULL DEFAULT 0,
+       last_fired_at TIMESTAMPTZ, confirmed BOOLEAN NOT NULL DEFAULT false,
+       created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+       PRIMARY KEY (src_id, dst_id, relation_type), CHECK (src_id <> dst_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_node_aliases_norm ON ${ KnowledgeGraphModel.ALIASES_TABLE } (alias_norm);
+      CREATE INDEX IF NOT EXISTS idx_node_aliases_trgm ON ${ KnowledgeGraphModel.ALIASES_TABLE } USING gin (alias_norm gin_trgm_ops);
+      CREATE INDEX IF NOT EXISTS idx_knowledge_nodes_tsv ON ${ KnowledgeGraphModel.NODES_TABLE } USING gin (search_tsv);
+      CREATE INDEX IF NOT EXISTS idx_node_links_src ON ${ KnowledgeGraphModel.LINKS_TABLE } (src_id) INCLUDE (dst_id, relation_type, strength, confirmed, last_fired_at, created_at);
+      CREATE INDEX IF NOT EXISTS idx_node_links_dst ON ${ KnowledgeGraphModel.LINKS_TABLE } (dst_id) INCLUDE (src_id, relation_type, strength, confirmed, last_fired_at, created_at);
+      CREATE INDEX IF NOT EXISTS idx_knowledge_nodes_hub ON ${ KnowledgeGraphModel.NODES_TABLE } (link_count DESC) WHERE archived = false;
+    `);
+  }
+
+  static async resolveAliases(terms: string[]): Promise<AliasResolutionRecord[]> {
+    const cleanTerms = terms.map(t => t.trim()).filter(Boolean);
+    if (cleanTerms.length === 0) return [];
+
+    return postgresClient.query<AliasResolutionRecord>(
+      `WITH input_terms AS (
+         SELECT unnest($1::text[]) AS term
+       ),
+       normalized_terms AS (
+         SELECT term, norm_alias(term) AS term_norm
+         FROM input_terms
+         WHERE norm_alias(term) <> ''
+       ),
+       exact_matches AS (
+         SELECT DISTINCT ON (a.node_id, a.alias_norm)
+           a.node_id, n.title, n.node_type, a.alias, 'exact'::text AS match, 1::real AS sim
+         FROM normalized_terms t
+         JOIN ${ KnowledgeGraphModel.ALIASES_TABLE } a ON a.alias_norm = t.term_norm
+         JOIN ${ KnowledgeGraphModel.NODES_TABLE } n ON n.id = a.node_id
+         WHERE n.archived = false AND n.merged_into IS NULL
+         ORDER BY a.node_id, a.alias_norm, a.alias
+       ),
+       fuzzy_matches AS (
+         SELECT DISTINCT ON (a.node_id, a.alias_norm)
+           a.node_id, n.title, n.node_type, a.alias, 'fuzzy'::text AS match,
+           similarity(a.alias_norm, t.term_norm)::real AS sim
+         FROM normalized_terms t
+         JOIN ${ KnowledgeGraphModel.ALIASES_TABLE } a ON a.alias_norm % t.term_norm
+         JOIN ${ KnowledgeGraphModel.NODES_TABLE } n ON n.id = a.node_id
+         WHERE n.archived = false
+           AND n.merged_into IS NULL
+           AND NOT EXISTS (
+             SELECT 1 FROM exact_matches e WHERE e.node_id = a.node_id
+           )
+         ORDER BY a.node_id, a.alias_norm, similarity(a.alias_norm, t.term_norm) DESC, a.alias
+       )
+       SELECT node_id, title, node_type, alias, match, sim
+       FROM (
+         SELECT * FROM exact_matches
+         UNION ALL
+         SELECT * FROM fuzzy_matches
+       ) matches
+       ORDER BY CASE match WHEN 'exact' THEN 0 ELSE 1 END, sim DESC, title ASC`,
+      [cleanTerms],
+    );
+  }
+
+  static async getNode(id: string): Promise<KnowledgeNodeRecord | null> {
+    return postgresClient.queryOne<KnowledgeNodeRecord>(
+      `SELECT * FROM ${ KnowledgeGraphModel.NODES_TABLE } WHERE id = $1 LIMIT 1`,
+      [id],
+    );
+  }
+
+  static async upsertNode(input: UpsertKnowledgeNodeInput): Promise<KnowledgeNodeRecord> {
+    const row = await postgresClient.queryOne<KnowledgeNodeRecord>(
+      `INSERT INTO ${ KnowledgeGraphModel.NODES_TABLE }
+         (id, node_type, title, summary, detail, source, archived, merged_into)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (id) DO UPDATE SET
+         node_type = EXCLUDED.node_type,
+         title = EXCLUDED.title,
+         summary = EXCLUDED.summary,
+         detail = EXCLUDED.detail,
+         source = EXCLUDED.source,
+         archived = EXCLUDED.archived,
+         merged_into = EXCLUDED.merged_into,
+         updated_at = now()
+       RETURNING *`,
+      [
+        input.id,
+        input.node_type ?? 'entity',
+        input.title,
+        input.summary ?? '',
+        input.detail ?? null,
+        input.source ?? null,
+        input.archived ?? false,
+        input.merged_into ?? null,
+      ],
+    );
+
+    if (!row) throw new Error(`Failed to upsert knowledge node: ${ input.id }`);
+    return row;
+  }
+
+  static async addAlias(nodeId: string, alias: string): Promise<NodeAliasRecord> {
+    const row = await postgresClient.queryOne<NodeAliasRecord>(
+      `INSERT INTO ${ KnowledgeGraphModel.ALIASES_TABLE } (alias, alias_norm, node_id)
+       VALUES ($1, norm_alias($1), $2)
+       ON CONFLICT (alias_norm, node_id) DO UPDATE SET alias = EXCLUDED.alias
+       RETURNING *`,
+      [alias, nodeId],
+    );
+
+    if (!row) throw new Error(`Failed to add alias "${ alias }" for node: ${ nodeId }`);
+    return row;
+  }
+
+  static async linkNodes(srcId: string, dstId: string, relationType = 'related_to', strength = 0.3): Promise<NodeLinkRecord> {
+    return postgresClient.transaction(async(client) => {
+      const { rows } = await client.query<NodeLinkRecord>(
+        `WITH inserted AS (
+           INSERT INTO ${ KnowledgeGraphModel.LINKS_TABLE }
+             (src_id, dst_id, relation_type, strength)
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT (src_id, dst_id, relation_type) DO UPDATE SET
+             strength = EXCLUDED.strength
+           RETURNING *, (xmax = 0) AS was_inserted
+         ),
+         bumped AS (
+           UPDATE ${ KnowledgeGraphModel.NODES_TABLE } n
+           SET link_count = link_count + 1, updated_at = now()
+           FROM inserted i
+           WHERE i.was_inserted
+             AND n.id IN (i.src_id, i.dst_id)
+           RETURNING n.id
+         )
+         SELECT src_id, dst_id, relation_type, strength, fire_count, last_fired_at, confirmed, created_at
+         FROM inserted`,
+        [srcId, dstId, relationType, strength],
+      );
+      if (!rows[0]) throw new Error(`Failed to link ${ srcId } -> ${ dstId } (${ relationType })`);
+      return rows[0];
+    });
+  }
+
+  static async reinforceLink(srcId: string, dstId: string, relationType = 'related_to'): Promise<NodeLinkRecord> {
+    const row = await postgresClient.queryOne<NodeLinkRecord>(
+      `UPDATE ${ KnowledgeGraphModel.LINKS_TABLE }
+       SET strength = strength + 0.2 * (1 - strength),
+           fire_count = fire_count + 1,
+           last_fired_at = now()
+       WHERE src_id = $1 AND dst_id = $2 AND relation_type = $3
+       RETURNING *`,
+      [srcId, dstId, relationType],
+    );
+
+    if (!row) throw new Error(`No link found to reinforce: ${ srcId } -> ${ dstId } (${ relationType })`);
+    return row;
+  }
+
+  static async bumpRecalled(ids: string[]): Promise<KnowledgeNodeRecord[]> {
+    const uniqueIds = Array.from(new Set(ids.map(id => id.trim()).filter(Boolean)));
+    if (uniqueIds.length === 0) return [];
+
+    return postgresClient.query<KnowledgeNodeRecord>(
+      `UPDATE ${ KnowledgeGraphModel.NODES_TABLE }
+       SET recall_count = recall_count + 1,
+           last_recalled_at = now(),
+           updated_at = now()
+       WHERE id = ANY($1::text[])
+       RETURNING *`,
+      [uniqueIds],
+    );
+  }
+
+  static async archiveNode(id: string): Promise<boolean> {
+    const result = await postgresClient.queryWithResult(
+      `UPDATE ${ KnowledgeGraphModel.NODES_TABLE }
+       SET archived = true, updated_at = now()
+       WHERE id = $1`,
+      [id],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+}

--- a/pkg/rancher-desktop/agent/database/models/__tests__/KnowledgeGraphModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/KnowledgeGraphModel.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { postgresClient } from '../../PostgresClient';
+import { KnowledgeGraphModel } from '../KnowledgeGraphModel';
+
+describe('KnowledgeGraphModel', () => {
+  let originalQuery: any;
+  let originalQueryOne: any;
+  let originalQueryWithResult: any;
+  let originalTransaction: any;
+
+  beforeAll(() => {
+    originalQuery = postgresClient.query;
+    originalQueryOne = postgresClient.queryOne;
+    originalQueryWithResult = postgresClient.queryWithResult;
+    originalTransaction = postgresClient.transaction;
+  });
+
+  afterEach(() => {
+    (postgresClient as any).query = originalQuery;
+    (postgresClient as any).queryOne = originalQueryOne;
+    (postgresClient as any).queryWithResult = originalQueryWithResult;
+    (postgresClient as any).transaction = originalTransaction;
+    jest.restoreAllMocks();
+  });
+
+  it('inserts a node, stores a normalized alias, and resolves aliases round-trip', async() => {
+    (postgresClient as any).queryOne = jest.fn((sql: string, params: any[]) => {
+      if (sql.includes('INSERT INTO knowledge_nodes')) {
+        return Promise.resolve({
+          id:                 params[0],
+          node_type:          params[1],
+          title:              params[2],
+          summary:            params[3],
+          detail:             params[4],
+          source:             params[5],
+          archived:           params[6],
+          merged_into:        params[7],
+          link_count:         0,
+          recall_count:       0,
+          last_recalled_at:   null,
+          created_at:         '2026-07-29T00:00:00.000Z',
+          updated_at:         '2026-07-29T00:00:00.000Z',
+        });
+      }
+      if (sql.includes('INSERT INTO node_aliases')) {
+        return Promise.resolve({
+          alias:      params[0],
+          alias_norm: 'ripplecore',
+          node_id:    params[1],
+        });
+      }
+      return Promise.resolve(null);
+    });
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([{
+      node_id:   'node-1',
+      title:     'RippleCore',
+      node_type: 'entity',
+      alias:     'RippleCore',
+      match:     'exact',
+      sim:       1,
+    }]));
+
+    const node = await KnowledgeGraphModel.upsertNode({
+      id:         'node-1',
+      title:      'RippleCore',
+      summary:    'Core Data Ripple project',
+      node_type:  'entity',
+      source:     'test',
+    });
+    const alias = await KnowledgeGraphModel.addAlias(node.id, 'Ripple-Core');
+    const resolved = await KnowledgeGraphModel.resolveAliases(['RippleCore', 'ripple-core']);
+
+    expect(node.id).toBe('node-1');
+    expect(alias.alias_norm).toBe('ripplecore');
+    expect(postgresClient.queryOne).toHaveBeenCalledWith(
+      expect.stringContaining('VALUES ($1, norm_alias($1), $2)'),
+      ['Ripple-Core', 'node-1'],
+    );
+    expect(postgresClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('norm_alias(term) AS term_norm'),
+      [['RippleCore', 'ripple-core']],
+    );
+    expect(resolved).toEqual([{
+      node_id:   'node-1',
+      title:     'RippleCore',
+      node_type: 'entity',
+      alias:     'RippleCore',
+      match:     'exact',
+      sim:       1,
+    }]);
+  });
+
+  it('normalizes aliases through the database norm_alias function', async() => {
+    (postgresClient as any).queryOne = jest.fn((sql: string, params: any[]) => Promise.resolve({
+      alias:      params[0],
+      alias_norm: 'cafe#12',
+      node_id:    params[1],
+    }));
+
+    const alias = await KnowledgeGraphModel.addAlias('node-cafe', 'Café #12!');
+
+    expect(alias.alias_norm).toBe('cafe#12');
+    expect(postgresClient.queryOne).toHaveBeenCalledWith(
+      expect.stringContaining('norm_alias($1)'),
+      ['Café #12!', 'node-cafe'],
+    );
+  });
+
+  it('maintains link_count in the same statement when inserting links', async() => {
+    const client: any = {
+      query: jest.fn((sql: string) => {
+        expect(sql).toContain('WITH inserted AS');
+        expect(sql).toContain('UPDATE knowledge_nodes n');
+        expect(sql).toContain('SET link_count = link_count + 1');
+        expect(sql).toContain('WHERE i.was_inserted');
+        expect(sql).toContain('n.id IN (i.src_id, i.dst_id)');
+        return Promise.resolve({
+          rows: [{
+            src_id:         'a',
+            dst_id:         'b',
+            relation_type:  'belongs_to',
+            strength:       0.4,
+            fire_count:     0,
+            last_fired_at:  null,
+            confirmed:      false,
+            created_at:     '2026-07-29T00:00:00.000Z',
+          }],
+        });
+      }),
+    };
+    (postgresClient as any).transaction = jest.fn((callback: any) => Promise.resolve(callback(client)));
+
+    const link = await KnowledgeGraphModel.linkNodes('a', 'b', 'belongs_to', 0.4);
+
+    expect(link.src_id).toBe('a');
+    expect(link.dst_id).toBe('b');
+    expect(postgresClient.transaction).toHaveBeenCalledTimes(1);
+    expect(client.query).toHaveBeenCalledWith(expect.any(String), ['a', 'b', 'belongs_to', 0.4]);
+  });
+
+  it('reinforces links using strength + 0.2 * (1 - strength)', async() => {
+    (postgresClient as any).queryOne = jest.fn((sql: string, params: any[]) => {
+      expect(sql).toContain('strength = strength + 0.2 * (1 - strength)');
+      expect(sql).toContain('fire_count = fire_count + 1');
+      expect(sql).toContain('last_fired_at = now()');
+      expect(params).toEqual(['a', 'b', 'related_to']);
+      return Promise.resolve({
+        src_id:         'a',
+        dst_id:         'b',
+        relation_type:  'related_to',
+        strength:       0.44,
+        fire_count:     2,
+        last_fired_at:  '2026-07-29T00:00:00.000Z',
+        confirmed:      false,
+        created_at:     '2026-07-29T00:00:00.000Z',
+      });
+    });
+
+    const reinforced = await KnowledgeGraphModel.reinforceLink('a', 'b');
+
+    expect(reinforced.strength).toBeCloseTo(0.44);
+    expect(reinforced.fire_count).toBe(2);
+  });
+
+  it('bumps recall counters and soft-archives nodes', async() => {
+    (postgresClient as any).query = jest.fn((_sql: string, params: any[]) => Promise.resolve(params[0].map((id: string) => ({
+      id,
+      recall_count:     1,
+      last_recalled_at: '2026-07-29T00:00:00.000Z',
+    }))));
+    (postgresClient as any).queryWithResult = jest.fn(() => Promise.resolve({
+      rowCount: 1,
+      rows:     [],
+      command:  'UPDATE',
+      oid:      0,
+      fields:   [],
+    }));
+
+    const recalled = await KnowledgeGraphModel.bumpRecalled(['a', 'b', 'a', '']);
+    const archived = await KnowledgeGraphModel.archiveNode('a');
+
+    expect(postgresClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('recall_count = recall_count + 1'),
+      [['a', 'b']],
+    );
+    expect(recalled).toHaveLength(2);
+    expect(archived).toBe(true);
+    expect(postgresClient.queryWithResult).toHaveBeenCalledWith(
+      expect.stringContaining('SET archived = true'),
+      ['a'],
+    );
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/episodic/episodic_resolve.ts
+++ b/pkg/rancher-desktop/agent/tools/episodic/episodic_resolve.ts
@@ -1,0 +1,33 @@
+import { KnowledgeGraphModel } from '../../database/models/KnowledgeGraphModel';
+import { BaseTool, ToolResponse } from '../base';
+
+export class EpisodicResolveWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const terms = Array.isArray(input.terms) ? input.terms.map(String) : [];
+    const cleanTerms = terms.map(t => t.trim()).filter(Boolean);
+
+    if (cleanTerms.length === 0) {
+      return {
+        successBoolean: false,
+        responseString: 'Provide at least one non-empty term to resolve.',
+      };
+    }
+
+    try {
+      const rows = await KnowledgeGraphModel.resolveAliases(cleanTerms);
+
+      return {
+        successBoolean: true,
+        responseString: JSON.stringify(rows, null, 2),
+      };
+    } catch (err: any) {
+      return {
+        successBoolean: false,
+        responseString: `Failed to resolve episodic aliases: ${ err?.message }`,
+      };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/episodic/episodic_resolve.ts
+++ b/pkg/rancher-desktop/agent/tools/episodic/episodic_resolve.ts
@@ -7,7 +7,7 @@ export class EpisodicResolveWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const terms = Array.isArray(input.terms) ? input.terms.map(String) : [];
-    const cleanTerms = terms.map(t => t.trim()).filter(Boolean);
+    const cleanTerms = terms.map((t: string) => t.trim()).filter(Boolean);
 
     if (cleanTerms.length === 0) {
       return {

--- a/pkg/rancher-desktop/agent/tools/episodic/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/episodic/manifests.ts
@@ -1,0 +1,44 @@
+import type { ToolManifest } from '../registry';
+
+const notImplemented = (issue: '#517' | '#518') => () => Promise.reject(new Error(`not implemented until ${ issue }`));
+
+export const episodicToolManifests: ToolManifest[] = [
+  {
+    name:        'episodic_resolve',
+    description: 'Resolve surface-form terms to knowledge graph nodes using exact normalized aliases and pg_trgm fuzzy matching.',
+    category:    'memory',
+    schemaDef:   {
+      terms: {
+        type:        'array',
+        description: 'Entity, event, or lesson terms to resolve against node aliases.',
+        items:       { type: 'string' },
+      },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./episodic_resolve'),
+  },
+  {
+    name:        'episodic_recall',
+    description: 'Recall associated episodic context from the knowledge graph. Declared for Phase 2.',
+    category:    'memory',
+    schemaDef:   {
+      terms:      { type: 'array', items: { type: 'string' }, description: 'Anchor terms for recall.' },
+      query_text: { type: 'string', optional: true, description: 'Optional original user query text.' },
+      limit:      { type: 'number', optional: true, description: 'Maximum recalled nodes to return.' },
+    },
+    operationTypes: ['read'],
+    loader:         notImplemented('#517'),
+  },
+  {
+    name:        'episodic_write_episode',
+    description: 'Write encoded episode nodes, aliases, and links to episodic memory. Declared for Phase 3.',
+    category:    'memory',
+    schemaDef:   {
+      nodes:    { type: 'array', optional: true, items: { type: 'object' }, description: 'Encoded knowledge nodes.' },
+      links:    { type: 'array', optional: true, items: { type: 'object' }, description: 'Encoded node links.' },
+      resolved: { type: 'array', optional: true, items: { type: 'object' }, description: 'Previously resolved node matches.' },
+    },
+    operationTypes: ['create', 'update'],
+    loader:         notImplemented('#518'),
+  },
+];

--- a/pkg/rancher-desktop/agent/tools/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/manifests.ts
@@ -9,10 +9,10 @@ import { browserToolManifests } from './browser/manifests';
 import { calendarToolManifests } from './calendar/manifests';
 import { captureToolManifests } from './capture/manifests';
 import { dockerToolManifests } from './docker/manifests';
+import { episodicToolManifests } from './episodic/manifests';
 import { extensionsToolManifests } from './extensions/manifests';
 import { functionToolManifests } from './function/manifests';
 import { githubToolManifests } from './github/manifests';
-
 import { integrationsToolManifests } from './integrations/manifests';
 import { kubectlToolManifests } from './kubectl/manifests';
 import { limaToolManifests } from './lima/manifests';
@@ -37,6 +37,7 @@ toolRegistry.registerManifests([
   ...calendarToolManifests,
   ...captureToolManifests,
   ...dockerToolManifests,
+  ...episodicToolManifests,
   ...extensionsToolManifests,
   ...functionToolManifests,
   ...githubToolManifests,


### PR DESCRIPTION
## What changed
- Added migration `0029_create_knowledge_graph` with the Phase 1 knowledge graph schema, `norm_alias(text)`, pg_trgm/unaccent setup, and graph indexes.
- Registered 0029 in the migration registry.
- Added `KnowledgeGraphModel` over the shared `postgresClient` singleton for schema bootstrap, alias resolution, node upsert/archive, alias writes, link writes, reinforcement, and recall bumps.
- Added episodic tool manifests for `episodic_resolve`, declared-only `episodic_recall` (#517), and declared-only `episodic_write_episode` (#518).
- Implemented `episodic_resolve` as a thin wrapper over `KnowledgeGraphModel.resolveAliases`.
- Added focused model tests for insert/link/alias round-trip, reinforce math, link_count maintenance SQL, recall bump/archive, and norm_alias-backed alias normalization.

## R4 live DB result
- `CREATE EXTENSION IF NOT EXISTS pg_trgm; CREATE EXTENSION IF NOT EXISTS unaccent;` as the `sulla` role: passed.
- Extensions present: `pg_trgm`, `unaccent`.
- Migration `up`: passed on live Sulla DB.
- `down -> up -> up`: passed on live Sulla DB.
- `SELECT norm_alias('Café #12!')`: returned `cafe#12`.

Note: the issue text expected `caf#12`, but the required verbatim DDL uses `lower(unaccent(...))` and strips only non-`[a-z0-9#]` characters, so PostgreSQL correctly preserves the unaccented `e`.

## Validation
- Passed: `yarn test:unit:jest pkg/rancher-desktop/agent/database/models/__tests__/KnowledgeGraphModel.test.ts --runInBand`
- Passed: direct ESLint on changed implementation/test files with `--max-warnings=0`.
- Attempted: `yarn lint:typescript:nofix` repo-wide. It failed through the project wrapper without diagnostics after host-native dependency install.
- Attempted: direct repo-wide ESLint and `tsc --noEmit --project tsconfig.json`. Both hit Node heap/tooling failures before actionable diagnostics; changed-file lint and focused Jest are clean.

Closes #516