### PR TITLE
feat: Agents tab in left sidebar — live view of running loops (Stage 1, #537)

### DIFF
--- a/pkg/rancher-desktop/agent/tools/ui/open_tab.ts
+++ b/pkg/rancher-desktop/agent/tools/ui/open_tab.ts
@@ -27,6 +27,7 @@ const VALID_MODES = new Set([
   'document',
   'browser',
   'welcome',
+  'agents',
 ]);
 
 export class UiOpenTabWorker extends BaseTool {

--- a/pkg/rancher-desktop/composables/useBrowserTabs.ts
+++ b/pkg/rancher-desktop/composables/useBrowserTabs.ts
@@ -2,7 +2,7 @@ import { reactive, readonly, ref, watch } from 'vue';
 
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
-export type BrowserTabMode = 'welcome' | 'browser' | 'chat' | 'calendar' | 'integrations' | 'document' | 'secretary' | 'vault' | 'account' | 'history' | 'routines' | 'marketplace' | 'labs' | 'file-editor' | 'terminal';
+export type BrowserTabMode = 'welcome' | 'browser' | 'chat' | 'calendar' | 'integrations' | 'document' | 'secretary' | 'vault' | 'account' | 'history' | 'routines' | 'marketplace' | 'labs' | 'file-editor' | 'terminal' | 'agents';
 
 export interface BrowserTab {
   id:       string;

--- a/pkg/rancher-desktop/main/agentsIpc.ts
+++ b/pkg/rancher-desktop/main/agentsIpc.ts
@@ -1,0 +1,134 @@
+// agentsIpc.ts — Thin read-only IPC surface for the Agents tab in the renderer UI.
+//
+// Flow: main owns the agent registry, heartbeat service, job registry, and
+// workflow scheduler. The UI asks "what's running?" via agents:list and
+// polls every 3s (v1 — push via a subscription channel is Stage 3).
+//
+// There is NO reactive two-way sync. Renderer mirrors main's state; that's it.
+
+import { ipcMain } from 'electron';
+
+import type { ActiveAgent } from '@pkg/agent/services/ActiveAgentsRegistry';
+
+// ── Response shape ───────────────────────────────────────────────────────────
+
+export interface AgentsListResponse {
+  agents: {
+    name:         string;
+    channel:      string;
+    type:         ActiveAgent['type'];
+    status:       ActiveAgent['status'];
+    statusNote?:  string;
+    startedAt:    number;
+    lastActiveAt: number;
+  }[];
+  heartbeat: {
+    initialized:      boolean;
+    isExecuting:      boolean;
+    lastTriggerMs:    number;
+    schedulerRunning: boolean;
+    totalTriggers:    number;
+    totalErrors:      number;
+    totalSkips:       number;
+    uptimeMs:         number;
+  } | null;
+  jobs: {
+    jobId:      string;
+    status:     string;
+    createdAt:  number;
+    finishedAt: number | null;
+    taskCount:  number;
+    error?:     string;
+  }[];
+  routines: {
+    workflowId:     string;
+    workflowName:   string;
+    nodeId:         string;
+    cronExpression: string;
+    timezone:       string;
+    nextInvocation: string | null;
+  }[];
+}
+
+// ── IPC handler ──────────────────────────────────────────────────────────────
+
+export function initAgentsIpc(): void {
+  ipcMain.handle('agents:list', async (): Promise<AgentsListResponse> => {
+    // Gather all four data sources in parallel. Each is wrapped so a
+    // failure in one never blocks the others.
+
+    const [agents, heartbeat, jobs, routines] = await Promise.all([
+      fetchAgents(),
+      fetchHeartbeat(),
+      fetchJobs(),
+      fetchRoutines(),
+    ]);
+
+    return { agents, heartbeat, jobs, routines };
+  });
+}
+
+// ── Data fetchers ────────────────────────────────────────────────────────────
+
+async function fetchAgents(): Promise<AgentsListResponse['agents']> {
+  try {
+    const { getActiveAgentsRegistry } = await import(
+      '@pkg/agent/services/ActiveAgentsRegistry'
+    );
+    const all = await getActiveAgentsRegistry().getAllAgents();
+    // Filter out human entries the same way list_agents.ts does.
+    return all
+      .filter(a => a.type !== 'human')
+      .map(a => ({
+        name:         a.name || a.agentId,
+        channel:      a.channel,
+        type:         a.type,
+        status:       a.status,
+        statusNote:   a.statusNote && a.statusNote !== 'idle' ? a.statusNote : undefined,
+        startedAt:    a.startedAt,
+        lastActiveAt: a.lastActiveAt,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+async function fetchHeartbeat(): Promise<AgentsListResponse['heartbeat']> {
+  try {
+    const { getHeartbeatService } = await import(
+      '@pkg/agent/services/HeartbeatService'
+    );
+    return getHeartbeatService().getStatus();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchJobs(): Promise<AgentsListResponse['jobs']> {
+  try {
+    const { getAllJobs } = await import(
+      '@pkg/agent/tools/agents/jobRegistry'
+    );
+    return getAllJobs().map(j => ({
+      jobId:      j.jobId,
+      status:     j.status,
+      createdAt:  j.createdAt,
+      finishedAt: j.finishedAt,
+      taskCount:  j.taskCount,
+      error:      j.error,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+async function fetchRoutines(): Promise<AgentsListResponse['routines']> {
+  try {
+    const { getWorkflowSchedulerService } = await import(
+      '@pkg/agent/services/WorkflowSchedulerService'
+    );
+    return getWorkflowSchedulerService().getScheduledJobs();
+  } catch {
+    return [];
+  }
+}

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -7,6 +7,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 import { initTabsIpc } from './browserTabs/tabsIpc';
+import { initAgentsIpc } from './agentsIpc';
 import { initClaudeCodeTestEvents } from './claudeCodeTest';
 import { initClaudeOAuthEvents } from './claudeOAuth';
 import { initOpenAIOAuthEvents } from './openaiOAuth';
@@ -68,6 +69,7 @@ function assertInsideUserHome(targetPath: string): string {
 export function initSullaEvents(): void {
   initMessageBusIpc();
   initTabsIpc();
+  initAgentsIpc();
   initConversationHistoryIpc();
   initChatMessagesIpc();
   initClaudeOAuthEvents();

--- a/pkg/rancher-desktop/pages/AgentsTab.vue
+++ b/pkg/rancher-desktop/pages/AgentsTab.vue
@@ -1,0 +1,412 @@
+<!--
+  AgentsTab — live view of every running "loop" in the system: the heartbeat,
+  active agents + subagents, scheduled routines, and spawned jobs.
+
+  Stage 1 (this file): read-only roster. Polls the main-process `agents:list`
+  IPC every 3s (v1 — a push channel replaces polling in Stage 3). Click-through
+  detail (live activity feed, kill/message controls) is Stage 2 — rows carry a
+  `cursor-default` for now and detail is intentionally stubbed.
+-->
+<template>
+  <div
+    class="text-sm font-sans page-root h-full agents-page"
+    :class="{ dark: isDark }"
+  >
+    <div class="flex flex-col h-full">
+      <!-- Hero header -->
+      <div class="overflow-hidden agents-header">
+        <div class="py-12 sm:px-2 lg:relative lg:px-0 lg:py-16">
+          <div class="mx-auto max-w-6xl px-4 md:px-6 lg:px-8">
+            <div class="flex items-center justify-between gap-8">
+              <div>
+                <p class="inline bg-linear-to-r from-indigo-500 via-sky-500 to-indigo-500 dark:from-indigo-200 dark:via-sky-400 dark:to-indigo-200 bg-clip-text font-display text-5xl tracking-tight text-transparent">
+                  Agents.
+                </p>
+                <p class="mt-3 text-2xl tracking-tight text-slate-500 dark:text-slate-400">
+                  Everything running right now — agents, heartbeat, routines, jobs.
+                </p>
+              </div>
+
+              <div class="flex items-center gap-3 text-xs text-slate-500 dark:text-slate-500">
+                <span
+                  class="inline-block w-2 h-2 rounded-full"
+                  :class="polling ? 'bg-emerald-400 animate-pulse' : 'bg-slate-400'"
+                />
+                <span>{{ polling ? 'Live · refreshes every 3s' : 'Paused' }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Body -->
+      <div class="flex-1 overflow-auto">
+        <div class="mx-auto max-w-6xl px-4 py-6 space-y-8">
+          <!-- Loading state -->
+          <div
+            v-if="loading"
+            class="flex items-center justify-center py-20 text-slate-500"
+          >
+            Loading agents...
+          </div>
+
+          <template v-else>
+            <!-- ── Heartbeat ── -->
+            <section>
+              <h3 class="section-label">
+                Heartbeat
+              </h3>
+              <div
+                v-if="data.heartbeat"
+                class="agents-card px-4 py-3 rounded-lg flex items-center gap-4"
+              >
+                <span
+                  class="flex-shrink-0 inline-block w-2.5 h-2.5 rounded-full"
+                  :class="heartbeatDot"
+                />
+                <div class="flex-1 min-w-0">
+                  <p class="text-sm text-slate-800 dark:text-slate-200">
+                    {{ data.heartbeat.isExecuting ? 'Executing a cycle' : data.heartbeat.schedulerRunning ? 'Idle — scheduler running' : 'Stopped' }}
+                  </p>
+                  <p class="text-xs text-slate-500 dark:text-slate-500 mt-0.5">
+                    {{ data.heartbeat.totalTriggers }} triggers · {{ data.heartbeat.totalErrors }} errors · {{ data.heartbeat.totalSkips }} skips
+                    <template v-if="data.heartbeat.lastTriggerMs">
+                      · last {{ relTime(data.heartbeat.lastTriggerMs) }}
+                    </template>
+                  </p>
+                </div>
+                <span class="flex-shrink-0 text-xs text-slate-500 dark:text-slate-600">
+                  up {{ formatDuration(data.heartbeat.uptimeMs) }}
+                </span>
+              </div>
+              <p
+                v-else
+                class="text-sm text-slate-500 dark:text-slate-500 px-1"
+              >
+                Heartbeat is not initialized.
+              </p>
+            </section>
+
+            <!-- ── Agents & subagents ── -->
+            <section>
+              <h3 class="section-label">
+                Agents &amp; Subagents
+                <span class="section-count">{{ data.agents.length }}</span>
+              </h3>
+              <div
+                v-if="data.agents.length"
+                class="space-y-1"
+              >
+                <div
+                  v-for="agent in data.agents"
+                  :key="agent.channel"
+                  class="agents-row group flex items-center gap-3 px-4 py-3 rounded-lg"
+                >
+                  <span
+                    class="flex-shrink-0 inline-block w-2.5 h-2.5 rounded-full"
+                    :class="statusDot(agent.status)"
+                  />
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm text-slate-800 dark:text-slate-200 truncate flex items-center gap-2">
+                      {{ agent.name }}
+                      <span
+                        v-if="isSubconscious(agent.channel)"
+                        class="badge"
+                      >subconscious</span>
+                      <span class="badge badge-type">{{ agent.type }}</span>
+                    </p>
+                    <p class="text-xs text-slate-500 dark:text-slate-500 truncate mt-0.5">
+                      <span class="font-mono">{{ agent.channel }}</span>
+                      <template v-if="agent.statusNote"> · {{ agent.statusNote }}</template>
+                    </p>
+                  </div>
+                  <span class="flex-shrink-0 text-xs text-slate-500 dark:text-slate-600 text-right">
+                    up {{ formatDuration(Date.now() - agent.startedAt) }}
+                    <template v-if="idleMins(agent.lastActiveAt) >= 1">
+                      <br>idle {{ idleMins(agent.lastActiveAt) }}m
+                    </template>
+                  </span>
+                </div>
+              </div>
+              <p
+                v-else
+                class="text-sm text-slate-500 dark:text-slate-500 px-1"
+              >
+                No active agents.
+              </p>
+            </section>
+
+            <!-- ── Routines ── -->
+            <section>
+              <h3 class="section-label">
+                Routines
+                <span class="section-count">{{ data.routines.length }}</span>
+              </h3>
+              <div
+                v-if="data.routines.length"
+                class="space-y-1"
+              >
+                <div
+                  v-for="routine in data.routines"
+                  :key="`${ routine.workflowId }:${ routine.nodeId }`"
+                  class="agents-row flex items-center gap-3 px-4 py-3 rounded-lg"
+                >
+                  <span class="flex-shrink-0 inline-block w-2.5 h-2.5 rounded-full bg-purple-400" />
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm text-slate-800 dark:text-slate-200 truncate">
+                      {{ routine.workflowName }}
+                    </p>
+                    <p class="text-xs text-slate-500 dark:text-slate-500 truncate mt-0.5 font-mono">
+                      {{ routine.cronExpression }} · {{ routine.timezone }}
+                    </p>
+                  </div>
+                  <span class="flex-shrink-0 text-xs text-slate-500 dark:text-slate-600">
+                    <template v-if="routine.nextInvocation">next {{ formatTime(routine.nextInvocation) }}</template>
+                    <template v-else>—</template>
+                  </span>
+                </div>
+              </div>
+              <p
+                v-else
+                class="text-sm text-slate-500 dark:text-slate-500 px-1"
+              >
+                No scheduled routines.
+              </p>
+            </section>
+
+            <!-- ── Jobs ── -->
+            <section>
+              <h3 class="section-label">
+                Jobs
+                <span class="section-count">{{ data.jobs.length }}</span>
+              </h3>
+              <div
+                v-if="data.jobs.length"
+                class="space-y-1"
+              >
+                <div
+                  v-for="job in data.jobs"
+                  :key="job.jobId"
+                  class="agents-row flex items-center gap-3 px-4 py-3 rounded-lg"
+                >
+                  <span
+                    class="flex-shrink-0 inline-block w-2.5 h-2.5 rounded-full"
+                    :class="jobDot(job.status)"
+                  />
+                  <div class="flex-1 min-w-0">
+                    <p class="text-sm text-slate-800 dark:text-slate-200 truncate font-mono">
+                      {{ job.jobId }}
+                    </p>
+                    <p class="text-xs text-slate-500 dark:text-slate-500 truncate mt-0.5">
+                      {{ job.status }} · {{ job.taskCount }} task{{ job.taskCount === 1 ? '' : 's' }}
+                      <template v-if="job.error"> · <span class="text-red-500 dark:text-red-400">{{ job.error }}</span></template>
+                    </p>
+                  </div>
+                  <span class="flex-shrink-0 text-xs text-slate-500 dark:text-slate-600">
+                    {{ relTime(job.createdAt) }}
+                  </span>
+                </div>
+              </div>
+              <p
+                v-else
+                class="text-sm text-slate-500 dark:text-slate-500 px-1"
+              >
+                No active jobs.
+              </p>
+            </section>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+
+import { useTheme } from '@pkg/composables/useTheme';
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
+
+import type { AgentsListResponse } from '@pkg/main/agentsIpc';
+
+const POLL_MS = 3_000;
+
+const { isDark } = useTheme();
+
+const loading = ref(true);
+const polling = ref(true);
+const data = ref<AgentsListResponse>({
+  agents: [], heartbeat: null, jobs: [], routines: [],
+});
+
+let pollTimer: ReturnType<typeof setInterval> | undefined;
+
+// ── Data loading ──
+
+async function loadAgents() {
+  try {
+    data.value = await ipcRenderer.invoke('agents:list' as any);
+    polling.value = true;
+  } catch {
+    // Leave the last snapshot in place; flag that the refresh failed.
+    polling.value = false;
+  } finally {
+    loading.value = false;
+  }
+}
+
+// ── Formatting helpers ──
+
+function formatDuration(ms: number): string {
+  if (!ms || ms < 0) return '0m';
+  const mins = Math.floor(ms / 60_000);
+
+  if (mins < 60) return `${ mins }m`;
+  const hours = Math.floor(mins / 60);
+
+  if (hours < 24) return `${ hours }h ${ mins % 60 }m`;
+
+  return `${ Math.floor(hours / 24) }d ${ hours % 24 }h`;
+}
+
+function relTime(epochMs: number): string {
+  const diff = Date.now() - epochMs;
+
+  if (diff < 60_000) return 'just now';
+
+  return `${ formatDuration(diff) } ago`;
+}
+
+function idleMins(lastActiveAt: number): number {
+  return Math.floor((Date.now() - lastActiveAt) / 60_000);
+}
+
+function formatTime(dateStr: string): string {
+  const d = new Date(dateStr);
+
+  return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+function isSubconscious(channel: string): boolean {
+  return channel.startsWith('subconscious');
+}
+
+// ── Status dot colors ──
+
+function statusDot(status: string): string {
+  if (status === 'running') return 'bg-emerald-400';
+  if (status === 'idle') return 'bg-amber-400';
+
+  return 'bg-slate-500';
+}
+
+function jobDot(status: string): string {
+  if (status === 'running') return 'bg-emerald-400';
+  if (status === 'completed') return 'bg-sky-400';
+  if (status === 'failed' || status === 'error') return 'bg-red-400';
+
+  return 'bg-slate-500';
+}
+
+const heartbeatDot = computed(() => {
+  const hb = data.value.heartbeat;
+
+  if (!hb) return 'bg-slate-500';
+  if (hb.isExecuting) return 'bg-emerald-400 animate-pulse';
+  if (hb.schedulerRunning) return 'bg-amber-400';
+
+  return 'bg-slate-500';
+});
+
+// ── Lifecycle ──
+
+onMounted(() => {
+  loadAgents();
+  pollTimer = setInterval(loadAgents, POLL_MS);
+});
+
+onUnmounted(() => {
+  if (pollTimer) clearInterval(pollTimer);
+});
+</script>
+
+<style scoped>
+.agents-page {
+  background: var(--bg-page, #ffffff);
+  color: var(--text-primary, #0d0d0d);
+}
+
+.agents-page.dark {
+  background: var(--bg-page, #0f172a);
+  color: var(--text-primary, #e0e0e0);
+}
+
+.agents-header {
+  background: var(--bg-surface, #f8fafc);
+}
+
+.agents-page.dark .agents-header {
+  background: #0f172a;
+}
+
+.section-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+  margin-bottom: 0.75rem;
+}
+
+.section-count {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: #94a3b8;
+  background: rgba(100, 116, 139, 0.12);
+  border-radius: 9999px;
+  padding: 0 0.5rem;
+  line-height: 1.25rem;
+}
+
+.agents-card,
+.agents-row {
+  background: transparent;
+}
+
+.agents-card {
+  background: var(--bg-surface, rgba(0, 0, 0, 0.02));
+}
+
+.agents-page.dark .agents-card {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.agents-row:hover {
+  background: var(--bg-surface-hover, rgba(0, 0, 0, 0.04));
+}
+
+.agents-page.dark .agents-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.625rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #7c8db5;
+  background: rgba(124, 141, 181, 0.14);
+  border-radius: 4px;
+  padding: 0 0.35rem;
+  line-height: 1rem;
+}
+
+.badge-type {
+  color: #6aa9c4;
+  background: rgba(106, 169, 196, 0.14);
+}
+</style>

--- a/pkg/rancher-desktop/pages/BrowserTab.vue
+++ b/pkg/rancher-desktop/pages/BrowserTab.vue
@@ -225,6 +225,13 @@
       </div>
     </template>
 
+    <!-- Agents mode: live view of every running loop (subagents, heartbeat, routines, jobs) -->
+    <template v-else-if="tabMode === 'agents'">
+      <div class="flex-1 min-h-0 overflow-hidden">
+        <AgentsTab />
+      </div>
+    </template>
+
     <!-- Secretary mode: continuous transcription with wake word -->
     <template v-else-if="tabMode === 'secretary'">
       <div class="flex-1 min-h-0 overflow-hidden">
@@ -301,6 +308,7 @@ import AgentRoutines from './AgentRoutines.vue';
 // Swapped to the new componentized chat at ./chat/ChatPage.vue.
 // Old implementation at ./BrowserTabChat.vue is kept for rollback.
 import BrowserTabChat from './chat/ChatPage.vue';
+import AgentsTab from './AgentsTab.vue';
 import HistoryTab from './HistoryTab.vue';
 import MyAccount from './MyAccount.vue';
 import NewTabWelcome from './NewTabWelcome.vue';

--- a/pkg/rancher-desktop/pages/chat/components/chrome/ModeRail.vue
+++ b/pkg/rancher-desktop/pages/chat/components/chrome/ModeRail.vue
@@ -94,6 +94,17 @@ const items: readonly ModeItem[] = Object.freeze([
     </svg>`,
   },
   {
+    mode:  'agents',
+    label: 'Agents',
+    icon: `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="18" cy="5" r="3"/>
+      <circle cx="6" cy="12" r="3"/>
+      <circle cx="18" cy="19" r="3"/>
+      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/>
+      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+    </svg>`,
+  },
+  {
     mode:    'routines',
     subTab:  'mywork',
     label:   'My Work',

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -389,6 +389,7 @@ export interface IpcMainInvokeEvents {
   'git-show-head':                 (dirPath: string, file: string) => string;
   'git-show-staged':               (dirPath: string, file: string) => string;
   'agents-list':                   () => { id: string; name: string; description: string; type: string; templateId: string; path: string }[];
+  'agents:list':                   () => import('@pkg/main/agentsIpc').AgentsListResponse;
   'agents-get-prompt-templates':   () => { soul: string; environment: string };
   'agents-delete':                 (agentId: string) => boolean;
   'agents-get-template-variables': () => { key: string; label: string; preview: string }[];


### PR DESCRIPTION
## Agents tab — live view of all running loops

Stage 1 slice of #537. Adds an **"Agents"** tab to the left mode-rail that lists every running "loop" and refreshes live.

### What's in this PR (Stage 1)
- **`main/agentsIpc.ts`** — new `agents:list` IPC handler (modeled on `browserTabs/tabsIpc.ts`) aggregating four sources, each wrapped so one failure never blocks the rest:
  - `ActiveAgentsRegistry.getAllAgents()` (agents/subagents, `type: 'human'` filtered out)
  - `HeartbeatService.getStatus()`
  - `jobRegistry.getAllJobs()` (spawned jobs)
  - `WorkflowSchedulerService.getScheduledJobs()` (routines)
- **`main/sullaEvents.ts`** — registers `initAgentsIpc()` next to `initTabsIpc()`.
- **`typings/electron-ipc.d.ts`** — `agents:list` channel type.
- **Tab registration** — `'agents'` added to `BrowserTabMode` + `MODE_TITLES` (`useBrowserTabs.ts`), a mode-rail item w/ network-nodes icon (`ModeRail.vue`), a render branch (`BrowserTab.vue`), and `VALID_MODES` (`open_tab.ts`) so Sulla can open it herself.
- **`pages/AgentsTab.vue`** — roster UI styled on `HistoryTab.vue`: sections for **Heartbeat / Agents & Subagents / Routines / Jobs**, status dots, uptime + idle formatting, `subconscious` badges (via `channel.startsWith('subconscious')`). Polls `agents:list` every **3s**.

### Deliberately deferred
- **Stage 2** — click-through detail panel (live activity feed via `IpcMessageBusRenderer.onMessage`, heartbeat cycle log — note `debug-heartbeat-*` handlers are typed but unregistered and must be implemented, kill via `stop_run`/`abortJob`, message via `ChatInterface`).
- **Stage 3** — replace polling with an `agents:change` push broadcast; allowed-tools display; stale-entry rule (Redis `status:running` can outlive a crashed loop).

### Notes
- Branch was started by a spawned Codex agent that stalled at ~55% (backend + tab wiring, uncommitted, no component). Sulla finished it: wrote `AgentsTab.vue`, added the `ModeRail`/`BrowserTab` edits, and **fixed a duplicate `'agents:list'` key** Codex left in the IPC typings.
- `.vue` SFCs aren't `tsc`-checkable in this repo (no `vue-tsc`); the `.ts` changes were verified against the real service signatures. Full-repo `tsc` has pre-existing errors under `scripts/` unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
