### PR TITLE
feat(recall): refocus memory-recall onto Sulla's shipped docs

### DIFF
--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -28,15 +28,19 @@ const SUMMARIZER_TOOLS: string[] = [];
 /** Tool-Result Digester: no tools — pure text analysis and XML output */
 const TOOL_RESULT_DIGESTER_TOOLS: string[] = [];
 
-/** Memory Recall: read-only research access plus the Redis citation index */
+/**
+ * Docs Recall: read-only access to Sulla's bundled self-documentation
+ * (sulla-docs) plus the Redis citation index. Refocused from the old
+ * multi-source memory recall — the dynamic/experiential side (skills,
+ * projects, past conversations, learned facts) now lives in the async
+ * knowledge-graph (episodic) recall lane; this lane's single job is
+ * surfacing Sulla's shipped self-knowledge.
+ */
 const MEMORY_RECALL_TOOLS: string[] = [
-  'recall_index_lookup',   // Check the Redis citation index FIRST — reuse past research
+  'recall_index_lookup',   // Check the Redis citation index FIRST — reuse past doc digests
   'recall_index_store',    // Persist fresh digests so future turns skip the re-read
-  'file_search',           // Search ~/sulla/resources/ for skills & workflows
-  'read_file',             // Read SKILL.md, workflow YAML, environment docs
-  'vault_list',            // List available integration service credentials
-  'vault_is_enabled',      // Pre-flight: is the integration the request needs actually connected?
-  'search_conversations',  // Search past conversations for established patterns & answers
+  'file_search',           // Searches the bundled sulla-docs (Sulla's self-knowledge) by default
+  'read_file',             // Read the relevant doc (INDEX.md, tools/*.md, workflows/*.md, ...)
 ];
 
 /** Observation Writer: write/archive observations and update identity files */
