### PR TITLE
feat(agents): persist async sub-agent jobs across restarts (PR-B)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0043_create_agent_jobs_table.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0043_create_agent_jobs_table.ts
@@ -1,0 +1,33 @@
+/**
+ * Migration 0043 — Create agent_jobs table.
+ *
+ * Persists async sub-agent jobs (spawn_agent async mode) so an app
+ * restart no longer silently loses every running job and its results.
+ * The in-memory Map in tools/agents/jobRegistry.ts stays as the hot
+ * cache; the registry writes through to this table on create/complete/
+ * fail/stop and sweeps stale 'running' rows to 'failed' on first use
+ * after boot — so check_agent_jobs answers honestly ("app restarted
+ * mid-job") instead of "not found".
+ *
+ * SCHEMA-ONLY (per the no-user-data-in-migrations rule). Results are
+ * stored as JSONB (label/status/output/threadId per task). Finished
+ * jobs are pruned after the registry's TTL — this is operational state,
+ * not history, so rows ARE deleted (unlike observations/rules).
+ */
+
+export const up = `
+  CREATE TABLE IF NOT EXISTS agent_jobs (
+    job_id      TEXT        PRIMARY KEY,
+    status      TEXT        NOT NULL DEFAULT 'running',
+    task_count  INTEGER     NOT NULL DEFAULT 0,
+    results     JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    error       TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    finished_at TIMESTAMPTZ
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_agent_jobs_status_created
+    ON agent_jobs (status, created_at DESC);
+`;
+
+export const down = `DROP TABLE IF EXISTS agent_jobs CASCADE;`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -31,6 +31,7 @@ import { up as up_0039, down as down_0039 } from './0039_create_routine_promotio
 import { up as up_0040, down as down_0040 } from './0040_create_heartbeat_seen_issues_table';
 import { up as up_0041, down as down_0041 } from './0041_add_trigram_index_to_observations';
 import { up as up_0042, down as down_0042 } from './0042_create_rules_table';
+import { up as up_0043, down as down_0043 } from './0043_create_agent_jobs_table';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -62,4 +63,5 @@ export const migrationsRegistry = [
   { name: '0040_create_heartbeat_seen_issues_table',        up: up_0040, down: down_0040 },
   { name: '0041_add_trigram_index_to_observations',         up: up_0041, down: down_0041 },
   { name: '0042_create_rules_table',                        up: up_0042, down: down_0042 },
+  { name: '0043_create_agent_jobs_table',                   up: up_0043, down: down_0043 },
 ] as const;

