### PR TITLE
fix(agentsIpc): await getAllJobs() after PR-B made it async

### DIFF
--- a/pkg/rancher-desktop/main/agentsIpc.ts
+++ b/pkg/rancher-desktop/main/agentsIpc.ts
@@ -109,7 +109,9 @@ async function fetchJobs(): Promise<AgentsListResponse['jobs']> {
     const { getAllJobs } = await import(
       '@pkg/agent/tools/agents/jobRegistry'
     );
-    return getAllJobs().map(j => ({
+    const allJobs = await getAllJobs();
+
+    return allJobs.map(j => ({
       jobId:      j.jobId,
       status:     j.status,
       createdAt:  j.createdAt,


### PR DESCRIPTION
## Why

`just build` on main failed in the main-process webpack pass:

```
TS2339: Property 'map' does not exist on type 'Promise<AgentJob[]>'.
TS7006: Parameter 'j' implicitly has an 'any' type.
```

PR-B (#553) made `getAllJobs()` async (Postgres write-through + boot sweep). `check_agent_jobs.ts` already awaited it. `agentsIpc.ts` still treated the return as a sync array.

## Change

```ts
const allJobs = await getAllJobs();
return allJobs.map(j => ({ ... }));
```

One-line product fix. No settings-path change. SullaSettingsModel untouched.

## Test plan
- [x] Confirmed this is the only leftover sync call site
- [ ] `just build` on merged main (host; native audio + darwin esbuild)
- [ ] No app restart until Jonathon