### PR TITLE
fix(threat-proxy): stream SSE responses instead of buffering them

### DIFF
--- a/resources/threat-proxy/addons/prompt_injection.py
+++ b/resources/threat-proxy/addons/prompt_injection.py
@@ -100,7 +100,36 @@ class PromptInjectionScanner:
             hits.append((severity, label, excerpt))
         return hits
 
+    def responseheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream (don't buffer) token-by-token SSE responses.
+
+        mitmproxy buffers the ENTIRE response body in memory before invoking the
+        `response` hook — unless streaming is enabled here, in the responseheaders
+        phase. For Anthropic's `text/event-stream` responses (Claude Code runs
+        with --output-format stream-json) this buffering turns streaming into
+        blocking: Claude Code receives nothing until the model has finished
+        generating the whole answer, inflating time-to-first-token to full
+        generation time (observed 40–108s in perf.log, ttftMs ~= totalMs).
+
+        `stream_large_bodies` doesn't help here — SSE token streams are small in
+        total, well under that threshold, so they get fully buffered. Streaming
+        only the event-stream content type keeps the scanner's full-body
+        inspection intact for scrapeable web content (html/json/markdown), which
+        is all it ever targeted; the model's own token stream was never scanned
+        (event-stream isn't in the scan content types).
+        """
+        if not flow.response:
+            return
+        ctype = (flow.response.headers.get("Content-Type", "") or "").split(";")[0].strip().lower()
+        if ctype == "text/event-stream":
+            flow.response.stream = True
+
     def response(self, flow: http.HTTPFlow) -> None:
+        # Streamed flows (see responseheaders) have no buffered .content; guard so
+        # accessing it can never raise. _should_scan already returns False for
+        # event-stream, but this is belt-and-suspenders if stream is set elsewhere.
+        if getattr(flow.response, "stream", False):
+            return
         if not self._should_scan(flow):
             return
 


### PR DESCRIPTION
## Problem

Claude Code runs inside the Lima VM with all traffic routed through the in-VM mitmproxy threat proxy. Users saw **40–108s of "Booting isolated environment…"** before Claude produced anything.

Root cause: the prompt-injection scanner defines a `response()` hook that reads `flow.response.content`. In mitmproxy, **any `response` hook forces the full response body to be buffered before a single byte is released** — unless streaming is opted into via `flow.response.stream = True` in a `responseheaders` hook. Nothing did.

Claude Code's API responses are `text/event-stream` (it runs with `--output-format stream-json`), so buffering turned streaming into blocking: nothing reached Claude until the model finished the entire answer. `--set stream_large_bodies=16m` doesn't help — SSE token streams are far under 16MB.

**Diagnostic signature** (`~/Library/Logs/rancher-desktop/perf.log`): on no-tool runs `ttftMs ≈ totalMs` (e.g. first token at 61381ms, run done at 61392ms).

## Fix

Add a `responseheaders` hook that sets `flow.response.stream = True` for `text/event-stream`, so tokens pass through as generated. The scanner's full-body inspection is unchanged for scrapeable web content (html/json/markdown) — the model's own token stream was never in the scan content-type set. `response()` also guards against streamed flows that have no buffered `.content`.

No security regression: event-stream bodies were already skipped by `_should_scan`; this just stops buffering them.

## Verification

Forced a test SSE vs JSON response through the running proxy:

| Content-Type | First byte |
|---|---|
| `application/json` (buffered, control) | +3s (only at completion) |
| `text/event-stream` (fixed) | **+0s (immediate)** |

Applied live to the running VM proxy and confirmed it loads clean. Expected effect: TTFT drops from full-generation time to real model TTFT (~1–3s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)