--- a/pkg/rancher-desktop/agent/tools/agents/check_agent_jobs.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/check_agent_jobs.ts
@@ -10,7 +10,7 @@ export class CheckAgentJobsWorker extends BaseTool {
 
     // ── Specific job lookup ──────────────────────────────────────
     if (jobId) {
-      const job = getJob(jobId);
+      const job = await getJob(jobId);
 
       if (!job) {
         return {
@@ -85,7 +85,7 @@ export class CheckAgentJobsWorker extends BaseTool {
     }
 
     // ── List all jobs ────────────────────────────────────────────
-    const allJobs = getAllJobs();
+    const allJobs = await getAllJobs();
 
     if (allJobs.length === 0) {
       return {

--- a/pkg/rancher-desktop/agent/tools/agents/jobRegistry.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/jobRegistry.ts
@@ -1,7 +1,23 @@
 /**
- * In-memory registry for tracking async sub-agent jobs.
- * Jobs are cleaned up after retrieval or after a TTL (1 hour).
+ * Registry for tracking async sub-agent jobs.
+ *
+ * Two layers, one owner (mirrors the SullaSettingsModel philosophy —
+ * the model owns persistence, callers never touch the store directly):
+ *   • In-memory Map — the hot cache; source of truth while the app runs.
+ *   • Postgres agent_jobs table (migration 0043) — write-through copy so
+ *     a restart no longer silently loses running jobs and their results.
+ *
+ * On first use after boot, stale 'running' rows are swept to 'failed'
+ * ("app restarted mid-job") so check_agent_jobs answers honestly instead
+ * of "not found". AbortControllers are in-memory ONLY — a signal cannot
+ * survive a restart, and after the boot sweep a restarted job is
+ * correctly reported dead, so nothing needs one.
+ *
+ * Jobs are cleaned up after retrieval or after a TTL (1 hour) — this is
+ * operational state, not history; rows are really deleted.
  */
+
+import { postgresClient } from '../../database/PostgresClient';
 
 export interface AgentJobResult {
   label:    string;
@@ -31,7 +47,53 @@ const abortControllers = new Map<string, AbortController>();
 
 let jobCounter = 0;
 
-export function createJob(taskCount: number): AgentJob {
+// ── Persistence (write-through; never blocks the happy path on failure) ──
+
+async function dbWrite(sql: string, params: any[]): Promise<void> {
+  try {
+    await postgresClient.query(sql, params);
+  } catch (err) {
+    // The Map stays authoritative for this process lifetime — a failed
+    // write only costs restart durability, never the running job.
+    console.warn('[jobRegistry] persistence write failed (job continues in-memory):', (err as Error).message);
+  }
+}
+
+function rowToJob(r: any): AgentJob {
+  return {
+    jobId:      r.job_id,
+    status:     r.status,
+    createdAt:  new Date(r.created_at).getTime(),
+    finishedAt: r.finished_at ? new Date(r.finished_at).getTime() : null,
+    taskCount:  Number(r.task_count) || 0,
+    results:    Array.isArray(r.results) ? r.results : [],
+    error:      r.error ?? undefined,
+  };
+}
+
+// One-time sweep after boot: any row still 'running' belonged to a previous
+// process — its promise chain is gone, so report it dead, honestly.
+let bootSweepDone: Promise<void> | null = null;
+function ensureBootSweep(): Promise<void> {
+  bootSweepDone ??= (async() => {
+    try {
+      await postgresClient.query(
+        `UPDATE agent_jobs
+            SET status = 'failed', error = 'app restarted mid-job', finished_at = now()
+          WHERE status = 'running'`,
+      );
+    } catch (err) {
+      console.warn('[jobRegistry] boot sweep failed (will rely on in-memory state):', (err as Error).message);
+    }
+  })();
+
+  return bootSweepDone;
+}
+
+// ── API ────────────────────────────────────────────────────────────────
+
+export async function createJob(taskCount: number): Promise<AgentJob> {
+  await ensureBootSweep();
   jobCounter += 1;
   const jobId = `agent-job-${ Date.now() }-${ jobCounter }`;
   const job: AgentJob = {
@@ -45,6 +107,13 @@ export function createJob(taskCount: number): AgentJob {
 
   jobs.set(jobId, job);
   abortControllers.set(jobId, new AbortController());
+
+  await dbWrite(
+    `INSERT INTO agent_jobs (job_id, status, task_count, created_at)
+     VALUES ($1, 'running', $2, to_timestamp($3 / 1000.0))
+     ON CONFLICT (job_id) DO NOTHING`,
+    [jobId, taskCount, job.createdAt],
+  );
 
   return job;
 }
@@ -70,15 +139,52 @@ export function abortJob(jobId: string): 'stopped' | 'not-found' | 'already-fini
   job.status = 'stopped';
   job.finishedAt = Date.now();
 
+  void dbWrite(
+    `UPDATE agent_jobs SET status = 'stopped', finished_at = now() WHERE job_id = $1`,
+    [jobId],
+  );
+
   return 'stopped';
 }
 
-export function getJob(jobId: string): AgentJob | undefined {
-  return jobs.get(jobId);
+export async function getJob(jobId: string): Promise<AgentJob | undefined> {
+  await ensureBootSweep();
+  const cached = jobs.get(jobId);
+  if (cached) return cached;
+
+  // Cache miss — a pre-restart job may still exist in Postgres (swept to
+  // 'failed' by ensureBootSweep, or finished before the restart).
+  try {
+    const rows = await postgresClient.query(
+      `SELECT * FROM agent_jobs WHERE job_id = $1`, [jobId],
+    ) as any[];
+    if (rows?.[0]) {
+      const job = rowToJob(rows[0]);
+      jobs.set(jobId, job);
+
+      return job;
+    }
+  } catch (err) {
+    console.warn('[jobRegistry] persistence read failed:', (err as Error).message);
+  }
+
+  return undefined;
 }
 
-export function getAllJobs(): AgentJob[] {
-  pruneStaleJobs();
+export async function getAllJobs(): Promise<AgentJob[]> {
+  await ensureBootSweep();
+  await pruneStaleJobs();
+
+  // Union: in-memory (authoritative for this process) + persisted rows the
+  // Map doesn't know about (pre-restart jobs within TTL).
+  try {
+    const rows = await postgresClient.query(`SELECT * FROM agent_jobs`) as any[];
+    for (const r of rows ?? []) {
+      if (!jobs.has(r.job_id)) jobs.set(r.job_id, rowToJob(r));
+    }
+  } catch (err) {
+    console.warn('[jobRegistry] persistence read failed:', (err as Error).message);
+  }
 
   return Array.from(jobs.values());
 }
@@ -92,6 +198,7 @@ export function completeJob(jobId: string, results: AgentJobResult[]): void {
   // 'stopped' verdict but record whatever partial results came back.
   if (job.status === 'stopped') {
     job.results = results;
+    void dbWrite(`UPDATE agent_jobs SET results = $2::jsonb WHERE job_id = $1`, [jobId, JSON.stringify(results)]);
 
     return;
   }
@@ -99,6 +206,11 @@ export function completeJob(jobId: string, results: AgentJobResult[]): void {
   job.status = 'completed';
   job.finishedAt = Date.now();
   job.results = results;
+
+  void dbWrite(
+    `UPDATE agent_jobs SET status = 'completed', finished_at = now(), results = $2::jsonb WHERE job_id = $1`,
+    [jobId, JSON.stringify(results)],
+  );
 }
 
 export function failJob(jobId: string, error: string): void {
@@ -112,14 +224,20 @@ export function failJob(jobId: string, error: string): void {
   job.status = 'failed';
   job.finishedAt = Date.now();
   job.error = error;
+
+  void dbWrite(
+    `UPDATE agent_jobs SET status = 'failed', finished_at = now(), error = $2 WHERE job_id = $1`,
+    [jobId, error],
+  );
 }
 
 export function deleteJob(jobId: string): void {
   jobs.delete(jobId);
   abortControllers.delete(jobId);
+  void dbWrite(`DELETE FROM agent_jobs WHERE job_id = $1`, [jobId]);
 }
 
-function pruneStaleJobs(): void {
+async function pruneStaleJobs(): Promise<void> {
   const now = Date.now();
 
   for (const [id, job] of jobs.entries()) {
@@ -128,4 +246,9 @@ function pruneStaleJobs(): void {
       abortControllers.delete(id);
     }
   }
+
+  await dbWrite(
+    `DELETE FROM agent_jobs WHERE finished_at IS NOT NULL AND finished_at < now() - interval '1 hour'`,
+    [],
+  );
 }

--- a/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
@@ -221,7 +221,7 @@ export class SpawnAgentWorker extends BaseTool {
 
     // ── Async mode: fire and forget ─────────────────────────────
     if (async_) {
-      const job = createJob(tasks.length);
+      const job = await createJob(tasks.length);
       // Wire this job's abort signal in BEFORE launching, so a stop_agent_job
       // call fans out to every sub-agent this job spawns.
       jobAbortSignal = getJobAbortSignal(job.jobId);


### PR DESCRIPTION
PR-B of the operator-simplification plan. Async spawn_agent jobs lived in an in-memory Map — an app restart silently lost every running job and its results.

- Migration 0043 (schema-only): agent_jobs table. Operational state, not history — finished rows prune after the 1-hour TTL.
- jobRegistry: Map stays the hot cache and in-process source of truth; create/complete/fail/stop write through to Postgres, mirroring the SullaSettingsModel philosophy (the model owns persistence — that code is untouched and remains the settings layer).
- Boot sweep: rows still running from a previous process are marked failed with the honest error "app restarted mid-job" — check_agent_jobs reports that instead of "not found".
- Cache-miss fallback: getJob/getAllJobs read Postgres so finished pre-restart results survive within TTL.
- A failed DB write never blocks a running job — durability degrades gracefully to the old in-memory behavior with a warning.
- createJob/getJob/getAllJobs are now async; both call sites updated. AbortControllers stay memory-only (a restarted job is dead; the sweep says so).

Generated with Claude Code.