### PR TITLE
feat(ledger): writer-maintained outcome ledger + boot scaffold + scoreboard (PR-C)

### DIFF
--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -67,7 +67,8 @@ const OBSERVATION_AGENT_TOOLS: string[] = [
   'search_observations',          // Check for existing similar observations before adding
   'list_observations',            // Browse active observations
   'file_search',                  // Search identity/observation files
-  'write_file',                   // Write updates to identity/observation files
+  'read_file',                    // Read ledger/identity files before updating them
+  'write_file',                   // Write updates to identity/observation/ledger files
 ];
 
 /** Observation Recall: read-only — search and list observations for context injection */
@@ -745,7 +746,22 @@ Your ONLY jobs:
    that are no longer accurate or have been superseded by a newer one.
 
 3. If something important should update an identity file at ~/sulla/identity/,
-   read and update that specific file with write_file. Nothing else.
+   read and update that specific file with write_file.
+
+4. Maintain the OUTCOME LEDGER at ~/sulla/ledger/ (the agent's single
+   work-state store). From THIS conversation only, extract:
+   - Commitments made ("I'll build X", "next step is Y") -> ensure a matching
+     WORKING/next-action line exists in ~/sulla/ledger/LEDGER.md (read_file
+     first; update the existing row instead of duplicating).
+   - Outcomes shipped (something merged, pushed, filed, fixed, verified,
+     decided) -> append ONE dated line to ~/sulla/ledger/OUTCOMES.md
+     (newest first, under the header): date — what shipped — what it changed.
+   - A gate opening or closing (approval given, PR merged, decision made) ->
+     update that row's state in LEDGER.md.
+   Never rewrite ledger history — append outcomes, edit only the live rows
+   you are updating. If ~/sulla/ledger/ does not exist, skip (the app
+   scaffolds it at boot). Skip entirely when the conversation contains no
+   commitment, outcome, or gate change — most turns need NO ledger write.
 
 When saving new observations, include why certain decisions were made (not just what). Like:
 
