### PR TITLE
fix(spawn_agent): wake the parent graph with async sub-agent results

### DIFF
--- a/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
@@ -86,6 +86,10 @@ export class SpawnAgentWorker extends BaseTool {
     const { GraphRegistry } = await import('../../services/GraphRegistry');
 
     const parentChannel = (this.state)?.metadata?.wsChannel || 'sulla-desktop';
+    // The orchestrator's own conversation thread. Async jobs use this to wake
+    // the parent graph with their results when they finish, so an orchestrator
+    // that fired-and-forgot doesn't sit thinking its sub-agents "died".
+    const parentThreadId: string | undefined = (this.state as any)?.metadata?.threadId;
 
     // Abort signal for THIS async job (set once the job is created below).
     // Threaded into each sub-agent so stop_agent_job(jobId) can cancel them.
@@ -228,11 +232,17 @@ export class SpawnAgentWorker extends BaseTool {
           completeJob(job.jobId, results);
           console.log(`[spawn_agent] Async job ${ job.jobId } completed — ${ results.length } result(s)`);
           await emitProactiveCompletion(parentChannel, job.jobId, results);
+          // Feed the results back INTO the orchestrator's loop, not just onto a
+          // UI card. Without this the parent's turn already ended and nothing
+          // re-invokes it — the results would strand and the orchestrator would
+          // report that the sub-agents "died".
+          wakeParentGraph(parentChannel, parentThreadId, job.jobId, results);
         })
         .catch(async(err) => {
           failJob(job.jobId, (err as Error).message);
           console.error(`[spawn_agent] Async job ${ job.jobId } failed:`, err);
           await emitProactiveCompletion(parentChannel, job.jobId, [], (err as Error).message);
+          wakeParentGraph(parentChannel, parentThreadId, job.jobId, [], (err as Error).message);
         });
 
       return {
@@ -263,6 +273,76 @@ export class SpawnAgentWorker extends BaseTool {
         : `${ results.length } sub-agent(s) completed.\n\n${ formatted }`,
     };
   }
+}
+
+// ─── Parent-graph wake ───────────────────────────────────────────
+// Re-enters the orchestrator's own graph loop with the finished sub-agent
+// results as input. The proactive card (below) is display-only — the
+// MessageDispatcher 'proactive' handler pushes it to the message list WITHOUT
+// calling graph.execute(), so on its own it never wakes the orchestrator.
+//
+// This sends a `user_message` on the parent channel + thread, which loops back
+// through getWebSocketClientService() into BackendGraphWebSocketService and
+// runs a fresh turn on the SAME thread (the exact primitive the inter-agent
+// `<channel:x wake>` tag uses). Because the orchestrator's turn has already
+// ended by the time an async job settles, that thread is idle and the wake
+// runs cleanly, injecting the results straight into its reasoning loop.
+//
+// No-op when there is no parent thread to resume (falls back to card-only,
+// the legacy behaviour).
+function wakeParentGraph(
+  parentChannel: string,
+  parentThreadId: string | undefined,
+  jobId: string,
+  results: AgentJobResult[],
+  failureReason?: string,
+): void {
+  if (!parentThreadId) return;
+
+  try {
+    const ws = getWebSocketClientService();
+    const content = buildWakeContent(jobId, results, failureReason);
+
+    ws.send(parentChannel, {
+      type: 'user_message',
+      data: {
+        content,
+        threadId: parentThreadId,
+        metadata: {
+          // Marks this as a background-completion wake rather than human input,
+          // so downstream nodes/telemetry can tell it apart from typed messages.
+          source:      'sub_agent_completion',
+          origin:      'spawn_agent',
+          inputSource: 'system',
+          jobId,
+        },
+      },
+    });
+    console.log(`[spawn_agent] Woke parent graph — channel="${ parentChannel }" thread="${ parentThreadId.slice(-8) }" job=${ jobId }`);
+  } catch (e) {
+    console.warn('[spawn_agent] wakeParentGraph failed:', e);
+  }
+}
+
+/** Format the finished job as an orchestrator-facing input message. */
+function buildWakeContent(
+  jobId: string,
+  results: AgentJobResult[],
+  failureReason?: string,
+): string {
+  if (failureReason) {
+    return `[sub-agent job ${ jobId } FAILED] ${ failureReason }\n\n` +
+      'Your background sub-agent(s) errored before returning results. Decide how to proceed (retry, adjust, or report back).';
+  }
+
+  const formatted = results.map(r =>
+    `### ${ r.label } [${ r.status.toUpperCase() }]\n${ r.output }`,
+  ).join('\n\n---\n\n');
+
+  return `[sub-agent job ${ jobId } complete — ${ results.length } result(s)]\n\n` +
+    'These are the results returned by the background sub-agent(s) you launched. ' +
+    'Continue your orchestration using them (do NOT call check_agent_jobs for this job — the results are below):\n\n' +
+    formatted;
 }
 
 // ─── Proactive completion emitter ────────────────────────────────


### PR DESCRIPTION
## Problem

Orchestrating graphs launch sub-agents via spawn_agent, but the orchestrator never hears back — it reports that the sub-agents "died."

**Root cause (verified in code):**
1. spawn_agent defaults to async/fire-and-forget: async_ = input.async !== false. It returns a jobId and the orchestrator's turn ends.
2. Nothing re-invokes the orchestrator to poll check_agent_jobs — its turn already finished.
3. When the job finishes it only emits a display-only proactive card. That handler at MessageDispatcher.ts:296 pushes to the message list WITHOUT calling graph.execute, so the orchestrator never re-runs.

Net: results strand on a UI card and never re-enter the orchestrator's reasoning loop.

## Fix

On async completion — success or failure — also WAKE the parent graph: send a user_message on the parent channel + thread. That loops back through getWebSocketClientService into BackendGraphWebSocketService.dispatchToAgent and runs a fresh turn on the same thread with the results as input — the exact primitive the inter-agent channel-wake tag already uses.

By the time an async job settles the orchestrator's turn has ended, so the thread is idle and the wake runs cleanly. Falls back to card-only when there is no parent thread to resume (legacy behaviour).

## Result

Async spawns become self-completing: no polling, results injected straight back into the orchestrator loop. No more "the sub-agent died."

## Scope / risk
- One file: pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts, +80 lines, additive.
- Reuses the shipped inter-agent wake path; no new transport.
- Needs a rebuild + app restart to go live.

Generated with Claude Code.