### PR TITLE
chore(prefs): clarify heartbeat toggle label as autonomous + interval

### DIFF
--- a/pkg/rancher-desktop/pages/LanguageModelSettings.vue
+++ b/pkg/rancher-desktop/pages/LanguageModelSettings.vue
@@ -1172,7 +1172,7 @@ export default defineComponent({
 
           <!-- Enable/Disable Toggle -->
           <div class="setting-group">
-            <label class="setting-label">Enable Heartbeat</label>
+            <label class="setting-label">Enable Autonomous Heartbeat (runs every 15 min)</label>
             <div class="toggle-switch">
               <label class="switch">
                 <input


### PR DESCRIPTION
Copy-only change: clarifies the Heartbeat toggle in Language Model Settings.

- Label changes from **"Enable Heartbeat"** to **"Enable Autonomous Heartbeat (runs every 15 min)"**, making the autonomous nature and 15-minute interval explicit in the UI.

## Files
- `pkg/rancher-desktop/pages/LanguageModelSettings.vue` — toggle label text

---
_Recovered stranded branch (built but never opened as a PR). Description regenerated from the actual `git diff origin/main...HEAD`, not the commit messages. Draft per always-draft-PR workflow — flip to ready on your word._