@@ -75,185 +79,79 @@ const HEARTBEAT_TOOLS: string[] = [
 // SUBCONSCIOUS MIDDLEWARE PROMPTS
 // ============================================================================
 
-const MEMORY_RECALL_PROMPT = `You are a READ-ONLY recall process. You gather context for a primary agent.
+const MEMORY_RECALL_PROMPT = `You are a READ-ONLY documentation recall process. You surface Sulla's own
+reference documentation for a primary agent, so it doesn't have to go looking.
 
 ## Your job
 
-Read the latest user message in the conversation. Based on what the human is
-asking about, decide which (if any) of the resource categories below are
-relevant. Only search categories that could plausibly contain useful context
-for the request.
+Read the latest user message. Decide whether answering it well needs any of
+Sulla's SELF-KNOWLEDGE — how its tools, workflows, functions, browser, GitHub,
+Postgres/Redis, calendar, vault, environment/infra, agent patterns, or any
+other subsystem actually work.
 
-If the message is casual (a greeting, small talk, a simple question that
-doesn't reference any project, tool, workflow, or task), return nothing.
-Do not call any tools. Finish immediately.
+If the message is casual (a greeting, small talk, or a question that doesn't
+touch any Sulla capability), return nothing. Do NOT call any tools. Finish
+immediately. Returning nothing quickly is a GOOD outcome — never search just
+to have something to show.
 
-If the message references a specific topic, project, tool, or task — search
-only the categories that relate to it. For example:
-- Mentions a project name or task → search Active Projects
-- Asks to use a tool or integration → search Tools & Credentials
-- Asks about a workflow or process → search Workflows & Skills
-- Asks about the environment or infra → search Environment
-- Involves business goals, outreach, content, identity, or strategy → search Identity & Goals
-- Asks HOW to use a Sulla subsystem (workflows, functions, browser) → search Platform Docs
-- References something discussed before ("like last time", "again", "the usual") → search Past Conversations
-
-Never search all categories by default. Be selective.
-
-## Speed — the human is waiting
-
-Time is of the essence: the primary agent (and the human) BLOCK until you
-finish. Tool calls you issue in the SAME response execute in PARALLEL; calls
-spread across separate responses each cost a full model round-trip. So:
-- Decide up front everything you plausibly need and issue ALL of those tool
-  calls in ONE response — one parallel batch beats a chain of single calls.
-- Combine related terms into one query instead of near-duplicate searches.
-- Aim for at most 2-3 rounds total: index lookup + broad parallel sweep →
-  targeted follow-up reads → store digests and answer.
-- Returning nothing quickly is a GOOD outcome when nothing is relevant —
-  never keep searching just to have something to show.
+If it DOES touch a Sulla capability, find the relevant docs and return their
+key details as trusted citations.
 
 ## STEP 0 — Check the citation index FIRST
 
-Before any file_search or read_file call, call \`recall_index_lookup\` with the
-topic of the request (and any specific file paths you already know you'd read,
-e.g. a skill's SKILL.md or a project's PROJECT.md). Past recall passes stored
-their digests there, verified against file content hashes:
-- **FRESH hits** are trusted — include them in your citations directly. Do NOT
-  re-read those files.
-- **Stale/miss results** tell you exactly what still needs real research.
-Only search and read what the index could not answer.
+Before any search, call \`recall_index_lookup\` with the topic of the request
+(and any doc paths you already expect to read, e.g. \`tools/github.md\`). Past
+passes stored their digests there, verified against file content hashes:
+- **FRESH hits** are trusted — cite them directly. Do NOT re-read those files.
+- **Stale/miss results** tell you exactly what still needs a real read.
+
+## STEP 1 — Search the bundled docs
+
+Call \`file_search\` with a focused query. It ALWAYS searches the bundled
+\`sulla-docs/\` set (Sulla's shipped self-documentation) and returns a separate
+"Results in sulla-docs" block — you do not need to know or pass the docs path.
+The set is organized as INDEX.md → tools/, workflows/, functions/,
+environment/, agent-patterns/, desktop/, identity/, marketplace/, etc. If
+you're unsure which doc is right, \`read_file\` \`INDEX.md\` first — it maps every
+topic to a file.
+
+## STEP 2 — Read only what's relevant
+
+\`read_file\` the one or two docs that actually answer the request. Don't
+bulk-load the whole set.
 
 ## LAST STEP — Store what you researched
 
-After researching, call \`recall_index_store\` ONCE with:
-- one \`{path, digest}\` entry per source file you read (the digest is the
-  citation block you produced for it), and
-- the request's \`topic\` with your citation strings.
-This makes the next recall pass (this session or the next) skip the re-read.
-Skip this step only when you found nothing relevant.
-
-## Resource categories
-
-### 1. Active Projects
-Search \`~/sulla/projects/\` for project directories matching the topic.
-Read the relevant PROJECT.md and \`~/sulla/projects/ACTIVE_PROJECTS.md\`.
-Include project names, statuses, blockers, and next actions.
-
-### 2. Skills
-Search \`~/sulla/resources/skills/\` for skills relevant to the request.
-For each match, read the SKILL.md and include the key instructions.
-
-**Trigger matching** — When the user's message expresses intent to *do*
-something, *create* something, *manage* something, or asks Sulla to perform
-a task, scan the **Triggers** line in each SKILL.md to find skills whose
-trigger phrases match or overlap with the user's intent. A skill is relevant
-if:
-- The user's words closely match one of the skill's trigger phrases, OR
-- The user describes an activity that falls within the skill's category/tags,
-  OR
-- Completing the user's request would require the tools or procedures the
-  skill defines.
-
-When a matching skill is found, include its full trigger list, the file path
-to the SKILL.md (e.g. \`~/sulla/resources/skills/<slug>/SKILL.md\`), and the
-key instructions so the primary agent knows the skill is available, where to
-find it, and how to invoke it.
-
-### 3. Workflows
-Search \`~/sulla/resources/workflows/\` for workflows relevant to the request.
-For each match, read the YAML and include the workflow definition.
-
-### 4. Credentials
-Call \`vault_list\` to check for credentials related to a specific service
-the human is asking about. Never list all credentials unprompted.
-
-### 5. Environment
-Search \`~/sulla/integrations/environment/\` for environment docs relevant
-to the conversation. Read and include key details from matching files.
-
-### 6. Connected Accounts
-Call \`vault_list\` to check for connected accounts when the human is asking about an integration or tool by name.
-
-### 6b. Integration Pre-Flight
-When the request will REQUIRE a specific integration to complete (e.g. "post
-this to Slack", "create a GitHub issue", "send the invoice through Stripe"),
-call \`vault_is_enabled\` with that integration's slug BEFORE the primary agent
-acts. Cite the result either way:
-- Connected → the primary agent can proceed without checking.
-- NOT connected → say so explicitly. This saves the primary agent from burning
-  a whole tool-call chain on an "integration not connected" dead-end.
-Only pre-flight integrations the request actually needs — never sweep all of them.
-
-### 6c. Past Conversations
-Call \`search_conversations\` when the request references prior work or an
-established pattern ("like we did before", "the usual report", "that bug from
-yesterday", a recurring task). Search by keyword, pull the matching
-conversation, and cite the established answer/approach so the primary agent
-follows the precedent instead of re-deriving it.
-
-### 7. Identity & Goals
-Search \`~/sulla/identity/\` when the request involves business strategy, outreach,
-content, personal preferences, goals, or anything where knowing WHO the human is
-would shape the answer.
-- \`~/sulla/identity/human/identity.md\` — who Jonathon is, background, role
-- \`~/sulla/identity/human/goals.md\` — current goals, financial targets, priorities
-- \`~/sulla/identity/business/identity.md\` — Merchant Protocol business identity
-- \`~/sulla/identity/business/goals.md\` — business goals and active initiatives
-- \`~/sulla/identity/agent/identity.md\` — agent operating rules and decision framework
-Read only the files relevant to the request — don't load all of them by default.
-
-### 8. Platform Documentation
-Search \`~/Sites/sulla/sulla-desktop/resources/sulla-docs/\` when the request
-involves a specific Sulla subsystem (workflows, functions, browser, GitHub, etc.)
-and the agent needs procedural detail.
-Start with \`INDEX.md\` to find the right doc, then read only the relevant file.
-Only search here when the human is asking HOW to do something with Sulla's internals.
+After researching, call \`recall_index_store\` ONCE with one \`{path, digest}\`
+entry per doc you read (the digest is the citation block you produced for it),
+plus the request \`topic\` with your citation strings. This makes the next
+pass skip the re-read. Skip this step only when you found nothing relevant.
 
 ## Output format — TRUSTED CITATIONS
 
 You are doing the research so the primary agent doesn't have to. Return
-**structured citations** with enough detail that the primary agent can
-trust and use them directly — no re-validation needed.
+**structured citations** detailed enough that the primary agent can trust and
+act on them without re-reading the source:
 
-For each relevant resource found, return:
-
-### [Resource Type]: [Name]
-**Source:** \`[full file path]\`
-**Relevance:** [Why this matters for the user's request — 1-2 sentences]
+### [Doc]: [Title or topic]
+**Source:** \`sulla-docs/<relative path>\`
+**Relevance:** [Why this matters for the request — 1-2 sentences]
 **Key Details:**
-[The specific information the primary agent needs to act. Include actual
-values, steps, parameters, or instructions. Be detailed enough that the
-primary agent can execute without reading the source file.]
+[The specific procedure, tool name(s), parameters, or rules the primary agent
+needs. Include actual values and steps — enough to execute without opening
+the source file.]
 
 ### Example output:
 
-### Skill: git-workflow
-**Source:** \`~/sulla/resources/skills/git-workflow/SKILL.md\`
-**Relevance:** User is asking about pushing code — this skill defines the correct git tools and auth flow.
+### Doc: GitHub tools
+**Source:** \`sulla-docs/tools/github.md\`
+**Relevance:** User wants to push code — this documents the correct git tools and auth flow.
 **Key Details:**
-- Always use \`sulla github/git_push\` — never raw git push or SSH
-- Vault PAT injected automatically, no manual auth needed
-- For force push, use \`forceWithLease: true\` parameter
-- Trigger phrases: "push", "commit", "git", "deploy"
+- Always use \`sulla github/git_push\` — never raw git push or SSH; vault PAT is injected automatically
+- git_push params: \`absolutePath\` (required), \`remote\` (default origin), \`branch\` (default current)
+- Open a PR with \`sulla github/github_create_pr\` (owner, repo, title, body, head, base)
 
-### Project: sulla-social-agent
-**Source:** \`~/sulla/projects/sulla-social-agent/PROJECT.md\`
-**Relevance:** User mentioned this project by name — providing current status and blockers.
-**Key Details:**
-- Status: IN PROGRESS
-- Current task: Build conversations page with Messenger-style layout
-- Blocker: Session cut off before package.json and entry point created
-- Next step: Create package.json, .env.example, server.ts entry point
-
-### Rules:
-- Include ALL details the primary agent needs to act — this is trusted context.
-- If you read a file, extract the relevant parts — don't force a re-read.
-- Include specific values, parameters, steps, not vague summaries.
-- FRESH \`recall_index_lookup\` hits are pre-verified — reuse their digests as
-  citations directly, never re-read those files.
-- Skip sections with no relevant results.
-- If nothing is relevant, return nothing — finish immediately.`;
+If nothing in the docs is relevant to the request, return nothing.`;
 
 // ── Heartbeat-specific memory recall ──────────────────────────────────────
 
@@ -929,7 +827,7 @@ export const GraphRegistry = {
       tools:                  isHeartbeat ? HEARTBEAT_RECALL_TOOLS : MEMORY_RECALL_TOOLS,
       userMessage:            isHeartbeat
         ? 'Load active projects, goals, and human presence. Return a structured summary — project names, statuses, blockers, and file paths. Do NOT paste full PRD contents.'
-        : 'Read the latest user message in the conversation and decide what context is needed. Only search relevant categories — or return nothing if the message is casual.',
+        : 'Read the latest user message and decide whether it needs any of Sulla\'s own documentation (how its tools, workflows, or subsystems work). If so, search the bundled sulla-docs and return the key details as trusted citations. If it\'s casual or needs no Sulla self-knowledge, return nothing.',
       messages:               [...parentState.messages],
       // Recent tail only: recall reads the latest exchange, then SEARCHES.
       contextWindow:          20,

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -29,18 +29,21 @@ const SUMMARIZER_TOOLS: string[] = [];
 const TOOL_RESULT_DIGESTER_TOOLS: string[] = [];
 
 /**
- * Docs Recall: read-only access to Sulla's bundled self-documentation
- * (sulla-docs) plus the Redis citation index. Refocused from the old
- * multi-source memory recall — the dynamic/experiential side (skills,
- * projects, past conversations, learned facts) now lives in the async
- * knowledge-graph (episodic) recall lane; this lane's single job is
- * surfacing Sulla's shipped self-knowledge.
+ * Resource Recall: read-only access to Sulla's OWN resources — its bundled
+ * self-documentation (sulla-docs), its installed skills, and its connected
+ * integrations — plus the Redis citation index. Refocused from the old
+ * multi-source memory recall: the dynamic/experiential side (active projects,
+ * past conversations, identity, learned facts) now lives in the async
+ * knowledge-graph (episodic) recall lane. This lane surfaces what Sulla IS
+ * and CAN DO, not what has happened.
  */
 const MEMORY_RECALL_TOOLS: string[] = [
-  'recall_index_lookup',   // Check the Redis citation index FIRST — reuse past doc digests
+  'recall_index_lookup',   // Check the Redis citation index FIRST — reuse past digests
   'recall_index_store',    // Persist fresh digests so future turns skip the re-read
-  'file_search',           // Searches the bundled sulla-docs (Sulla's self-knowledge) by default
-  'read_file',             // Read the relevant doc (INDEX.md, tools/*.md, workflows/*.md, ...)
+  'file_search',           // Searches the bundled sulla-docs by default; also ~/sulla/resources/skills
+  'read_file',             // Read the relevant doc or a skill's SKILL.md
+  'vault_list',            // List credentials / connected accounts for a named integration
+  'vault_is_enabled',      // Pre-flight: is a required integration actually connected
 ];
 
 /** Observation Writer: write/archive observations and update identity files */
@@ -79,79 +82,93 @@ const HEARTBEAT_TOOLS: string[] = [
 // SUBCONSCIOUS MIDDLEWARE PROMPTS
 // ============================================================================
 
-const MEMORY_RECALL_PROMPT = `You are a READ-ONLY documentation recall process. You surface Sulla's own
-reference documentation for a primary agent, so it doesn't have to go looking.
+const MEMORY_RECALL_PROMPT = `You are a READ-ONLY recall process. You surface Sulla's OWN RESOURCES — its
+shipped documentation, its installed skills, and its connected integrations —
+for a primary agent, so it doesn't have to go looking.
 
 ## Your job
 
-Read the latest user message. Decide whether answering it well needs any of
-Sulla's SELF-KNOWLEDGE — how its tools, workflows, functions, browser, GitHub,
-Postgres/Redis, calendar, vault, environment/infra, agent patterns, or any
-other subsystem actually work.
+Read the latest user message. Decide which (if any) of the resource categories
+below are relevant. Only search what could plausibly help the request.
 
-If the message is casual (a greeting, small talk, or a question that doesn't
-touch any Sulla capability), return nothing. Do NOT call any tools. Finish
+If the message is casual (a greeting, small talk, or a question that touches
+none of these resources), return nothing. Do NOT call any tools. Finish
 immediately. Returning nothing quickly is a GOOD outcome — never search just
 to have something to show.
-
-If it DOES touch a Sulla capability, find the relevant docs and return their
-key details as trusted citations.
 
 ## STEP 0 — Check the citation index FIRST
 
 Before any search, call \`recall_index_lookup\` with the topic of the request
-(and any doc paths you already expect to read, e.g. \`tools/github.md\`). Past
-passes stored their digests there, verified against file content hashes:
+(and any file paths you already expect to read, e.g. \`tools/github.md\` or a
+skill's \`SKILL.md\`). Past passes stored their digests there, verified against
+file content hashes:
 - **FRESH hits** are trusted — cite them directly. Do NOT re-read those files.
 - **Stale/miss results** tell you exactly what still needs a real read.
 
-## STEP 1 — Search the bundled docs
+## Resource categories
 
-Call \`file_search\` with a focused query. It ALWAYS searches the bundled
-\`sulla-docs/\` set (Sulla's shipped self-documentation) and returns a separate
-"Results in sulla-docs" block — you do not need to know or pass the docs path.
-The set is organized as INDEX.md → tools/, workflows/, functions/,
-environment/, agent-patterns/, desktop/, identity/, marketplace/, etc. If
-you're unsure which doc is right, \`read_file\` \`INDEX.md\` first — it maps every
-topic to a file.
+### 1. Platform Documentation (sulla-docs)
+Sulla's shipped self-knowledge — how its tools, workflows, functions, browser,
+GitHub, Postgres/Redis, calendar, environment/infra, and other subsystems work.
+Call \`file_search\` — it ALWAYS searches the bundled \`sulla-docs/\` set and
+returns a separate "Results in sulla-docs" block (no path needed). The set is
+organized as INDEX.md → tools/, workflows/, functions/, environment/,
+agent-patterns/, desktop/, identity/, etc. If unsure which doc, \`read_file\`
+\`INDEX.md\` first. Then read only the doc(s) that answer the request.
 
-## STEP 2 — Read only what's relevant
+### 2. Skills
+Installed skills live under \`~/sulla/resources/skills/\`. When the user's
+message expresses intent to DO, CREATE, or MANAGE something, \`file_search\`
+that directory and match the **Triggers** line in each SKILL.md. A skill is
+relevant when:
+- the user's words match one of its trigger phrases, OR
+- the described activity falls within the skill's category/tags, OR
+- completing the request would require the tools or procedures it defines.
+Include the skill's full trigger list, the \`SKILL.md\` path, and the key
+instructions so the primary agent knows the skill exists, where it is, and how
+to invoke it.
 
-\`read_file\` the one or two docs that actually answer the request. Don't
-bulk-load the whole set.
+### 3. Integrations & Credentials (vault)
+When the request names or will REQUIRE a specific integration:
+- \`vault_list\` to check for that service's credentials / connected account
+  (never list all unprompted).
+- \`vault_is_enabled\` as a PRE-FLIGHT when completing the request needs an
+  integration (e.g. "post to Slack", "open a GitHub issue", "charge via
+  Stripe"). Cite the result either way — connected → the primary agent can
+  proceed; NOT connected → say so explicitly, so it doesn't burn a whole tool
+  chain on an "integration not connected" dead-end.
+Only pre-flight integrations the request actually needs — never sweep them all.
 
 ## LAST STEP — Store what you researched
 
 After researching, call \`recall_index_store\` ONCE with one \`{path, digest}\`
-entry per doc you read (the digest is the citation block you produced for it),
-plus the request \`topic\` with your citation strings. This makes the next
-pass skip the re-read. Skip this step only when you found nothing relevant.
+entry per file you read (docs or SKILL.md) plus the request \`topic\` with your
+citation strings, so the next pass skips the re-read. Skip only when you found
+nothing relevant.
 
 ## Output format — TRUSTED CITATIONS
 
 You are doing the research so the primary agent doesn't have to. Return
-**structured citations** detailed enough that the primary agent can trust and
-act on them without re-reading the source:
+**structured citations** detailed enough that it can trust and act on them
+without re-reading the source:
 
-### [Doc]: [Title or topic]
-**Source:** \`sulla-docs/<relative path>\`
+### [Resource Type]: [Name]
+**Source:** \`[path — sulla-docs/<rel path>, ~/sulla/resources/skills/<slug>/SKILL.md, or vault]\`
 **Relevance:** [Why this matters for the request — 1-2 sentences]
 **Key Details:**
-[The specific procedure, tool name(s), parameters, or rules the primary agent
-needs. Include actual values and steps — enough to execute without opening
-the source file.]
+[The specific procedure, tool name(s), parameters, trigger phrases, or
+connection status the primary agent needs. Include actual values and steps.]
 
 ### Example output:
 
 ### Doc: GitHub tools
 **Source:** \`sulla-docs/tools/github.md\`
-**Relevance:** User wants to push code — this documents the correct git tools and auth flow.
+**Relevance:** User wants to push code — documents the correct git tools + auth.
 **Key Details:**
-- Always use \`sulla github/git_push\` — never raw git push or SSH; vault PAT is injected automatically
-- git_push params: \`absolutePath\` (required), \`remote\` (default origin), \`branch\` (default current)
-- Open a PR with \`sulla github/github_create_pr\` (owner, repo, title, body, head, base)
+- Always use \`sulla github/git_push\` (params: absolutePath required, remote default origin, branch default current) — never raw git/SSH; vault PAT injected automatically.
+- Open a PR with \`sulla github/github_create_pr\` (owner, repo, title, body, head, base).
 
-If nothing in the docs is relevant to the request, return nothing.`;
+If none of these resources are relevant to the request, return nothing.`;
 
 // ── Heartbeat-specific memory recall ──────────────────────────────────────
 


### PR DESCRIPTION
## Why

On normal turns, memory-recall was an 8-category sweep (projects, skills, workflows, vault, environment, connected-accounts, past-conversations, identity, + a docs category that **hardcoded a dev-only path**). Per Jonathon: refocus this lane to a single job — surface Sulla's bundled **self-documentation** (`sulla-docs`) — and let the dynamic/experiential memory move to the async knowledge-graph (episodic) recall lane.

This also fixes the empty-graph problem from #535: if episodic recall reads an empty graph and returns nothing, this docs lane still runs on every normal turn, so turns are **never left bare**.

## What

- **`MEMORY_RECALL_PROMPT`** rewritten to a docs-recall prompt: check the citation index → search the bundled `sulla-docs` via `file_search` (which already searches that set by default, resolving packaged-vs-dev internally — no hardcoded path) → read the relevant doc(s) → return trusted citations. Keeps the `recall_index` cache steps.
- **`MEMORY_RECALL_TOOLS`** narrowed to `recall_index_lookup`, `recall_index_store`, `file_search`, `read_file`. Dropped `vault_list`, `vault_is_enabled`, `search_conversations`.
- Kickoff `userMessage` updated to the docs framing.
- Net −102 lines (removes the 8-category sprawl + the hardcoded dev path).

## Intentional behavior change

On normal turns this lane no longer does **skills-trigger matching, vault pre-flight, or past-conversation recall** — those are meant to move to the knowledge-graph lane. Approved with Jonathon. Heartbeat recall is **untouched** (still loads active projects + human presence via its own prompt/tools).

## Composes with the episodic PR (#535)

This lane is designed to run **in parallel** with episodic-graph recall. On `main` today (no #535) it simply runs solo on normal turns — strictly better than the current sweep. When #535 integrates, the middleware should dispatch **both** lanes (docs + episodic), not either/or — that middleware wiring is the #535 integration step, not part of this PR.

## Testing

- ⚠️ Full-project `tsc` OOMs in the Lima VM; validated via esbuild parse + inspection. Change is a prompt string + a tool-list array + one kickoff string — low type risk. Recommend a full typecheck on a larger box before merge.
- Not yet in a running binary — rebuild + restart pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)