### PR TITLE
fix(spawn_agent): keep options.abort as AbortService when combining job stop

### DIFF
--- a/pkg/rancher-desktop/agent/services/AbortService.ts
+++ b/pkg/rancher-desktop/agent/services/AbortService.ts
@@ -68,6 +68,79 @@ export class AbortService {
   }
 }
 
+
+/**
+ * True when `value` is a real AbortSignal. Duck-typed so jsdom/Node both work.
+ */
+export function isAbortSignal(value: unknown): value is AbortSignal {
+  return !!value &&
+    typeof value === 'object' &&
+    typeof (value as AbortSignal).aborted === 'boolean' &&
+    typeof (value as AbortSignal).addEventListener === 'function' &&
+    !('signal' in (value as object) && typeof (value as { signal?: unknown }).signal === 'object');
+}
+
+export type AbortSource = AbortService | AbortSignal | undefined | null;
+
+function sourceSignal(src: AbortService | AbortSignal): AbortSignal {
+  return src instanceof AbortService ? src.signal : src;
+}
+
+/**
+ * Combine parent-stop + job-stop into one AbortService.
+ *
+ * `metadata.options.abort` is typed and consumed as AbortService
+ * (`abort.signal`, `throwIfAborted` → `abort?.signal`). The 2026-07-15
+ * spawn_agent change stuffed a raw AbortSignal (or AbortSignal.any()) into
+ * that slot. Two fallout modes:
+ *   1. Parent is AbortService + job is AbortSignal → AbortSignal.any throws
+ *      `signals[0] must be AbortSignal` and the sub-agent never starts.
+ *   2. Only the job signal is present → raw AbortSignal is assigned, and
+ *      throwIfAborted silently no-ops because `signal.signal` is undefined.
+ *
+ * Returns the sole AbortService when that's the only source (preserves
+ * onAbort callbacks). Otherwise wraps any-of-the-signals in a fresh
+ * AbortService so consumers keep their contract.
+ */
+export function combineAborts(...sources: AbortSource[]): AbortService | undefined {
+  const services: AbortService[] = [];
+  const signals: AbortSignal[] = [];
+
+  for (const src of sources) {
+    if (!src) continue;
+    if (src instanceof AbortService) {
+      services.push(src);
+      signals.push(src.signal);
+      continue;
+    }
+    if (isAbortSignal(src)) {
+      signals.push(src);
+      continue;
+    }
+    const maybe = (src as { signal?: unknown }).signal;
+    if (isAbortSignal(maybe)) {
+      signals.push(maybe);
+    }
+  }
+
+  if (signals.length === 0) return undefined;
+  if (signals.length === 1 && services.length === 1) return services[0];
+
+  const combined = new AbortService();
+  const fanIn = () => combined.abort();
+
+  for (const sig of signals) {
+    if (sig.aborted) {
+      combined.abort();
+
+      return combined;
+    }
+    sig.addEventListener('abort', fanIn, { once: true });
+  }
+
+  return combined;
+}
+
 /**
  * Portable function to check abort signal and throw AbortError if triggered.
  * Use this to immediately stop execution when abort is detected.
@@ -79,10 +152,12 @@ export class AbortService {
 export function throwIfAborted(stateOrSignal?: any | AbortSignal, message?: string): void {
   let signal: AbortSignal | undefined;
 
-  // If it's a state object, extract the abort signal from options.abort
+  // If it's a state object, extract the abort signal from options.abort.
+  // Accept either AbortService (the contract) or a raw AbortSignal (legacy
+  // spawn_agent assigned those; combineAborts no longer does).
   if (stateOrSignal && typeof stateOrSignal === 'object' && stateOrSignal.metadata) {
     const abort = stateOrSignal.metadata?.options?.abort;
-    signal = abort?.signal;
+    signal = isAbortSignal(abort) ? abort : abort?.signal;
   } else {
     // Assume it's already an AbortSignal
     signal = stateOrSignal;

--- a/pkg/rancher-desktop/agent/services/__tests__/AbortService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/AbortService.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  AbortService,
+  combineAborts,
+  isAbortSignal,
+  throwIfAborted,
+} from '../AbortService';
+
+describe('combineAborts', () => {
+  it('returns undefined when no sources are present', () => {
+    expect(combineAborts()).toBeUndefined();
+    expect(combineAborts(undefined, null)).toBeUndefined();
+  });
+
+  it('returns the same AbortService when it is the only source', () => {
+    const parent = new AbortService();
+
+    expect(combineAborts(parent)).toBe(parent);
+    expect(combineAborts(parent, undefined)).toBe(parent);
+  });
+
+  it('wraps a lone AbortSignal in an AbortService so throwIfAborted can read .signal', () => {
+    const job = new AbortController();
+    const combined = combineAborts(undefined, job.signal);
+
+    expect(combined).toBeInstanceOf(AbortService);
+    expect(combined?.aborted).toBe(false);
+
+    job.abort();
+    expect(combined?.aborted).toBe(true);
+  });
+
+  it('does not throw when combining AbortService + AbortSignal (the spawn_agent bug)', () => {
+    const parent = new AbortService();
+    const job = new AbortController();
+
+    // Regression: AbortSignal.any([parent, job.signal]) threw
+    // TypeError: Failed to execute 'any' on 'AbortSignal':
+    // Failed to convert value to 'AbortSignal'.
+    let combined: AbortService | undefined;
+
+    expect(() => {
+      combined = combineAborts(parent, job.signal);
+    }).not.toThrow();
+
+    expect(combined).toBeInstanceOf(AbortService);
+    expect(combined).not.toBe(parent);
+    expect(combined?.aborted).toBe(false);
+  });
+
+  it('aborts the combined service when the parent AbortService aborts', () => {
+    const parent = new AbortService();
+    const job = new AbortController();
+    const combined = combineAborts(parent, job.signal);
+
+    parent.abort();
+    expect(combined?.aborted).toBe(true);
+  });
+
+  it('aborts the combined service when the job signal aborts', () => {
+    const parent = new AbortService();
+    const job = new AbortController();
+    const combined = combineAborts(parent, job.signal);
+
+    job.abort();
+    expect(combined?.aborted).toBe(true);
+  });
+
+  it('starts already-aborted when a source is already aborted', () => {
+    const parent = new AbortService();
+
+    parent.abort();
+    const combined = combineAborts(parent, new AbortController().signal);
+
+    expect(combined?.aborted).toBe(true);
+  });
+});
+
+describe('isAbortSignal', () => {
+  it('accepts a real AbortSignal and rejects AbortService', () => {
+    expect(isAbortSignal(new AbortController().signal)).toBe(true);
+    expect(isAbortSignal(new AbortService())).toBe(false);
+    expect(isAbortSignal(undefined)).toBe(false);
+    expect(isAbortSignal({})).toBe(false);
+  });
+});
+
+describe('throwIfAborted', () => {
+  it('throws when state.metadata.options.abort is an aborted AbortService', () => {
+    const abort = new AbortService();
+
+    abort.abort();
+    const state = { metadata: { options: { abort } } };
+
+    expect(() => throwIfAborted(state, 'stopped')).toThrow(/stopped/);
+  });
+
+  it('throws when state.metadata.options.abort is an aborted raw AbortSignal (legacy)', () => {
+    const ctl = new AbortController();
+
+    ctl.abort();
+    const state = { metadata: { options: { abort: ctl.signal } } };
+
+    expect(() => throwIfAborted(state, 'stopped')).toThrow(/stopped/);
+  });
+
+  it('does not throw when abort is live', () => {
+    const state = { metadata: { options: { abort: new AbortService() } } };
+
+    expect(() => throwIfAborted(state)).not.toThrow();
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
@@ -1,6 +1,7 @@
 import { BaseTool, ToolResponse } from '../base';
 import { createJob, completeJob, failJob, getJobAbortSignal } from './jobRegistry';
 import { getWebSocketClientService } from '../../services/WebSocketClientService';
+import { combineAborts } from '../../services/AbortService';
 import { findAgentDir } from '../../utils/sullaPaths';
 
 import type { AgentJobResult } from './jobRegistry';
@@ -116,17 +117,19 @@ export class SpawnAgentWorker extends BaseTool {
         subState.metadata.subAgentDepth = parentDepth + 1;
         subState.metadata.workflowParentChannel = parentChannel;
 
-        // Propagate abort signals so both the user's stop button (parent abort)
+        // Propagate abort so both the user's stop button (parent AbortService)
         // AND stop_agent_job(jobId) (this job's signal) reach the sub-agents.
-        const parentAbort: AbortSignal | undefined = (this.state as any)?.metadata?.options?.abort;
-        const signals = [parentAbort, jobAbortSignal].filter(Boolean) as AbortSignal[];
-        if (signals.length) {
+        // options.abort is typed AbortService everywhere else (Graph / BaseNode /
+        // throwIfAborted). The 2026-07-15 wiring treated it as AbortSignal and
+        // called AbortSignal.any([AbortService, jobSignal]) — TypeError:
+        // "signals[0] must be AbortSignal". Keep the contract: always write
+        // an AbortService that fans out from whichever sources exist.
+        const parentAbort = (this.state as any)?.metadata?.options?.abort;
+        const combined = combineAborts(parentAbort, jobAbortSignal);
+
+        if (combined) {
           subState.metadata.options ??= {};
-          // AbortSignal.any (Node 20+) fires when EITHER source aborts; fall back
-          // to the single signal if only one is present.
-          subState.metadata.options.abort = signals.length === 1
-            ? signals[0]
-            : (AbortSignal as any).any(signals);
+          subState.metadata.options.abort = combined;
         }
 
         // Register this threadId on the parent so user-abort fans out to it


### PR DESCRIPTION
## Why

Async `spawn_agent` treated `metadata.options.abort` as an `AbortSignal` and called `AbortSignal.any([parentAbort, jobSignal])`. Parent abort is an **AbortService** (`Graph.ts` contract — `options.abort?: AbortService`). Node/Electron then threw:

```
TypeError: Failed to execute 'any' on 'AbortSignal': Failed to convert value to 'AbortSignal'.
```

(`signals[0] must be AbortSignal` in some runtimes.) The sub-agent never started. This is the live blocker on Epic 1 parent-graph wake verification.

Introduced 2026-07-15 in `24f288524` (`feat(agents): add stop_agent_job`).

## What

- `combineAborts(...sources)` in `AbortService.ts` fans parent-stop + job-stop into an **AbortService** so `throwIfAborted` / `BaseNode` keep reading `.signal`.
- Lone AbortService is returned as-is (preserves `onAbort` callbacks).
- Lone job `AbortSignal` is wrapped so `throwIfAborted` no longer silently no-ops (`signal.signal` was undefined).
- `spawn_agent` writes the combined AbortService; no more `AbortSignal.any`.
- `throwIfAborted` also accepts a leftover raw AbortSignal (legacy safety).

## Verify

```
yarn test:unit:jest pkg/rancher-desktop/agent/services/__tests__/AbortService.test.ts
```

11/11 green, including the TypeError regression and both abort sources (parent AbortService, job signal, already-aborted).

Did **not** rebuild or restart — Jonathon's `just build` / session is untouched. Live-QA of Epic 1 wake still waits on this landing + a restart.

## Rollback

Revert this PR. `spawn_agent` goes back to the throwing path; stop_agent_job still exists but still cannot combine with parent stop.