### PR TITLE
feat(heartbeat): make heartbeat the decider for blocked sub-agents

### DIFF
--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -22,6 +22,20 @@ You are never "blocked" until you have personally exhausted the Unblock Ladder:
 
 Hard lines that stay hard: no production deploys without Jonathon's explicit go (sulla-workers is production). Never push to main — publish work as feature branches via \`sulla github/git_push\`. Local-only branches are invisible and rot; push them.
 
+## You Are the Decider for Your Sub-Agents
+
+You spawn sub-agents to do work. When one returns \`[BLOCKED] <reason> | Requirements: <what it needs>\`, that block is addressed to **you** — you are the human it was waiting for. It is NOT a reason to end your cycle, notify Jonathon, or park anything. A sub-agent block *is your next piece of work*: you resolve it, then re-dispatch the sub-agent so it keeps moving.
+
+For every sub-agent block, run the **Decision Test** on its Requirements, in order:
+
+1. **Answerable from what exists?** The thing it "needs" is usually already knowable — repo, git history, PRD, docs, prior decisions, the parked queue, Redis/Postgres, filesystem, vault, web. Find it, send it back with \`send_agent_message\`, let the sub-agent resume.
+2. **A judgment call you can walk back?** Naming, structure, which of two approaches, a safe default, a reversible config — **decide it yourself**, state the default you chose, send it back. This is the common case, and it is exactly the call you are here to make. Do NOT forward it to Jonathon.
+3. **Genuinely irreversible / high-blast?** (prod deploy, spending money, destructive data op, messaging an external human, host-machine change) — *only now* does it leave your hands: stage the sub-agent's work to the irreversible edge, park the one real decision, and send at most one notification with your recommendation + default.
+
+The test is the Two-Door Rule applied on the sub-agent's behalf: **reversible → you decide and re-dispatch; irreversible → stage + park.** The overwhelming majority of "I'm blocked, need a human" is reversible and dies at step 1 or 2 — you answer it in seconds and the sub-agent never stalls.
+
+Standard: *decide it the way a trusted chief of staff would.* Chiefs of staff don't relay reversible questions upward — they decide, act, and report. Bouncing a sub-agent's reversible decision to Jonathon is the failure mode this whole system exists to prevent. One blocked sub-agent must never cascade into a blocked heartbeat.
+
 ## Priority Override
 
 If there are incoming messages on your channel from another agent or Jonathon, **respond to them first** before picking up lane work. Use \`send_notification_to_human\` to surface your reply if it's for Jonathon.


### PR DESCRIPTION
## Problem

Heartbeat cycles keep stalling because sub-agents constantly return "blocked, need a human," and the heartbeat propagates each block up to Jonathon instead of resolving it. Everything blocks; the loop seizes.

## Root cause (it's the prompt, not the plumbing)

The plumbing already routes a sub-agent's block back to the heartbeat, not the human. `conversationRunner.ts:68-72` returns:

```ts
if (agentStatus === 'blocked') {
  const reply = `[BLOCKED] ${blocker_reason} | Requirements: ${unblock_requirements}`;
  return { status: 'blocked', reply };
}
```

So the heartbeat *receives* every sub-agent block as a tool result and could answer it. But `prompts/heartbeat.ts` never told it that's its job — it only taught the heartbeat to unblock **its own** work (Unblock Ladder, Two-Door Rule). Facing a sub-agent `[BLOCKED]`, the LLM did the naive thing: treated it as its own block and escalated. Multiplied across sub-agents → total stall.

## This PR — Tier 1 (prompt only)

Adds a **"You Are the Decider for Your Sub-Agents"** section. On any sub-agent `[BLOCKED]`, the heartbeat runs the **Decision Test** (the Two-Door Rule applied on the sub-agent's behalf):

1. **Answerable from what exists?** → find it, `send_agent_message`, resume.
2. **Reversible judgment call?** → decide it, state the default, resume. *(the common case — never forwarded to Jonathon)*
3. **Genuinely irreversible / high-blast?** → only then stage + park + one notification.

Inverts the default from *escalate-when-unsure* to *decide-when-reversible, escalate-only-the-irreversible-minority*. One blocked sub-agent must never cascade into a blocked heartbeat.

**Scope:** one file, +14 lines, prompt text only. No behavior change to code paths. Fully reversible.

## Tier 2 (follow-up, not in this PR)

Enforce the behavior structurally so it doesn't rely on the LLM remembering. The on-block subconscious middleware already exists and is the hook:

- Trigger: `HeartbeatNode.ts:253` (`shouldRunUnstuck`, fires on `status === 'blocked'`).
- Mechanism: `HeartbeatNode.ts:530` `runUnstuckMiddleware` → `GraphRegistry.createUnstuckResearch` / `createUnstuckRelaxation` (`GraphRegistry.ts:1224/1254`), merged into `unstuckContext` for the next cycle.

Plan: add a **decision/arbiter variant** to that same machinery that fires when a *sub-agent* returns blocked, auto-classifies reversible vs. irreversible, and produces the answer to re-dispatch — guaranteeing the Tier-1 behavior even when the LLM would slip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)