### PR TITLE
fix(cli): route settings/ledger/work/rules/secretary via `sulla <category>/<tool>`

### DIFF
--- a/pkg/rancher-desktop/agent/tools/registry.ts
+++ b/pkg/rancher-desktop/agent/tools/registry.ts
@@ -49,7 +49,7 @@ export class ToolRegistry {
   /** Native tool definitions that bypass convertToolToLLM (e.g. Anthropic computer use). */
   private nativeToolDefs = new Map<string, Record<string, any>>();
   private categoriesList = [
-    'agents', 'applescript', 'bridge', 'browser', 'calendar', 'capture', 'docker', 'extensions', 'fs', 'function', 'github', 'integrations', 'kubectl', 'ledger', 'lima', 'marketplace', 'memory', 'meta', 'mobile', 'notify', 'observation', 'pg', 'projects', 'rdctl', 'redis', 'rules', 'skills', 'slack', 'ui', 'vault', 'work', 'workspace', 'workflow',
+    'agents', 'applescript', 'bridge', 'browser', 'calendar', 'capture', 'docker', 'extensions', 'fs', 'function', 'github', 'integrations', 'kubectl', 'ledger', 'lima', 'marketplace', 'memory', 'meta', 'mobile', 'notify', 'observation', 'pg', 'projects', 'rdctl', 'redis', 'rules', 'secretary', 'settings', 'skills', 'slack', 'ui', 'vault', 'work', 'workspace', 'workflow',
     // Integration catalog categories (AP backed)
     'communication', 'developer_tools', 'productivity', 'project_management', 'crm_sales', 'marketing', 'customer_support', 'social_media', 'finance', 'file_storage', 'ecommerce', 'analytics', 'automation', 'database', 'design', 'hr_recruiting', 'ai_ml',
   ];
@@ -88,6 +88,8 @@ export class ToolRegistry {
     capture:            'Capture Studio control — teleprompter (open/close/script/style), microphone + speaker loopback lifecycle, screen/camera enumeration, screenshots, recorder start/stop/status with auto-acquire.',
     marketplace:        'Marketplace for community artifacts (skills, functions, workflows, agents, recipes) — search, info, download, scaffold, validate, publish, update, unpublish.',
     ui:                 'Open Sulla Desktop views (marketplace, vault, routines, etc.) from chat so the user can inspect them directly.',
+    settings:           'Read and write Sulla Desktop settings through SullaSettingsModel (the single authoritative read-path — never raw Redis sulla_settings).',
+    secretary:          'Secretary Mode control — start, stop, and check live meeting transcription without pressing Cmd+Shift+S.',
     // Integration catalog categories (tools executed via ActivePieces)
     communication:      'Email, messaging, SMS, and video conferencing tools — Gmail, Slack, Teams, Zoom, Discord, Telegram, Twilio, WhatsApp, and more.',
     developer_tools:    'DevOps, CI/CD, monitoring, hosting, CMS, and web scraping tools — GitHub, GitLab, Vercel, Sentry, Datadog, Jenkins, Webflow, and more.',

--- a/resources/darwin/bin/sulla
+++ b/resources/darwin/bin/sulla
@@ -25,7 +25,7 @@ BODY="$2"
 # Known internal tool categories. Must stay in sync with agent/tools/registry.ts
 # `categoriesList` so `sulla <category>/<tool>` routes to /v1/tools/internal
 # instead of falling through as a proxy call.
-TOOL_CATEGORIES="agents|applescript|bridge|browser|calendar|capture|docker|extensions|fs|function|github|integrations|kubectl|lima|marketplace|memory|meta|mobile|notify|observation|pg|projects|rdctl|redis|skills|slack|ui|vault|workflow|workspace"
+TOOL_CATEGORIES="agents|applescript|bridge|browser|calendar|capture|docker|extensions|fs|function|github|integrations|kubectl|ledger|lima|marketplace|memory|meta|mobile|notify|observation|pg|projects|rdctl|redis|rules|secretary|settings|skills|slack|ui|vault|work|workflow|workspace"
 
 # ── Help & discovery ─────────────────────────────────────────────
 # sulla --help | sulla -h | sulla help | sulla (no args) — query the backend


### PR DESCRIPTION
## Operator gap: 5 internal-tool categories silently misroute via the documented slash form

The `sulla` CLI gates `<category>/<tool>` routing behind a hardcoded `TOOL_CATEGORIES` allowlist in `resources/darwin/bin/sulla` that had drifted from the registry `categoriesList`. Five real internal-tool categories were missing, so these all fell through to the proxy pass-through and died with the misleading `Missing required field "path"` error:

| Command | Was | Now |
|---|---|---|
| `sulla ledger/scoreboard` | path error | scoreboard |
| `sulla work/list_work_items` | path error | 45 tasks |
| `sulla rules/list_rules` | path error | rules |
| `sulla settings/settings_get` | path error | value |
| `sulla secretary/status` | path error | listening state |

The operator's own scoreboard, the Postgres workboard (Epic 7), Secretary Mode, settings, and rules were all unreachable via the slash form the docs tell operators to use.

### Root cause
- `ledger`, `rules`, `work` were in `registry.categoriesList` but NOT in the CLI script -- pure drift (the script comment even says "Must stay in sync with categoriesList").
- `settings` and `secretary` were in NEITHER list, though both register tools with a `category` field and `getCategories()` already surfaces them via its runtime-catch, so the server accepts them.

### Fix
- `resources/darwin/bin/sulla`: add all five to `TOOL_CATEGORIES`.
- `registry.ts`: add `settings` + `secretary` to `categoriesList` so the invariant literally holds, with category descriptions.

### Verified live against the tool socket
Ran the edited script directly -- all five now resolve to `/v1/tools/internal` (`<category>_<tool>` then bare `<tool>` fallback) and return real results instead of the proxy path error.

Draft -- reaches the live `/usr/local/bin/sulla` only on rebuild + reinstall (Jonathon-gated). No runtime behavior change until then.

Generated with Claude Code.