### PR TITLE
fix(heartbeat): hold caffeinate continuously while enabled — close the inter-cycle sleep hole

### DIFF
--- a/pkg/rancher-desktop/agent/services/HeartbeatService.ts
+++ b/pkg/rancher-desktop/agent/services/HeartbeatService.ts
@@ -72,6 +72,18 @@ export class HeartbeatService {
   private executionStartedMs = 0;
   private suspendStartedMs = 0;
 
+  // ── Standing sleep-prevention (continuous, not per-cycle) ──
+  // The per-execution caffeinate (startCaffeinate('heartbeat') in
+  // triggerHeartbeat) only spans a single cycle. Between cycles nothing held
+  // the Mac awake, so an idle-sleep in the inter-cycle gap froze the 60s
+  // scheduler timer — and scheduleWake() is a root-gated no-op, so nothing
+  // woke it. The operator silently stopped standing until a manual wake.
+  // Fix: hold caffeinate -i -s for the WHOLE enabled lifetime, transition-
+  // guarded so we call start/stop once per toggle (not every minute).
+  // Limits (documented, need root/pmset to fully solve): caffeinate -s only
+  // asserts on AC power and does not defeat clamshell/lid-close sleep.
+  private standingCaffeineHeld = false;
+
   async initialize(): Promise<void> {
     if (this.initialized) return;
     console.log('[HeartbeatService] Initializing scheduler...');
@@ -123,6 +135,26 @@ export class HeartbeatService {
     this.eventCount++;
   }
 
+  /**
+   * Acquire the continuous standing-shift caffeinate hold. Idempotent: the
+   * transition guard means we only spawn/log on the disabled→enabled edge, so
+   * calling this every minute from the scheduler is safe.
+   */
+  private acquireStandingCaffeine(): void {
+    if (this.standingCaffeineHeld) return;
+    startCaffeinate('heartbeat-standing');
+    this.standingCaffeineHeld = true;
+    this.recordEvent('sleep_prevention_started', 'Standing caffeinate held — prevents inter-cycle idle sleep while heartbeat is enabled');
+  }
+
+  /** Release the standing-shift hold (heartbeat disabled or service destroyed). */
+  private releaseStandingCaffeine(): void {
+    if (!this.standingCaffeineHeld) return;
+    stopCaffeinate('heartbeat-standing');
+    this.standingCaffeineHeld = false;
+    this.recordEvent('sleep_prevention_stopped', 'Standing caffeinate released — heartbeat disabled or service stopped');
+  }
+
   private startScheduler(): void {
     if (this.schedulerId) return;
 
@@ -145,6 +177,9 @@ export class HeartbeatService {
         this.totalSkips++;
         this.recordEvent('heartbeat_skipped', 'Heartbeat disabled in settings');
 
+        // Let the Mac sleep again once the operator is off-shift.
+        this.releaseStandingCaffeine();
+
         // Abort any in-flight heartbeat when disabled
         if (this.isExecuting && this.activeAbort) {
           console.log('[HeartbeatService] Heartbeat disabled while executing — aborting');
@@ -153,6 +188,12 @@ export class HeartbeatService {
         }
         return;
       }
+
+      // Enabled → keep the operator standing. Held continuously (through the
+      // window gate below too) so that if the Mac would otherwise idle-sleep
+      // during an out-of-window stretch, the scheduler timer survives and the
+      // next in-window minute still fires. scheduleWake() can't do this (root).
+      this.acquireStandingCaffeine();
 
       // ── Time-window gate ──
       // Users who only want autonomous runs during certain hours (e.g.
@@ -360,6 +401,9 @@ Your active projects and goals have been loaded into your recall context. Review
 
   destroy(): void {
     this.initialized = false;
+    // Drop the standing sleep-prevention hold so we don't leak a caffeinate
+    // process across a service teardown/reinit.
+    this.releaseStandingCaffeine();
     // Abort any in-flight execution
     if (this.activeAbort) {
       this.activeAbort.abort();

--- a/pkg/rancher-desktop/agent/services/__tests__/HeartbeatService.standingCaffeine.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/HeartbeatService.standingCaffeine.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Standing sleep-prevention regression tests.
+ *
+ * The bug: caffeinate was only held DURING a heartbeat execution, so the Mac
+ * could idle-sleep in the inter-cycle gap, freezing the scheduler timer —
+ * and scheduleWake() is a root-gated no-op, so nothing woke it. These tests
+ * pin the fix: while heartbeatEnabled is true the standing hold is acquired
+ * exactly once (not every minute), released when disabled, and released on
+ * destroy so the caffeinate process can't leak across a teardown.
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const startCaffeinateMock: any = jest.fn();
+const stopCaffeinateMock: any = jest.fn();
+const getSettingMock: any = jest.fn();
+
+// ESM: jest.unstable_mockModule + dynamic import (see SubconsciousMiddleware.test.ts).
+jest.unstable_mockModule('../../../main/SleepPreventionService', () => ({
+  startCaffeinate: startCaffeinateMock,
+  stopCaffeinate:  stopCaffeinateMock,
+  scheduleWake:    jest.fn(),
+}));
+jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
+  SullaSettingsModel: {
+    get: getSettingMock,
+    set: jest.fn(),
+  },
+}));
+
+const STANDING = 'heartbeat-standing';
+
+/** Make SullaSettingsModel.get return `enabled` for heartbeatEnabled, defaults otherwise. */
+function useSettings(enabled: boolean) {
+  getSettingMock.mockImplementation((key: string, dflt: unknown) => {
+    if (key === 'heartbeatEnabled') return Promise.resolve(enabled);
+    if (key === 'heartbeatWindow') return Promise.resolve(null);
+    return Promise.resolve(dflt);
+  });
+}
+
+/** A service parked so checkAndMaybeTrigger exercises only the caffeine path (never dispatches a cycle). */
+async function makeParkedService(): Promise<any> {
+  const { HeartbeatService } = await import('../HeartbeatService');
+  const svc: any = new HeartbeatService();
+  svc.initialized = true;
+  // Recent last-trigger → the delay gate short-circuits before triggerHeartbeat.
+  svc.lastTriggerMs = Date.now();
+  return svc;
+}
+
+const standingStarts = () => startCaffeinateMock.mock.calls.filter((c: unknown[]) => c[0] === STANDING);
+
+describe('HeartbeatService standing sleep-prevention', () => {
+  beforeEach(() => {
+    startCaffeinateMock.mockReset();
+    stopCaffeinateMock.mockReset();
+    getSettingMock.mockReset();
+  });
+
+  it('acquires the standing hold once while enabled, even across many minute-checks', async() => {
+    useSettings(true);
+    const svc = await makeParkedService();
+
+    await svc.checkAndMaybeTrigger();
+    await svc.checkAndMaybeTrigger();
+    await svc.checkAndMaybeTrigger();
+
+    expect(standingStarts()).toHaveLength(1); // transition-guarded, not per-minute
+    expect(stopCaffeinateMock).not.toHaveBeenCalledWith(STANDING);
+  });
+
+  it('releases the standing hold when the heartbeat is disabled', async() => {
+    const svc = await makeParkedService();
+
+    useSettings(true);
+    await svc.checkAndMaybeTrigger();
+    expect(startCaffeinateMock).toHaveBeenCalledWith(STANDING);
+
+    useSettings(false);
+    await svc.checkAndMaybeTrigger();
+    expect(stopCaffeinateMock).toHaveBeenCalledWith(STANDING);
+  });
+
+  it('re-acquires after an enable→disable→enable cycle', async() => {
+    const svc = await makeParkedService();
+
+    useSettings(true);
+    await svc.checkAndMaybeTrigger();
+    useSettings(false);
+    await svc.checkAndMaybeTrigger();
+    useSettings(true);
+    await svc.checkAndMaybeTrigger();
+
+    expect(standingStarts()).toHaveLength(2);
+  });
+
+  it('does not release when it was never held (disabled from the start)', async() => {
+    useSettings(false);
+    const svc = await makeParkedService();
+
+    await svc.checkAndMaybeTrigger();
+
+    expect(startCaffeinateMock).not.toHaveBeenCalledWith(STANDING);
+    expect(stopCaffeinateMock).not.toHaveBeenCalledWith(STANDING); // guard prevents a spurious stop
+  });
+
+  it('releases the standing hold on destroy so caffeinate cannot leak', async() => {
+    useSettings(true);
+    const svc = await makeParkedService();
+    await svc.checkAndMaybeTrigger();
+    expect(startCaffeinateMock).toHaveBeenCalledWith(STANDING);
+
+    svc.destroy();
+    expect(stopCaffeinateMock).toHaveBeenCalledWith(STANDING);
+  });
+});

--- a/pkg/rancher-desktop/main/SleepPreventionService.ts
+++ b/pkg/rancher-desktop/main/SleepPreventionService.ts
@@ -75,10 +75,12 @@ export function getActiveHolders(): ReadonlySet<string> {
 
 /**
  * Schedule a macOS wake event.
- * `pmset schedule wake` requires root privileges which we don't have.
- * caffeinate -i -s already prevents sleep while active, which is sufficient
- * for keeping the agent running. If the machine sleeps between heartbeats,
- * it will wake on its own schedule (user activity, Power Nap, etc.).
+ * `pmset schedule wake` requires root privileges which we don't have, so this
+ * stays a no-op. The actual "keep the operator standing" guarantee comes from
+ * HeartbeatService holding a CONTINUOUS caffeinate -i -s for the whole enabled
+ * lifetime (label 'heartbeat-standing'), which prevents the inter-cycle idle
+ * sleep that this wake was meant to recover from. Remaining gap (needs root):
+ * caffeinate -s only asserts on AC power and does not defeat clamshell sleep.
  *
  * This is a no-op — kept for API compatibility with callers.
  */


### PR DESCRIPTION
## The gap
The operator could **silently stop standing.** `caffeinate -i -s` was acquired only *during* a heartbeat execution (`startCaffeinate(heartbeat)` in `triggerHeartbeat`) and released in the `finally`. Between cycles — the whole ~15-min gap — nothing held the Mac awake. An idle-sleep in that window froze the 60s scheduler `setInterval`, and `scheduleWake()` is a root-gated no-op (`pmset` needs root), so nothing woke it. One idle-sleep during a gap -> the heartbeat stops firing until the machine is physically woken.

## The fix (non-root, reversible)
`HeartbeatService` now holds a **continuous** caffeinate (label `heartbeat-standing`) for the whole *enabled* lifetime, not per-cycle:
- `acquireStandingCaffeine()` on the enabled edge in `checkAndMaybeTrigger`, **before** the time-window gate, so the timer survives out-of-window stretches and the next in-window minute still fires.
- `releaseStandingCaffeine()` when `heartbeatEnabled` flips false, and on `destroy()` so a caffeinate process cannot leak across a teardown/reinit.
- transition-guarded (`standingCaffeineHeld`) so the per-minute scheduler calls start/stop exactly once per toggle — no log spam — reusing the existing reference-counted `SleepPreventionService`.

Fully reversible: disabling the heartbeat releases the hold.

## Known remaining gap (needs root)
`caffeinate -s` only asserts on **AC power** and does **not** defeat clamshell/lid-close sleep. `scheduleWake()` doc updated to point at the standing hold as the real keep-alive and to record this limit.

## Tests
5 jest tests (ESM `unstable_mockModule`), all green: acquire-once-across-many-checks, release-on-disable, re-acquire across enable/disable/enable, no spurious stop when never held, release-on-destroy.

⚠️ Reaches the running binary only on rebuild+restart — **do not merge/rebuild without Jonathon** (heartbeat/settings-adjacent runtime behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)