### PR TITLE
fix(workflow): auto-run catch_up_schedules on boot + early-fire grace window

### DIFF
--- a/pkg/rancher-desktop/agent/services/WorkflowSchedulerService.ts
+++ b/pkg/rancher-desktop/agent/services/WorkflowSchedulerService.ts
@@ -108,6 +108,37 @@ export class WorkflowSchedulerService {
 
     this.initialized = true;
     await this.scanAndSchedule();
+    await this.catchUpMissedFires();
+  }
+
+  /**
+   * Recover fires that were missed while the app was off or the scheduler
+   * dormant. node-schedule only fires crons that trip while the process is
+   * running, so a cron time that passed during downtime is silently skipped
+   * until its next occurrence — a whole week of drift for a weekly routine.
+   *
+   * This runs the exact same scan the `catch_up_schedules` tool exposes,
+   * right after schedules are armed on boot, so recovery is automatic and
+   * doesn't depend on an agent remembering to invoke the tool. It relies on
+   * the FIRE_GRACE_MS tolerance in runCatchUpScan so an on-time-but-early
+   * fire is never misread as missed and re-dispatched. Dispatch is otherwise
+   * fire-and-forget and idempotent (a fire already present in
+   * workflow_executions since the last expected occurrence is skipped), so
+   * re-running on every boot is safe. Never throws into the boot path.
+   */
+  private async catchUpMissedFires(): Promise<void> {
+    try {
+      const { runCatchUpScan } = await import('@pkg/agent/tools/workflow/catch_up_schedules');
+      const { missedCount, dispatchedCount } = await runCatchUpScan({});
+
+      if (missedCount === 0) {
+        console.log('[WorkflowSchedulerService] Catch-up scan: no missed fires');
+      } else {
+        console.log(`[WorkflowSchedulerService] Catch-up scan: ${ missedCount } missed fire(s), ${ dispatchedCount } dispatched`);
+      }
+    } catch (err) {
+      console.warn('[WorkflowSchedulerService] Catch-up scan failed (schedules still armed):', err);
+    }
   }
 
   /**

--- a/pkg/rancher-desktop/agent/tools/workflow/catch_up_schedules.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/catch_up_schedules.ts
@@ -41,6 +41,15 @@ export class CatchUpSchedulesWorker extends BaseTool {
     const lookbackMs = lookbackDays * 24 * 60 * 60 * 1000;
     const now = new Date();
 
+    // A scheduled fire can land a hair BEFORE its exact cron boundary (timer
+    // coalescing / tick granularity): e.g. a Mon-04:00 cron observed firing at
+    // 03:59:59.112 — 888ms early. Without a grace window the strict
+    // `latestStart >= prevFire` comparison reads that perfectly on-time run as
+    // "missed" and (outside dryRun) dispatches a DUPLICATE. Any two legitimate
+    // fires of the same schedule are at least an hour apart, so a small grace
+    // can never collapse two real fires into one.
+    const FIRE_GRACE_MS = 60 * 1000;
+
     const { WorkflowModel } = await import('../../database/models/WorkflowModel');
     const { WorkflowExecutionModel } = await import('../../database/models/WorkflowExecutionModel');
     const { buildCronExpression } = await import('../../services/WorkflowSchedulerService');
@@ -94,7 +103,7 @@ export class CatchUpSchedulesWorker extends BaseTool {
         const latestStartRaw = latest?.attributes.started_at;
         const latestStart = latestStartRaw ? new Date(latestStartRaw) : null;
 
-        if (latestStart && latestStart.getTime() >= prevFire.getTime()) {
+        if (latestStart && latestStart.getTime() >= prevFire.getTime() - FIRE_GRACE_MS) {
           lines.push(`  • ${ name } — ok: fired ${ latestStart.toISOString() } (expected ${ prevFire.toISOString() })`);
           continue;
         }

--- a/pkg/rancher-desktop/agent/tools/workflow/catch_up_schedules.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/catch_up_schedules.ts
@@ -18,6 +18,123 @@ import { SCHEDULE_TRIGGER } from '@pkg/pages/editor/workflow/types';
  * callback uses. Dispatch is fire-and-forget (routine runs can take
  * minutes); verify completion via the workflow_executions table.
  */
