### PR TITLE
fix(build): remove duplicate BrowserTabChat import from #533 merge

### DIFF
--- a/pkg/rancher-desktop/pages/BrowserTab.vue
+++ b/pkg/rancher-desktop/pages/BrowserTab.vue
@@ -320,7 +320,6 @@ import SecretaryMode from './SecretaryMode.vue';
 import TerminalTab from './TerminalTab.vue';
 import AgentHeader from './agent/AgentHeader.vue';
 import { useStartupProgress } from './agent/useStartupProgress';
-import BrowserTabChat from './chat/ChatPage.vue';
 
 import HtmlMessageRenderer from '@pkg/components/HtmlMessageRenderer.vue';
 import { useBrowserTabs, type BrowserTabMode } from '@pkg/composables/useBrowserTabs';


### PR DESCRIPTION
One-line fix: the #533 conflict resolution kept two identical BrowserTabChat imports in BrowserTab.vue — duplicate identifiers in script-setup crash vue-loader. Caught by the post-merge test build. Completes the merge-wave build verification.