### PR TITLE
fix(test): polyfill TextEncoder/TextDecoder for jsdom pg suites

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,6 +31,9 @@ export default {
     '^@pkg/(.*)$':   '<rootDir>/pkg/rancher-desktop/$1',
   },
   setupFiles: [
+    // Must run first: polyfills TextEncoder/TextDecoder onto the jsdom
+    // global so suites that import `pg` can load (jsdom omits them).
+    '<rootDir>/pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts',
     '<rootDir>/pkg/rancher-desktop/utils/testUtils/setupVue.ts',
   ],
   testEnvironment:        'jsdom',

--- a/pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts
+++ b/pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts
@@ -1,0 +1,22 @@
+/**
+ * Preloaded into all Jest tests (see jest.config.js `setupFiles`, listed
+ * BEFORE setupVue so it runs first).
+ *
+ * The `jsdom` test environment does not expose `TextEncoder`/`TextDecoder`
+ * as globals, but Node does. Modules that pull in `pg` (and its
+ * dependencies) reference them at import time, so any suite that loads a
+ * database model crashes with `ReferenceError: TextEncoder is not defined`
+ * before a single test runs. Bridge Node's implementation onto the jsdom
+ * global so those suites can load.
+ */
+
+import { TextEncoder, TextDecoder } from 'node:util';
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder;
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  // Node's TextDecoder is structurally compatible; the DOM lib typing is
+  // stricter than the runtime contract these tests rely on.
+  globalThis.TextDecoder = TextDecoder as unknown as typeof globalThis.TextDecoder;
+}


### PR DESCRIPTION
Registers a Jest setup file that polyfills Node's `TextEncoder`/`TextDecoder` onto the global before suites run, so any suite importing `pg` can load under jsdom.

- **Root cause:** jsdom omits `TextEncoder`/`TextDecoder`, but `pg` (and deps) reference them at import time → suites loading a DB model die with `ReferenceError: TextEncoder is not defined` before any test runs.
- **Fix:** new setup file imports both from `node:util` and assigns to `globalThis` if undefined (guarded to avoid clobbering native globals).
- **Wiring:** added to `jest.config.js` `setupFiles` **before** `setupVue.ts` so it runs first.

## Files
- `jest.config.js` — prepend `setupTextEncoder.ts` to `setupFiles`
- `pkg/rancher-desktop/utils/testUtils/setupTextEncoder.ts` — the polyfill

---
_Recovered stranded branch (built but never opened as a PR). Description regenerated from the actual `git diff origin/main...HEAD`, not the commit messages. Draft per always-draft-PR workflow — flip to ready on your word._