+export interface CatchUpScanResult {
+  lines:           string[];
+  missedCount:     number;
+  dispatchedCount: number;
+}
+
+/**
+ * Core catch-up scan, shared by the `catch_up_schedules` tool and the
+ * WorkflowSchedulerService boot path. Computes each armed schedule's
+ * previous expected fire, compares against workflow_executions, and
+ * (unless dryRun) dispatches any missed fire through executeRoutine.
+ *
+ * Throws only if the production-workflow list itself can't be loaded;
+ * per-workflow problems are reported as lines, never thrown.
+ */
+export async function runCatchUpScan(
+  input: { dryRun?: boolean; lookbackDays?: number } = {},
+): Promise<CatchUpScanResult> {
+  const dryRun = input.dryRun === true;
+  const lookbackDays = Math.min(Math.max(Number(input.lookbackDays ?? 7), 1), 31);
+  const lookbackMs = lookbackDays * 24 * 60 * 60 * 1000;
+  const now = new Date();
+
+  // A scheduled fire can land a hair BEFORE its exact cron boundary (timer
+  // coalescing / tick granularity): e.g. a Mon-04:00 cron observed firing at
+  // 03:59:59.112 — 888ms early. Without a grace window the strict
+  // `latestStart >= prevFire` comparison reads that perfectly on-time run as
+  // "missed" and (outside dryRun) dispatches a DUPLICATE. Any two legitimate
+  // fires of the same schedule are at least an hour apart, so a small grace
+  // can never collapse two real fires into one.
+  const FIRE_GRACE_MS = 60 * 1000;
+
+  const { WorkflowModel } = await import('../../database/models/WorkflowModel');
+  const { WorkflowExecutionModel } = await import('../../database/models/WorkflowExecutionModel');
+  const { buildCronExpression } = await import('../../services/WorkflowSchedulerService');
+
+  const rows: any[] = await WorkflowModel.listByStatus('production');
+
+  const lines: string[] = [];
+  let missedCount = 0;
+  let dispatchedCount = 0;
+
+  for (const row of rows) {
+    if (row.attributes.enabled === false) continue;
+
+    const { id, name } = row.attributes;
+    const definition = row.attributes.definition || {};
+    const nodes = Array.isArray((definition as any).nodes) ? (definition as any).nodes : [];
+
+    for (const node of nodes) {
+      if (node?.data?.category !== SCHEDULE_TRIGGER.category || node?.data?.subtype !== SCHEDULE_TRIGGER.subtype) continue;
+
+      const config = node.data?.config || {};
+      const cron = buildCronExpression(config);
+      if (!cron) {
+        lines.push(`  • ${ name } — SKIP: could not build cron from schedule config`);
+        continue;
+      }
+      const tz = (config.timezone as string || '').trim() || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+      let prevFire: Date;
+      try {
+        prevFire = parser.parseExpression(cron, { tz, currentDate: now }).prev().toDate();
+      } catch (err) {
+        lines.push(`  • ${ name } — SKIP: cron "${ cron }" unparsable (${ (err as Error).message })`);
+        continue;
+      }
+
+      if (now.getTime() - prevFire.getTime() > lookbackMs) {
+        lines.push(`  • ${ name } — ok: last expected fire ${ prevFire.toISOString() } is outside the ${ lookbackDays }d lookback`);
+        continue;
+      }
+
+      const latest = await WorkflowExecutionModel.findLatestByWorkflow(id);
+      const latestStartRaw = latest?.attributes.started_at;
+      const latestStart = latestStartRaw ? new Date(latestStartRaw) : null;
+
+      if (latestStart && latestStart.getTime() >= prevFire.getTime() - FIRE_GRACE_MS) {
+        lines.push(`  • ${ name } — ok: fired ${ latestStart.toISOString() } (expected ${ prevFire.toISOString() })`);
+        continue;
+      }
+
+      missedCount++;
+
+      const active = await WorkflowExecutionModel.findActiveByWorkflow(id);
+      if (active) {
+        lines.push(`  • ${ name } — MISSED ${ prevFire.toISOString() } but an execution is already active (${ (active.attributes as any).execution_id }) — skipped`);
+        continue;
+      }
+
+      if (dryRun) {
+        lines.push(`  • ${ name } — MISSED: expected ${ prevFire.toISOString() }, last run ${ latestStart?.toISOString() ?? 'never' } (dry-run, not dispatched)`);
+        continue;
+      }
+
+      try {
+        // Same entry point the cron callback uses. Fire-and-forget: routine
+        // runs can take minutes and this tool must return promptly.
+        const { executeRoutine } = await import('@pkg/main/sullaRoutineTemplateEvents');
+
+        void executeRoutine(
+          id,
+          `Catch-up: the scheduled run of "${ name }" expected at ${ prevFire.toISOString() } was missed (app offline or scheduler dormant). Run it now.`,
+        ).catch((err: unknown) => {
+          console.error(`[CatchUpSchedules] Dispatched catch-up for "${ name }" failed:`, err);
+        });
+        dispatchedCount++;
+        lines.push(`  • ${ name } — MISSED ${ prevFire.toISOString() } → DISPATCHED (verify via workflow_executions)`);
+      } catch (err) {
+        lines.push(`  • ${ name } — MISSED ${ prevFire.toISOString() } but dispatch failed: ${ (err as Error).message }`);
+      }
+    }
+  }
+
+  return { lines, missedCount, dispatchedCount };
+}
+
 export class CatchUpSchedulesWorker extends BaseTool {
   name = 'catch_up_schedules';
   description = 'Detect scheduled workflow fires that were missed (app off or scheduler dormant when the cron time passed) and dispatch them through the real executor. Compares each armed schedule\'s previous expected fire time against workflow_executions. Use dryRun to report without firing.';
@@ -36,27 +153,9 @@ export class CatchUpSchedulesWorker extends BaseTool {
   };
 
   protected async _validatedCall(input: { dryRun?: boolean; lookbackDays?: number }): Promise<ToolResponse> {
-    const dryRun = input.dryRun === true;
-    const lookbackDays = Math.min(Math.max(Number(input.lookbackDays ?? 7), 1), 31);
-    const lookbackMs = lookbackDays * 24 * 60 * 60 * 1000;
-    const now = new Date();
-
-    // A scheduled fire can land a hair BEFORE its exact cron boundary (timer
-    // coalescing / tick granularity): e.g. a Mon-04:00 cron observed firing at
-    // 03:59:59.112 — 888ms early. Without a grace window the strict
-    // `latestStart >= prevFire` comparison reads that perfectly on-time run as
-    // "missed" and (outside dryRun) dispatches a DUPLICATE. Any two legitimate
-    // fires of the same schedule are at least an hour apart, so a small grace
-    // can never collapse two real fires into one.
-    const FIRE_GRACE_MS = 60 * 1000;
-
-    const { WorkflowModel } = await import('../../database/models/WorkflowModel');
-    const { WorkflowExecutionModel } = await import('../../database/models/WorkflowExecutionModel');
-    const { buildCronExpression } = await import('../../services/WorkflowSchedulerService');
-
-    let rows: any[];
+    let result: CatchUpScanResult;
     try {
-      rows = await WorkflowModel.listByStatus('production');
+      result = await runCatchUpScan(input);
     } catch (err) {
       return {
         successBoolean: false,
@@ -64,81 +163,7 @@ export class CatchUpSchedulesWorker extends BaseTool {
       };
     }
 
-    const lines: string[] = [];
-    let missedCount = 0;
-    let dispatchedCount = 0;
-
-    for (const row of rows) {
-      if (row.attributes.enabled === false) continue;
-
-      const { id, name } = row.attributes;
-      const definition = row.attributes.definition || {};
-      const nodes = Array.isArray((definition as any).nodes) ? (definition as any).nodes : [];
-
-      for (const node of nodes) {
-        if (node?.data?.category !== SCHEDULE_TRIGGER.category || node?.data?.subtype !== SCHEDULE_TRIGGER.subtype) continue;
-
-        const config = node.data?.config || {};
-        const cron = buildCronExpression(config);
-        if (!cron) {
-          lines.push(`  • ${ name } — SKIP: could not build cron from schedule config`);
-          continue;
-        }
-        const tz = (config.timezone as string || '').trim() || Intl.DateTimeFormat().resolvedOptions().timeZone;
-
-        let prevFire: Date;
-        try {
-          prevFire = parser.parseExpression(cron, { tz, currentDate: now }).prev().toDate();
-        } catch (err) {
-          lines.push(`  • ${ name } — SKIP: cron "${ cron }" unparsable (${ (err as Error).message })`);
-          continue;
-        }
-
-        if (now.getTime() - prevFire.getTime() > lookbackMs) {
-          lines.push(`  • ${ name } — ok: last expected fire ${ prevFire.toISOString() } is outside the ${ lookbackDays }d lookback`);
-          continue;
-        }
-
-        const latest = await WorkflowExecutionModel.findLatestByWorkflow(id);
-        const latestStartRaw = latest?.attributes.started_at;
-        const latestStart = latestStartRaw ? new Date(latestStartRaw) : null;
-
-        if (latestStart && latestStart.getTime() >= prevFire.getTime() - FIRE_GRACE_MS) {
-          lines.push(`  • ${ name } — ok: fired ${ latestStart.toISOString() } (expected ${ prevFire.toISOString() })`);
-          continue;
-        }
-
-        missedCount++;
-
-        const active = await WorkflowExecutionModel.findActiveByWorkflow(id);
-        if (active) {
-          lines.push(`  • ${ name } — MISSED ${ prevFire.toISOString() } but an execution is already active (${ (active.attributes as any).execution_id }) — skipped`);
-          continue;
-        }
-
-        if (dryRun) {
-          lines.push(`  • ${ name } — MISSED: expected ${ prevFire.toISOString() }, last run ${ latestStart?.toISOString() ?? 'never' } (dry-run, not dispatched)`);
-          continue;
-        }
-
-        try {
-          // Same entry point the cron callback uses. Fire-and-forget: routine
-          // runs can take minutes and this tool must return promptly.
-          const { executeRoutine } = await import('@pkg/main/sullaRoutineTemplateEvents');
-
-          void executeRoutine(
-            id,
-            `Catch-up: the scheduled run of "${ name }" expected at ${ prevFire.toISOString() } was missed (app offline or scheduler dormant). Run it now.`,
-          ).catch((err: unknown) => {
-            console.error(`[CatchUpSchedules] Dispatched catch-up for "${ name }" failed:`, err);
-          });
-          dispatchedCount++;
-          lines.push(`  • ${ name } — MISSED ${ prevFire.toISOString() } → DISPATCHED (verify via workflow_executions)`);
-        } catch (err) {
-          lines.push(`  • ${ name } — MISSED ${ prevFire.toISOString() } but dispatch failed: ${ (err as Error).message }`);
-        }
-      }
-    }
+    const { lines, missedCount, dispatchedCount } = result;
 
     if (lines.length === 0) {
       return {
@@ -147,7 +172,7 @@ export class CatchUpSchedulesWorker extends BaseTool {
       };
     }
 
-    const header = dryRun
+    const header = input.dryRun === true
       ? `Catch-up scan (dry-run): ${ missedCount } missed fire(s) found.`
       : `Catch-up scan: ${ missedCount } missed fire(s) found, ${ dispatchedCount } dispatched.`;
 


### PR DESCRIPTION
Recovers missed scheduled workflow fires on boot, and stops on-time-but-slightly-early fires from being misread as missed.

**Supersedes `fix/catch-up-schedules-early-fire-grace`** (contains it).

## Changes
- **`services/WorkflowSchedulerService.ts`** — `initialize()` now awaits a new private `catchUpMissedFires()` after `scanAndSchedule()`. It dynamically imports and runs the extracted scan, wrapped in try/catch (logs count; never throws into the boot path), so any fire missed while the app was offline is recovered automatically at startup.
- **`tools/workflow/catch_up_schedules.ts`** — scan core extracted into shared **`runCatchUpScan({dryRun?, lookbackDays?})`** returning `{lines, missedCount, dispatchedCount}`, now called by both the boot hook and the existing `catch_up_schedules` tool. Adds **`FIRE_GRACE_MS = 60_000`**: the missed-fire test changes from `latestStart >= prevFire` to `latestStart >= prevFire - FIRE_GRACE_MS`, so a fire up to 60s early (timer coalescing) isn't flagged as missed and re-dispatched. Dispatch stays idempotent (a fire already in `workflow_executions` since the last expected occurrence is skipped), making boot-time re-runs safe.

## Files
- `agent/services/WorkflowSchedulerService.ts` — boot-time `catchUpMissedFires()` hook
- `agent/tools/workflow/catch_up_schedules.ts` — extracted `runCatchUpScan()` + 60s grace window

---
_Recovered stranded branch (built but never opened as a PR). Description regenerated from the actual `git diff origin/main...HEAD`, not the commit messages. Draft per always-draft-PR workflow — flip to ready on your word._