### PR TITLE
perf(recall): SQL fast-path for observation recall + trgm index + tier logging

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0041_add_trigram_index_to_observations.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0041_add_trigram_index_to_observations.ts
@@ -1,0 +1,21 @@
+/**
+ * Migration 0041 — Trigram GIN index on observations.content.
+ *
+ * Observation recall (and the writer's dedup search) hits the table with
+ * `content ILIKE '%word%'`. Without a trigram index those substring matches
+ * are sequential scans — fine at a few hundred rows, but they degrade to
+ * 50-200ms+ as the table grows past ~10k observations.
+ *
+ * A GIN index using the pg_trgm `gin_trgm_ops` operator class makes ILIKE
+ * (and case-insensitive substring search generally) index-assisted, keeping
+ * the SQL fast-path fast at any table size. Schema-only — no user data (nAYP).
+ */
+
+export const up = `
+  CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+  CREATE INDEX IF NOT EXISTS idx_observations_content_trgm
+    ON observations USING gin (content gin_trgm_ops);
+`;
+
+export const down = `DROP INDEX IF EXISTS idx_observations_content_trgm;`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -29,6 +29,7 @@ import { up as up_0037, down as down_0037 } from './0037_create_routine_stewards
 import { up as up_0038, down as down_0038 } from './0038_create_routine_digest_views';
 import { up as up_0039, down as down_0039 } from './0039_create_routine_promotion_candidates_view';
 import { up as up_0040, down as down_0040 } from './0040_create_heartbeat_seen_issues_table';
