### PR TITLE
feat(episodic): give the heartbeat the same recall + episodic context as user turns

### DIFF
--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -6,8 +6,8 @@
  * 2. Memory Recall Agent — broad recall: tools, skills, environment, resources
  *    (recallContext). Always runs on an actionable turn.
  * 3. Episodic Recall Agent — fast knowledge-graph neighborhood recall
- *    (episodicContext). Runs ALONGSIDE #2 on normal user turns (coexists,
- *    does not replace); skipped on the heartbeat variant.
+ *    (episodicContext). Runs ALONGSIDE #2 (coexists, does not replace) on
+ *    both user turns and the heartbeat.
  * 4. Observation Writer Agent — writes/archives observational memories (fire-and-forget)
  * 5. Observation Recall Agent — surfaces relevant observations for context injection
  * 6. Tool-Result Digester — compresses stale tool_result blocks into
@@ -202,16 +202,14 @@ export async function runSubconsciousMiddleware(
   // dispatching at all when a turn carries nothing to analyze — not by
   // cutting the agents off mid-job.
 
-  // 2. Recall — awaited. Two lanes COEXIST on a normal user turn, running in
-  //    parallel (wall-clock is the slower of the two, not the sum):
-  //      • Broad recall (recallContext) — always runs. On user turns it
-  //        delivers the Sulla tool surface + environment so the primary agent
-  //        knows what it can do; on heartbeat it loads active projects,
-  //        presence, and sub-agent jobs.
-  //      • Episodic graph recall (episodicContext) — runs ALONGSIDE broad
-  //        recall on user turns, surfacing the ranked knowledge-graph
-  //        neighborhood. Skipped on heartbeat: the episodic graph doesn't
-  //        model the projects/presence/jobs the heartbeat recall gathers.
+  // 2. Recall — awaited. Two lanes COEXIST, running in parallel (wall-clock is
+  //    the slower of the two, not the sum), on BOTH user turns AND heartbeat:
+  //      • Broad recall (recallContext) — on user turns it delivers the Sulla
+  //        tool surface + environment so the agent knows what it can do; on
+  //        heartbeat it loads active projects, presence, and sub-agent jobs.
+  //      • Episodic graph recall (episodicContext) — surfaces the ranked
+  //        knowledge-graph neighborhood. The heartbeat gets the same memory
+  //        picture as a user turn (recallContext + episodicContext).
   //    They write distinct metadata keys and inject as distinct blocks, so the
   //    two are additive, not competing.
   if (options.recallVariant === 'heartbeat' || analyzable) {
@@ -219,11 +217,9 @@ export async function runSubconsciousMiddleware(
     const recallPromise = runMemoryRecall(state, options.recallVariant);
     awaitedTasks.push(timed('memory-recall', 'Recalling memories', recallPromise.then(ctx => { (state.metadata as any).recallContext = ctx })));
 
-    if (options.recallVariant !== 'heartbeat') {
-      launched.push('episodic-recall');
-      const episodicPromise = runEpisodicRecall(state);
-      awaitedTasks.push(timed('episodic-recall', 'Recalling graph memories', episodicPromise.then(ctx => { (state.metadata as any).episodicContext = ctx })));
-    }
+    launched.push('episodic-recall');
+    const episodicPromise = runEpisodicRecall(state);
+    awaitedTasks.push(timed('episodic-recall', 'Recalling graph memories', episodicPromise.then(ctx => { (state.metadata as any).episodicContext = ctx })));
   } else {
     console.log('[SubconsciousMiddleware] Recall skipped — no user message in state to analyze');
   }

--- a/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
@@ -126,6 +126,38 @@ export class HeartbeatNode extends BaseNode {
       }
     }
 
+    // Merge episodic graph context so the heartbeat gets the SAME memory
+    // picture as a user turn (recall_context + episodic_context). Same
+    // merge-into-last-assistant pattern as recall above; stripInjectedContextBlocks
+    // already covers <episodic_context> so this replaces rather than accumulates.
+    const episodicContext = (state.metadata as any).episodicContext;
+    if (episodicContext) {
+      const episodicBlock = `\n\n<episodic_context>\n${ episodicContext }\n</episodic_context>`;
+      let merged = false;
+      for (let i = state.messages.length - 1; i >= 0; i--) {
+        if (state.messages[i].role === 'assistant') {
+          const msg = state.messages[i];
+          if (typeof msg.content === 'string') {
+            msg.content += episodicBlock;
+          } else if (Array.isArray(msg.content)) {
+            msg.content.push({ type: 'text', text: episodicBlock });
+          } else {
+            msg.content = (msg.content ? JSON.stringify(msg.content) : '') + episodicBlock;
+          }
+          merged = true;
+          break;
+        }
+      }
+      if (!merged) {
+        const insertIdx = Math.max(0, state.messages.length - 1);
+        state.messages.splice(insertIdx, 0, {
+          role:     'assistant',
+          content:  episodicBlock.trim(),
+          metadata: { source: 'episodic', _synthetic: true },
+        });
+      }
+    }
+
     // Merge unstuck context from a previous cycle's analysis (if any)
     const unstuckContext = (state.metadata as any).unstuckContext;
     if (unstuckContext) {


### PR DESCRIPTION
Follow-up to #535 (which merged episodic graph recall, coexisting with broad recall on user turns). #535 gated episodic recall to non-heartbeat turns; this extends it so the **heartbeat gets the same memory picture as a user turn**.

## What changed
- **`SubconsciousMiddleware`** — episodic recall now runs on the heartbeat path too (dropped the `recallVariant !== 'heartbeat'` guard). Heartbeat keeps its heartbeat-variant broad recall (active projects / presence / sub-agent jobs) **and** now also gets `episodicContext`, both in parallel.
- **`HeartbeatNode`** — injects `<episodic_context>` alongside `<recall_context>` (same merge-into-last-assistant pattern). Without this the heartbeat would compute episodic context but never see it — only `AgentNode` injected it before. `BaseNode.stripInjectedContextBlocks` already covers `<episodic_context>`, so the heartbeat's strip-then-merge replaces rather than accumulates.

## Testing
- `tsc --noEmit` clean — 0 errors in the touched files (project's pre-existing baseline unchanged).
- Not yet exercised in a running binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)