### PR TITLE
feat(work): 4-table work-items model + tools

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0044_create_work_items_tables.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0044_create_work_items_tables.ts
@@ -1,0 +1,133 @@
+/**
+ * Migration 0044 — Create work-item tables (projects → epics → tasks → comments).
+ *
+ * Structured operator workboard in the desktop Postgres. This is NOT CRM
+ * (CRM belongs in Sulla Cloud) and it is NOT the filesystem PRD registry
+ * (`~/sulla/projects/** /PROJECT.md` via ProjectRegistry).
+ *
+ * Hierarchy:
+ *   work_projects
+ *     └── work_epics
+ *           └── work_tasks (parent_id = subtask)
+ *                 └── work_task_comments
+ *
+ * SCHEMA-ONLY (no-user-data-in-migrations rule). Any install-local ledger
+ * markdown is imported at runtime by WorkItemsImportSeeder, which reads
+ * THIS machine's ~/sulla/ledger/goals/ and never ships user rows.
+ *
+ * Extra columns (due_at / slug / source_ref / labels / assignee) exist so
+ * the 8 work tools + ledger seeder can persist the fields they already send.
+ *
+ * Rows are NEVER hard-deleted — soft-archive via `archived`, mirroring
+ * observations / sulla_rules.
+ */
+
+export const up = `
+  CREATE TABLE IF NOT EXISTS work_projects (
+    id              TEXT        PRIMARY KEY,
+    slug            TEXT        NOT NULL UNIQUE,
+    title           TEXT        NOT NULL,
+    description     TEXT        NOT NULL DEFAULT '',
+    outcome_metric  TEXT,
+    status          TEXT        NOT NULL DEFAULT 'working',
+    priority        TEXT        NOT NULL DEFAULT 'p2',
+    owner           TEXT,
+    due_at          TIMESTAMPTZ,
+    source          TEXT,
+    source_path     TEXT,
+    source_ref      TEXT,
+    github_repo     TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ,
+    last_moved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    archived        BOOLEAN     NOT NULL DEFAULT false
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_work_projects_board
+    ON work_projects (archived, status, priority, last_moved_at ASC);
+
+  CREATE TABLE IF NOT EXISTS work_epics (
+    id              TEXT        PRIMARY KEY,
+    project_id      TEXT        NOT NULL REFERENCES work_projects(id),
+    slug            TEXT,
+    title           TEXT        NOT NULL,
+    description     TEXT        NOT NULL DEFAULT '',
+    status          TEXT        NOT NULL DEFAULT 'working',
+    priority        TEXT        NOT NULL DEFAULT 'p2',
+    position        INTEGER     NOT NULL DEFAULT 0,
+    due_at          TIMESTAMPTZ,
+    source          TEXT,
+    source_ref      TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ,
+    last_moved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    archived        BOOLEAN     NOT NULL DEFAULT false
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_work_epics_project
+    ON work_epics (project_id, archived, position, status);
+
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_work_epics_project_slug
+    ON work_epics (project_id, slug)
+    WHERE slug IS NOT NULL AND archived = false;
+
+  CREATE TABLE IF NOT EXISTS work_tasks (
+    id              TEXT        PRIMARY KEY,
+    project_id      TEXT        NOT NULL REFERENCES work_projects(id),
+    epic_id         TEXT        REFERENCES work_epics(id),
+    parent_id       TEXT        REFERENCES work_tasks(id),
+    slug            TEXT,
+    title           TEXT        NOT NULL,
+    description     TEXT        NOT NULL DEFAULT '',
+    status          TEXT        NOT NULL DEFAULT 'todo',
+    priority        TEXT        NOT NULL DEFAULT 'p2',
+    assignee        TEXT,
+    due_at          TIMESTAMPTZ,
+    labels          TEXT[]      NOT NULL DEFAULT '{}',
+    github_issue    TEXT,
+    position        INTEGER     NOT NULL DEFAULT 0,
+    source          TEXT,
+    source_ref      TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ,
+    last_moved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at    TIMESTAMPTZ,
+    archived        BOOLEAN     NOT NULL DEFAULT false
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_work_tasks_epic
+    ON work_tasks (epic_id, archived, status, position);
+
+  CREATE INDEX IF NOT EXISTS idx_work_tasks_project
+    ON work_tasks (project_id, archived, status, priority, due_at);
+
+  CREATE INDEX IF NOT EXISTS idx_work_tasks_parent
+    ON work_tasks (parent_id) WHERE parent_id IS NOT NULL;
+
+  CREATE INDEX IF NOT EXISTS idx_work_tasks_due
+    ON work_tasks (archived, due_at) WHERE due_at IS NOT NULL AND archived = false;
+
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_work_tasks_epic_slug
+    ON work_tasks (epic_id, slug)
+    WHERE slug IS NOT NULL AND archived = false;
+
+  CREATE TABLE IF NOT EXISTS work_task_comments (
+    id              TEXT        PRIMARY KEY,
+    task_id         TEXT        NOT NULL REFERENCES work_tasks(id),
+    body            TEXT        NOT NULL,
+    author          TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ,
+    archived        BOOLEAN     NOT NULL DEFAULT false
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_work_task_comments_task
+    ON work_task_comments (task_id, archived, created_at ASC);
+`;
+
+export const down = `
+  DROP TABLE IF EXISTS work_task_comments CASCADE;
+  DROP TABLE IF EXISTS work_tasks CASCADE;
+  DROP TABLE IF EXISTS work_epics CASCADE;
+  DROP TABLE IF EXISTS work_projects CASCADE;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -32,6 +32,7 @@ import { up as up_0040, down as down_0040 } from './0040_create_heartbeat_seen_i
 import { up as up_0041, down as down_0041 } from './0041_add_trigram_index_to_observations';
 import { up as up_0042, down as down_0042 } from './0042_create_rules_table';
 import { up as up_0043, down as down_0043 } from './0043_create_agent_jobs_table';
+import { up as up_0044, down as down_0044 } from './0044_create_work_items_tables';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -64,4 +65,5 @@ export const migrationsRegistry = [
   { name: '0041_add_trigram_index_to_observations',         up: up_0041, down: down_0041 },
   { name: '0042_create_rules_table',                        up: up_0042, down: down_0042 },
   { name: '0043_create_agent_jobs_table',                   up: up_0043, down: down_0043 },
+  { name: '0044_create_work_items_tables',                   up: up_0044, down: down_0044 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -1,0 +1,1008 @@
+/**
+ * WorkItemsModel — Projects → epics → tasks (+ comments) in PostgreSQL.
+ *
+ * This is the operator workboard. It is NOT the filesystem ProjectRegistry
+ * (those are PROJECT.md PRDs under ~/sulla/projects/). It is NOT CRM —
+ * CRM belongs in Sulla Cloud. Rows here are the structured agenda:
+ * what needs to be done, what stage it is in, last time it moved.
+ *
+ * Soft-archive only (never hard-delete). SCHEMA-ONLY migration 0044;
+ * install-local ledger markdown is imported at runtime by
+ * WorkItemsImportSeeder (no user data in shipped code).
+ *
+ * DUAL-STORE NOTE: reads and writes ONLY Postgres — no Redis hash.
+ */
+
+import { postgresClient } from '../PostgresClient';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export type WorkItemKind = 'project' | 'epic' | 'task';
+
+export interface WorkProjectRecord {
+  id:              string;
+  slug:            string;
+  title:           string;
+  description:     string;
+  outcome_metric:  string | null;
+  status:          string;
+  priority:        string;
+  owner:           string | null;
+  source:          string | null;
+  source_path:     string | null;
+  github_repo:     string | null;
+  due_at:          string | null;
+  created_at:      string;
+  updated_at:      string | null;
+  last_moved_at:   string;
+  archived:        boolean;
+}
+
+export interface WorkEpicRecord {
+  id:            string;
+  project_id:    string;
+  slug:          string | null;
+  title:         string;
+  description:   string;
+  status:        string;
+  priority:      string;
+  position:      number;
+  due_at:        string | null;
+  source:        string | null;
+  source_ref:    string | null;
+  created_at:    string;
+  updated_at:    string | null;
+  last_moved_at: string;
+  archived:      boolean;
+}
+
+export interface WorkTaskRecord {
+  id:            string;
+  project_id:    string;
+  epic_id:       string | null;
+  parent_id:     string | null;
+  slug:          string | null;
+  title:         string;
+  description:   string;
+  status:        string;
+  priority:      string;
+  due_at:        string | null;
+  github_issue:  string | null;
+  assignee:      string | null;
+  labels:        string[] | null;
+  position:      number;
+  source:        string | null;
+  source_ref:    string | null;
+  created_at:    string;
+  updated_at:    string | null;
+  last_moved_at: string;
+  completed_at:  string | null;
+  archived:      boolean;
+}
+
+export interface WorkCommentRecord {
+  id:         string;
+  task_id:    string;
+  body:       string;
+  author:     string | null;
+  created_at: string;
+  updated_at: string | null;
+  archived:   boolean;
+}
+
+export interface SearchHit {
+  kind:     WorkItemKind;
+  id:       string;
+  title:    string;
+  status:   string;
+  priority: string;
+  archived: boolean;
+}
+
+export interface UpsertProjectInput {
+  id?:              string;
+  slug?:            string;
+  title:            string;
+  description?:     string;
+  outcome_metric?:  string | null;
+  status?:          string;
+  priority?:        string;
+  owner?:           string | null;
+  due_at?:          string | null;
+  source?:          string | null;
+  source_ref?:      string | null;
+  source_path?:     string | null;
+  github_repo?:     string | null;
+}
+
+export interface UpdateProjectInput {
+  slug?:            string;
+  title?:           string;
+  description?:     string;
+  outcome_metric?:  string | null;
+  status?:          string;
+  priority?:        string;
+  owner?:           string | null;
+  due_at?:          string | null;
+  source?:          string | null;
+  source_path?:     string | null;
+  github_repo?:     string | null;
+}
+
+export interface UpsertEpicInput {
+  id?:           string;
+  project_id:    string;
+  slug?:         string;
+  title:         string;
+  description?:  string;
+  status?:       string;
+  priority?:     string;
+  position?:     number;
+  due_at?:       string | null;
+  source?:       string | null;
+  source_ref?:   string | null;
+}
+
+export interface UpdateEpicInput {
+  project_id?:   string;
+  slug?:         string;
+  title?:        string;
+  description?:  string;
+  status?:       string;
+  priority?:     string;
+  position?:     number;
+  due_at?:       string | null;
+  source?:       string | null;
+  source_ref?:   string | null;
+}
+
+export interface UpsertTaskInput {
+  id?:            string;
+  project_id?:    string;
+  epic_id?:       string | null;
+  parent_id?:     string | null;
+  slug?:          string;
+  title:          string;
+  description?:   string;
+  status?:        string;
+  priority?:      string;
+  assignee?:      string | null;
+  due_at?:        string | null;
+  labels?:        string[];
+  github_issue?:  string | null;
+  position?:      number;
+  source?:        string | null;
+  source_ref?:    string | null;
+}
+
+export interface UpdateTaskInput {
+  epic_id?:       string | null;
+  parent_id?:     string | null;
+  slug?:          string | null;
+  title?:         string;
+  description?:   string;
+  status?:        string;
+  priority?:      string;
+  assignee?:      string | null;
+  due_at?:        string | null;
+  labels?:        string[];
+  github_issue?:  string | null;
+  position?:      number;
+  source?:        string | null;
+  source_ref?:    string | null;
+}
+
+export interface AddCommentInput {
+  id?:      string;
+  task_id:  string;
+  body:     string;
+  author?:  string;
+}
+
+export interface ListOpts {
+  status?:      string;
+  priority?:    string;
+  includeDone?: boolean;
+  limit?:       number;
+}
+
+export interface ListEpicsOpts extends ListOpts {
+  projectId?: string;
+}
+
+export interface ListTasksOpts extends ListOpts {
+  projectId?: string;
+  epicId?:    string;
+  parentId?:  string;
+  assignee?:  string;
+}
+
+export interface SearchOpts {
+  query:             string;
+  kind?:             WorkItemKind | string;
+  includeArchived?:  boolean;
+  limit?:            number;
+}
+
+// ── Tiny-ID generator (4-char) — same alphabet as observations/rules ──
+
+function generateTinyId(): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let id = '';
+  for (let i = 0; i < 4; i++) {
+    id += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return id;
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'item';
+}
+
+const CLOSED_STATUSES = `status IN ('done', 'cancelled', 'parked')`;
+
+const PRIORITY_RANK = `
+  CASE priority
+    WHEN '🔴' THEN 0 WHEN 'critical' THEN 0 WHEN 'p0' THEN 0 WHEN 'P0' THEN 0
+    WHEN 'p1' THEN 1 WHEN 'P1' THEN 1 WHEN 'high' THEN 1
+    WHEN '🟡' THEN 2 WHEN 'p2' THEN 2 WHEN 'P2' THEN 2 WHEN 'medium' THEN 2
+    WHEN 'p3' THEN 3 WHEN 'P3' THEN 3
+    WHEN '⚪' THEN 4 WHEN 'low' THEN 4 WHEN 'p4' THEN 4 WHEN 'P4' THEN 4
+    ELSE 5
+  END ASC`;
+
+const STOPWORDS = new Set([
+  'the', 'and', 'for', 'are', 'was', 'were', 'with', 'that', 'this', 'these', 'those',
+  'have', 'has', 'had', 'about', 'into', 'from', 'when', 'where', 'what', 'which', 'who',
+  'how', 'why', 'did', 'does', 'doing', 'will', 'would', 'could', 'should', 'can', 'not',
+  'you', 'your', 'our', 'his', 'her', 'its', 'their', 'them', 'they', 'all', 'any', 'some',
+  'just', 'than', 'then', 'too', 'very', 'out', 'now', 'get', 'got', 'been', 'being',
+]);
+
+function tokenizeQuery(query: string): string[] {
+  return Array.from(new Set(
+    (query.toLowerCase().match(/[a-z0-9_-]+/g) ?? [])
+      .filter(w => w.length >= 3 && !STOPWORDS.has(w)),
+  ));
+}
+
+function isClosedStatus(status: string | undefined): boolean {
+  return status === 'done' || status === 'cancelled' || status === 'parked';
+}
+
+// ── Model ──────────────────────────────────────────────────────────────
+
+export class WorkItemsModel {
+  private static readonly PROJECTS = 'work_projects';
+  private static readonly EPICS    = 'work_epics';
+  private static readonly TASKS    = 'work_tasks';
+  private static readonly COMMENTS = 'work_task_comments';
+
+  // ──────────────────────────────────────────────
+  // Table bootstrap (idempotent) — mirrors migration 0044
+  // ──────────────────────────────────────────────
+
+  static async ensureTables(): Promise<void> {
+    try {
+      await postgresClient.query(`
+        CREATE TABLE IF NOT EXISTS ${ WorkItemsModel.PROJECTS } (
+          id              TEXT        PRIMARY KEY,
+          slug            TEXT        NOT NULL UNIQUE,
+          title           TEXT        NOT NULL,
+          description     TEXT        NOT NULL DEFAULT '',
+          outcome_metric  TEXT,
+          status          TEXT        NOT NULL DEFAULT 'working',
+          priority        TEXT        NOT NULL DEFAULT 'p2',
+          owner           TEXT,
+          source          TEXT,
+          source_path     TEXT,
+          github_repo     TEXT,
+          due_at          TIMESTAMPTZ,
+          created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at      TIMESTAMPTZ,
+          last_moved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+          archived        BOOLEAN     NOT NULL DEFAULT false
+        )
+      `);
+      await postgresClient.query(`
+        CREATE INDEX IF NOT EXISTS idx_work_projects_board
+          ON ${ WorkItemsModel.PROJECTS } (archived, status, priority, last_moved_at ASC)
+      `);
+
+      await postgresClient.query(`
+        CREATE TABLE IF NOT EXISTS ${ WorkItemsModel.EPICS } (
+          id              TEXT        PRIMARY KEY,
+          project_id      TEXT        NOT NULL REFERENCES ${ WorkItemsModel.PROJECTS }(id),
+          slug            TEXT,
+          title           TEXT        NOT NULL,
+          description     TEXT        NOT NULL DEFAULT '',
+          status          TEXT        NOT NULL DEFAULT 'working',
+          priority        TEXT        NOT NULL DEFAULT 'p2',
+          position        INTEGER     NOT NULL DEFAULT 0,
+          due_at          TIMESTAMPTZ,
+          source          TEXT,
+          source_ref      TEXT,
+          created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at      TIMESTAMPTZ,
+          last_moved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+          archived        BOOLEAN     NOT NULL DEFAULT false
+        )
+      `);
+      await postgresClient.query(`
+        CREATE INDEX IF NOT EXISTS idx_work_epics_project
+          ON ${ WorkItemsModel.EPICS } (project_id, archived, position, status)
+      `);
+      await postgresClient.query(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_work_epics_project_slug
+          ON ${ WorkItemsModel.EPICS } (project_id, slug)
+          WHERE slug IS NOT NULL
+      `);
+
+      await postgresClient.query(`
+        CREATE TABLE IF NOT EXISTS ${ WorkItemsModel.TASKS } (
+          id              TEXT        PRIMARY KEY,
+          project_id      TEXT        NOT NULL REFERENCES ${ WorkItemsModel.PROJECTS }(id),
+          epic_id         TEXT        REFERENCES ${ WorkItemsModel.EPICS }(id),
+          parent_id       TEXT        REFERENCES ${ WorkItemsModel.TASKS }(id),
+          slug            TEXT,
+          title           TEXT        NOT NULL,
+          description     TEXT        NOT NULL DEFAULT '',
+          status          TEXT        NOT NULL DEFAULT 'todo',
+          priority        TEXT        NOT NULL DEFAULT 'p2',
+          due_at          TIMESTAMPTZ,
+          github_issue    TEXT,
+          assignee        TEXT,
+          labels          TEXT[],
+          position        INTEGER     NOT NULL DEFAULT 0,
+          source          TEXT,
+          source_ref      TEXT,
+          created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at      TIMESTAMPTZ,
+          last_moved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+          completed_at    TIMESTAMPTZ,
+          archived        BOOLEAN     NOT NULL DEFAULT false
+        )
+      `);
+      await postgresClient.query(`
+        CREATE INDEX IF NOT EXISTS idx_work_tasks_epic
+          ON ${ WorkItemsModel.TASKS } (epic_id, archived, status, position)
+      `);
+      await postgresClient.query(`
+        CREATE INDEX IF NOT EXISTS idx_work_tasks_project
+          ON ${ WorkItemsModel.TASKS } (project_id, archived, status, priority, due_at)
+      `);
+      await postgresClient.query(`
+        CREATE INDEX IF NOT EXISTS idx_work_tasks_parent
+          ON ${ WorkItemsModel.TASKS } (parent_id) WHERE parent_id IS NOT NULL
+      `);
+      await postgresClient.query(`
+        CREATE INDEX IF NOT EXISTS idx_work_tasks_due
+          ON ${ WorkItemsModel.TASKS } (archived, due_at)
+          WHERE due_at IS NOT NULL AND archived = false
+      `);
+      await postgresClient.query(`
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_work_tasks_epic_slug
+          ON ${ WorkItemsModel.TASKS } (epic_id, slug)
+          WHERE slug IS NOT NULL
+      `);
+
+      await postgresClient.query(`
+        CREATE TABLE IF NOT EXISTS ${ WorkItemsModel.COMMENTS } (
+          id              TEXT        PRIMARY KEY,
+          task_id         TEXT        NOT NULL REFERENCES ${ WorkItemsModel.TASKS }(id),
+          body            TEXT        NOT NULL,
+          author          TEXT,
+          created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at      TIMESTAMPTZ,
+          archived        BOOLEAN     NOT NULL DEFAULT false
+        )
+      `);
+      await postgresClient.query(`
+        CREATE INDEX IF NOT EXISTS idx_work_task_comments_task
+          ON ${ WorkItemsModel.COMMENTS } (task_id, archived, created_at ASC)
+      `);
+
+      try {
+        await postgresClient.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+        await postgresClient.query(`
+          CREATE INDEX IF NOT EXISTS idx_work_projects_title_trgm
+            ON ${ WorkItemsModel.PROJECTS } USING gin (title gin_trgm_ops)
+        `);
+        await postgresClient.query(`
+          CREATE INDEX IF NOT EXISTS idx_work_epics_title_trgm
+            ON ${ WorkItemsModel.EPICS } USING gin (title gin_trgm_ops)
+        `);
+        await postgresClient.query(`
+          CREATE INDEX IF NOT EXISTS idx_work_tasks_title_trgm
+            ON ${ WorkItemsModel.TASKS } USING gin (title gin_trgm_ops)
+        `);
+      } catch (trgmErr) {
+        console.warn('[WorkItemsModel] pg_trgm index unavailable (non-fatal):', trgmErr);
+      }
+    } catch (err) {
+      console.error('[WorkItemsModel] Failed to ensure tables:', err);
+    }
+  }
+
+  /** Alias — ObservationsModel/RulesModel style. */
+  static async ensureTable(): Promise<void> {
+    return WorkItemsModel.ensureTables();
+  }
+
+  // ──────────────────────────────────────────────
+  // Helpers
+  // ──────────────────────────────────────────────
+
+  private static async uniqueId(table: string): Promise<string> {
+    for (let i = 0; i < 8; i++) {
+      const id = generateTinyId();
+      const rows = await postgresClient.query<{ id: string }>(
+        `SELECT id FROM ${ table } WHERE id = $1 LIMIT 1`,
+        [id],
+      );
+      if (rows.length === 0) return id;
+    }
+    return `${ generateTinyId() }${ generateTinyId() }`;
+  }
+
+  private static async requireEpic(epicId: string): Promise<WorkEpicRecord> {
+    const epic = await WorkItemsModel.getEpic(epicId);
+    if (!epic) throw new Error(`No epic found with id: ${ epicId }`);
+    return epic;
+  }
+
+  private static pushClosedFilter(conds: string[], opts: ListOpts): void {
+    if (opts.status) return;
+    if (!opts.includeDone) conds.push(`NOT (${ CLOSED_STATUSES })`);
+  }
+
+  // ──────────────────────────────────────────────
+  // Projects
+  // ──────────────────────────────────────────────
+
+  static async getProject(id: string): Promise<WorkProjectRecord | null> {
+    const rows = await postgresClient.query<WorkProjectRecord>(
+      `SELECT * FROM ${ WorkItemsModel.PROJECTS } WHERE id = $1 LIMIT 1`,
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  static async getProjectBySlug(slug: string): Promise<WorkProjectRecord | null> {
+    const rows = await postgresClient.query<WorkProjectRecord>(
+      `SELECT * FROM ${ WorkItemsModel.PROJECTS }
+        WHERE slug = $1 AND archived = false
+        LIMIT 1`,
+      [slug],
+    );
+    return rows[0] ?? null;
+  }
+
+  static async upsertProject(input: UpsertProjectInput): Promise<WorkProjectRecord> {
+    const slug = (input.slug || slugify(input.title)).slice(0, 80);
+    const existing = await WorkItemsModel.getProjectBySlug(slug);
+    if (existing) {
+      return (await WorkItemsModel.updateProject(existing.id, {
+        title:          input.title,
+        description:    input.description,
+        outcome_metric: input.outcome_metric,
+        status:         input.status,
+        priority:       input.priority,
+        owner:          input.owner,
+        due_at:         input.due_at,
+        source:         input.source,
+        source_path:    input.source_path ?? input.source_ref,
+        github_repo:    input.github_repo,
+      })) ?? existing;
+    }
+
+    const id = input.id || await WorkItemsModel.uniqueId(WorkItemsModel.PROJECTS);
+    const rows = await postgresClient.query<WorkProjectRecord>(
+      `INSERT INTO ${ WorkItemsModel.PROJECTS }
+         (id, slug, title, description, outcome_metric, status, priority,
+          owner, source, source_path, github_repo, due_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+       RETURNING *`,
+      [
+        id,
+        slug,
+        input.title,
+        input.description ?? '',
+        input.outcome_metric ?? null,
+        input.status ?? 'working',
+        input.priority ?? 'p2',
+        input.owner ?? null,
+        input.source ?? null,
+        input.source_path ?? input.source_ref ?? null,
+        input.github_repo ?? null,
+        input.due_at ?? null,
+      ],
+    );
+    return rows[0];
+  }
+
+  static async updateProject(id: string, changes: UpdateProjectInput): Promise<WorkProjectRecord | null> {
+    const existing = await WorkItemsModel.getProject(id);
+    if (!existing) return null;
+
+    const setClauses: string[] = ['updated_at = now()'];
+    const values: any[] = [];
+    let idx = 1;
+    let moved = false;
+
+    const assign = (col: string, val: any) => {
+      setClauses.push(`${ col } = $${ idx++ }`);
+      values.push(val);
+    };
+
+    if (changes.slug           !== undefined) assign('slug', changes.slug);
+    if (changes.title          !== undefined) assign('title', changes.title);
+    if (changes.description    !== undefined) assign('description', changes.description);
+    if (changes.outcome_metric !== undefined) assign('outcome_metric', changes.outcome_metric);
+    if (changes.status         !== undefined) { assign('status', changes.status); moved = true; }
+    if (changes.priority       !== undefined) { assign('priority', changes.priority); moved = true; }
+    if (changes.owner          !== undefined) assign('owner', changes.owner);
+    if (changes.due_at         !== undefined) { assign('due_at', changes.due_at); moved = true; }
+    if (changes.source         !== undefined) assign('source', changes.source);
+    if (changes.source_path    !== undefined) assign('source_path', changes.source_path);
+    if (changes.github_repo    !== undefined) assign('github_repo', changes.github_repo);
+
+    if (moved) setClauses.push('last_moved_at = now()');
+    if (setClauses.length === 1) return existing;
+
+    values.push(id);
+    const rows = await postgresClient.query<WorkProjectRecord>(
+      `UPDATE ${ WorkItemsModel.PROJECTS } SET ${ setClauses.join(', ') }
+        WHERE id = $${ idx } RETURNING *`,
+      values,
+    );
+    return rows[0] ?? null;
+  }
+
+  static async listProjects(opts: ListOpts = {}): Promise<WorkProjectRecord[]> {
+    const conds = ['archived = false'];
+    const values: any[] = [];
+    let idx = 1;
+    WorkItemsModel.pushClosedFilter(conds, opts);
+    if (opts.status)   { conds.push(`status = $${ idx++ }`);   values.push(opts.status); }
+    if (opts.priority) { conds.push(`priority = $${ idx++ }`); values.push(opts.priority); }
+    const limit = opts.limit ?? 50;
+    values.push(limit);
+    return postgresClient.query<WorkProjectRecord>(
+      `SELECT * FROM ${ WorkItemsModel.PROJECTS }
+        WHERE ${ conds.join(' AND ') }
+        ORDER BY ${ PRIORITY_RANK }, last_moved_at ASC, slug ASC
+        LIMIT $${ idx }`,
+      values,
+    );
+  }
+
+  // ──────────────────────────────────────────────
+  // Epics
+  // ──────────────────────────────────────────────
+
+  static async getEpic(id: string): Promise<WorkEpicRecord | null> {
+    const rows = await postgresClient.query<WorkEpicRecord>(
+      `SELECT * FROM ${ WorkItemsModel.EPICS } WHERE id = $1 LIMIT 1`,
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  static async upsertEpic(input: UpsertEpicInput): Promise<WorkEpicRecord> {
+    const project = await WorkItemsModel.getProject(input.project_id);
+    if (!project) throw new Error(`No project found with id: ${ input.project_id }`);
+
+    const slug = input.slug ? input.slug.slice(0, 80) : slugify(input.title);
+    if (slug) {
+      const existing = await postgresClient.query<WorkEpicRecord>(
+        `SELECT * FROM ${ WorkItemsModel.EPICS }
+          WHERE project_id = $1 AND slug = $2 AND archived = false
+          LIMIT 1`,
+        [input.project_id, slug],
+      );
+      if (existing[0]) {
+        return (await WorkItemsModel.updateEpic(existing[0].id, {
+          title:       input.title,
+          description: input.description,
+          status:      input.status,
+          priority:    input.priority,
+          position:    input.position,
+          due_at:      input.due_at,
+          source:      input.source,
+          source_ref:  input.source_ref,
+        })) ?? existing[0];
+      }
+    }
+
+    const id = input.id || await WorkItemsModel.uniqueId(WorkItemsModel.EPICS);
+    const rows = await postgresClient.query<WorkEpicRecord>(
+      `INSERT INTO ${ WorkItemsModel.EPICS }
+         (id, project_id, slug, title, description, status, priority,
+          position, due_at, source, source_ref)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+       RETURNING *`,
+      [
+        id,
+        input.project_id,
+        slug || null,
+        input.title,
+        input.description ?? '',
+        input.status ?? 'working',
+        input.priority ?? 'p2',
+        input.position ?? 0,
+        input.due_at ?? null,
+        input.source ?? null,
+        input.source_ref ?? null,
+      ],
+    );
+    return rows[0];
+  }
+
+  static async updateEpic(id: string, changes: UpdateEpicInput): Promise<WorkEpicRecord | null> {
+    const existing = await WorkItemsModel.getEpic(id);
+    if (!existing) return null;
+
+    if (changes.project_id) {
+      const project = await WorkItemsModel.getProject(changes.project_id);
+      if (!project) throw new Error(`No project found with id: ${ changes.project_id }`);
+    }
+
+    const setClauses: string[] = ['updated_at = now()'];
+    const values: any[] = [];
+    let idx = 1;
+    let moved = false;
+
+    const assign = (col: string, val: any) => {
+      setClauses.push(`${ col } = $${ idx++ }`);
+      values.push(val);
+    };
+
+    if (changes.project_id  !== undefined) { assign('project_id', changes.project_id); moved = true; }
+    if (changes.slug        !== undefined) assign('slug', changes.slug);
+    if (changes.title       !== undefined) assign('title', changes.title);
+    if (changes.description !== undefined) assign('description', changes.description);
+    if (changes.status      !== undefined) { assign('status', changes.status); moved = true; }
+    if (changes.priority    !== undefined) { assign('priority', changes.priority); moved = true; }
+    if (changes.position    !== undefined) assign('position', changes.position);
+    if (changes.due_at      !== undefined) { assign('due_at', changes.due_at); moved = true; }
+    if (changes.source      !== undefined) assign('source', changes.source);
+    if (changes.source_ref  !== undefined) assign('source_ref', changes.source_ref);
+
+    if (moved) setClauses.push('last_moved_at = now()');
+    if (setClauses.length === 1) return existing;
+
+    values.push(id);
+    const rows = await postgresClient.query<WorkEpicRecord>(
+      `UPDATE ${ WorkItemsModel.EPICS } SET ${ setClauses.join(', ') }
+        WHERE id = $${ idx } RETURNING *`,
+      values,
+    );
+    return rows[0] ?? null;
+  }
+
+  static async listEpics(opts: ListEpicsOpts = {}): Promise<WorkEpicRecord[]> {
+    const conds = ['archived = false'];
+    const values: any[] = [];
+    let idx = 1;
+    WorkItemsModel.pushClosedFilter(conds, opts);
+    if (opts.projectId) { conds.push(`project_id = $${ idx++ }`); values.push(opts.projectId); }
+    if (opts.status)    { conds.push(`status = $${ idx++ }`);     values.push(opts.status); }
+    if (opts.priority)  { conds.push(`priority = $${ idx++ }`);   values.push(opts.priority); }
+    const limit = opts.limit ?? 50;
+    values.push(limit);
+    return postgresClient.query<WorkEpicRecord>(
+      `SELECT * FROM ${ WorkItemsModel.EPICS }
+        WHERE ${ conds.join(' AND ') }
+        ORDER BY position ASC, ${ PRIORITY_RANK }, last_moved_at ASC
+        LIMIT $${ idx }`,
+      values,
+    );
+  }
+
+  // ──────────────────────────────────────────────
+  // Tasks
+  // ──────────────────────────────────────────────
+
+  static async getTask(id: string): Promise<WorkTaskRecord | null> {
+    const rows = await postgresClient.query<WorkTaskRecord>(
+      `SELECT * FROM ${ WorkItemsModel.TASKS } WHERE id = $1 LIMIT 1`,
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  static async insertTask(input: UpsertTaskInput): Promise<WorkTaskRecord> {
+    if (!input.epic_id) throw new Error('epic_id is required to create a task.');
+    const epic = await WorkItemsModel.requireEpic(input.epic_id);
+    const projectId = input.project_id || epic.project_id;
+    const slug = input.slug ? input.slug.slice(0, 80) : null;
+    const status = input.status ?? 'working';
+    const id = input.id || await WorkItemsModel.uniqueId(WorkItemsModel.TASKS);
+
+    const rows = await postgresClient.query<WorkTaskRecord>(
+      `INSERT INTO ${ WorkItemsModel.TASKS }
+         (id, project_id, epic_id, parent_id, slug, title, description, status,
+          priority, due_at, github_issue, assignee, labels, position, source,
+          source_ref, completed_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+       RETURNING *`,
+      [
+        id,
+        projectId,
+        input.epic_id,
+        input.parent_id ?? null,
+        slug,
+        input.title,
+        input.description ?? '',
+        status,
+        input.priority ?? 'p2',
+        input.due_at ?? null,
+        input.github_issue ?? null,
+        input.assignee ?? null,
+        input.labels ?? [],
+        input.position ?? 0,
+        input.source ?? null,
+        input.source_ref ?? null,
+        isClosedStatus(status) ? new Date().toISOString() : null,
+      ],
+    );
+    return rows[0];
+  }
+
+  static async upsertTask(input: UpsertTaskInput): Promise<WorkTaskRecord> {
+    if (!input.epic_id) throw new Error('epic_id is required to create a task.');
+    const slug = input.slug ? input.slug.slice(0, 80) : null;
+    if (slug) {
+      const existing = await postgresClient.query<WorkTaskRecord>(
+        `SELECT * FROM ${ WorkItemsModel.TASKS }
+          WHERE epic_id = $1 AND slug = $2 AND archived = false
+          LIMIT 1`,
+        [input.epic_id, slug],
+      );
+      if (existing[0]) {
+        return (await WorkItemsModel.updateTask(existing[0].id, {
+          parent_id:    input.parent_id,
+          title:        input.title,
+          description:  input.description,
+          status:       input.status,
+          priority:     input.priority,
+          assignee:     input.assignee,
+          due_at:       input.due_at,
+          labels:       input.labels,
+          github_issue: input.github_issue,
+          position:     input.position,
+          source:       input.source,
+          source_ref:   input.source_ref,
+        })) ?? existing[0];
+      }
+    }
+    return WorkItemsModel.insertTask(input);
+  }
+
+  static async updateTask(id: string, changes: UpdateTaskInput): Promise<WorkTaskRecord | null> {
+    const existing = await WorkItemsModel.getTask(id);
+    if (!existing) return null;
+
+    let nextProjectId: string | undefined;
+    if (changes.epic_id) {
+      const epic = await WorkItemsModel.requireEpic(changes.epic_id);
+      nextProjectId = epic.project_id;
+    }
+
+    const setClauses: string[] = ['updated_at = now()'];
+    const values: any[] = [];
+    let idx = 1;
+    let moved = false;
+
+    const assign = (col: string, val: any) => {
+      setClauses.push(`${ col } = $${ idx++ }`);
+      values.push(val);
+    };
+
+    if (changes.epic_id      !== undefined) { assign('epic_id', changes.epic_id); moved = true; }
+    if (nextProjectId        !== undefined) assign('project_id', nextProjectId);
+    if (changes.parent_id    !== undefined) { assign('parent_id', changes.parent_id); moved = true; }
+    if (changes.slug         !== undefined) assign('slug', changes.slug);
+    if (changes.title        !== undefined) assign('title', changes.title);
+    if (changes.description  !== undefined) assign('description', changes.description);
+    if (changes.status       !== undefined) { assign('status', changes.status); moved = true; }
+    if (changes.priority     !== undefined) { assign('priority', changes.priority); moved = true; }
+    if (changes.assignee     !== undefined) { assign('assignee', changes.assignee); moved = true; }
+    if (changes.due_at       !== undefined) { assign('due_at', changes.due_at); moved = true; }
+    if (changes.labels       !== undefined) assign('labels', changes.labels);
+    if (changes.github_issue !== undefined) assign('github_issue', changes.github_issue);
+    if (changes.position     !== undefined) assign('position', changes.position);
+    if (changes.source       !== undefined) assign('source', changes.source);
+    if (changes.source_ref   !== undefined) assign('source_ref', changes.source_ref);
+
+    if (changes.status !== undefined) {
+      assign('completed_at', isClosedStatus(changes.status) ? new Date().toISOString() : null);
+    }
+
+    if (moved) setClauses.push('last_moved_at = now()');
+    if (setClauses.length === 1) return existing;
+
+    values.push(id);
+    const rows = await postgresClient.query<WorkTaskRecord>(
+      `UPDATE ${ WorkItemsModel.TASKS } SET ${ setClauses.join(', ') }
+        WHERE id = $${ idx } RETURNING *`,
+      values,
+    );
+    return rows[0] ?? null;
+  }
+
+  static async listTasks(opts: ListTasksOpts = {}): Promise<WorkTaskRecord[]> {
+    const conds = ['archived = false'];
+    const values: any[] = [];
+    let idx = 1;
+    WorkItemsModel.pushClosedFilter(conds, opts);
+    if (opts.projectId) { conds.push(`project_id = $${ idx++ }`); values.push(opts.projectId); }
+    if (opts.epicId)    { conds.push(`epic_id = $${ idx++ }`);    values.push(opts.epicId); }
+    if (opts.parentId)  { conds.push(`parent_id = $${ idx++ }`);  values.push(opts.parentId); }
+    if (opts.status)    { conds.push(`status = $${ idx++ }`);     values.push(opts.status); }
+    if (opts.priority)  { conds.push(`priority = $${ idx++ }`);   values.push(opts.priority); }
+    if (opts.assignee)  { conds.push(`assignee = $${ idx++ }`);   values.push(opts.assignee); }
+    const limit = opts.limit ?? 50;
+    values.push(limit);
+    return postgresClient.query<WorkTaskRecord>(
+      `SELECT * FROM ${ WorkItemsModel.TASKS }
+        WHERE ${ conds.join(' AND ') }
+        ORDER BY ${ PRIORITY_RANK }, due_at ASC NULLS LAST, last_moved_at ASC, position ASC
+        LIMIT $${ idx }`,
+      values,
+    );
+  }
+
+  // ──────────────────────────────────────────────
+  // Comments
+  // ──────────────────────────────────────────────
+
+  static async addComment(input: AddCommentInput): Promise<WorkCommentRecord> {
+    const task = await WorkItemsModel.getTask(input.task_id);
+    if (!task) throw new Error(`No task found with id: ${ input.task_id }`);
+    const id = input.id || await WorkItemsModel.uniqueId(WorkItemsModel.COMMENTS);
+    const rows = await postgresClient.query<WorkCommentRecord>(
+      `INSERT INTO ${ WorkItemsModel.COMMENTS } (id, task_id, body, author)
+       VALUES ($1, $2, $3, $4)
+       RETURNING *`,
+      [id, input.task_id, input.body, input.author ?? 'agent'],
+    );
+    return rows[0];
+  }
+
+  static async listComments(taskId: string): Promise<WorkCommentRecord[]> {
+    return postgresClient.query<WorkCommentRecord>(
+      `SELECT * FROM ${ WorkItemsModel.COMMENTS }
+        WHERE task_id = $1 AND archived = false
+        ORDER BY created_at ASC`,
+      [taskId],
+    );
+  }
+
+  // ──────────────────────────────────────────────
+  // Archive (soft-delete, cascades down)
+  // ──────────────────────────────────────────────
+
+  static async archive(kind: WorkItemKind | string, id: string): Promise<boolean> {
+    if (kind === 'project') {
+      const project = await WorkItemsModel.getProject(id);
+      if (!project || project.archived) return false;
+      await postgresClient.query(
+        `UPDATE ${ WorkItemsModel.COMMENTS } SET archived = true, updated_at = now()
+          WHERE task_id IN (SELECT id FROM ${ WorkItemsModel.TASKS } WHERE project_id = $1)`,
+        [id],
+      );
+      await postgresClient.query(
+        `UPDATE ${ WorkItemsModel.TASKS } SET archived = true, updated_at = now()
+          WHERE project_id = $1`,
+        [id],
+      );
+      await postgresClient.query(
+        `UPDATE ${ WorkItemsModel.EPICS } SET archived = true, updated_at = now()
+          WHERE project_id = $1`,
+        [id],
+      );
+      await postgresClient.query(
+        `UPDATE ${ WorkItemsModel.PROJECTS } SET archived = true, updated_at = now()
+          WHERE id = $1`,
+        [id],
+      );
+      return true;
+    }
+
+    if (kind === 'epic') {
+      const epic = await WorkItemsModel.getEpic(id);
+      if (!epic || epic.archived) return false;
+      await postgresClient.query(
+        `UPDATE ${ WorkItemsModel.COMMENTS } SET archived = true, updated_at = now()
+          WHERE task_id IN (SELECT id FROM ${ WorkItemsModel.TASKS } WHERE epic_id = $1)`,
+        [id],
+      );
+      await postgresClient.query(
+        `UPDATE ${ WorkItemsModel.TASKS } SET archived = true, updated_at = now()
+          WHERE epic_id = $1`,
+        [id],
+      );
+      await postgresClient.query(
+        `UPDATE ${ WorkItemsModel.EPICS } SET archived = true, updated_at = now()
+          WHERE id = $1`,
+        [id],
+      );
+      return true;
+    }
+
+    if (kind === 'task') {
+      const task = await WorkItemsModel.getTask(id);
+      if (!task || task.archived) return false;
+      await postgresClient.query(
+        `UPDATE ${ WorkItemsModel.COMMENTS } SET archived = true, updated_at = now()
+          WHERE task_id = $1
+             OR task_id IN (SELECT id FROM ${ WorkItemsModel.TASKS } WHERE parent_id = $1)`,
+        [id],
+      );
+      await postgresClient.query(
+        `UPDATE ${ WorkItemsModel.TASKS } SET archived = true, updated_at = now()
+          WHERE id = $1 OR parent_id = $1`,
+        [id],
+      );
+      return true;
+    }
+
+    return false;
+  }
+
+  // ──────────────────────────────────────────────
+  // Search
+  // ──────────────────────────────────────────────
+
+  static async search(opts: SearchOpts): Promise<SearchHit[]> {
+    const words = tokenizeQuery(opts.query);
+    const limit = opts.limit ?? 20;
+    const kinds: WorkItemKind[] = opts.kind && ['project', 'epic', 'task'].includes(opts.kind)
+      ? [opts.kind as WorkItemKind]
+      : ['project', 'epic', 'task'];
+
+    const hits: SearchHit[] = [];
+    for (const kind of kinds) {
+      const remaining = limit - hits.length;
+      if (remaining <= 0) break;
+      const table = kind === 'project' ? WorkItemsModel.PROJECTS
+        : kind === 'epic' ? WorkItemsModel.EPICS
+          : WorkItemsModel.TASKS;
+      const conds: string[] = [];
+      const values: any[] = [];
+      let idx = 1;
+      if (!opts.includeArchived) conds.push('archived = false');
+
+      if (words.length === 0) {
+        conds.push(`(title ILIKE $${ idx } OR description ILIKE $${ idx })`);
+        values.push(`%${ opts.query }%`);
+        idx += 1;
+      } else {
+        const wordConds = words.map((w) => {
+          const p = `$${ idx++ }`;
+          values.push(`%${ w }%`);
+          return `(title ILIKE ${ p } OR description ILIKE ${ p })`;
+        });
+        conds.push(`(${ wordConds.join(' OR ') })`);
+      }
+
+      values.push(remaining);
+      const rows = await postgresClient.query<SearchHit>(
+        `SELECT '${ kind }' AS kind, id, title, status, priority, archived
+           FROM ${ table }
+          WHERE ${ conds.join(' AND ') }
+          ORDER BY last_moved_at DESC
+          LIMIT $${ idx }`,
+        values,
+      );
+      hits.push(...rows);
+    }
+    return hits.slice(0, limit);
+  }
+}

--- a/pkg/rancher-desktop/agent/database/seeders/WorkItemsImportSeeder.ts
+++ b/pkg/rancher-desktop/agent/database/seeders/WorkItemsImportSeeder.ts
@@ -1,0 +1,273 @@
+/**
+ * WorkItemsImportSeeder
+ *
+ * One-time import of the local install's markdown ledger
+ * (`~/sulla/ledger/goals/*.md`) into the work-items tables
+ * (migration 0044). SCHEMA-ONLY rule: this seeder never ships
+ * hardcoded user data. It reads whatever is on THIS install at
+ * boot and upserts by stable slug (`goal-<file>` / `epic-<file>-<n>` /
+ * `task-<file>-<n>-<m>`). Safe to re-run — existing rows are
+ * refreshed, never duplicated.
+ *
+ * Filesystem PROJECT.md folders under ~/sulla/projects/ stay as
+ * PRDs (ProjectRegistry). This seeder only imports the ledger.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { WorkItemsModel } from '../models/WorkItemsModel';
+import { resolveSullaLedgerDir } from '../../utils/sullaPaths';
+
+interface ParsedTask {
+  title:       string;
+  description: string;
+  status:      string;
+  position:    number;
+}
+
+interface ParsedEpic {
+  title:       string;
+  description: string;
+  status:      string;
+  position:    number;
+  tasks:       ParsedTask[];
+}
+
+interface ParsedGoal {
+  slug:        string;
+  title:       string;
+  description: string;
+  status:      string;
+  priority:    string;
+  sourcePath:  string;
+  epics:       ParsedEpic[];
+}
+
+const SKIP_FILES = new Set(['README.md']);
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80) || 'item';
+}
+
+function mapStatus(raw: string): string {
+  const s = raw.toLowerCase();
+  if (/done|shipped|complete|closed|retired|superseded/.test(s)) return 'done';
+  if (/blocked|gate|waiting/.test(s)) return 'blocked';
+  if (/park|hold|tabled/.test(s)) return 'parked';
+  if (/should|want|might|backlog/.test(s)) return 'backlog';
+  if (/working|wip|active|in.?progress/.test(s)) return 'in_progress';
+  return 'todo';
+}
+
+function mapPriority(raw: string): string {
+  const s = raw.toLowerCase();
+  if (/p0|critical/.test(s)) return 'critical';
+  if (/p1|high/.test(s)) return 'high';
+  if (/p3|p4|low/.test(s)) return 'low';
+  return 'medium';
+}
+
+function checkboxStatus(mark: string): string {
+  const m = mark.trim().toLowerCase();
+  if (m === 'x') return 'done';
+  if (m === '~' || m === '-') return 'in_progress';
+  return 'todo';
+}
+
+function parseGoalFile(filePath: string, slug: string): ParsedGoal | null {
+  let text: string;
+  try {
+    text = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+  if (!text.trim()) return null;
+
+  const lines = text.split('\n');
+  let title = slug;
+  let status = 'todo';
+  let priority = 'medium';
+  const descParts: string[] = [];
+  const epics: ParsedEpic[] = [];
+  let currentEpic: ParsedEpic | null = null;
+  let inEpics = false;
+  let inWhy = false;
+
+  for (const line of lines) {
+    const h1 = line.match(/^#\s+(?:Goal:\s*)?(.+?)\s*$/);
+    if (h1 && title === slug) {
+      title = h1[1].trim();
+      continue;
+    }
+
+    const meta = line.match(/^\*\*([^*]+):\*\*\s*(.+?)\s*$/);
+    if (meta) {
+      const key = meta[1].trim().toLowerCase();
+      const val = meta[2].trim();
+      if (key === 'status') status = mapStatus(val);
+      else if (key === 'priority') priority = mapPriority(val);
+      else if (key === 'outcome metric' || key === 'metric') descParts.push(val);
+      continue;
+    }
+
+    if (/^##\s+Epics\b/i.test(line)) {
+      inEpics = true;
+      inWhy = false;
+      continue;
+    }
+    if (/^##\s+Why\b/i.test(line)) {
+      inWhy = true;
+      inEpics = false;
+      continue;
+    }
+    if (/^##\s+/.test(line)) {
+      inWhy = false;
+      // stay in epics only for ## Epics; other H2s end both
+      if (!/^##\s+Epics\b/i.test(line)) inEpics = false;
+      continue;
+    }
+
+    if (inWhy && line.trim() && !line.startsWith('#')) {
+      descParts.push(line.trim());
+    }
+
+    const epicHead = line.match(/^###\s+Epic\s+(\d+)\s*[—–-]\s*(.+?)\s*$/i)
+      || line.match(/^###\s+(.+?)\s*$/);
+    if (inEpics && epicHead) {
+      if (currentEpic) epics.push(currentEpic);
+      const rawTitle = (epicHead[2] || epicHead[1]).trim();
+      currentEpic = {
+        title:       rawTitle.replace(/\s*[✅⏳].*$/, '').trim(),
+        description: '',
+        status:      /✅/.test(rawTitle) && !/⏳/.test(rawTitle) ? 'done' : 'todo',
+        position:    epics.length,
+        tasks:       [],
+      };
+      continue;
+    }
+
+    const box = line.match(/^\s*-\s*\[([ xX~-])\]\s+(.+?)\s*$/);
+    if (currentEpic && box) {
+      currentEpic.tasks.push({
+        title:       box[2].trim(),
+        description: '',
+        status:      checkboxStatus(box[1]),
+        position:    currentEpic.tasks.length,
+      });
+      continue;
+    }
+
+    if (currentEpic && line.trim() && !line.startsWith('#') && !line.startsWith('-')) {
+      currentEpic.description = currentEpic.description
+        ? `${currentEpic.description}\n${line.trim()}`
+        : line.trim();
+    }
+  }
+  if (currentEpic) epics.push(currentEpic);
+
+  return {
+    slug,
+    title,
+    description: descParts.join('\n').trim(),
+    status,
+    priority,
+    sourcePath:  filePath,
+    epics,
+  };
+}
+
+async function importGoal(goal: ParsedGoal): Promise<{ projects: number; epics: number; tasks: number }> {
+  const counts = { projects: 0, epics: 0, tasks: 0 };
+  const projectSlug = `goal-${goal.slug}`;
+  const project = await WorkItemsModel.upsertProject({
+    slug:        projectSlug,
+    title:       goal.title,
+    description: goal.description,
+    status:      goal.status,
+    priority:    goal.priority,
+    source:      'ledger_import',
+    source_ref:  goal.sourcePath,
+  });
+  counts.projects = 1;
+
+  for (const epic of goal.epics) {
+    const epicSlug = `epic-${goal.slug}-${epic.position + 1}-${slugify(epic.title)}`;
+    const epicRow = await WorkItemsModel.upsertEpic({
+      project_id:  project.id,
+      slug:        epicSlug,
+      title:       epic.title,
+      description: epic.description,
+      status:      epic.status,
+      priority:    goal.priority,
+      position:    epic.position,
+      source:      'ledger_import',
+      source_ref:  `${goal.sourcePath}#epic-${epic.position + 1}`,
+    });
+    counts.epics += 1;
+
+    for (const task of epic.tasks) {
+      const taskSlug = `task-${goal.slug}-${epic.position + 1}-${task.position + 1}-${slugify(task.title)}`;
+      await WorkItemsModel.upsertTask({
+        epic_id:     epicRow.id,
+        parent_id:   null,
+        slug:        taskSlug,
+        title:       task.title,
+        description: task.description,
+        status:      task.status,
+        priority:    goal.priority,
+        position:    task.position,
+        source:      'ledger_import',
+        source_ref:  `${goal.sourcePath}#task-${epic.position + 1}-${task.position + 1}`,
+      });
+      counts.tasks += 1;
+    }
+  }
+
+  return counts;
+}
+
+async function initialize(): Promise<void> {
+  console.log('[WorkItemsImportSeeder] Importing local ledger goals...');
+  await WorkItemsModel.ensureTables();
+
+  const goalsDir = path.join(resolveSullaLedgerDir(), 'goals');
+  if (!fs.existsSync(goalsDir)) {
+    console.log('[WorkItemsImportSeeder] No ledger/goals directory — nothing to import');
+    return;
+  }
+
+  let files: string[];
+  try {
+    files = fs.readdirSync(goalsDir).filter(f => f.endsWith('.md') && !SKIP_FILES.has(f));
+  } catch (err) {
+    console.warn('[WorkItemsImportSeeder] Could not read ledger/goals:', err);
+    return;
+  }
+
+  let projects = 0;
+  let epics = 0;
+  let tasks = 0;
+
+  for (const file of files) {
+    const slug = file.replace(/\.md$/i, '');
+    const parsed = parseGoalFile(path.join(goalsDir, file), slug);
+    if (!parsed) continue;
+    try {
+      const counts = await importGoal(parsed);
+      projects += counts.projects;
+      epics += counts.epics;
+      tasks += counts.tasks;
+    } catch (err) {
+      console.warn(`[WorkItemsImportSeeder] Failed to import ${file}:`, err);
+    }
+  }
+
+  console.log(`[WorkItemsImportSeeder] Imported ${projects} project(s), ${epics} epic(s), ${tasks} task(s) from ${files.length} goal file(s)`);
+}
+
+export { initialize };

--- a/pkg/rancher-desktop/agent/database/seeders/index.ts
+++ b/pkg/rancher-desktop/agent/database/seeders/index.ts
@@ -4,6 +4,7 @@
 
 import { initialize as firstRunRemoteCredentialsSeeder } from './FirstRunRemoteCredentialsSeeder';
 import { initialize as observationsImportSeeder } from './ObservationsImportSeeder';
+import { initialize as workItemsImportSeeder } from './WorkItemsImportSeeder';
 
 // n8n user and settings seeders have been replaced by the recipe's
 // post-server-migration.sql which handles user creation, bcrypt password
@@ -20,6 +21,10 @@ export const seedersRegistry = [
   {
     name: 'observations-import-seeder',
     run:  observationsImportSeeder,
+  },
+  {
+    name: 'work-items-import-seeder',
+    run:  workItemsImportSeeder,
   },
   // {
   //   name: 'core-data-seed',

--- a/pkg/rancher-desktop/agent/tools/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/manifests.ts
@@ -31,6 +31,7 @@ import { settingsToolManifests } from './settings/manifests';
 import { slackToolManifests } from './slack/manifests';
 import { uiToolManifests } from './ui/manifests';
 import { workflowToolManifests } from './workflow/manifests';
+import { workItemsToolManifests } from './work/manifests';
 
 toolRegistry.registerManifests([
   ...agentToolManifests,
@@ -61,4 +62,5 @@ toolRegistry.registerManifests([
   ...slackToolManifests,
   ...uiToolManifests,
   ...workflowToolManifests,
+  ...workItemsToolManifests,
 ]);

--- a/pkg/rancher-desktop/agent/tools/registry.ts
+++ b/pkg/rancher-desktop/agent/tools/registry.ts
@@ -49,7 +49,7 @@ export class ToolRegistry {
   /** Native tool definitions that bypass convertToolToLLM (e.g. Anthropic computer use). */
   private nativeToolDefs = new Map<string, Record<string, any>>();
   private categoriesList = [
-    'agents', 'applescript', 'bridge', 'browser', 'calendar', 'capture', 'docker', 'extensions', 'fs', 'function', 'github', 'integrations', 'kubectl', 'lima', 'marketplace', 'memory', 'meta', 'mobile', 'notify', 'observation', 'pg', 'projects', 'rdctl', 'redis', 'skills', 'slack', 'ui', 'vault', 'workspace', 'workflow',
+    'agents', 'applescript', 'bridge', 'browser', 'calendar', 'capture', 'docker', 'extensions', 'fs', 'function', 'github', 'integrations', 'kubectl', 'ledger', 'lima', 'marketplace', 'memory', 'meta', 'mobile', 'notify', 'observation', 'pg', 'projects', 'rdctl', 'redis', 'rules', 'skills', 'slack', 'ui', 'vault', 'work', 'workspace', 'workflow',
     // Integration catalog categories (AP backed)
     'communication', 'developer_tools', 'productivity', 'project_management', 'crm_sales', 'marketing', 'customer_support', 'social_media', 'finance', 'file_storage', 'ecommerce', 'analytics', 'automation', 'database', 'design', 'hr_recruiting', 'ai_ml',
   ];
@@ -79,6 +79,9 @@ export class ToolRegistry {
     notify:             'Send desktop notifications to alert the user when async work completes or needs attention.',
     vault:              'Credential vault — list saved credentials, check integration connection status, read secrets, and autofill login forms.',
     function:           'Custom function runner — list installed functions and invoke them by slug across python, shell, and node runtimes. Returns full execution trace in one call.',
+    ledger:             'Outcome-ledger measurement — scoreboard of WORKING / OUTCOMES / AUDIT at ~/sulla/ledger/. Files remain the human-readable agenda; the workboard is the structured store.',
+    rules:              'User-created rules the Security Conscience enforces. Distinct from global markdown under ~/sulla/rules/global/.',
+    work:               'Local workboard — projects, epics, tasks, sub-tasks, and comments in Postgres. Distinct from filesystem PROJECT.md PRDs (projects category) and from Cloud CRM.',
     workflow:           'Workflow management — execute, validate, import, and manage Sulla workflow definitions.',
     skills:             'Tools for searching, loading, and creating reusable skill files that teach the agent how to perform repeatable tasks.',
     projects:           'Tools for searching, loading, creating, updating, patching, and deleting project PRDs (PROJECT.md) and their workspace folders.',

--- a/pkg/rancher-desktop/agent/tools/work/add_task_comment.ts
+++ b/pkg/rancher-desktop/agent/tools/work/add_task_comment.ts
@@ -1,0 +1,32 @@
+import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Append a GitHub-issue-style comment to a task. Append-only.
+ */
+export class AddTaskCommentWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const taskId = typeof input.task_id === 'string' ? input.task_id.trim() : '';
+    const body = typeof input.body === 'string' ? input.body.trim() : '';
+    if (!taskId) return { successBoolean: false, responseString: 'task_id is required.' };
+    if (!body) return { successBoolean: false, responseString: 'body is required.' };
+
+    try {
+      await WorkItemsModel.ensureTables();
+      const comment = await WorkItemsModel.addComment({
+        task_id: taskId,
+        body,
+        author:  input.author || 'agent',
+      });
+      return {
+        successBoolean: true,
+        responseString: `Comment added on task ${ taskId } (id: ${ comment.id }, author: ${ comment.author }).`,
+      };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to add comment: ${ err?.message }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/work/archive_work_item.ts
+++ b/pkg/rancher-desktop/agent/tools/work/archive_work_item.ts
@@ -1,0 +1,35 @@
+import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Soft-archive a project, epic, or task. Cascades down. Never hard-deletes.
+ */
+export class ArchiveWorkItemWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const id = typeof input.id === 'string' ? input.id.trim() : '';
+    if (!id) return { successBoolean: false, responseString: 'id is required.' };
+    const hint = typeof input.kind === 'string' ? input.kind.trim().toLowerCase() : '';
+
+    try {
+      await WorkItemsModel.ensureTables();
+      const tryKinds = (hint ? [hint] : ['task', 'epic', 'project']) as Array<'project' | 'epic' | 'task'>;
+      for (const kind of tryKinds) {
+        const ok = await WorkItemsModel.archive(kind, id);
+        if (ok) {
+          return {
+            successBoolean: true,
+            responseString: `${ kind[0].toUpperCase() + kind.slice(1) } archived (soft-deleted): ${ id }${
+              kind === 'project' ? ' (epics + tasks cascaded)' : kind === 'epic' ? ' (tasks cascaded)' : ''
+            }`,
+          };
+        }
+      }
+      return { successBoolean: false, responseString: `No work item found with id: ${ id }` };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to archive work item: ${ err?.message }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/work/get_work_item.ts
+++ b/pkg/rancher-desktop/agent/tools/work/get_work_item.ts
@@ -1,0 +1,89 @@
+import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+function block(label: string, rec: Record<string, any>, extra: string[] = []): string {
+  const keys = [
+    'id', 'slug', 'title', 'status', 'priority', 'owner', 'assignee',
+    'due_at', 'github_issue', 'parent_id', 'project_id', 'epic_id',
+    'source', 'created_at', 'updated_at', 'last_moved_at', 'archived',
+    ...extra,
+  ];
+  const lines = [`# ${ label }: ${ rec.title || rec.id }`];
+  for (const k of keys) {
+    if (rec[k] === undefined || rec[k] === null || rec[k] === '') continue;
+    if (k === 'archived' && rec[k] === false) continue;
+    lines.push(`${ k }: ${ Array.isArray(rec[k]) ? rec[k].join(', ') : rec[k] }`);
+  }
+  if (rec.description) {
+    lines.push('', rec.description);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Fetch one work item + its children / comments.
+ */
+export class GetWorkItemWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const id = typeof input.id === 'string' ? input.id.trim() : '';
+    if (!id) return { successBoolean: false, responseString: 'id is required.' };
+    const hint = typeof input.kind === 'string' ? input.kind.trim().toLowerCase() : '';
+
+    try {
+      await WorkItemsModel.ensureTables();
+
+      const tryKinds = hint ? [hint] : ['task', 'epic', 'project'];
+      for (const kind of tryKinds) {
+        if (kind === 'project') {
+          const p = await WorkItemsModel.getProject(id);
+          if (!p) continue;
+          const epics = await WorkItemsModel.listEpics({ projectId: p.id, includeDone: true, limit: 100 });
+          const parts = [block('Project', p)];
+          parts.push('', `${ epics.length } epic(s):`);
+          for (const e of epics) {
+            parts.push(`- [${ e.id }] ${ e.priority } ${ e.status } ${ e.title }`);
+          }
+          return { successBoolean: true, responseString: parts.join('\n') };
+        }
+        if (kind === 'epic') {
+          const e = await WorkItemsModel.getEpic(id);
+          if (!e) continue;
+          const tasks = await WorkItemsModel.listTasks({ epicId: e.id, includeDone: true, limit: 200 });
+          const parts = [block('Epic', e)];
+          parts.push('', `${ tasks.length } task(s):`);
+          for (const t of tasks) {
+            const nest = t.parent_id ? ` └ ${ t.parent_id }` : '';
+            parts.push(`- [${ t.id }] ${ t.priority } ${ t.status } ${ t.title }${ nest }`);
+          }
+          return { successBoolean: true, responseString: parts.join('\n') };
+        }
+        if (kind === 'task') {
+          const t = await WorkItemsModel.getTask(id);
+          if (!t) continue;
+          const comments = await WorkItemsModel.listComments(t.id);
+          const subs = await WorkItemsModel.listTasks({ parentId: t.id, includeDone: true, limit: 100 });
+          const parts = [block('Task', t, ['labels'])];
+          if (subs.length) {
+            parts.push('', `${ subs.length } subtask(s):`);
+            for (const s of subs) parts.push(`- [${ s.id }] ${ s.priority } ${ s.status } ${ s.title }`);
+          }
+          if (comments.length) {
+            parts.push('', `${ comments.length } comment(s):`);
+            for (const c of comments) {
+              parts.push(`- [${ c.id }] ${ c.author } @ ${ c.created_at}`);
+              parts.push(`  ${ c.body.replace(/\n/g, '\n  ') }`);
+            }
+          }
+          return { successBoolean: true, responseString: parts.join('\n') };
+        }
+      }
+
+      return { successBoolean: false, responseString: `No work item found with id: ${ id }` };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Get work item failed: ${ err?.message }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/work/list_work_items.ts
+++ b/pkg/rancher-desktop/agent/tools/work/list_work_items.ts
@@ -1,0 +1,66 @@
+import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+function fmtProject(p: any): string {
+  return `[project ${ p.id }] ${ p.priority } ${ p.status } ${ p.title } (slug: ${ p.slug }${ p.due_at ? `, due ${ p.due_at }` : '' }${ p.owner ? `, owner ${ p.owner }` : '' }) moved ${ p.last_moved_at }`;
+}
+function fmtEpic(e: any): string {
+  return `[epic ${ e.id }] ${ e.priority } ${ e.status } ${ e.title } (project: ${ e.project_id }${ e.due_at ? `, due ${ e.due_at }` : '' }) moved ${ e.last_moved_at }`;
+}
+function fmtTask(t: any): string {
+  const labels = Array.isArray(t.labels) && t.labels.length ? ` [${ t.labels.join(',') }]` : '';
+  const nest = t.parent_id ? ` subtask-of ${ t.parent_id }` : '';
+  return `[task ${ t.id }] ${ t.priority } ${ t.status } ${ t.title }${ labels } (epic: ${ t.epic_id }${ nest }${ t.assignee ? `, @${ t.assignee }` : '' }${ t.due_at ? `, due ${ t.due_at }` : '' }${ t.github_issue ? `, ${ t.github_issue }` : '' }) moved ${ t.last_moved_at }`;
+}
+
+/**
+ * List the operator workboard from Postgres.
+ */
+export class ListWorkItemsWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const kind = String(input.kind || 'task').toLowerCase();
+    const limit = Number(input.limit) || 50;
+    const includeDone = Boolean(input.include_done ?? input.includeDone ?? false);
+    const status = input.status || undefined;
+    const priority = input.priority || undefined;
+    const projectId = input.project_id || undefined;
+    const epicId = input.epic_id || undefined;
+    const parentId = input.parent_id || undefined;
+    const assignee = input.assignee || undefined;
+
+    try {
+      await WorkItemsModel.ensureTables();
+      const lines: string[] = [];
+
+      if (kind === 'project' || kind === 'all') {
+        const rows = await WorkItemsModel.listProjects({ status, priority, includeDone, limit });
+        lines.push(rows.length ? `${ rows.length } project(s):` : 'No projects.');
+        lines.push(...rows.map(fmtProject));
+      }
+      if (kind === 'epic' || kind === 'all') {
+        const rows = await WorkItemsModel.listEpics({ projectId, status, priority, includeDone, limit });
+        if (lines.length) lines.push('');
+        lines.push(rows.length ? `${ rows.length } epic(s):` : 'No epics.');
+        lines.push(...rows.map(fmtEpic));
+      }
+      if (kind === 'task' || kind === 'all') {
+        const rows = await WorkItemsModel.listTasks({
+          projectId, epicId, parentId, status, priority, assignee, includeDone, limit,
+        });
+        if (lines.length) lines.push('');
+        lines.push(rows.length ? `${ rows.length } task(s):` : 'No tasks.');
+        lines.push(...rows.map(fmtTask));
+      }
+      if (!['project', 'epic', 'task', 'all'].includes(kind)) {
+        return { successBoolean: false, responseString: `Unknown kind "${ kind }". Use project, epic, task, or all.` };
+      }
+
+      return { successBoolean: true, responseString: lines.join('\n') };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `List work items failed: ${ err?.message }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/work/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/work/manifests.ts
@@ -1,0 +1,135 @@
+import type { ToolManifest } from '../registry';
+
+/**
+ * Work-item tools — the operator agenda in Postgres.
+ *
+ * Hierarchy: work_projects → work_epics → work_tasks (optional parent_id
+ * for subtasks) + work_task_comments. Distinct from the filesystem
+ * `projects` category (PROJECT.md PRDs). Soft-archive only.
+ */
+export const workItemsToolManifests: ToolManifest[] = [
+  {
+    name:        'list_work_items',
+    description: 'List the operator workboard from Postgres: projects, epics, and/or tasks. Filter by kind, status, priority, project, epic, parent task, or assignee. Default kind=task shows open work ordered by priority then due date then last_moved_at. This is the structured agenda — not the filesystem PROJECT.md PRDs.',
+    category:    'work',
+    schemaDef:   {
+      kind:         { type: 'string', optional: true, description: 'What to list: "project", "epic", "task", or "all" (default "task").' },
+      status:       { type: 'string', optional: true, description: 'Filter by status (e.g. working, should, want, gated, done, cancelled). Omit for all non-archived.' },
+      priority:     { type: 'string', optional: true, description: 'Filter by priority: p0, p1, p2, p3, p4.' },
+      project_id:   { type: 'string', optional: true, description: 'Limit to one project id (applies to epics + tasks).' },
+      epic_id:      { type: 'string', optional: true, description: 'Limit to one epic id (tasks only).' },
+      parent_id:    { type: 'string', optional: true, description: 'Limit to subtasks of this task id.' },
+      assignee:     { type: 'string', optional: true, description: 'Filter tasks by assignee (e.g. heartbeat, sulla-ea, jonathon).' },
+      include_done: { type: 'boolean', optional: true, description: 'When true, include done/cancelled rows. Default false.' },
+      limit:        { type: 'number', optional: true, description: 'Max rows per kind (default 50).' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./list_work_items'),
+  },
+  {
+    name:        'get_work_item',
+    description: 'Fetch one work item by id. Auto-detects project / epic / task. For a project, also returns its epics. For an epic, also returns its tasks. For a task, also returns comments (GitHub-issue style notes) and any subtasks.',
+    category:    'work',
+    schemaDef:   {
+      id:   { type: 'string', description: 'Work-item id (tiny id from list_work_items / upsert_*).' },
+      kind: { type: 'string', optional: true, description: 'Optional hint: "project", "epic", or "task". Omit to search all three.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./get_work_item'),
+  },
+  {
+    name:        'search_work_items',
+    description: 'Keyword search across project / epic / task titles and descriptions. Split into words; any-word ILIKE match, ranked by phrase hit then word-count then recency. Use before creating a new item to avoid duplicates, or to find work related to the current turn.',
+    category:    'work',
+    schemaDef:   {
+      query:            { type: 'string', description: 'Search keyword or phrase.' },
+      kind:             { type: 'string', optional: true, description: 'Limit to "project", "epic", or "task". Omit to search all three.' },
+      limit:            { type: 'number', optional: true, description: 'Max results (default 20).' },
+      include_archived: { type: 'boolean', optional: true, description: 'When true, also search archived rows. Default false.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./search_work_items'),
+  },
+  {
+    name:        'upsert_project',
+    description: 'Create or update a work project (the top of the operator agenda: description, status, priority, due date). Pass id to update in place; otherwise a matching slug is updated instead of creating a duplicate. Distinct from create_project, which writes a filesystem PROJECT.md PRD.',
+    category:    'work',
+    schemaDef:   {
+      id:          { type: 'string', optional: true, description: 'Existing project id to update in place.' },
+      slug:        { type: 'string', optional: true, description: 'Stable slug (e.g. operator-transition). Auto-derived from title when omitted.' },
+      title:       { type: 'string', optional: true, description: 'Short project name. Required when creating.' },
+      description: { type: 'string', optional: true, description: 'What this project is and what done looks like.' },
+      status:      { type: 'string', optional: true, description: 'working | should | want | might | gated | done | cancelled. Default working.' },
+      priority:    { type: 'string', optional: true, description: 'p0 | p1 | p2 | p3 | p4. Default p2.' },
+      owner:       { type: 'string', optional: true, description: 'Who owns the project (e.g. heartbeat, sulla-ea, jonathon).' },
+      due_at:      { type: 'string', optional: true, description: 'ISO due date, or empty string to clear.' },
+      source:      { type: 'string', optional: true, description: 'Optional source label (defaults to "agent").' },
+    },
+    operationTypes: ['create', 'update'],
+    loader:         () => import('./upsert_project'),
+  },
+  {
+    name:        'upsert_epic',
+    description: 'Create or update an epic under a work project. Epics are the major chunks of a project (their own description, status, priority, due date). Pass id to update; otherwise a matching (project_id, slug) is updated.',
+    category:    'work',
+    schemaDef:   {
+      id:          { type: 'string', optional: true, description: 'Existing epic id to update in place.' },
+      project_id:  { type: 'string', optional: true, description: 'Parent project id. Required when creating.' },
+      slug:        { type: 'string', optional: true, description: 'Stable slug inside the project. Auto-derived from title when omitted.' },
+      title:       { type: 'string', optional: true, description: 'Short epic name. Required when creating.' },
+      description: { type: 'string', optional: true, description: 'What this epic delivers.' },
+      status:      { type: 'string', optional: true, description: 'working | should | want | might | gated | done | cancelled. Default working.' },
+      priority:    { type: 'string', optional: true, description: 'p0 | p1 | p2 | p3 | p4. Default p2.' },
+      position:    { type: 'number', optional: true, description: 'Manual sort order inside the project (default 0).' },
+      due_at:      { type: 'string', optional: true, description: 'ISO due date, or empty string to clear.' },
+      source:      { type: 'string', optional: true, description: 'Optional source label (defaults to "agent").' },
+    },
+    operationTypes: ['create', 'update'],
+    loader:         () => import('./upsert_epic'),
+  },
+  {
+    name:        'upsert_task',
+    description: 'Create or update a task (GitHub-issue shaped: title, description, status, priority, due date, assignee, labels, optional github_issue). Pass parent_id to nest a subtask under another task. Pass id to update in place. Moving status/priority/assignee/due_at/parent_id/epic_id stamps last_moved_at so the board can show what actually moved.',
+    category:    'work',
+    schemaDef:   {
+      id:            { type: 'string', optional: true, description: 'Existing task id to update in place.' },
+      epic_id:       { type: 'string', optional: true, description: 'Parent epic id. Required when creating a top-level task.' },
+      parent_id:     { type: 'string', optional: true, description: 'Parent task id when this is a subtask. Empty string clears it.' },
+      title:         { type: 'string', optional: true, description: 'Task title. Required when creating.' },
+      description:   { type: 'string', optional: true, description: 'Issue-style body — what done looks like.' },
+      status:        { type: 'string', optional: true, description: 'working | should | want | might | gated | done | cancelled. Default working.' },
+      priority:      { type: 'string', optional: true, description: 'p0 | p1 | p2 | p3 | p4. Default p2.' },
+      assignee:      { type: 'string', optional: true, description: 'Who is carrying it (heartbeat, sulla-ea, jonathon, or empty to unassign).' },
+      due_at:        { type: 'string', optional: true, description: 'ISO due date, or empty string to clear.' },
+      labels:        { type: 'array', optional: true, description: 'String labels (e.g. ["gate","operator"]). Replaces the full set when provided.' },
+      github_issue:  { type: 'string', optional: true, description: 'Optional owner/repo#n or URL mapping to a GitHub issue.' },
+      position:      { type: 'number', optional: true, description: 'Manual sort order inside the epic (default 0).' },
+      source:        { type: 'string', optional: true, description: 'Optional source label (defaults to "agent").' },
+    },
+    operationTypes: ['create', 'update'],
+    loader:         () => import('./upsert_task'),
+  },
+  {
+    name:        'add_task_comment',
+    description: 'Add a note/comment on a task (GitHub-issue style). Comments are append-only history — they are never edited or hard-deleted. Use this for progress notes, blockers, and decisions; use upsert_task to change status/priority/due date.',
+    category:    'work',
+    schemaDef:   {
+      task_id: { type: 'string', description: 'Task id to comment on.' },
+      body:    { type: 'string', description: 'Comment markdown/text.' },
+      author:  { type: 'string', optional: true, description: 'Who wrote it (defaults to "agent").' },
+    },
+    operationTypes: ['create'],
+    loader:         () => import('./add_task_comment'),
+  },
+  {
+    name:        'archive_work_item',
+    description: 'Soft-archive a project, epic, or task by id. Never hard-deleted. Archiving a project also archives its epics + tasks; archiving an epic also archives its tasks. History stays recoverable via get_work_item / search with include_archived.',
+    category:    'work',
+    schemaDef:   {
+      id:   { type: 'string', description: 'Work-item id to archive.' },
+      kind: { type: 'string', optional: true, description: 'Optional hint: "project", "epic", or "task". Omit to search all three.' },
+    },
+    operationTypes: ['update'],
+    loader:         () => import('./archive_work_item'),
+  },
+];

--- a/pkg/rancher-desktop/agent/tools/work/search_work_items.ts
+++ b/pkg/rancher-desktop/agent/tools/work/search_work_items.ts
@@ -1,0 +1,35 @@
+import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Keyword search across projects, epics, and tasks.
+ */
+export class SearchWorkItemsWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const query = typeof input.query === 'string' ? input.query.trim() : '';
+    if (!query) return { successBoolean: false, responseString: 'query is required.' };
+    const kind = input.kind || undefined;
+    const limit = Number(input.limit) || 20;
+    const includeArchived = Boolean(input.include_archived ?? input.includeArchived ?? false);
+
+    try {
+      await WorkItemsModel.ensureTables();
+      const rows = await WorkItemsModel.search({ query, kind, limit, includeArchived });
+      if (rows.length === 0) {
+        return { successBoolean: true, responseString: `No work items matched "${ query }".` };
+      }
+      const lines = rows.map(r =>
+        `[${ r.kind } ${ r.id }] ${ r.priority } ${ r.status } ${ r.title }${ r.archived ? ' (archived)' : '' }`,
+      );
+      return {
+        successBoolean: true,
+        responseString: `${ rows.length } match(es) for "${ query }":\n${ lines.join('\n') }`,
+      };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Search work items failed: ${ err?.message }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/work/upsert_epic.ts
+++ b/pkg/rancher-desktop/agent/tools/work/upsert_epic.ts
@@ -1,0 +1,67 @@
+import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Create or update an epic under a work project.
+ */
+export class UpsertEpicWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const id = typeof input.id === 'string' ? input.id.trim() : '';
+    const projectId = typeof input.project_id === 'string' ? input.project_id.trim() : '';
+    const title = typeof input.title === 'string' ? input.title.trim() : '';
+    const slug = typeof input.slug === 'string' ? input.slug.trim() : '';
+
+    if (!id && !title) {
+      return { successBoolean: false, responseString: 'title is required to create an epic (or pass id to update).' };
+    }
+    if (!id && !projectId) {
+      return { successBoolean: false, responseString: 'project_id is required to create an epic.' };
+    }
+
+    try {
+      await WorkItemsModel.ensureTables();
+
+      if (id) {
+        const updated = await WorkItemsModel.updateEpic(id, {
+          project_id:  projectId || undefined,
+          slug:        slug || undefined,
+          title:       title || undefined,
+          description: input.description,
+          status:      input.status,
+          priority:    input.priority,
+          position:    input.position,
+          due_at:      input.due_at === '' ? null : input.due_at,
+          source:      input.source,
+        });
+        if (!updated) {
+          return { successBoolean: false, responseString: `No epic found with id: ${ id }` };
+        }
+        return {
+          successBoolean: true,
+          responseString: `Epic updated: "${ updated.title }" (id: ${ updated.id }, project: ${ updated.project_id }, status: ${ updated.status }, priority: ${ updated.priority })`,
+        };
+      }
+
+      const record = await WorkItemsModel.upsertEpic({
+        project_id:  projectId,
+        slug:        slug || undefined,
+        title,
+        description: input.description,
+        status:      input.status,
+        priority:    input.priority,
+        position:    input.position,
+        due_at:      input.due_at === '' ? null : input.due_at,
+        source:      input.source || 'agent',
+      });
+      return {
+        successBoolean: true,
+        responseString: `Epic saved: "${ record.title }" (id: ${ record.id }, project: ${ record.project_id }, status: ${ record.status }, priority: ${ record.priority })`,
+      };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to save epic: ${ err?.message }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/work/upsert_project.ts
+++ b/pkg/rancher-desktop/agent/tools/work/upsert_project.ts
@@ -1,0 +1,61 @@
+import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Create or update a work project (operator agenda, not a filesystem PRD).
+ */
+export class UpsertProjectWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const id = typeof input.id === 'string' ? input.id.trim() : '';
+    const title = typeof input.title === 'string' ? input.title.trim() : '';
+    const slug = typeof input.slug === 'string' ? input.slug.trim() : '';
+
+    if (!id && !title) {
+      return { successBoolean: false, responseString: 'title is required to create a project (or pass id to update).' };
+    }
+
+    try {
+      await WorkItemsModel.ensureTables();
+
+      if (id) {
+        const updated = await WorkItemsModel.updateProject(id, {
+          slug:        slug || undefined,
+          title:       title || undefined,
+          description: input.description,
+          status:      input.status,
+          priority:    input.priority,
+          owner:       input.owner,
+          due_at:      input.due_at === '' ? null : input.due_at,
+          source:      input.source,
+        });
+        if (!updated) {
+          return { successBoolean: false, responseString: `No project found with id: ${ id }` };
+        }
+        return {
+          successBoolean: true,
+          responseString: `Project updated: "${ updated.title }" (id: ${ updated.id }, slug: ${ updated.slug }, status: ${ updated.status }, priority: ${ updated.priority })`,
+        };
+      }
+
+      const record = await WorkItemsModel.upsertProject({
+        slug:        slug || undefined,
+        title,
+        description: input.description,
+        status:      input.status,
+        priority:    input.priority,
+        owner:       input.owner,
+        due_at:      input.due_at === '' ? null : input.due_at,
+        source:      input.source || 'agent',
+      });
+      return {
+        successBoolean: true,
+        responseString: `Project saved: "${ record.title }" (id: ${ record.id }, slug: ${ record.slug }, status: ${ record.status }, priority: ${ record.priority })`,
+      };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to save project: ${ err?.message }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/work/upsert_task.ts
+++ b/pkg/rancher-desktop/agent/tools/work/upsert_task.ts
@@ -1,0 +1,79 @@
+import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Create or update a task (GitHub-issue shaped). parent_id nests a subtask.
+ */
+export class UpsertTaskWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const id = typeof input.id === 'string' ? input.id.trim() : '';
+    const epicId = typeof input.epic_id === 'string' ? input.epic_id.trim() : '';
+    const title = typeof input.title === 'string' ? input.title.trim() : '';
+    const parentRaw = input.parent_id;
+    const parentId = parentRaw === '' ? null
+      : (typeof parentRaw === 'string' ? parentRaw.trim() : undefined);
+
+    if (!id && !title) {
+      return { successBoolean: false, responseString: 'title is required to create a task (or pass id to update).' };
+    }
+    if (!id && !epicId) {
+      return { successBoolean: false, responseString: 'epic_id is required to create a task.' };
+    }
+
+    try {
+      await WorkItemsModel.ensureTables();
+
+      const labels = Array.isArray(input.labels)
+        ? input.labels.map((l: any) => String(l)).filter(Boolean)
+        : undefined;
+
+      if (id) {
+        const updated = await WorkItemsModel.updateTask(id, {
+          epic_id:      epicId || undefined,
+          parent_id:    parentId,
+          title:        title || undefined,
+          description:  input.description,
+          status:       input.status,
+          priority:     input.priority,
+          assignee:     input.assignee === '' ? null : input.assignee,
+          due_at:       input.due_at === '' ? null : input.due_at,
+          labels,
+          github_issue: input.github_issue === '' ? null : input.github_issue,
+          position:     input.position,
+          source:       input.source,
+        });
+        if (!updated) {
+          return { successBoolean: false, responseString: `No task found with id: ${ id }` };
+        }
+        return {
+          successBoolean: true,
+          responseString: `Task updated: "${ updated.title }" (id: ${ updated.id }, status: ${ updated.status }, priority: ${ updated.priority }, last_moved_at: ${ updated.last_moved_at })`,
+        };
+      }
+
+      const record = await WorkItemsModel.insertTask({
+        epic_id:      epicId,
+        parent_id:    typeof parentId === 'string' ? parentId : undefined,
+        title,
+        description:  input.description,
+        status:       input.status,
+        priority:     input.priority,
+        assignee:     input.assignee,
+        due_at:       input.due_at === '' ? null : input.due_at,
+        labels,
+        github_issue: input.github_issue,
+        position:     input.position,
+        source:       input.source || 'agent',
+      });
+      return {
+        successBoolean: true,
+        responseString: `Task created: "${ record.title }" (id: ${ record.id }, epic: ${ record.epic_id }, status: ${ record.status }, priority: ${ record.priority })`,
+      };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to save task: ${ err?.message }` };
+    }
+  }
+}

--- a/resources/sulla-docs/INDEX.md
+++ b/resources/sulla-docs/INDEX.md
@@ -58,6 +58,7 @@ For unfamiliar requests: `grep -rli '<keyword>' <path-to-this-dir>/` to find the
 - `notify.md` — notify_user, presence detection, when (and when not) to notify
 - `settings.md` — SullaSettingsModel is the one settings path; settings_get / settings_set; Redis hash is cache-only
 - `ledger.md` — outcome ledger scoreboard (zero-LLM measurement of WORKING / OUTCOMES / AUDIT)
+- `work.md` — structured work items (projects → epics → tasks → comments) in desktop Postgres; not CRM
 - `calendar.md` — calendar_create/list/update/cancel, scheduler triggers, no GCal sync
 - `applescript.md` — Drive macOS apps via AppleScript; per-app allowlist + macOS Automation perms
 - `computer-use.md` — What's shipped (AppleScript + browser pixel control) vs what's planned (full OS pixel-level)

--- a/resources/sulla-docs/tools/inventory.md
+++ b/resources/sulla-docs/tools/inventory.md
@@ -223,6 +223,19 @@ For `kubectl get`, `kubectl logs`, etc. → workaround via `rdctl_shell`.
 
 → The ledger itself is files under `~/sulla/ledger/` (LEDGER.md / OUTCOMES.md / AUDIT.md / goals/).
 
+## work — structured projects / epics / tasks (8 tools)
+- `sulla work/list_work_items` — Board: filter by kind / status / priority / bucket / project / epic
+- `sulla work/get_work_item` — One project, epic, or task + children + comments
+- `sulla work/search_work_items` — Title + description search
+- `sulla work/upsert_project` — Create or update a project (outcome + metric + bucket)
+- `sulla work/upsert_epic` — Create or update an epic under a project
+- `sulla work/upsert_task` — Create or update a task (set parent_task_id for a subtask; optional github_issue)
+- `sulla work/add_task_comment` — Append a note on a task
+- `sulla work/archive_work_item` — Soft-delete a project, epic, or task
+
+→ See [`tools/work.md`](work.md). Files under `~/sulla/ledger/` stay the human-readable agenda; these tables are the structured store. Not CRM.
+
+
 ## pg — PostgreSQL queries (6 tools)
 - `sulla pg/pg_query` — SELECT, all rows
 - `sulla pg/pg_queryall` — SELECT, all rows (explicit)

--- a/resources/sulla-docs/tools/ledger.md
+++ b/resources/sulla-docs/tools/ledger.md
@@ -24,3 +24,15 @@ The ledger files themselves are maintained by the observation writer (post-turn)
 ```
 
 Scaffolded at boot if missing (template-only, never overwrites user content, no user data in shipped code).
+
+## Structured store (migration 0044)
+
+`LEDGER.md` is still the pick-path. The structured ending of "what exists,
+what stage, what priority, when it last moved" lives in Postgres:
+
+`work_projects` → `work_epics` → `work_tasks` → `work_task_comments`
+
+See [`tools/work.md`](work.md). A runtime seeder imports this install's
+`~/sulla/ledger/goals/*.md` on first boot. After that, prefer the work
+tools over inventing a second markdown task list.
+

--- a/resources/sulla-docs/tools/pg.md
+++ b/resources/sulla-docs/tools/pg.md
@@ -1,6 +1,6 @@
 # PostgreSQL
 
-Sulla's primary data store. Container `sulla_postgres` on port **30116** (host) inside Lima. 16 tables across workflow execution, calendar, chat, settings, and credentials. **Critical safety section below — some tables will corrupt Sulla if you write to them directly.**
+Sulla's primary data store. Container `sulla_postgres` on port **30116** (host) inside Lima. Workflow, calendar, chat, settings, credentials, observations, rules, and work items. **Critical safety section below — some tables will corrupt Sulla if you write to them directly.**
 
 ## Connection
 
@@ -34,7 +34,7 @@ sulla pg/pg_queryall '{
 ```
 Params are typed `string[]` in manifests but `pg.Pool` coerces to the column type at bind.
 
-## Tables (verified live — 18 tables)
+## Tables (verified live — plus work items from migration 0044)
 
 | Table | Purpose | Safe to read? | Safe to write? |
 |-------|---------|---------------|----------------|
@@ -56,6 +56,10 @@ Params are typed `string[]` in manifests but `pg.Pool` coerces to the column typ
 | `knowledgebase_categories` | KB category taxonomy | ✅ | ⚠️ via KB UI |
 | `sulla_migrations` | Migration tracking (infrastructure) | ✅ debug | ❌ App-owned |
 | `sulla_seeders` | Seed data tracking (infrastructure) | ✅ debug | ❌ App-owned |
+| `work_projects` | Operator projects (outcome + metric + bucket) | ✅ | ⚠️ Use work tools, not raw SQL |
+| `work_epics` | Epics under a project | ✅ | ⚠️ Use work tools |
+| `work_tasks` | Tasks / subtasks (parent_task_id) under an epic | ✅ | ⚠️ Use work tools |
+| `work_task_comments` | Notes on a task (GitHub-issue style) | ✅ | ⚠️ Use `add_task_comment` |
 
 ## Schemas of the tables you'll query most
 
@@ -180,3 +184,34 @@ If you've genuinely thought it through and the dedicated tool can't do what you 
 - Pool config: `pkg/rancher-desktop/agent/database/PostgresClient.ts:23-28`
 - Migrations: `pkg/rancher-desktop/agent/database/migrations/`
 - Models (preferred over raw SQL): `pkg/rancher-desktop/agent/database/models/`
+
+### `work_projects` / `work_epics` / `work_tasks` / `work_task_comments` (migration 0044)
+
+Schema-only. Soft-archive, never hard-delete. `last_moved_at` updates on
+status/priority/bucket/assignee/due-date changes.
+
+```
+work_projects
+  id TEXT PK · slug UNIQUE · title · description · outcome_metric
+  status · priority · bucket · source · source_ref
+  created_at · updated_at · last_moved_at · archived
+
+work_epics
+  id TEXT PK · project_id FK work_projects(id) ON DELETE RESTRICT
+  title · description · status · priority · position · source_ref
+  created_at · updated_at · last_moved_at · archived
+
+work_tasks
+  id TEXT PK · epic_id FK work_epics(id) ON DELETE RESTRICT
+  parent_task_id FK work_tasks(id) ON DELETE RESTRICT  -- NULL = task
+  title · description · status · priority · position
+  due_at · assignee · github_owner · github_repo · github_issue
+  source_ref · created_at · updated_at · last_moved_at · archived
+
+work_task_comments
+  id TEXT PK · task_id FK work_tasks(id) ON DELETE CASCADE
+  author · body · created_at · updated_at · archived
+```
+
+Not CRM. Do not write these with raw `pg_execute` — use the `work/*` tools.
+

--- a/resources/sulla-docs/tools/work.md
+++ b/resources/sulla-docs/tools/work.md
@@ -1,0 +1,64 @@
+# Work items — projects, epics, tasks, comments
+
+The desktop Postgres database is the structured work store. Files under
+`~/sulla/ledger/` stay the human-readable agenda (LEDGER.md pick-path,
+OUTCOMES.md, AUDIT.md). The tables answer: what exists, what stage, what
+priority, when it last moved, what's due, what's blocked.
+
+This is **not CRM**. CRM lives in Sulla Cloud. These four tables are
+operator work only.
+
+Filesystem PRDs (`~/sulla/projects/<slug>/PROJECT.md`, `create_project`)
+are a different thing — product specs. Do not confuse them with work
+projects.
+
+## Hierarchy
+
+```
+work_projects          one outcome with a metric
+  └── work_epics       major chunk of a project
+        └── work_tasks parent_task_id NULL = task, set = subtask
+              └── work_task_comments  notes (GitHub-issue style)
+```
+
+## Status / priority / bucket
+
+| Field | Allowed values |
+|---|---|
+| `status` | `backlog` · `todo` · `in_progress` · `blocked` · `done` · `cancelled` |
+| `priority` | `critical` · `high` · `medium` · `low` |
+| `bucket` (projects only) | `WORKING` · `SHOULD` · `WANT` · `MIGHT` · `DONE` |
+
+Rows are **never hard-deleted**. `archive_*` sets `archived=true`.
+`last_moved_at` updates on every status/priority/bucket/assignee/due-date
+change so staleness is queryable (7-day WORKING rule).
+
+## Tools (bare names — slash paths misroute)
+
+| Tool | Use |
+|---|---|
+| `sulla list_work_items '{}'` | Board: filter by `kind` / `status` / `priority` / `bucket` / `project_id` / `epic_id` / `parent_task_id`. |
+| `sulla get_work_item '{"id":"…"}'` | One row + children + comments. |
+| `sulla search_work_items '{"query":"wake"}'` | Title + description search. |
+| `sulla upsert_project '{"title":"…","description":"…"}'` | Create / update a project. Pass `id` to update. |
+| `sulla upsert_epic '{"project_id":"…","title":"…"}'` | Create / update an epic. |
+| `sulla upsert_task '{"epic_id":"…","title":"…"}'` | Create / update a task. Set `parent_task_id` for a subtask. Optional `github_issue`. |
+| `sulla add_task_comment '{"task_id":"…","body":"…"}'` | Append a note. |
+| `sulla archive_work_item '{"id":"…"}'` | Soft-delete. |
+
+Schema-only migration `0044_create_work_items_tables`. No user data in
+the migration. A runtime seeder (`WorkItemsImportSeeder`, registered as
+`work-items-import-seeder`) reads THIS install's
+`~/sulla/ledger/goals/*.md` on first boot and upserts by stable slug
+(`goal-<file>` / `epic-<file>-<n>` / `task-<file>-<n>-<m>`). Safe to re-run.
+
+Optional GitHub mapping on tasks: `github_owner` / `github_repo` /
+`github_issue`. Not a live sync in this pass.
+
+## Do not
+
+- Do not invent a parallel markdown task list once the tables exist.
+- Do not write these tables with raw `pg_execute` — use the tools.
+- Do not put CRM records, contacts, or deals here.
+- Do not drop the leftover `crm_*` tables without Jonathon — they are
+  a wrong-build remnant, not this schema.


### PR DESCRIPTION
## Why

Heartbeat pick-path (2026-08-14): finish the dirty `feat/work-items-schema` worktree so the operator workboard has a 4-table model the tools already call. This is the operator agenda in Postgres — not CRM, not filesystem PROJECT.md PRDs.

## What

- Schema-only migration `0044_create_work_items_tables` (`work_projects` → `work_epics` → `work_tasks` + `parent_id` subtask → `work_task_comments`). Soft-archive only.
- Rewrite `WorkItemsModel` from leftover single-table `work_items` / `work_item_comments` to the 4-table API: `ensureTables`, `upsertProject` / `upsertEpic` / `upsertTask`, `addComment({task_id})`, `archive(kind, id)`, get/list/search per kind. Tiny IDs, never hard-delete.
- 8 `tools/work/` workers + `workItemsToolManifests` export (registry already imported that name).
- Runtime `WorkItemsImportSeeder` reads THIS install `~/sulla/ledger/goals/*.md`. Deleted leftover `WorkItemsLedgerImportSeeder`.
- Docs: `tools/work.md` + inventory / ledger / pg rows.

## Not in this PR

- No merge of #557 (`feat/heartbeat-wake-resume`). That checkout was not touched.
- No rebuild, no `heartbeatEnabled` flip, no raw Redis `sulla_settings` writes.
- No live migration run (schema-only; seeder is first-boot).

## Verify

Isolated `tsc --noEmit --pretty false` on the new files: no errors. Full `just tsc` needs Lima (not available in this heartbeat VM) — run after review.