+import { up as up_0041, down as down_0041 } from './0041_add_trigram_index_to_observations';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -58,4 +59,5 @@ export const migrationsRegistry = [
   { name: '0038_create_routine_digest_views',               up: up_0038, down: down_0038 },
   { name: '0039_create_routine_promotion_candidates_view',  up: up_0039, down: down_0039 },
   { name: '0040_create_heartbeat_seen_issues_table',        up: up_0040, down: down_0040 },
+  { name: '0041_add_trigram_index_to_observations',         up: up_0041, down: down_0041 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/ObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/ObservationsModel.ts
@@ -82,6 +82,20 @@ export class ObservationsModel {
         CREATE INDEX IF NOT EXISTS idx_observations_archived_created
           ON ${ ObservationsModel.TABLE } (archived, created_at DESC)
       `);
+      // Trigram GIN index — keeps the `content ILIKE '%word%'` search path
+      // (recall + writer dedup) index-assisted instead of a seq scan as the
+      // table grows. Mirrors migration 0041. Best-effort: pg_trgm may be
+      // unavailable on a locked-down cluster, so it's isolated in its own try
+      // and never blocks table creation.
+      try {
+        await postgresClient.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+        await postgresClient.query(`
+          CREATE INDEX IF NOT EXISTS idx_observations_content_trgm
+            ON ${ ObservationsModel.TABLE } USING gin (content gin_trgm_ops)
+        `);
+      } catch (trgmErr) {
+        console.warn('[ObservationsModel] pg_trgm index unavailable (non-fatal):', trgmErr);
+      }
     } catch (err) {
       console.error('[ObservationsModel] Failed to ensure table:', err);
     }

--- a/pkg/rancher-desktop/agent/languagemodels/index.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/index.ts
@@ -18,6 +18,12 @@ import { isTierName, resolveTierToModelId, type ModelTier } from './ModelTierRes
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { getIntegrationService } from '../services/IntegrationService';
 
+// Dedupe key for the one-line subconscious-model resolution log (verify the
+// 'fast' tier actually resolves, and catch a SILENT fallback to primary). We
+// log only when the resolved provider/tier/model/fallback signature changes,
+// so the truth surfaces in background.log without spamming every dispatch.
+let lastSubconsciousResolutionSig = '';
+
 // Provider factory map — lazy-loaded to avoid circular imports
 const PROVIDER_FACTORIES: Record<string, () => Promise<BaseLanguageModel>> = {
   'claude-code': async() => { const { getClaudeCodeService } = await import('./ClaudeCodeService'); return getClaudeCodeService() },
@@ -229,10 +235,31 @@ class LLMRegistryImpl {
       try { return !!(svc?.getModel?.() || '').trim() } catch { return false }
     };
 
-    const svc = await this.getServiceByProvider(effectiveProvider, modelOverride);
-    if (hasUsableModel(svc)) return svc;
+    // One-line resolution trace (deduped). `modelOverride` is the tier already
+    // resolved to a concrete model id (when subconsciousModelId is a tier
+    // name); `resolved` is what the service will actually call. When the
+    // subconscious service has no usable model we fall back to PRIMARY — that
+    // is the silent-degradation case worth flagging loudly.
+    const logResolution = (resolved: string, fellBackToPrimary: boolean) => {
+      const sig = `${ effectiveProvider }|${ subconsciousModelId }|${ modelOverride ?? '' }|${ resolved }|${ fellBackToPrimary }`;
+      if (sig === lastSubconsciousResolutionSig) return;
+      lastSubconsciousResolutionSig = sig;
+      console.log(
+        `[SubconsciousLLM] provider=${ effectiveProvider } tier/id=${ subconsciousModelId } ` +
+        `resolvedTierModel=${ modelOverride ?? '(none)' } effectiveModel=${ resolved || '(empty)' } ` +
+        `fellBackToPrimary=${ fellBackToPrimary }`,
+      );
+    };
 
-    return this.getPrimaryService();
+    const svc = await this.getServiceByProvider(effectiveProvider, modelOverride);
+    if (hasUsableModel(svc)) {
+      logResolution((() => { try { return svc?.getModel?.() || '' } catch { return '' } })(), false);
+      return svc;
+    }
+
+    const primary = await this.getPrimaryService();
+    logResolution((() => { try { return primary?.getModel?.() || '' } catch { return '' } })(), true);
+    return primary;
   }
 
   /**

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -515,34 +515,94 @@ async function runObservationAgent(state: BaseThreadState): Promise<void> {
 }
 
 // ============================================================================
-// OBSERVATION RECALL AGENT
+// OBSERVATION RECALL — DETERMINISTIC SQL FAST-PATH
 // ============================================================================
 
+/**
+ * Max observation rows surfaced into <observation_context> per turn.
+ * Observations are short, so a tight cap keeps the injection cheap while
+ * still covering the handful the primary agent could plausibly need.
+ */
+const OBSERVATION_RECALL_MAX_ROWS = 8;
+
+/**
+ * Pull the text of the most recent REAL user message — the thing recall
+ * exists to search against. Walks from the tail, skipping subconscious-
+ * injected turns, and returns the joined text of the first user message
+ * that carries any (string or text-block) content.
+ */
+function extractLatestUserText(state: BaseThreadState): string {
+  const messages = state.messages as any[];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m?.role !== 'user') continue;
+    if ((m?.metadata as any)?.source === 'subconscious') continue;
+
+    const c = m?.content;
+    if (typeof c === 'string') {
+      if (c.trim()) return c.trim();
+      continue;
+    }
+    if (Array.isArray(c)) {
+      const text = c
+        .filter((b: any) => b?.type === 'text' && typeof b.text === 'string')
+        .map((b: any) => b.text)
+        .join('\n')
+        .trim();
+      if (text) return text;
+    }
+  }
+  return '';
+}
+
+/**
+ * Observation recall used to spin up a full subconscious agent loop (up to
+ * 10 LLM iterations) whose entire job was to keyword-search the observations
+ * table and filter the hits. That cost 17-120s of BLOCKING prelude while the
+ * underlying query runs in 3-17ms. The LLM added relevance filtering, but
+ * observations are short and the primary agent is perfectly capable of
+ * ignoring an off-topic line — so we trade a little precision for a ~1000x
+ * latency win by querying the table directly.
+ *
+ * We tokenize the latest user message and run ObservationsModel.search
+ * (word-level ILIKE, ranked phrase-hit → word-match count → recency),
+ * formatting the top rows exactly as the old agent did:
+ * `[id] priority date — content`. Returns null when nothing matches so no
+ * <observation_context> block is injected.
+ *
+ * NOTE: this is not time-limited or fenced (per design) — a direct DB query
+ * has no loop to cut short; it simply returns as fast as Postgres answers.
+ * The old agent graph (GraphRegistry.createObservationRecall) and the
+ * search_observations / list_observations tools remain in place for the
+ * observation WRITER's dedup path; only the recall dispatch changed.
+ */
 async function runObservationRecall(state: BaseThreadState): Promise<string | null> {
   const startTime = Date.now();
+  const threadId = (state.metadata as any).threadId;
 
   try {
-    const { graph, state: subState, threadId } = await GraphRegistry.createObservationRecall(state);
-    console.log(`[SubconsciousMiddleware:ObservationRecall] Started | threadId: ${ threadId }`);
-
-    await graph.execute(subState, 'subconscious', { maxIterations: 10 });
-
-    const agentMeta = (subState.metadata as any).agent || {};
-    const iterations = (subState.metadata as any).iterations || 0;
-    const toolCalls = subState.messages.filter((m: any) =>
-      Array.isArray(m.content) && m.content.some((b: any) => b?.type === 'tool_use'),
-    ).length;
-
-    // Extract the structured response from AGENT_DONE (same pattern as memory-recall).
-    const response = agentMeta.response;
-
-    if (response && typeof response === 'string' && response.trim()) {
-      console.log(`[SubconsciousMiddleware:ObservationRecall] Returning ${ response.length } chars in ${ Date.now() - startTime }ms | iterations: ${ iterations }, tool_calls: ${ toolCalls }, status: ${ agentMeta.status }`);
-      return response.trim();
+    const query = extractLatestUserText(state);
+    if (!query) {
+      console.log('[SubconsciousMiddleware:ObservationRecall] No user text to search — skipped');
+      return null;
     }
 
-    console.log(`[SubconsciousMiddleware:ObservationRecall] No relevant observations in ${ Date.now() - startTime }ms | iterations: ${ iterations }, tool_calls: ${ toolCalls }, status: ${ agentMeta.status }`);
-    return null;
+    const rows = await ObservationsModel.search(query, OBSERVATION_RECALL_MAX_ROWS, false);
+    const elapsed = Date.now() - startTime;
+
+    if (!rows || rows.length === 0) {
+      perf.log(`[ObservationRecall] threadId=${ threadId } matched=0 ms=${ elapsed } path=sql-fast-path`);
+      console.log(`[SubconsciousMiddleware:ObservationRecall] No matching observations in ${ elapsed }ms (sql-fast-path)`);
+      return null;
+    }
+
+    const response = rows
+      .map((r) => `[${ r.id }] ${ r.priority } ${ (r.created_at || '').slice(0, 10) } — ${ r.content }`)
+      .join('\n');
+
+    perf.log(`[ObservationRecall] threadId=${ threadId } matched=${ rows.length } chars=${ response.length } ms=${ elapsed } path=sql-fast-path`);
+    console.log(`[SubconsciousMiddleware:ObservationRecall] Returning ${ rows.length } observations (${ response.length } chars) in ${ elapsed }ms (sql-fast-path)`);
+    return response;
   } catch (error) {
     console.error(`[SubconsciousMiddleware:ObservationRecall] Failed in ${ Date.now() - startTime }ms:`, error instanceof Error ? error.message : error);
     return null;


### PR DESCRIPTION
## Why

Observation recall ("Recalling what I know about…") previously spun up a full subconscious agent loop (up to 10 LLM iterations) whose only job was to keyword-search the observations table and filter the hits. That's **17–120s of blocking prelude** for a query that runs in **3–17ms**. The bottleneck was never the SQL — it was the agent loop wrapped around it.

This PR implements 3 of 4 approved recall speedups (the 4th — a warm/pooled Claude Code sidecar — is deliberately deferred to its own branch as a riskier core-turn-path change).

## What

**#1 — Observation-recall SQL fast-path** (the big win)
`SubconsciousMiddleware.runObservationRecall()` no longer spins up an agent graph. It pulls the latest user message, calls `ObservationsModel.search(query, 8)` directly, and formats the top rows (`[id] priority date — content`) straight into `<observation_context>`. Eliminates **one of the two per-turn recall sidecar spawns** entirely. Not time-limited/fenced — a direct DB query has no loop to cut short. The old graph + `search_observations`/`list_observations` tools remain in place for the observation *writer*'s dedup path.

**#5 — pg_trgm GIN index** (migration 0041)
`CREATE EXTENSION pg_trgm` + `gin_trgm_ops` GIN index on `observations.content` so the `ILIKE '%word%'` search stays index-assisted as the table grows past a few thousand rows. Registered in the migration index and mirrored best-effort in `ObservationsModel.ensureTable()`. Schema-only — no user data.

**#4 — Fast-tier resolution logging**
`getSubconsciousLLM()` now emits a deduped `[SubconsciousLLM] provider=… tier/id=… effectiveModel=… fellBackToPrimary=…` line so we can verify the `fast` tier actually resolves and catch a silent fallback to the primary model in background.log.

## Deferred (not in this PR)
- **#2 warm/pooled sidecar** — persistent stream-json process + MCP rebind. Core turn-path rewrite for every agent; too risky to bundle. #1 already halved per-turn spawn pressure, lowering its urgency.
- **#3 lower maxIterations** — skipped per maintainer.

## Testing / caveats
- ⚠️ Full-project `tsc --noEmit` could not run in the Lima VM (OOM at ~4.6G free, exit 134/137 even with --skipLibCheck). Validated via esbuild parse/transform (all changed files pass) + type inspection. **Recommend a full typecheck on a larger box before merge.**
- Not yet in a running binary — rebuild + restart pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)