### PR TITLE
refactor(agents): extract shared sub-agent turn-outcome reader

### DIFF
--- a/pkg/rancher-desktop/agent/tools/agents/__tests__/agentTurnOutcome.test.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/__tests__/agentTurnOutcome.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { extractAgentTurnOutcome } from '../agentTurnOutcome';
+
+describe('extractAgentTurnOutcome', () => {
+  it('reports blocked with reason and requirements', () => {
+    const out = extractAgentTurnOutcome({
+      metadata: {
+        agent: {
+          status:                'BLOCKED',
+          blocker_reason:        'needs credential',
+          unblock_requirements:  'GITHUB_TOKEN',
+        },
+      },
+    });
+
+    expect(out.status).toBe('blocked');
+    expect(out.text).toBe('[BLOCKED] needs credential | Requirements: GITHUB_TOKEN');
+  });
+
+  it('reports blocked with a default reason and no requirements clause', () => {
+    const out = extractAgentTurnOutcome({ metadata: { agent: { status: 'blocked' } } });
+
+    expect(out.status).toBe('blocked');
+    expect(out.text).toBe('[BLOCKED] Unknown blocker');
+  });
+
+  it('prefers finalSummary for completed turns', () => {
+    const out = extractAgentTurnOutcome({
+      metadata: {
+        finalSummary: 'all done',
+        agent:        { status: 'completed' },
+      },
+      messages: [{ role: 'assistant', content: 'ignored last message' }],
+    });
+
+    expect(out.status).toBe('completed');
+    expect(out.text).toBe('all done');
+  });
+
+  it('falls back to the last message content when there is no finalSummary', () => {
+    const out = extractAgentTurnOutcome({
+      metadata: {},
+      messages: [
+        { role: 'user',      content: 'do the thing' },
+        { role: 'assistant', content: 'the result' },
+      ],
+    });
+
+    expect(out.status).toBe('completed');
+    expect(out.text).toBe('the result');
+  });
+
+  it('falls back to (no output) when neither summary nor messages exist', () => {
+    const out = extractAgentTurnOutcome({ metadata: {}, messages: [] });
+
+    expect(out.status).toBe('completed');
+    expect(out.text).toBe('(no output)');
+  });
+
+  it('stringifies non-string message content', () => {
+    const payload = { foo: 'bar' };
+    const out = extractAgentTurnOutcome({
+      metadata: {},
+      messages: [{ role: 'assistant', content: payload }],
+    });
+
+    expect(out.status).toBe('completed');
+    expect(out.text).toBe(JSON.stringify(payload));
+  });
+
+  it('tolerates a bare/empty state', () => {
+    expect(extractAgentTurnOutcome({}).text).toBe('(no output)');
+    expect(extractAgentTurnOutcome(undefined).text).toBe('(no output)');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/agents/agentTurnOutcome.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/agentTurnOutcome.ts
@@ -1,0 +1,49 @@
+/**
+ * Canonical reader for a finished sub-agent graph state.
+ *
+ * After `graph.execute(subState)` returns, both delegation paths derived the
+ * same reply the same way — a blocked-status branch, then a
+ * finalSummary → last-message → '(no output)' fallback chain. That logic lived
+ * in two places (`conversationRunner.runConversationTurn` for persistent
+ * multi-turn conversations, `spawn_agent.executeSingle` for fire-and-forget
+ * jobs) and had to be kept byte-identical by hand. This is the single source of
+ * truth both call.
+ *
+ * Pure function of `finalState` — it does not touch the graph, the abort
+ * service, or the synchronous multi-turn contract. It only turns a settled
+ * state into `{ status, text }`; each caller maps that onto its own result
+ * shape (TurnResult vs AgentJobResult).
+ */
+
+export interface AgentTurnOutcome {
+  status: 'completed' | 'blocked';
+  text:   string;
+}
+
+/**
+ * Derive the reply text + terminal status from a finished sub-agent graph
+ * state. `finalState` is the value resolved by `graph.execute(subState)`.
+ */
+export function extractAgentTurnOutcome(finalState: any): AgentTurnOutcome {
+  const agentMeta    = finalState?.metadata?.agent || {};
+  const agentStatus  = String(agentMeta.status || '').toLowerCase();
+
+  if (agentStatus === 'blocked') {
+    const blockerReason = agentMeta.blocker_reason || 'Unknown blocker';
+    const unblockReqs   = agentMeta.unblock_requirements || '';
+
+    return {
+      status: 'blocked',
+      text:   `[BLOCKED] ${ blockerReason }${ unblockReqs ? ` | Requirements: ${ unblockReqs }` : '' }`,
+    };
+  }
+
+  const out = finalState?.metadata?.finalSummary ||
+    finalState?.messages?.[finalState.messages.length - 1]?.content ||
+    '(no output)';
+
+  return {
+    status: 'completed',
+    text:   typeof out === 'string' ? out : JSON.stringify(out),
+  };
+}

--- a/pkg/rancher-desktop/agent/tools/agents/conversationRunner.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/conversationRunner.ts
@@ -8,6 +8,7 @@
  */
 
 import { appendTranscript, setStatus } from './agentConversations';
+import { extractAgentTurnOutcome } from './agentTurnOutcome';
 
 import type { AgentConversation } from './agentConversations';
 import type { AbortService } from '../../services/AbortService';
@@ -62,23 +63,10 @@ export async function runConversationTurn(
   try {
     const finalState = await graph.execute(subState);
 
-    const agentMeta = finalState.metadata?.agent || {};
-    const agentStatus = String(agentMeta.status || '').toLowerCase();
-
-    if (agentStatus === 'blocked') {
-      const reply = `[BLOCKED] ${ agentMeta.blocker_reason || 'Unknown blocker' }${ agentMeta.unblock_requirements ? ` | Requirements: ${ agentMeta.unblock_requirements }` : '' }`;
-      appendTranscript(conv.conversationId, 'agent', reply);
-
-      return { status: 'blocked', reply };
-    }
-
-    const out = finalState.metadata?.finalSummary ||
-      finalState.messages?.[finalState.messages.length - 1]?.content ||
-      '(no output)';
-    const reply = typeof out === 'string' ? out : JSON.stringify(out);
+    const { status, text: reply } = extractAgentTurnOutcome(finalState);
     appendTranscript(conv.conversationId, 'agent', reply);
 
-    return { status: 'completed', reply };
+    return { status, reply };
   } catch (err) {
     const reply = `Error: ${ (err as Error).message }`;
     appendTranscript(conv.conversationId, 'agent', reply);

--- a/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
@@ -1,4 +1,5 @@
 import { BaseTool, ToolResponse } from '../base';
+import { extractAgentTurnOutcome } from './agentTurnOutcome';
 import { createJob, completeJob, failJob, getJobAbortSignal } from './jobRegistry';
 import { getWebSocketClientService } from '../../services/WebSocketClientService';
 import { combineAborts } from '../../services/AbortService';
@@ -142,31 +143,13 @@ export class SpawnAgentWorker extends BaseTool {
         // Execute the sub-agent graph
         const finalState = await graph.execute(subState);
 
-        // Check if blocked
-        const agentMeta = finalState.metadata?.agent || {};
-        const agentStatus = String(agentMeta.status || '').toLowerCase();
-
-        if (agentStatus === 'blocked') {
-          const blockerReason = agentMeta.blocker_reason || 'Unknown blocker';
-          const unblockReqs = agentMeta.unblock_requirements || '';
-
-          return {
-            label,
-            status:   'blocked',
-            output:   `[BLOCKED] ${ blockerReason }${ unblockReqs ? ` | Requirements: ${ unblockReqs }` : '' }`,
-            threadId,
-          };
-        }
-
-        // Extract result
-        const output = finalState.metadata?.finalSummary ||
-          finalState.messages?.[finalState.messages.length - 1]?.content ||
-          '(no output)';
+        // Same blocked-branch + output-fallback chain conversationRunner uses.
+        const { status, text } = extractAgentTurnOutcome(finalState);
 
         return {
           label,
-          status: 'completed',
-          output: typeof output === 'string' ? output : JSON.stringify(output),
+          status,
+          output: text,
           threadId,
         };
       } catch (err) {


### PR DESCRIPTION
## What

`conversationRunner` (persistent multi-turn) and `spawn_agent` (fire-and-forget jobs) each carried a byte-identical block after `graph.execute()`: a blocked branch formatting `[BLOCKED] <reason> | Requirements: <reqs>`, then a `finalSummary -> last-message -> (no output)` fallback chain with non-string stringify. Two hand-synced copies.

Extracts both into one canonical reader: `extractAgentTurnOutcome(finalState) -> { status, text }`. Each caller maps that onto its own result shape (TurnResult / AgentJobResult).

## Why

Epic 6 D-phase-2 option (b) from the operator ledger. A full conversationRunner -> spawn_agent migration is a design call (would break start_agent_conversation s synchronous multi-turn contract). This is the safe, reversible first inch: make the shared result-extraction canonical so the eventual migration has one source of truth.

## Scope / safety

- Pure state -> text function. Does NOT touch the graph, abort wiring, async job flow, or the synchronous multi-turn contract.
- Behavior-preserving; helper is also null-safe on finalState where the inline copies were not.
- 7 unit tests green (blocked with/without requirements, finalSummary vs last-message vs empty fallback, non-string stringify, bare/undefined state).

## Reach-the-binary note

Touches the delegation loop live-verified today (Epic 1). Reaches the running app only on rebuild+restart, which stays Jonathon-gated. Not self-merged — ready to merge on your next rebuild.

Generated with Claude Code