### PR TITLE
fix(db): make earliest migrations idempotent (0002/0011/0012)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0002_create_agent_awareness_table.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0002_create_agent_awareness_table.ts
@@ -1,5 +1,5 @@
 export const up = `
-  CREATE TABLE agent_awareness (
+  CREATE TABLE IF NOT EXISTS agent_awareness (
     id INTEGER PRIMARY KEY CHECK (id = 1),
     data JSONB NOT NULL DEFAULT '{}',
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/pkg/rancher-desktop/agent/database/migrations/0011_create_settings_table.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0011_create_settings_table.ts
@@ -1,8 +1,8 @@
 export const up = `
-  CREATE TABLE sulla_settings (
+  CREATE TABLE IF NOT EXISTS sulla_settings (
     property TEXT PRIMARY KEY,
     value TEXT 
   );
 `;
 
-export const down = `DROP TABLE IF EXISTS settings;`;
+export const down = `DROP TABLE IF EXISTS sulla_settings;`;

--- a/pkg/rancher-desktop/agent/database/migrations/0012_add_cast_column_to_sulla_settings.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0012_add_cast_column_to_sulla_settings.ts
@@ -1,7 +1,7 @@
 export const up = `
-  ALTER TABLE sulla_settings ADD COLUMN "cast" TEXT;
+  ALTER TABLE sulla_settings ADD COLUMN IF NOT EXISTS "cast" TEXT;
 `;
 
 export const down = `
-  ALTER TABLE sulla_settings DROP COLUMN "cast";
+  ALTER TABLE sulla_settings DROP COLUMN IF EXISTS "cast";
 `;


### PR DESCRIPTION
Makes the three earliest migrations safe to re-run, and fixes a wrong-table-name bug in a down-migration.

## Changes
- **`0002_create_agent_awareness_table.ts`** — `CREATE TABLE IF NOT EXISTS agent_awareness`.
- **`0011_create_settings_table.ts`** — `CREATE TABLE IF NOT EXISTS sulla_settings`; **bug fix:** the `down` migration dropped the wrong table (`settings`) → now `DROP TABLE IF EXISTS sulla_settings`.
- **`0012_add_cast_column_to_sulla_settings.ts`** — `ADD COLUMN IF NOT EXISTS "cast"` (up) and `DROP COLUMN IF EXISTS "cast"` (down).

## Files
- `agent/database/migrations/0002_create_agent_awareness_table.ts`
- `agent/database/migrations/0011_create_settings_table.ts`
- `agent/database/migrations/0012_add_cast_column_to_sulla_settings.ts`

---
_Recovered stranded branch (built but never opened as a PR). Description regenerated from the actual `git diff origin/main...HEAD`, not the commit messages. Draft per always-draft-PR workflow — flip to ready on your word._