### PR TITLE
fix(spawn_agent): honor agentName alias + reject unresolvable agent selector

### DIFF
--- a/pkg/rancher-desktop/agent/tools/agents/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/manifests.ts
@@ -8,13 +8,14 @@ export const agentToolManifests: ToolManifest[] = [
     schemaDef:   {
       tasks: {
         type:        'array',
-        description: 'Array of task objects. Each task has: prompt (required — the instruction), agentId (optional — agent config from ~/sulla/agents/, defaults to primary agent), label (optional — human-readable name for the task).',
+        description: 'Array of task objects. Each task has: prompt (required — the instruction), agentId (optional — agent config folder name from ~/sulla/agents/, defaults to the parent/primary agent; agentName is accepted as an alias), label (optional — human-readable name for the task). A non-empty agentId/agentName that does not match a config folder is rejected — it is NOT silently run as the default agent.',
         items:       {
           type:       'object',
           properties: {
-            agentId: { type: 'string', description: 'Agent config ID from ~/sulla/agents/. Omit to use the default agent.', optional: true },
-            prompt:  { type: 'string', description: 'The task/instruction to give the sub-agent.' },
-            label:   { type: 'string', description: 'Optional human-readable label for this task.', optional: true },
+            agentId:   { type: 'string', description: 'Agent config folder name from ~/sulla/agents/ (e.g. "codex-test"). Omit to use the default agent. Must match an existing folder.', optional: true },
+            agentName: { type: 'string', description: 'Alias for agentId. Same resolution rules.', optional: true },
+            prompt:    { type: 'string', description: 'The task/instruction to give the sub-agent.' },
+            label:     { type: 'string', description: 'Optional human-readable label for this task.', optional: true },
           },
         },
       },

--- a/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
@@ -1,6 +1,7 @@
 import { BaseTool, ToolResponse } from '../base';
 import { createJob, completeJob, failJob, getJobAbortSignal } from './jobRegistry';
 import { getWebSocketClientService } from '../../services/WebSocketClientService';
+import { findAgentDir } from '../../utils/sullaPaths';
 
 import type { AgentJobResult } from './jobRegistry';
 
@@ -8,9 +9,19 @@ const MAX_DEPTH = 3;
 const MAX_TASKS = 10;
 
 interface SpawnTask {
-  agentId?: string;
-  prompt:   string;
-  label?:   string;
+  agentId?:   string;
+  /** Alias for agentId — the agent config folder name under ~/sulla/agents/.
+   *  Accepted because callers routinely reach for "agentName"; resolved to the
+   *  same selector so a natural-but-wrong key no longer silently no-ops. */
+  agentName?: string;
+  prompt:     string;
+  label?:     string;
+}
+
+/** The agent-config selector for a task: agentId, or its agentName alias. */
+function taskAgentSelector(task: SpawnTask): string | undefined {
+  const sel = task.agentId || task.agentName;
+  return typeof sel === 'string' && sel.trim() ? sel.trim() : undefined;
 }
 
 export class SpawnAgentWorker extends BaseTool {
@@ -42,6 +53,19 @@ export class SpawnAgentWorker extends BaseTool {
           responseString: `Task at index ${ i } is missing a "prompt" string.`,
         };
       }
+
+      // Fail fast on an unresolvable agent selector. Without this the task
+      // silently fell back to the PARENT persona on the subconscious model
+      // (e.g. a caller passing the wrong key ran a generic sub-agent on the
+      // fallback provider instead of the intended worker) — a costly no-op
+      // with no signal. A missing selector is still fine (documented default).
+      const selector = taskAgentSelector(tasks[i]);
+      if (selector && !findAgentDir(selector)) {
+        return {
+          successBoolean: false,
+          responseString: `Task at index ${ i } references agent "${ selector }" but no config folder exists under ~/sulla/agents/. Use a valid agentId (or omit it to use the default agent).`,
+        };
+      }
     }
 
     // ── Options ───────────────────────────────────────────────────
@@ -69,8 +93,9 @@ export class SpawnAgentWorker extends BaseTool {
 
     // ── Single task executor ────────────────────────────────────
     const executeSingle = async(task: SpawnTask, index: number): Promise<AgentJobResult> => {
-      const label = task.label || task.agentId || `task-${ index }`;
-      const agentConfigChannel = task.agentId || parentChannel;
+      const selector = taskAgentSelector(task);
+      const label = task.label || selector || `task-${ index }`;
+      const agentConfigChannel = selector || parentChannel;
       const threadId = `spawn-agent-${ label.replace(/\s+/g, '-').toLowerCase() }-${ Date.now() }-${ index }`;
 
       try {
@@ -182,7 +207,7 @@ export class SpawnAgentWorker extends BaseTool {
         }
 
         return {
-          label:    tasks[i].label || tasks[i].agentId || `task-${ i }`,
+          label:    tasks[i].label || taskAgentSelector(tasks[i]) || `task-${ i }`,
           status:   'error' as const,
           output:   `Unexpected error: ${ s.reason }`,
           threadId: '',


### PR DESCRIPTION
## What this fixes

`spawn_agent` picked a sub-agent's config with `task.agentId || parentChannel`. A task that passed **any other key** (e.g. `agentName`) left `agentId` undefined, so it **silently loaded the parent persona** instead of the intended worker.

That parent persona (`sulla-desktop`) declares no `provider`/`model`, so `BaseNode` fell through to the **subconscious provider slot** — currently `alibaba` → **`qwen3.5-plus`**. Qwen then emitted malformed tool-call XML and no-op'd after ~2-3 iterations with zero commits.

**Net effect:** every `codex-test` dispatch made with the wrong key ran **Qwen, not Codex** — hours of "completed with no artifacts" sub-agent jobs.

## The change

- Accept **`agentName`** as an alias for `agentId` (`taskAgentSelector` helper) — the natural key callers reach for now resolves correctly.
- **Fail fast** when a non-empty selector doesn't match a config folder under `~/sulla/agents/` (`findAgentDir`), instead of silently running the default agent on the fallback model. A costly silent no-op becomes an instant, obvious error.
- Document both in the tool manifest.

A missing selector is still valid (documented default → parent/primary agent). This only rejects a selector that was *provided but wrong*.

## Verification

Dispatching with the correct selector (`agentId: "codex-test"`) loads the codex-test config and runs **`model:codex`** (real Codex in the Lima VM), confirmed in the sub-agent transcript — not `qwen3.5-plus`.

## Notes

- Draft — not build-tested locally; opening for review/local test per workflow. `findAgentDir` is an existing named export from `agent/utils/sullaPaths`; the change is additive and type-safe.
- Two files: `spawn_agent.ts`, `manifests.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)