### PR TITLE
feat(operator): settings_get/set + redis sulla_settings guard + docs (PR-D/E)

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/SullaSettingsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/SullaSettingsModel.ts
@@ -33,6 +33,17 @@ function getIpcRenderer(): any {
   return _ipcRenderer;
 }
 
+/**
+ * SINGLE AUTHORITATIVE SETTINGS PATH.
+ *
+ * Reads: Redis `sulla_settings` hash as cache → Postgres on miss → backfill
+ * Redis. Writes: through Postgres AND Redis. File-JSON fallback pre-DB.
+ *
+ * Do NOT read or write the `sulla_settings` Redis hash directly anywhere
+ * else (code or agent redis tools) — a raw hget can serve a stale cache and
+ * a raw hset desyncs the stores. Verified 2026-08-13: no product code
+ * bypasses this model.
+ */
 export class SullaSettingsModel extends BaseModel<SettingsAttributes> {
   protected readonly tableName = 'sulla_settings';
   protected get tableRef(): string {

--- a/pkg/rancher-desktop/agent/tools/agents/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/manifests.ts
@@ -27,7 +27,7 @@ export const agentToolManifests: ToolManifest[] = [
       async: {
         type:        'boolean',
         optional:    true,
-        description: 'When true (default), launches agents in the background and returns immediately with a jobId. Use check_agent_jobs to poll for results. Set to false to block until all agents complete.',
+        description: 'When true (default), launches agents in the background and returns immediately with a jobId. Results wake the parent graph on completion; check_agent_jobs is the fallback/history read. Set to false to block until all agents complete.',
       },
     },
     operationTypes: ['execute'],
@@ -35,7 +35,7 @@ export const agentToolManifests: ToolManifest[] = [
   },
   {
     name:        'check_agent_jobs',
-    description: 'Check the status and results of async sub-agent jobs launched with spawn_agent(async: true). Pass a jobId to check a specific job, or omit to list all pending/completed jobs.',
+    description: 'Fallback/history read of async sub-agent jobs launched with spawn_agent(async: true). Results normally arrive via parent-graph wake — use this after a restart or to inspect a specific jobId. Omit jobId to list all pending/completed jobs.',
     category:    'agents',
     schemaDef:   {
       jobId: { type: 'string', optional: true, description: 'The job ID returned by an async spawn_agent call. Omit to list all jobs.' },
@@ -45,7 +45,7 @@ export const agentToolManifests: ToolManifest[] = [
   },
   {
     name:        'stop_agent_job',
-    description: 'Kill switch for a running async sub-agent job (from spawn_agent(async: true)). Fires the job\'s abort signal, which cascades to every sub-agent it spawned, unwinding them cooperatively (an in-flight LLM/tool call finishes first, then the loop stops). Use when a job was misfired, duplicated, or is no longer needed. Poll check_agent_jobs afterwards to confirm it settled as \'stopped\'.',
+    description: 'Kill switch for a running async sub-agent job (from spawn_agent(async: true)). Fires the job\'s abort signal, which cascades to every sub-agent it spawned, unwinding them cooperatively (an in-flight LLM/tool call finishes first, then the loop stops). Use when a job was misfired, duplicated, or is no longer needed. Results wake the parent graph; check_agent_jobs afterwards is the fallback/history read to confirm it settled as \'stopped\'.',
     category:    'agents',
     schemaDef:   {
       jobId: { type: 'string', description: 'The job ID to cancel (returned by the async spawn_agent call).' },
@@ -55,7 +55,7 @@ export const agentToolManifests: ToolManifest[] = [
   },
   {
     name:        'start_agent_conversation',
-    description: 'Open a persistent, multi-turn conversation with a sub-agent (vs. spawn_agent\'s fire-and-forget). Runs the first turn and returns the sub-agent\'s reply plus a conversationId. The sub-agent stays alive between messages, keeping full context, so you can delegate then clarify, correct, or ask follow-ups. Continue with send_agent_message; end with close_agent_conversation.',
+    description: 'LEGACY multi-turn wrapper. Prefer spawn_agent for delegation. Use only when you genuinely need iterative back-and-forth with the same worker. Runs the first turn and returns a conversationId. Continue with send_agent_message; end with close_agent_conversation.',
     category:    'agents',
     schemaDef:   {
       prompt:  { type: 'string', description: 'The opening message/instruction to the sub-agent.' },

--- a/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
@@ -252,7 +252,7 @@ export class SpawnAgentWorker extends BaseTool {
           jobId:     job.jobId,
           taskCount: tasks.length,
           parallel,
-          message:   `${ tasks.length } sub-agent(s) launched in the background. Use check_agent_jobs(jobId: "${ job.jobId }") to poll for results.`,
+          message:   `${ tasks.length } sub-agent(s) launched in the background. Results will wake this graph when they finish (check_agent_jobs is the fallback/history read).`,
         }, null, 2),
       };
     }
@@ -347,9 +347,9 @@ function buildWakeContent(
 
 // ─── Proactive completion emitter ────────────────────────────────
 // Surfaces a ProactiveCard in the parent channel's chat when an async
-// spawn_agent job finishes. The parent agent will still poll via
-// check_agent_jobs to read the full results — this card is a user-
-// facing heads-up that the background work settled.
+// spawn_agent job finishes. The parent graph is woken automatically
+// with the full results; this card is a user-facing heads-up that
+// the background work settled.
 async function emitProactiveCompletion(
   parentChannel: string,
   jobId: string,

--- a/pkg/rancher-desktop/agent/tools/agents/start_agent_conversation.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/start_agent_conversation.ts
@@ -5,11 +5,11 @@ import { runConversationTurn } from './conversationRunner';
 const MAX_DEPTH = 3;
 
 /**
- * Open a persistent, multi-turn conversation with a sub-agent. Runs the first
- * turn synchronously and returns the sub-agent's reply plus a conversationId to
- * continue with send_agent_message / read_agent_conversation. Unlike
- * spawn_agent, the sub-agent stays alive between messages so you can have a real
- * back-and-forth (delegate, then clarify, correct, or ask follow-ups).
+ * LEGACY multi-turn wrapper. Prefer spawn_agent for delegation.
+ * Open a persistent conversation with a sub-agent. Runs the first turn
+ * synchronously and returns the sub-agent's reply plus a conversationId to
+ * continue with send_agent_message / read_agent_conversation. Use only when
+ * you genuinely need iterative back-and-forth with the same worker.
  */
 export class StartAgentConversationWorker extends BaseTool {
   name = '';

--- a/pkg/rancher-desktop/agent/tools/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/manifests.ts
@@ -27,6 +27,7 @@ import { toolRegistry } from './registry';
 import { rulesToolManifests } from './rules/manifests';
 import { ledgerToolManifests } from './ledger/manifests';
 import { secretaryToolManifests } from './secretary/manifests';
+import { settingsToolManifests } from './settings/manifests';
 import { slackToolManifests } from './slack/manifests';
 import { uiToolManifests } from './ui/manifests';
 import { workflowToolManifests } from './workflow/manifests';
@@ -56,6 +57,7 @@ toolRegistry.registerManifests([
   ...rulesToolManifests,
   ...ledgerToolManifests,
   ...secretaryToolManifests,
+  ...settingsToolManifests,
   ...slackToolManifests,
   ...uiToolManifests,
   ...workflowToolManifests,

--- a/pkg/rancher-desktop/agent/tools/redis/redis_decr.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_decr.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Decr Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisDecrWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key } = input;
+
+    const blocked = rejectSettingsBypass(key, undefined, 'decr');
+
+    if (blocked) return blocked;
 
     try {
       const newValue = await redisClient.decr(key);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_del.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_del.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Del Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisDelWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { keys } = input;
+
+    const blocked = rejectSettingsBypass(keys, undefined, 'del');
+
+    if (blocked) return blocked;
 
     try {
       const count = await redisClient.del(keys);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_expire.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_expire.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Expire Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisExpireWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key, seconds } = input;
+
+    const blocked = rejectSettingsBypass(key, undefined, 'expire');
+
+    if (blocked) return blocked;
 
     try {
       const result = await redisClient.expire(key, seconds);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_get.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_get.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Get Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisGetWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key } = input;
+
+    const blocked = rejectSettingsBypass(key, undefined, 'get');
+
+    if (blocked) return blocked;
 
     try {
       const value = await redisClient.get(key);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_hget.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_hget.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Hget Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisHgetWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key, field } = input;
+
+    const blocked = rejectSettingsBypass(key, field, 'hget');
+
+    if (blocked) return blocked;
 
     try {
       const value = await redisClient.hget(key, field);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_hgetall.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_hgetall.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Hgetall Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisHgetallWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key } = input;
+
+    const blocked = rejectSettingsBypass(key, undefined, 'hgetall');
+
+    if (blocked) return blocked;
 
     try {
       const obj = await redisClient.hgetall(key);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_hset.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_hset.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Hset Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisHsetWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key, field, value } = input;
+
+    const blocked = rejectSettingsBypass(key, field, 'hset');
+
+    if (blocked) return blocked;
 
     try {
       const count = await redisClient.hset(key, field, value);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_incr.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_incr.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Incr Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisIncrWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key } = input;
+
+    const blocked = rejectSettingsBypass(key, undefined, 'incr');
+
+    if (blocked) return blocked;
 
     try {
       const newValue = await redisClient.incr(key);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_lpop.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_lpop.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Lpop Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisLpopWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key } = input;
+
+    const blocked = rejectSettingsBypass(key, undefined, 'lpop');
+
+    if (blocked) return blocked;
 
     try {
       const value = await redisClient.lpop(key);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_rpush.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_rpush.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Rpush Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisRpushWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key, values } = input;
+
+    const blocked = rejectSettingsBypass(key, undefined, 'rpush');
+
+    if (blocked) return blocked;
 
     try {
       const length = await redisClient.rpush(key, ...values);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_set.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_set.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Set Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisSetWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key, value, ttl } = input;
+
+    const blocked = rejectSettingsBypass(key, undefined, 'set');
+
+    if (blocked) return blocked;
 
     try {
       await redisClient.set(key, value, ttl);

--- a/pkg/rancher-desktop/agent/tools/redis/redis_ttl.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/redis_ttl.ts
@@ -1,5 +1,6 @@
 import { redisClient } from '../../database/RedisClient';
 import { BaseTool, ToolResponse } from '../base';
+import { rejectSettingsBypass } from './settingsGuard';
 
 /**
  * Redis Ttl Tool - Worker class for execution
@@ -9,6 +10,10 @@ export class RedisTtlWorker extends BaseTool {
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { key } = input;
+
+    const blocked = rejectSettingsBypass(key, undefined, 'ttl');
+
+    if (blocked) return blocked;
 
     try {
       const seconds = await redisClient.ttl(key);

--- a/pkg/rancher-desktop/agent/tools/redis/settingsGuard.ts
+++ b/pkg/rancher-desktop/agent/tools/redis/settingsGuard.ts
@@ -1,0 +1,35 @@
+/**
+ * Refuse agent Redis-tool access to the `sulla_settings` hash.
+ *
+ * SullaSettingsModel is the single authoritative settings path
+ * (Redis cache → Postgres on miss → write-through both). A raw
+ * hget can serve a stale cache; a raw hset/del desyncs the stores.
+ * Product code already goes through the model — this guard closes
+ * the remaining hole: the agent redis_* tools.
+ */
+import type { ToolResponse } from '../base';
+
+export const SULLA_SETTINGS_HASH = 'sulla_settings';
+
+export function blockedSettingsKey(keyOrKeys: unknown): string | null {
+  const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
+  const hit = keys.some(k => typeof k === 'string' && k === SULLA_SETTINGS_HASH);
+  if (!hit) return null;
+
+  return [
+    'Blocked: Redis key `sulla_settings` is owned by SullaSettingsModel.',
+    'Read with `sulla settings/settings_get` and write with `sulla settings/settings_set`.',
+    'A raw Redis read can serve a stale cache; a raw write desyncs Redis from Postgres.',
+  ].join(' ');
+}
+
+/** Return a failed ToolResponse if `key` (or any of `keys`) is the settings hash. */
+export function rejectSettingsBypass(
+  keyOrKeys: unknown,
+  _field?: unknown,
+  _op?: string,
+): ToolResponse | null {
+  const msg = blockedSettingsKey(keyOrKeys);
+  if (!msg) return null;
+  return { successBoolean: false, responseString: msg };
+}

--- a/pkg/rancher-desktop/agent/tools/settings/get.ts
+++ b/pkg/rancher-desktop/agent/tools/settings/get.ts
@@ -1,0 +1,40 @@
+import { SullaSettingsModel } from '../../database/models/SullaSettingsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Authoritative settings read. Goes through SullaSettingsModel
+ * (Redis cache → Postgres → file fallback). Do NOT use redis_hget
+ * on the sulla_settings hash — that is blocked and this is the
+ * replacement.
+ */
+export class SettingsGetWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const property = typeof input?.property === 'string' ? input.property.trim() : '';
+    if (!property) {
+      return {
+        successBoolean: false,
+        responseString: 'property is required (e.g. "heartbeatEnabled", "remoteProvider").',
+      };
+    }
+
+    try {
+      const value = await SullaSettingsModel.get(property, input?.default ?? null);
+      return {
+        successBoolean: true,
+        responseString: JSON.stringify({
+          property,
+          value,
+          source: 'SullaSettingsModel',
+        }, null, 2),
+      };
+    } catch (error) {
+      return {
+        successBoolean: false,
+        responseString: `Error reading setting "${ property }": ${ (error as Error).message }`,
+      };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/settings/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/settings/manifests.ts
@@ -1,0 +1,32 @@
+import type { ToolManifest } from '../registry';
+
+/**
+ * Settings tools — the single agent-facing path into SullaSettingsModel.
+ * Product code already uses the model; these tools exist so agents do
+ * the same instead of hitting the Redis `sulla_settings` hash directly.
+ */
+export const settingsToolManifests: ToolManifest[] = [
+  {
+    name:        'settings_get',
+    description: 'Read a Sulla Desktop setting through SullaSettingsModel (Redis cache → Postgres → file fallback). Use this instead of redis_hget on sulla_settings — raw Redis reads of that hash are blocked.',
+    category:    'settings',
+    schemaDef:   {
+      property: { type: 'string', description: 'Setting key (e.g. heartbeatEnabled, remoteProvider).' },
+      default:  { type: 'string', optional: true, description: 'Value to return if the setting is unset.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./get'),
+  },
+  {
+    name:        'settings_set',
+    description: 'Write a Sulla Desktop setting through SullaSettingsModel so Postgres and the Redis cache stay in sync. Use this instead of redis_hset on sulla_settings — raw Redis writes of that hash are blocked.',
+    category:    'settings',
+    schemaDef:   {
+      property: { type: 'string', description: 'Setting key.' },
+      value:    { type: 'string', description: 'Value to store. Booleans/numbers/json are accepted and cast via the optional cast field.' },
+      cast:     { type: 'string', optional: true, description: 'Optional cast: string | number | boolean | json | array. Defaults to typeof value.' },
+    },
+    operationTypes: ['update'],
+    loader:         () => import('./set'),
+  },
+];

--- a/pkg/rancher-desktop/agent/tools/settings/set.ts
+++ b/pkg/rancher-desktop/agent/tools/settings/set.ts
@@ -1,0 +1,48 @@
+import { SullaSettingsModel } from '../../database/models/SullaSettingsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Authoritative settings write. Goes through SullaSettingsModel so
+ * Postgres and the Redis cache stay in sync. Do NOT use redis_hset
+ * on the sulla_settings hash — that is blocked and this is the
+ * replacement.
+ */
+export class SettingsSetWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const property = typeof input?.property === 'string' ? input.property.trim() : '';
+    if (!property) {
+      return {
+        successBoolean: false,
+        responseString: 'property is required.',
+      };
+    }
+    if (!('value' in (input || {}))) {
+      return {
+        successBoolean: false,
+        responseString: 'value is required.',
+      };
+    }
+
+    try {
+      await SullaSettingsModel.set(property, input.value, input.cast);
+      return {
+        successBoolean: true,
+        responseString: JSON.stringify({
+          property,
+          value:  input.value,
+          cast:   input.cast ?? null,
+          source: 'SullaSettingsModel',
+          note:   'Wrote through Postgres and Redis cache.',
+        }, null, 2),
+      };
+    } catch (error) {
+      return {
+        successBoolean: false,
+        responseString: `Error writing setting "${ property }": ${ (error as Error).message }`,
+      };
+    }
+  }
+}

--- a/resources/sulla-docs/INDEX.md
+++ b/resources/sulla-docs/INDEX.md
@@ -17,7 +17,7 @@ When you wake up on a non-trivial task, read these in order:
 6. `~/sulla/identity/human/identity.md` — who you work for, operating model
 7. `~/sulla/identity/business/identity.md` — business model, active deadlines
 8. `~/sulla/identity/human/goals.md` — current goals, financial targets, operating rules
-9. `~/sulla/projects/ACTIVE_PROJECTS.md` — active projects and blockers
+9. `~/sulla/ledger/LEDGER.md` — the ONE work-state store (WORKING / SHOULD / WANT / DONE). `projects/ACTIVE_PROJECTS.md` is a legacy index in transition.
 
 For unfamiliar requests: `grep -rli '<keyword>' <path-to-this-dir>/` to find the relevant doc.
 
@@ -56,6 +56,8 @@ For unfamiliar requests: `grep -rli '<keyword>' <path-to-this-dir>/` to find the
 - `function.md` — function_list, function_run, invocation examples
 - `vault.md` — Password vault: encryption, LLM access levels, autofill, proxy injection
 - `notify.md` — notify_user, presence detection, when (and when not) to notify
+- `settings.md` — SullaSettingsModel is the one settings path; settings_get / settings_set; Redis hash is cache-only
+- `ledger.md` — outcome ledger scoreboard (zero-LLM measurement of WORKING / OUTCOMES / AUDIT)
 - `calendar.md` — calendar_create/list/update/cancel, scheduler triggers, no GCal sync
 - `applescript.md` — Drive macOS apps via AppleScript; per-app allowlist + macOS Automation perms
 - `computer-use.md` — What's shipped (AppleScript + browser pixel control) vs what's planned (full OS pixel-level)
@@ -111,5 +113,5 @@ For unfamiliar requests: `grep -rli '<keyword>' <path-to-this-dir>/` to find the
 - Actual template: `<app-resources>/design-system/template.html` → also at `~/sulla/designs/template.html`
 
 ## identity/
-- `structure.md` — ~/sulla/identity/ layout, file formats, observational memory
+- `structure.md` — ~/sulla/identity/ layout, file formats, observational memory, and the outcome ledger at ~/sulla/ledger/
 - `icp.md` — Ideal customer profile, content framing arc, post angles, cache pattern

--- a/resources/sulla-docs/identity/structure.md
+++ b/resources/sulla-docs/identity/structure.md
@@ -21,6 +21,13 @@
 └── world/
     ├── identity.md          # External market, competitive landscape
     └── goals.md             # Market-level targets
+
+~/sulla/ledger/              # ONE work-state store (operator agenda)
+├── LEDGER.md                # Priority stack + WORKING table
+├── OUTCOMES.md              # What shipped and what it changed
+├── AUDIT.md                 # One line per gate-free unilateral action
+├── BACKLOG.md               # WANT / MIGHT
+└── goals/                   # Goal files with epics + tasks
 ```
 
 ---
@@ -108,3 +115,9 @@ exec({ command: "sulla meta/remove_observational_memory '{\"id\":\"abc123\"}'" }
 ```
 
 Observations appear in every agent's context automatically. Use for facts that affect ongoing behavior — not for temporary task state.
+
+---
+
+## Outcome Ledger (the one work-state store)
+
+Work in motion lives in `~/sulla/ledger/`, not in `identity/agent/goals.md` and not in `projects/ACTIVE_PROJECTS.md` / `PARKED_DECISIONS.md` (those two are transition leftovers and freeze after the operator rebuild). Every autonomous cycle starts at `LEDGER.md` WORKING, moves one item, and writes back — either an outcome in `OUTCOMES.md` or a next-action change. Measure with `sulla ledger/ledger_scoreboard`.

--- a/resources/sulla-docs/tools/agents.md
+++ b/resources/sulla-docs/tools/agents.md
@@ -1,13 +1,15 @@
 # Sub-Agents
 
-Spawn parallel sub-agents to do work independently and check on their progress later. Useful for: gathering data from multiple sources, batch operations, anything you want fanned out.
+Spawn parallel sub-agents to do work independently. **The ONE delegation pattern is `spawn_agent`**: async jobs (the default) now **wake the parent graph with their results when they finish** — the orchestrator continues automatically with the results injected into its loop. No polling loop is required; `check_agent_jobs` remains as a fallback/history read (e.g. after an app restart, when jobs are reported honestly as "app restarted mid-job").
+
+Useful for: gathering data from multiple sources, batch operations, anything you want fanned out.
 
 ## Tools
 
 | Tool | Canonical category | Purpose |
 |------|--------------------|---------|
 | `sulla meta/spawn_agent` | meta | Launch one or more sub-agents (fire-and-forget or blocking) |
-| `sulla agents/check_agent_jobs` | agents | Poll for results of async sub-agent jobs |
+| `sulla agents/check_agent_jobs` | agents | Fallback/history read of async jobs (results normally arrive via parent-graph wake) |
 | `sulla agents/stop_agent_job` | agents | Kill switch — cancel a running async job |
 | `sulla agents/start_agent_conversation` | agents | Open a persistent, multi-turn conversation with a sub-agent |
 | `sulla agents/send_agent_message` | agents | Send a follow-up to an open conversation, get the reply |
@@ -17,7 +19,10 @@ Spawn parallel sub-agents to do work independently and check on their progress l
 
 **Important:** the tool registry resolves tools by **name only** — `sulla agents/spawn_agent` and `sulla anything/spawn_agent` also work because the backend ignores the category segment in the URL. But the canonical surfacing in `sulla meta --help` lists `spawn_agent` under `meta`. Use that form for clarity.
 
-**Two ways to talk to a sub-agent:** `spawn_agent` is fire-one-prompt-and-run (poll for the result). `start_agent_conversation` keeps the sub-agent alive so you can go back and forth — delegate, then clarify/correct/ask follow-ups with full context retained. To reach the already-running *named* agents (heartbeat, workbench, mobile-relay), use a `<channel:NAME>` tag — `list_agents` shows who's addressable.
+**Pattern hierarchy (use the first that fits):**
+1. **`spawn_agent`** — THE delegation primitive. Fire one or many tasks; async results wake your graph automatically with the output injected. Prefer this for everything delegable.
+2. **`start_agent_conversation`** — legacy multi-turn wrapper: keeps a sub-agent alive for back-and-forth clarification. Use only when you genuinely need iterative dialogue with the same worker; for everything else prefer `spawn_agent`.
+3. **`<channel:NAME>` tags** — inter-agent MESSAGING (not delegation) to already-running named agents (heartbeat, workbench, mobile-relay); `list_agents` shows who's addressable. Add `wake` to trigger a turn.
 
 ## `spawn_agent`
 
@@ -41,7 +46,7 @@ sulla meta/spawn_agent '{
 | `async` | `true` | Fire-and-forget; return jobId immediately. `false` = block until done. |
 
 **Returns:**
-- `async: true` → `{ jobId, taskCount, status: "running" }` — poll with `check_agent_jobs`
+- `async: true` → `{ jobId, taskCount, status: "running" }` — on completion the results WAKE your graph as a new turn (no polling needed); `check_agent_jobs` is the fallback read
 - `async: false` → array of completed task results (blocks until all done)
 
 ## `check_agent_jobs`
@@ -88,11 +93,11 @@ sulla agents/check_agent_jobs '{"jobId":"job_..."}'
 sulla agents/stop_agent_job '{"jobId":"agent-job-..."}'
 ```
 
-Cancels a running async job (misfired, duplicated, or no longer needed). Fires the job's abort signal, which cascades to every sub-agent it spawned — the same signal the user's stop button uses. **Cooperative, not preemptive:** jobs run in-process (not child processes), so a sub-agent mid-LLM/tool-call finishes that call, then unwinds on its next step. The job settles as `status: "stopped"`; poll `check_agent_jobs` to confirm. Returns `already-finished` if the job isn't running, `not-found` if it expired.
+Cancels a running async job (misfired, duplicated, or no longer needed). Fires the job's abort signal, which cascades to every sub-agent it spawned — the same signal the user's stop button uses. **Cooperative, not preemptive:** jobs run in-process (not child processes), so a sub-agent mid-LLM/tool-call finishes that call, then unwinds on its next step. The job settles as `status: "stopped"`; `check_agent_jobs` is the fallback/history read to confirm. Returns `already-finished` if the job isn't running, `not-found` if it expired.
 
 ## Conversations — talk back-and-forth with a sub-agent
 
-Unlike `spawn_agent` (one prompt, run to completion), a **conversation** keeps the sub-agent's thread alive so you can send follow-ups with full context retained.
+**Legacy wrapper.** Prefer `spawn_agent` unless you genuinely need iterative back-and-forth with the same worker. A conversation keeps the sub-agent's thread alive so you can send follow-ups with full context retained. Conversations do **not** wake the parent graph — they block and return the reply.
 
 ```bash
 # Open — runs the first turn, returns the reply + a conversationId
@@ -128,19 +133,20 @@ Returns the live named agents (heartbeat, workbench, mobile-relay, frontends) wi
 - **Max 10 tasks per `spawn_agent` call** — prevents accidental fan-out explosions.
 - **Depth max 3** — a sub-agent that spawns sub-agents that spawn sub-agents will hit the depth guard at level 3.
 - **Job TTL: 1 hour** — auto-expire whether they finished or not. Cleaned up on retrieval.
-- **In-memory only** — job IDs and pending work do not survive a Sulla Desktop restart.
+- **Jobs persist across restarts** — `agent_jobs` (Postgres, migration 0043) is the write-through store. A restart marks leftover `running` rows `failed` with `"app restarted mid-job"` so `check_agent_jobs` answers honestly. AbortControllers stay in-memory (a signal cannot survive a restart).
+- **Conversations are still in-memory only** — they do not survive a restart. Close them when done.
 
 ## When to use what — sub-agent vs channel vs workflow
 
 | Pattern | Latency | Interaction model | Best for |
 |---------|---------|------------------|----------|
-| `spawn_agent(async:true)` | Returns ~100ms; results later via poll | Independent | Multi-task delegation, parallel work that doesn't need back-and-forth |
+| `spawn_agent(async:true)` | Returns ~100ms; results wake your graph on completion | Independent | Multi-task delegation, parallel work (the default choice) |
 | `<channel:workbench>...</channel:workbench>` | Fire-and-forget; reply may come back | Coordinated | Real-time agent-to-agent messaging when the other agent is already running |
 | `sulla meta/execute_workflow` | Async, returns executionId | Fixed pipeline | Deterministic multi-step automation that doesn't need agent reasoning at each step |
 | `spawn_agent(async:false)` | Blocks until done | Synchronous | When you need the result before you can proceed |
 
 **Quick guide:**
-- Need 5 things researched in parallel and you'll synthesize → `spawn_agent` async, then `check_agent_jobs`
+- Need 5 things researched in parallel and you'll synthesize → `spawn_agent` async; the results arrive as your next turn
 - Need the workbench agent to verify something while you keep going → channel tag
 - Need a known repeatable pipeline → workflow
 - Need one focused task done before continuing → `spawn_agent` sync (or just do it yourself)

--- a/resources/sulla-docs/tools/inventory.md
+++ b/resources/sulla-docs/tools/inventory.md
@@ -208,7 +208,20 @@ For `kubectl get`, `kubectl logs`, etc. → workaround via `rdctl_shell`.
 - `sulla redis/redis_hget` / `redis_hset` / `redis_hgetall` — Hash fields
 - `sulla redis/redis_lpop` / `redis_rpush` — List ops
 
+**Do not use these on `sulla_settings`.** That hash is owned by `SullaSettingsModel`; the redis tools refuse it. Use `sulla settings/settings_get` / `settings_set` instead.
+
 → See [`tools/redis.md`](redis.md)
+
+## settings — authoritative settings path (2 tools)
+- `sulla settings/settings_get` — Read a setting through `SullaSettingsModel` (Redis cache → Postgres → file fallback)
+- `sulla settings/settings_set` — Write a setting through `SullaSettingsModel` (Postgres + Redis write-through)
+
+→ See [`tools/redis.md`](redis.md) (settings guardrail) and `pkg/rancher-desktop/agent/database/models/SullaSettingsModel.ts`
+
+## ledger — outcome measurement (1 tool)
+- `sulla ledger/ledger_scoreboard` — Zero-LLM scoreboard of `~/sulla/ledger/` (outcomes shipped, WORKING/staged counts, audit lines, 7-day staleness)
+
+→ The ledger itself is files under `~/sulla/ledger/` (LEDGER.md / OUTCOMES.md / AUDIT.md / goals/).
 
 ## pg — PostgreSQL queries (6 tools)
 - `sulla pg/pg_query` — SELECT, all rows
@@ -240,15 +253,15 @@ For `kubectl get`, `kubectl logs`, etc. → workaround via `rdctl_shell`.
 Read-only. Hits sulla-workers with the mobile JWT from vault `sulla-cloud/api_token`.
 
 ## agents — sub-agent jobs, conversations, directory (7 tools)
-- `sulla agents/check_agent_jobs` — Poll for results of async spawn_agent calls
+- `sulla agents/check_agent_jobs` — Fallback/history read of async spawn_agent jobs (results normally arrive via parent-graph wake)
 - `sulla agents/stop_agent_job` — Kill switch: cancel a running async job (cooperative abort, cascades to its sub-agents)
-- `sulla agents/start_agent_conversation` — Open a persistent, multi-turn conversation with a sub-agent (keeps context between messages)
+- `sulla agents/start_agent_conversation` — LEGACY: open a persistent multi-turn conversation with a sub-agent. Prefer `spawn_agent`.
 - `sulla agents/send_agent_message` — Send a follow-up to an open conversation, get the reply
 - `sulla agents/read_agent_conversation` — Read a conversation transcript, or list all open conversations
 - `sulla agents/close_agent_conversation` — Close a conversation and free its graph + state
 - `sulla agents/list_agents` — Directory of live named agents (heartbeat, workbench, mobile-relay, …) you can `<channel:>`-message
 
-**`spawn_agent` is NOT under `agents/`** — it's canonically `sulla meta/spawn_agent`. `spawn_agent` = fire-and-forget; `start_agent_conversation` = interactive back-and-forth; `list_agents` + `<channel:NAME>` = reach already-running named agents. See [`tools/agents.md`](agents.md).
+**ONE delegation pattern:** `sulla meta/spawn_agent` (async results wake the parent graph). `start_agent_conversation` is a legacy multi-turn wrapper. `list_agents` + `<channel:NAME>` is messaging to already-running named agents, not delegation. See [`tools/agents.md`](agents.md).
 
 ## bridge — human presence (2 tools)
 - `sulla bridge/get_human_presence` — Read presence state from Redis

--- a/resources/sulla-docs/tools/ledger.md
+++ b/resources/sulla-docs/tools/ledger.md
@@ -1,0 +1,26 @@
+# Outcome Ledger
+
+The ledger at `~/sulla/ledger/` is the **one work-state store**. Autonomous cycles start at `LEDGER.md` WORKING, move one item, and write back.
+
+## Tool
+
+```bash
+sulla ledger/ledger_scoreboard '{"days":7}'
+```
+
+Deterministic, zero LLM. Counts outcomes shipped in-window, WORKING / staged-at-gate rows, AUDIT lines, and flags the 7-day staleness rule. The heartbeat reads this each cycle; the human reads it as trust-ratchet evidence.
+
+The ledger files themselves are maintained by the observation writer (post-turn) and by agents via `read_file` / `write_file`. This tool only measures.
+
+## Layout
+
+```
+~/sulla/ledger/
+├── LEDGER.md      # priority stack + WORKING table
+├── OUTCOMES.md    # what shipped and what it changed
+├── AUDIT.md       # one line per gate-free unilateral action
+├── BACKLOG.md     # WANT / MIGHT
+└── goals/         # goal files with epics + tasks
+```
+
+Scaffolded at boot if missing (template-only, never overwrites user content, no user data in shipped code).

--- a/resources/sulla-docs/tools/redis.md
+++ b/resources/sulla-docs/tools/redis.md
@@ -9,6 +9,7 @@ The codebase has been audited — Redis is sparsely used today. Primary namespac
 | Key / namespace | Type | Purpose | Owner |
 |----------------|------|---------|-------|
 | `sulla:bridge:human_presence` | hash | Human presence state (availability, idle minutes, view, channel) | `HumanHeartbeatBridge` |
+| `sulla_settings` | hash | **Cache only** for SullaSettingsModel. Do not read/write with redis_* tools (blocked). | `SullaSettingsModel` |
 | Other namespaces (anticipated) | — | Queues, sessions, locks not actively used yet | — |
 
 Pub/sub channels: **none active**. Sulla uses WebSocket channels (BackendGraphWebSocketService) for inter-agent comms, not Redis pub/sub. The wire is there (`RedisClient.publish()`) but no active subscribers.
@@ -44,6 +45,14 @@ sulla bridge/get_human_presence '{}'
 ```
 The bridge tool is preferred — it parses and returns a typed object.
 
+### "Read or write a Sulla Desktop setting"
+**Do not use these Redis tools.** `sulla_settings` is owned by `SullaSettingsModel` (Redis cache → Postgres → file fallback; writes go through both). The agent `redis_*` tools **block** that key at runtime.
+
+```bash
+sulla settings/settings_get '{"property":"heartbeatEnabled"}'
+sulla settings/settings_set '{"property":"heartbeatEnabled","value":"true","cast":"boolean"}'
+```
+
 ### "Cache this small value with a 1-hour TTL"
 ```bash
 sulla redis/redis_set '{"key":"my-cache:topic-X","value":"...","ttl":3600}'
@@ -71,6 +80,7 @@ sulla meta/exec '{"command":"docker exec sulla_redis redis-cli KEYS \"*\""}'
 ## Hard rules
 
 - **Don't write to `sulla:bridge:human_presence` directly.** Let the `HumanPresenceTracker` (frontend) and `HumanHeartbeatBridge` (service) own it. If you corrupt it, the heartbeat will make wrong decisions about whether to act autonomously.
+- **Don't touch `sulla_settings` with redis_*.** That hash is SullaSettingsModel's cache. Raw reads can be stale; raw writes desync Postgres. Use `sulla settings/settings_get` / `settings_set`. The redis_* tools refuse the key.
 - **Don't use Redis as the source of truth for anything durable.** Sulla's Redis runs without persistence — restarting the container loses all keys.
 - **Namespace your keys.** Use prefixes like `agent:<your-purpose>:<key>` so you don't collide with future Sulla internals.
 - **Strings only.** Don't try to store binary data — base64-encode it first.

--- a/resources/sulla-docs/tools/settings.md
+++ b/resources/sulla-docs/tools/settings.md
@@ -1,0 +1,53 @@
+# Settings
+
+`SullaSettingsModel` is the **single authoritative settings path**. Product code already uses it. Agents must too.
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `sulla settings/settings_get` | Read a setting (Redis cache → Postgres → file fallback) |
+| `sulla settings/settings_set` | Write a setting through Postgres AND the Redis cache |
+
+```bash
+sulla settings/settings_get '{"property":"heartbeatEnabled"}'
+sulla settings/settings_set '{"property":"heartbeatEnabled","value":"true","cast":"boolean"}'
+```
+
+`cast` is optional (`string` | `number` | `boolean` | `json` | `array`). Defaults to `typeof value`.
+
+## Why this exists
+
+Sulla used to have a dual-store gotcha: Redis `sulla_settings` and Postgres `sulla_settings` could disagree (`remoteProvider` showing grok in one store and claude-code in the other). The model already owned the correct write-through path. The remaining hole was **agent Redis tools** — a raw `hget`/`hset` on that hash bypassed the model.
+
+That hole is now closed two ways:
+1. `redis_*` tools **refuse** the `sulla_settings` key and point here.
+2. These tools are the replacement.
+
+Do **not** replace `SullaSettingsModel`. Promote it. Redis is its cache, not a second source of truth.
+
+## Settings-read map (verified 2026-08-13)
+
+Every product read/write of durable settings already goes through `SullaSettingsModel.get` / `.set` / `.delete` / `.bootstrap`. Representative owners:
+
+| Owner | What it reads/writes |
+|-------|----------------------|
+| `sulla.ts` | bootstrap, `kubernetes.enabled`, `pathUserData` |
+| `main/sullaEvents.ts` | IPC `sulla-settings-get/set/delete` (renderer proxy) |
+| `config/settingsImpl.ts` | host-access / administrative gates |
+| `backend/lima.ts` | API token, Claude creds, compose secrets, proxy knobs |
+| `main/desktopRelay.ts` | `pairedMobileUserId` |
+| `main/deviceIdentity.ts` | device id |
+| `SullaWebRequestFixer.ts` | persisted cookies |
+| `composables/useTheme.ts` | theme |
+| `main/claudeCodeTest.ts` | Claude OAuth / API key |
+
+**No product file** calls `redisClient.hget('sulla_settings', …)` except `SullaSettingsModel` itself.
+
+The Electron settings-store (`settings.json` via `rdctl_list_settings`) is a **different** surface — Rancher Desktop / k8s / VM knobs — not the `sulla_settings` hash. Leave it alone.
+
+## Hard rules
+
+- Never `redis_hget` / `redis_hset` / `redis_hgetall` / `redis_del` the `sulla_settings` hash.
+- Never invent a second settings writer.
+- Heartbeat on/off is the human's manual control. Do not flip `heartbeatEnabled` unless they ask.


### PR DESCRIPTION
## What

PR-D phase-1 + PR-E of the operator-simplification plan.

### PR-D phase-1 (docs + copy)
- `spawn_agent` + parent-graph wake is the **one** delegation pattern
- `start_agent_conversation` documented as a legacy thin wrapper
- Channel tags stay inter-agent messaging, not delegation
- `check_agent_jobs` is a fallback/history read, not a poll loop
- leftover "Poll check_agent_jobs" copy removed from `stop_agent_job`

### PR-E (settings single read-path)
Hard constraint: **SullaSettingsModel stays**. This PR promotes it, does not replace it.

- New `settings_get` / `settings_set` tools call `SullaSettingsModel.get` / `.set` (Redis cache → Postgres → file fallback; write-through both)
- All 12 agent `redis_*` tools refuse the `sulla_settings` hash via `settingsGuard.ts` so a raw hget cannot serve a stale cache and a raw hset cannot desync the stores
- Docs: `tools/settings.md` (read/write map), `tools/ledger.md`, INDEX + inventory + redis.md + agents.md + identity/structure.md

## Why

Agents could still hit Redis `sulla_settings` directly and desync the dual store (the heartbeatEnabled / remoteProvider gotcha). Product code already goes through the model — this closes the remaining hole.

## Out of scope

- PR-D phase-2 (`conversationRunner` → `spawn_agent` internally) is gated on live wake QA after the next rebuild
- Draft #550 (recall-tools) still open, not this PR
- No app rebuild/restart in this PR

## Test plan
- [x] D/E files typecheck clean against pkg/rancher-desktop/tsconfig.json
- [ ] After merge: test-rebuild main (no app restart until Jonathon)
