### PR TITLE
fix(scheduler): recover cron fires missed during macOS sleep on resume

### DIFF
--- a/pkg/rancher-desktop/agent/services/WorkflowSchedulerService.ts
+++ b/pkg/rancher-desktop/agent/services/WorkflowSchedulerService.ts
@@ -150,6 +150,25 @@ export class WorkflowSchedulerService {
   }
 
   /**
+   * Re-arm schedules AND recover any fires missed while the process was
+   * suspended. Call this from the power `resume` handler.
+   *
+   * Boot catch-up (`initialize`) only helps when the app was fully OFF across
+   * a cron: on wake from macOS sleep the same process resumes, `initialize`
+   * is already `initialized`-guarded, and node-schedule silently recomputes
+   * its frozen in-process timers forward — so a weekly cron that tripped while
+   * asleep is lost to next week with nothing queued. Re-arming here guarantees
+   * forward crons are correctly scheduled post-wake, and the catch-up scan
+   * recovers the missed slot. Idempotent via the same FIRE_GRACE_MS +
+   * since-last-fire guard as boot catch-up, so an on-time fire is never
+   * double-dispatched. Never throws into the resume path.
+   */
+  async resumeCatchUp(): Promise<void> {
+    await this.scanAndSchedule();
+    await this.catchUpMissedFires();
+  }
+
+  /**
    * Cancel all scheduled workflow jobs and tear the service down.
    */
   shutdown(): void {

--- a/pkg/rancher-desktop/agent/services/__tests__/WorkflowSchedulerService.resumeCatchUp.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/WorkflowSchedulerService.resumeCatchUp.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { WorkflowSchedulerService } from '../WorkflowSchedulerService';
+
+// resumeCatchUp() is the power-`resume` recovery entry point. On wake from
+// macOS sleep the same process resumes, so boot catch-up (`initialize`) is
+// already `initialized`-guarded and does nothing — node-schedule's frozen
+// in-process timers silently recompute forward and any cron that tripped
+// while asleep is lost. resumeCatchUp must therefore re-arm schedules AND
+// run the missed-fire scan every time it is called, regardless of the
+// `initialized` flag.
+describe('WorkflowSchedulerService.resumeCatchUp', () => {
+  const stub = (svc: WorkflowSchedulerService) => {
+    const calls: string[] = [];
+    const scan = jest.fn(async () => { calls.push('scanAndSchedule'); });
+    const catchUp = jest.fn(async () => { calls.push('catchUpMissedFires'); });
+    // Both are private; replace them on the instance for the test.
+    (svc as unknown as Record<string, unknown>).scanAndSchedule = scan;
+    (svc as unknown as Record<string, unknown>).catchUpMissedFires = catchUp;
+    return { calls, scan, catchUp };
+  };
+
+  it('re-arms schedules then runs the missed-fire scan, in that order', async () => {
+    const svc = new WorkflowSchedulerService();
+    const { calls, scan, catchUp } = stub(svc);
+
+    await svc.resumeCatchUp();
+
+    expect(scan).toHaveBeenCalledTimes(1);
+    expect(catchUp).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['scanAndSchedule', 'catchUpMissedFires']);
+  });
+
+  it('runs even after initialize() has already set the initialized guard', async () => {
+    const svc = new WorkflowSchedulerService();
+    // Simulate an already-booted service: the initialized flag is set, which
+    // would short-circuit initialize() — resumeCatchUp must NOT be gated by it.
+    (svc as unknown as Record<string, unknown>).initialized = true;
+    const { scan, catchUp } = stub(svc);
+
+    await svc.resumeCatchUp();
+
+    expect(scan).toHaveBeenCalledTimes(1);
+    expect(catchUp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -909,6 +909,19 @@ export function initSullaEvents(): void {
       console.warn('[Power] Failed to resume heartbeat scheduler:', err);
     }
 
+    // Re-arm scheduled routines and recover any weekly fire skipped while the
+    // machine slept. node-schedule freezes its in-process timers during
+    // suspend, so a cron that trips while asleep is lost to next week — and
+    // boot catch-up can't help because the app never restarted. Idempotent
+    // (FIRE_GRACE_MS + since-last-fire guard) so it can't double-fire an
+    // on-time run.
+    try {
+      const { getWorkflowSchedulerService } = require('@pkg/agent/services/WorkflowSchedulerService');
+      void getWorkflowSchedulerService().resumeCatchUp();
+    } catch (err) {
+      console.warn('[Power] Failed to catch up missed schedules on resume:', err);
+    }
+
     // Notify all renderer windows so frontend services can react
     for (const win of BrowserWindow.getAllWindows()) {
       try {


### PR DESCRIPTION
## Problem
`node-schedule` only fires crons that trip while the process is running. On wake from macOS sleep the **same** process resumes, so boot catch-up (`WorkflowSchedulerService.initialize`) is already `initialized`-guarded and does nothing — meanwhile node-schedule silently recomputes its frozen in-process timers forward. Result: a weekly routine whose cron time passed while the Mac slept is lost to next week with nothing queued. This is the self-heal gap left after the PR #557 powerMonitor `resume` kick (which only revived the heartbeat, not the workflow scheduler).

## Fix
- Add `WorkflowSchedulerService.resumeCatchUp()` — re-arms schedules (`scanAndSchedule`) then runs the **same** missed-fire scan boot uses (`catchUpMissedFires` → `runCatchUpScan`).
- Wire it into the `powerMonitor.on(resume)` handler in `sullaEvents.ts`, right after the existing heartbeat resume kick, following the same lazy-require + try/catch pattern.
- Idempotent via `runCatchUpScan` FIRE_GRACE_MS + since-last-fire guard (a fire already in `workflow_executions` since the last expected occurrence is skipped) so an on-time fire is never double-dispatched. Never throws into the resume path.

## Tests
`WorkflowSchedulerService.resumeCatchUp.test.ts` — 2 green: (1) re-arms then scans, in order; (2) runs even after the `initialized` guard is set (unlike `initialize`).

eslint clean; base `main @ d6eed29ea`.

## Gate
Draft — reaches the running binary only on **rebuild + restart**, Jonathon-gated. Live verification needs a real macOS sleep→resume across a routine cron time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)