### PR TITLE
fix(settings): make bootstrap fail loud, not silent (dual-store heartbeatEnabled #1)

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/SullaSettingsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/SullaSettingsModel.ts
@@ -139,13 +139,28 @@ export class SullaSettingsModel extends BaseModel<SettingsAttributes> {
 
   private static isReady = false;
 
+  // Retry policy for bootstrap (overridable in tests).
+  // Delay before retry N (1-indexed) = min(baseDelayMs * 2^(N-1), maxDelayMs).
+  public static bootstrapMaxAttempts = 5;
+  public static bootstrapBaseDelayMs = 500;
+  public static bootstrapMaxDelayMs = 8000;
+
   // ──────────────────────────────────────────────
   // Bootstrap: sync fallback → real backends
   // Call once after PG + Redis are confirmed ready
   // ──────────────────────────────────────────────
 
   /**
-   * Full bootstrap: call when DBs are ready
+   * Full bootstrap: call when DBs are ready.
+   *
+   * Fails LOUD, not silent. A transient PG/Redis unavailability during the
+   * restart window used to leave `isReady=false` forever with the error
+   * swallowed, so every later read (e.g. `heartbeatEnabled`) silently fell
+   * back to the caller default (`false`) while PG/Redis still held `true` —
+   * the operator quietly turned itself off. We now retry with backoff and, if
+   * every attempt fails, THROW so the `database-manager` lifecycle gate fails
+   * visibly instead of the heartbeat reading defaults. See
+   * `~/sulla/projects/dual-store-heartbeat-trace.md`.
    *
    * @returns
    */
@@ -155,35 +170,64 @@ export class SullaSettingsModel extends BaseModel<SettingsAttributes> {
       throw new Error('Installation lock file not set for bootstrap');
     }
 
-    try {
-      console.log('SullaSettingsModel: full bootstrap starting');
+    const maxAttempts = Math.max(1, this.bootstrapMaxAttempts);
+    let lastErr: unknown = null;
 
-      // PG → Redis
-      // now that the system is ready we can write to persistent storage
-      await this.initialize();
-      this.isReady = true;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        console.log(`SullaSettingsModel: full bootstrap starting (attempt ${ attempt }/${ maxAttempts })`);
 
-      if (!(await this.getSetting('sullaInstalled', false))) {
-        // Read from installation lock file and sync to persistent storage
-        try {
-          const content = await fs.readFile(this.getFallbackFilePath(), 'utf8');
-          const data = JSON.parse(content) as Record<string, any>;
-          for (const [property, value] of Object.entries(data)) {
-            await this.setSetting(property, value);
+        // PG → Redis
+        // now that the system is ready we can write to persistent storage
+        await this.initialize();
+        this.isReady = true;
+
+        if (!(await this.getSetting('sullaInstalled', false))) {
+          // Read from installation lock file and sync to persistent storage
+          try {
+            const content = await fs.readFile(this.getFallbackFilePath(), 'utf8');
+            const data = JSON.parse(content) as Record<string, any>;
+            for (const [property, value] of Object.entries(data)) {
+              await this.setSetting(property, value);
+            }
+            console.log(`SullaSettingsModel: synced ${ Object.keys(data).length } settings from lock file`);
+          } catch (err) {
+            console.log('SullaSettingsModel: no lock file to sync or error reading:', err);
           }
-          console.log(`SullaSettingsModel: synced ${ Object.keys(data).length } settings from lock file`);
-        } catch (err) {
-          console.log('SullaSettingsModel: no lock file to sync or error reading:', err);
+
+          await this.setSetting('sullaInstalled', true, 'boolean');
+
+          // do not delete the fallback file. it acts as our installation lock file
+          console.log('SullaSettingsModel: full bootstrap complete');
         }
 
-        await this.setSetting('sullaInstalled', true, 'boolean');
+        return; // success
+      } catch (err) {
+        lastErr = err;
+        // A failure mid-bootstrap must NOT leave a half-ready process reading
+        // stale/default values — force a clean retry from the top.
+        this.isReady = false;
 
-        // do not delete the fallback file. it acts as our installation lock file
-        console.log('SullaSettingsModel: full bootstrap complete');
+        const delayMs = Math.min(this.bootstrapBaseDelayMs * 2 ** (attempt - 1), this.bootstrapMaxDelayMs);
+        console.error(
+          `SullaSettingsModel: bootstrap attempt ${ attempt }/${ maxAttempts } failed` +
+          (attempt < maxAttempts ? `; retrying in ${ delayMs }ms` : ''),
+          err,
+        );
+        if (attempt < maxAttempts) {
+          await new Promise(resolve => setTimeout(resolve, delayMs));
+        }
       }
-    } catch (err) {
-      console.error('SullaSettingsModel: bootstrap is not ready yet. Try again later');
     }
+
+    // All attempts exhausted — fail LOUD so the lifecycle gate fails visibly
+    // instead of the heartbeat silently reading default-`false` forever.
+    throw new Error(
+      `SullaSettingsModel: bootstrap failed after ${ maxAttempts } attempts — settings backends ` +
+      '(PostgreSQL/Redis) did not become ready. Refusing to run with silent file-fallback ' +
+      'defaults for critical flags (e.g. heartbeatEnabled). Last error: ' +
+      `${ lastErr instanceof Error ? lastErr.message : String(lastErr) }`,
+    );
   }
 
   // ──────────────────────────────────────────────

--- a/pkg/rancher-desktop/agent/database/models/__tests__/SullaSettingsModel.bootstrap.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/SullaSettingsModel.bootstrap.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression test for the dual-store `heartbeatEnabled` flip-false bug.
+ *
+ * Root cause (see ~/sulla/projects/dual-store-heartbeat-trace.md): a single
+ * transient PG/Redis unavailability during a restart made `bootstrap()` throw,
+ * which was swallowed, leaving `isReady=false` for the whole process. Every
+ * later read then silently fell back to the caller default (`heartbeatEnabled`
+ * → `false`) while PG/Redis still held `true` — the operator quietly disabled
+ * itself.
+ *
+ * The fix: retry with backoff, and if every attempt fails, THROW so the
+ * `database-manager` lifecycle gate fails loudly instead of the heartbeat
+ * silently reading defaults.
+ */
+
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+import { SullaSettingsModel } from '../SullaSettingsModel';
+
+describe('SullaSettingsModel.bootstrap — fail loud, not silent', () => {
+  let initializeSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    // Reset the per-process static readiness flag between tests.
+    (SullaSettingsModel as any).isReady = false;
+    // Bootstrap requires an installation lock file path to be set.
+    SullaSettingsModel.setFallbackFilePath('/tmp/sulla-bootstrap-test-settings.json');
+
+    // Fast retries so the exhaustion path does not sleep for seconds.
+    SullaSettingsModel.bootstrapMaxAttempts = 3;
+    SullaSettingsModel.bootstrapBaseDelayMs = 1;
+    SullaSettingsModel.bootstrapMaxDelayMs = 1;
+
+    // Treat the install as already done so bootstrap skips the file-sync block
+    // and we exercise only the initialize()/readiness path under test.
+    jest.spyOn(SullaSettingsModel, 'getSetting').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (SullaSettingsModel as any).isReady = false;
+  });
+
+  test('retries a transient failure and eventually succeeds → isReady=true', async() => {
+    // Fail the first two attempts (backends slow to accept connections), then succeed.
+    initializeSpy = jest.spyOn(SullaSettingsModel, 'initialize')
+      .mockRejectedValueOnce(new Error('ECONNREFUSED redis'))
+      .mockRejectedValueOnce(new Error('ECONNREFUSED postgres'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(SullaSettingsModel.bootstrap()).resolves.toBeUndefined();
+
+    expect(initializeSpy).toHaveBeenCalledTimes(3);
+    expect((SullaSettingsModel as any).isReady).toBe(true);
+  });
+
+  test('throws loudly after exhausting all attempts, and leaves isReady=false', async() => {
+    // Every attempt fails — the old code swallowed this and left isReady=false silently.
+    initializeSpy = jest.spyOn(SullaSettingsModel, 'initialize')
+      .mockRejectedValue(new Error('ECONNREFUSED postgres'));
+
+    await expect(SullaSettingsModel.bootstrap())
+      .rejects.toThrow(/bootstrap failed after 3 attempts/i);
+
+    expect(initializeSpy).toHaveBeenCalledTimes(3);
+    // Critical: a failed bootstrap must NOT leave a half-ready process that
+    // would read default-`false` for heartbeatEnabled.
+    expect((SullaSettingsModel as any).isReady).toBe(false);
+  });
+
+  test('is idempotent — a second call after success does not re-initialize', async() => {
+    initializeSpy = jest.spyOn(SullaSettingsModel, 'initialize').mockResolvedValue(undefined);
+
+    await SullaSettingsModel.bootstrap();
+    await SullaSettingsModel.bootstrap();
+
+    expect(initializeSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Why

Fix #1 (highest-leverage) from the dual-store `heartbeatEnabled` flip-false trace (`~/sulla/projects/dual-store-heartbeat-trace.md`).

**Root cause:** a single transient PG/Redis unavailability during a rebuild/restart made `SullaSettingsModel.bootstrap()` throw. The error was **swallowed** (logged only), leaving the per-process `isReady=false` forever. Every later read then silently fell back to the caller default — `HeartbeatService.get('heartbeatEnabled', false)` resolved to **`false`** while PG/Redis still held `true`. The operator quietly turned itself off, no error surfaced. This matches the recurring symptom in memory `2PA7`.

## What

- `bootstrap()` now **retries `initialize()` with exponential backoff**, and if every attempt fails it **throws** instead of swallowing.
- The authoritative caller — `DatabaseManager.initialize()` (main process) — does **not** catch it, so the `database-manager` lifecycle gate fails **visibly** rather than the heartbeat silently reading defaults. The renderer caller (`sulla.ts initiateWindowContext`) still swallows, which is harmless (it proxies get/set to main via IPC).
- A mid-bootstrap failure now resets `isReady=false` before retrying, so a half-ready process can never serve stale/default values.
- Retry policy is exposed as static fields (`bootstrapMaxAttempts` / `bootstrapBaseDelayMs` / `bootstrapMaxDelayMs`) so tests drive it fast.

## Tests

New `SullaSettingsModel.bootstrap.test.ts` (jest, no live PG/Redis needed — spies on `initialize`/`getSetting`):
1. retries a transient failure and **eventually succeeds** → `isReady=true`
2. **throws loudly** after exhausting all attempts, and leaves `isReady=false`
3. idempotent — a second call after success does not re-initialize

Local run: **3/3 pass**; existing `SullaSettingsModel.simple.test.ts` **2/2 still pass**. Diff is scoped to the `bootstrap()` region + the new test. (Two pre-existing `no-case-declarations` lint errors at lines 98–99 in `castValue` are on `main`, unrelated to this change — left untouched to keep the diff tight.)

## ⚠️ Gate

**Do NOT merge without Jonathon.** Touches settings/boot. No rebuild/restart performed; the running binary is unchanged. Staged for review per the standing "never lose work → draft PR" policy. `heartbeatEnabled` was never flipped.

Remaining trace fixes #2–#4 (distinguish pre-DB vs DB-errored-after-ready; seed fallback JSON at install; remove the unread `config/settings.ts heartbeatEnabled`) are follow-ups, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