@@ -1348,7 +1364,7 @@ export const GraphRegistry = {
     const state = await buildSubconsciousState({
       systemPrompt:           OBSERVATION_AGENT_PROMPT,
       tools:                  OBSERVATION_AGENT_TOOLS,
-      userMessage:            'Review this conversation. Search for existing observations before adding any new ones (update instead of duplicate). Soft-archive stale or superseded entries. Update identity files if warranted. If nothing needs to change, finish immediately.',
+      userMessage:            'Review this conversation. Search for existing observations before adding any new ones (update instead of duplicate). Soft-archive stale or superseded entries. Update identity files if warranted. Write any commitments/outcomes/gate-changes from this conversation to the outcome ledger (~/sulla/ledger/). If nothing needs to change, finish immediately.',
       messages:               [...parentState.messages],
       // Wider than recall — the writer mines the conversation for facts —
       // but still bounded; the summarizer compacts anything older anyway.

--- a/pkg/rancher-desktop/agent/tools/ledger/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/ledger/manifests.ts
@@ -1,0 +1,20 @@
+import type { ToolManifest } from '../registry';
+
+/**
+ * Ledger tools — deterministic reads of the outcome ledger at ~/sulla/ledger/.
+ * The ledger itself is maintained by the observation writer (each turn) and
+ * the agents directly (via read_file/write_file); these tools provide the
+ * zero-LLM measurement layer.
+ */
+export const ledgerToolManifests: ToolManifest[] = [
+  {
+    name:        'ledger_scoreboard',
+    description: 'Deterministic outcome-ledger scoreboard (zero LLM): outcomes shipped in the window, WORKING items and how many are staged at a gate, unilateral actions logged in AUDIT.md, and a staleness flag against the 7-day rule. The heartbeat reads this each cycle; the human reads it as the trust-ratchet evidence.',
+    category:    'ledger',
+    schemaDef:   {
+      days: { type: 'number', optional: true, description: 'Window in days for the "recent" counts (default 7).' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./scoreboard'),
+  },
+];

--- a/pkg/rancher-desktop/agent/tools/ledger/scoreboard.ts
+++ b/pkg/rancher-desktop/agent/tools/ledger/scoreboard.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { BaseTool, ToolResponse } from '../base';
+import { resolveSullaLedgerDir } from '../../utils/sullaPaths';
+
+/**
+ * Ledger Scoreboard — deterministic, zero-LLM read of the outcome ledger.
+ *
+ * Counts what the operator actually shipped (OUTCOMES.md dated lines),
+ * what is in motion and what is staged at a gate (LEDGER.md WORKING rows),
+ * unilateral actions logged (AUDIT.md), and flags staleness against the
+ * ledger's own 7-day rule. The heartbeat reads this each cycle and the
+ * human reads it as the trust-ratchet evidence — measured, not vibes.
+ */
+
+const DATE_LINE = /^-\s*(\d{4}-\d{2}-\d{2})\s*—/;
+
+function countDatedLines(file: string, sinceDays: number): { total: number; recent: number; newestDate: string | null } {
+  let total = 0; let recent = 0; let newestDate: string | null = null;
+  const cutoff = Date.now() - sinceDays * 24 * 60 * 60 * 1000;
+
+  try {
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+    for (const line of lines) {
+      const m = line.match(DATE_LINE);
+      if (!m) continue;
+      total += 1;
+      const t = new Date(m[1]).getTime();
+      if (!Number.isNaN(t) && t >= cutoff) recent += 1;
+      if (!newestDate || m[1] > newestDate) newestDate = m[1];
+    }
+  } catch { /* missing file → zeros */ }
+
+  return { total, recent, newestDate };
+}
+
+function countWorkingRows(ledgerFile: string): { working: number; staged: number } {
+  let working = 0; let staged = 0;
+
+  try {
+    const text = fs.readFileSync(ledgerFile, 'utf8');
+    let inWorking = false;
+    for (const line of text.split('\n')) {
+      if (/^##\s/.test(line)) inWorking = /^##\s+WORKING/i.test(line);
+      if (!inWorking) continue;
+      // Table data rows only — skip headers and separator rows.
+      if (/^\|/.test(line) && !/^\|\s*(Item|Decision|---)/.test(line) && !/^\|[-\s|]+\|$/.test(line)) {
+        working += 1;
+        if (/gate|staged/i.test(line)) staged += 1;
+      }
+    }
+  } catch { /* missing file → zeros */ }
+
+  return { working, staged };
+}
+
+export class LedgerScoreboardWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const days = Number(input?.days) || 7;
+    const dir = resolveSullaLedgerDir();
+
+    if (!fs.existsSync(dir)) {
+      return {
+        successBoolean: true,
+        responseString: `No ledger found at ${ dir } — it is scaffolded at app boot; nothing to score yet.`,
+      };
+    }
+
+    const outcomes = countDatedLines(path.join(dir, 'OUTCOMES.md'), days);
+    const audit = countDatedLines(path.join(dir, 'AUDIT.md'), days);
+    const { working, staged } = countWorkingRows(path.join(dir, 'LEDGER.md'));
+
+    const staleWarning = outcomes.newestDate &&
+      (Date.now() - new Date(outcomes.newestDate).getTime()) > 7 * 24 * 60 * 60 * 1000
+      ? `\n⚠️ No outcome recorded in over 7 days (newest: ${ outcomes.newestDate }) — the 7-day rule says review WORKING items now.`
+      : '';
+
+    return {
+      successBoolean: true,
+      responseString: [
+        `# Ledger Scoreboard (last ${ days } day(s))`,
+        '',
+        `- Outcomes shipped: ${ outcomes.recent } (all-time recorded: ${ outcomes.total }, newest: ${ outcomes.newestDate ?? 'none' })`,
+        `- WORKING items: ${ working } (${ staged } staged at a gate)`,
+        `- Unilateral actions logged: ${ audit.recent } (all-time: ${ audit.total })`,
+        staleWarning,
+      ].filter(Boolean).join('\n'),
+    };
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/manifests.ts
@@ -25,6 +25,7 @@ import { rdctlToolManifests } from './rdctl/manifests';
 import { redisToolManifests } from './redis/manifests';
 import { toolRegistry } from './registry';
 import { rulesToolManifests } from './rules/manifests';
+import { ledgerToolManifests } from './ledger/manifests';
 import { secretaryToolManifests } from './secretary/manifests';
 import { slackToolManifests } from './slack/manifests';
 import { uiToolManifests } from './ui/manifests';
@@ -53,6 +54,7 @@ toolRegistry.registerManifests([
   ...rdctlToolManifests,
   ...redisToolManifests,
   ...rulesToolManifests,
+  ...ledgerToolManifests,
   ...secretaryToolManifests,
   ...slackToolManifests,
   ...uiToolManifests,

--- a/pkg/rancher-desktop/agent/utils/sullaPaths.ts
+++ b/pkg/rancher-desktop/agent/utils/sullaPaths.ts
@@ -411,6 +411,87 @@ These are product defaults — extend per-install via rules/user/ or add_rule.
  * Seed the default global rule files if they are missing. Idempotent:
  * existing files (including user edits) are never overwritten.
  */
+export function resolveSullaLedgerDir(): string {
+  return path.join(resolveSullaHomeDir(), 'ledger');
+}
+
+/**
+ * Seed the outcome-ledger scaffold (generic templates only — per the
+ * no-user-data-in-shipped-code rule, nothing install-specific is written).
+ * The ledger is the operator's single work-state store: the soul defines the
+ * contract, the observation writer maintains it each turn, the heartbeat
+ * reads it each cycle, and ledger/scoreboard measures it. Idempotent: only
+ * missing files are created; user content is never overwritten.
+ */
+function seedLedgerDefaults(): void {
+  const dir = resolveSullaLedgerDir();
+  fs.mkdirSync(path.join(dir, 'goals'), { recursive: true });
+
+  const templates: Array<{ filename: string; content: string }> = [
+    {
+      filename: 'LEDGER.md',
+      content:  `# Outcome Ledger — Governing Document
+
+This is the operator's agenda and record — the ONE work-state store. Every autonomous cycle starts here: pick the top WORKING item, move it, write the outcome back.
+
+## Buckets
+| Bucket | Meaning | Lives in |
+|---|---|---|
+| WORKING | In motion now, or staged at a gate | this file + its goal file |
+| SHOULD | Committed — has an owner and a definition of done | goals/ |
+| WANT / MIGHT | Valuable-not-committed / speculative | this file, Backlog section |
+| DONE | Shipped, outcome recorded | OUTCOMES.md |
+
+## Aging rules
+- WORKING untouched 7 days -> flag in weekly review: unblock, demote, or kill.
+- WANT untouched 30 days -> MIGHT. MIGHT untouched 90 days -> archive with one line of why.
+- Every cycle writes back: an outcome in OUTCOMES.md or a changed next-action line here. A cycle that changes nothing was an observer cycle.
+
+## WORKING
+
+| Item | Goal | State | Next action | Gate? |
+|---|---|---|---|---|
+
+## Backlog (WANT / MIGHT)
+
+`,
+    },
+    {
+      filename: 'OUTCOMES.md',
+      content:  `# Outcomes — What Shipped and What It Changed
+
+Newest first. One line per outcome: date — what shipped — what it changed.
+
+`,
+    },
+    {
+      filename: 'AUDIT.md',
+      content:  `# Audit — Unilateral Actions
+
+One line per gate-free autonomous action: date — action — why — undo path. This record is what earns a wider authority envelope.
+
+`,
+    },
+    {
+      filename: path.join('goals', 'README.md'),
+      content:  `One file per goal: outcome metric, definition of done, epics with tasks, and a dated log. Referenced from LEDGER.md WORKING rows.
+`,
+    },
+  ];
+
+  for (const { filename, content } of templates) {
+    const target = path.join(dir, filename);
+    try {
+      if (!fs.existsSync(target)) {
+        fs.writeFileSync(target, content, 'utf8');
+        console.log(`[Sulla] Seeded ledger file: ${ target }`);
+      }
+    } catch (err) {
+      console.error(`[Sulla] Failed to seed ledger file ${ target }:`, err);
+    }
+  }
+}
+
 function seedGlobalRuleDefaults(): void {
   const dir = resolveSullaGlobalRulesDir();
   for (const { filename, content } of DEFAULT_GLOBAL_RULES) {
@@ -477,4 +558,8 @@ export async function bootstrapSullaHome(): Promise<void> {
   fs.mkdirSync(resolveSullaGlobalRulesDir(), { recursive: true });
   fs.mkdirSync(resolveSullaUserRulesDir(), { recursive: true });
   seedGlobalRuleDefaults();
+
+  // Outcome ledger — the operator's single work-state store (generic
+  // templates only; user content is never overwritten).
+  seedLedgerDefaults();
 }


### PR DESCRIPTION
PR-C of the operator-simplification plan.

- Observation writer lane extended with ledger duties — deliberately NOT a new subconscious agent (one post-turn writer = less latency, less cost, one less dispatch to break). It extracts commitments / shipped outcomes / gate changes and maintains ~/sulla/ledger/ with the file tools it already had.
- bootstrapSullaHome seeds the generic ledger scaffold (LEDGER.md, OUTCOMES.md, AUDIT.md, goals/) — idempotent, never overwrites user content, nothing install-specific ships.
- New ledger_scoreboard tool: deterministic zero-LLM measurement of outcomes shipped, WORKING/staged counts, audit lines, and 7-day staleness. Heartbeat reads it each cycle; the human reads it as trust-ratchet evidence.

Generated with Claude Code.