### PR TITLE
feat(heartbeat): persist last-run and kick scheduler on Mac wake

### DIFF
--- a/pkg/rancher-desktop/agent/services/HeartbeatService.ts
+++ b/pkg/rancher-desktop/agent/services/HeartbeatService.ts
@@ -69,12 +69,19 @@ export class HeartbeatService {
   // ── Abort controller for in-flight heartbeat ──
   private activeAbort: AbortController | null = null;
 
+  private executionStartedMs = 0;
+  private suspendStartedMs = 0;
+
   async initialize(): Promise<void> {
     if (this.initialized) return;
     console.log('[HeartbeatService] Initializing scheduler...');
     this.initialized = true;
     this.startedAtMs = Date.now();
-    this.recordEvent('scheduler_started', 'Heartbeat scheduler initialized');
+    const persisted = Number(await SullaSettingsModel.get('heartbeatLastTriggerMs', 0)) || 0;
+    if (persisted > 0) this.lastTriggerMs = persisted;
+    this.recordEvent('scheduler_started', persisted
+      ? `Heartbeat scheduler initialized (last run ${ new Date(persisted).toISOString() })`
+      : 'Heartbeat scheduler initialized');
     this.startScheduler();
   }
 
@@ -171,6 +178,7 @@ export class HeartbeatService {
         this.recordEvent('scheduler_check', `Heartbeat due (${ delayMin }min interval) — triggering`);
         await this.triggerHeartbeat();
         this.lastTriggerMs = Date.now();
+        void SullaSettingsModel.set('heartbeatLastTriggerMs', this.lastTriggerMs, 'number');
 
         // Schedule a macOS wake event for the next heartbeat (only if >5 min away)
         if (delayMin > 5) {
@@ -201,6 +209,7 @@ export class HeartbeatService {
     this.isExecuting = true;
     this.totalTriggers++;
     const triggerStart = Date.now();
+    this.executionStartedMs = triggerStart;
     this.recordEvent('heartbeat_triggered', 'Heartbeat execution started');
 
     // Create abort controller for this execution
@@ -270,6 +279,7 @@ export class HeartbeatService {
       this.recordEvent('sleep_prevention_stopped', 'caffeinate released after heartbeat execution');
       this.activeAbort = null;
       this.isExecuting = false;
+      this.executionStartedMs = 0;
     }
   }
 
@@ -300,6 +310,52 @@ Your active projects and goals have been loaded into your recall context. Review
   /** Call from UI after settings change to force immediate check */
   async forceCheck(): Promise<void> {
     if (this.initialized) await this.checkAndMaybeTrigger();
+  }
+
+  /** powerMonitor suspend — remember when the machine went down. */
+  handleSuspend(): void {
+    if (!this.initialized) return;
+    this.suspendStartedMs = Date.now();
+    this.recordEvent('scheduler_check', 'System suspending');
+  }
+
+  /**
+   * powerMonitor resume — the 60s setInterval freezes across sleep and is
+   * unreliable after thaw. Relay already reconnects here; the standing shift
+   * must too. A long sleep kills in-flight LLM sockets, so abort those and
+   * let the delayed check start a fresh cycle.
+   */
+  async handleResume(): Promise<void> {
+    if (!this.initialized) return;
+
+    // Prefer the suspend stamp. macOS sometimes delivers resume without
+    // suspend (clamshell, some lid events); fall back to how long the
+    // current run has been latched so isExecuting cannot stay stuck.
+    const now = Date.now();
+    const stampedMs = this.suspendStartedMs > 0 ? now - this.suspendStartedMs : 0;
+    const inferredMs = (this.isExecuting && this.executionStartedMs > 0)
+      ? now - this.executionStartedMs
+      : 0;
+    const sleptMs = Math.max(stampedMs, inferredMs);
+    const inferred = stampedMs === 0 && inferredMs > 0;
+    this.suspendStartedMs = 0;
+    const sleptMin = Math.round(sleptMs / 60000);
+    this.recordEvent('scheduler_check', sleptMs > 0
+      ? `System resumed after ${ sleptMin }min ${ inferred ? 'inferred ' : '' }sleep — forcing heartbeat check`
+      : 'System resumed — forcing heartbeat check');
+
+    const LONG_SLEEP_MS = 120_000;
+    if (this.isExecuting && sleptMs > LONG_SLEEP_MS && this.activeAbort) {
+      console.log(`[HeartbeatService] Aborting in-flight heartbeat after ${ sleptMin }min sleep`);
+      this.activeAbort.abort();
+      this.recordEvent('heartbeat_aborted', `In-flight heartbeat aborted after ${ sleptMin }min sleep`);
+      setTimeout(() => {
+        void this.checkAndMaybeTrigger();
+      }, 2000);
+      return;
+    }
+
+    await this.checkAndMaybeTrigger();
   }
 
   destroy(): void {

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -849,6 +849,15 @@ export function initSullaEvents(): void {
   powerMonitor.on('suspend', () => {
     console.log('[Power] System suspending');
 
+    // Stamp HeartbeatService so resume can measure sleep and abort a
+    // mid-tick run whose LLM sockets died while the Mac was down.
+    try {
+      const { getHeartbeatService } = require('@pkg/agent/services/HeartbeatService');
+      getHeartbeatService().handleSuspend();
+    } catch (err) {
+      console.warn('[Power] Failed to suspend heartbeat scheduler:', err);
+    }
+
     // Close the mobile-relay socket cleanly so the relay DO drops this peer
     // now — mobile then sees the desktop offline immediately instead of
     // after the server-side stale timeout.
@@ -888,6 +897,16 @@ export function initSullaEvents(): void {
       getBackendGraphWebSocketService().reinitialize();
     } catch (err) {
       console.warn('[Power] Failed to reinitialize backend graph service:', err);
+    }
+
+    // Kick the standing shift. Sleep freezes the 60s interval and can leave
+    // a mid-tick run latch stuck; without this the heartbeat stays silent
+    // until the next minute-aligned check — or forever if isExecuting leaked.
+    try {
+      const { getHeartbeatService } = require('@pkg/agent/services/HeartbeatService');
+      void getHeartbeatService().handleResume();
+    } catch (err) {
+      console.warn('[Power] Failed to resume heartbeat scheduler:', err);
     }
 
     // Notify all renderer windows so frontend services can react


### PR DESCRIPTION
Sleep was killing the standing shift. `lastTriggerMs` lived only in memory, `powerMonitor` resume reconnected the relay but never called HeartbeatService, and a mid-sleep tick could leave `isExecuting` stuck. After a night of sleep the scheduler stayed silent.

## What this does

- Persist last-run as `heartbeatLastTriggerMs` via `SullaSettingsModel` (PG + Redis write-through). Restart/sleep no longer resets cadence to "due immediately."
- Stamp `handleSuspend()` from `powerMonitor.suspend` so resume can measure sleep.
- Call `handleResume()` from `powerMonitor.resume` — force a scheduler check instead of waiting on the frozen 60s interval.
- After >2 min of sleep, abort a latched in-flight run (LLM sockets die across sleep) and re-check 2s later.
- If macOS delivers resume without suspend (clamshell / some lid events), infer sleep from `executionStartedMs` so `isExecuting` cannot stay stuck.

## What this does not do

- Does **not** flip `heartbeatEnabled`. That stays Jonathon's toggle.
- Does **not** make `scheduleWake` / `pmset` actually wake the Mac (still a documented no-op without root).
- Does **not** rebuild the running binary. Live after Jonathon rebuilds + restarts.

## Live QA after restart

1. Confirm `[HeartbeatService] Initializing scheduler` and a `last run` ISO timestamp in the log (or "initialized" on first boot with no persisted value).
2. Sleep the Mac >2 min with heartbeat enabled, wake it. Expect `[Power] System resumed` then a `System resumed after Nmin sleep — forcing heartbeat check` event. If a run was in flight, expect `heartbeat_aborted` then a fresh check.
3. Confirm the next due cycle still respects `heartbeatDelayMinutes` against the persisted last-run, not "fire immediately because memory reset."

Undo: revert this PR. Setting key `heartbeatLastTriggerMs` can stay; it is inert if the code is gone.
