### PR TITLE
fix(test): exclude .claude/ from jest scanning

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,6 +22,7 @@ export default {
     '<rootDir>/dist',
     '<rootDir>/pkg/rancher-desktop/dist',
     '<rootDir>/.git',
+    '<rootDir>/.claude',
     '<rootDir>/e2e',
     '<rootDir>/screenshots',
   ],
@@ -42,6 +43,7 @@ export default {
   },
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
+    '<rootDir>/.claude/',
     '<rootDir>/pkg/rancher-desktop/sudo-prompt/',
   ],
 };


### PR DESCRIPTION
Excludes the project-root `.claude/` directory from Jest scanning so nested Claude Code worktrees/checkouts don't pollute module and test discovery.

- Adds `'<rootDir>/.claude'` to **both** `modulePathIgnorePatterns` and `testPathIgnorePatterns` in `jest.config.js`.
- `.claude/` can hold nested git worktrees/checkouts; without the ignore, Jest tries to resolve modules and discover tests under them.

## Files
- `jest.config.js` — add `.claude/` to both ignore-pattern lists

---
_Recovered stranded branch (built but never opened as a PR). Description regenerated from the actual `git diff origin/main...HEAD`, not the commit messages. Draft per always-draft-PR workflow — flip to ready on your word._