### PR TITLE
fix(digest): age-bound stale routine-failure re-nag (30-day window)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0045_bound_stale_routine_digest_failures.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0045_bound_stale_routine_digest_failures.ts
@@ -1,0 +1,120 @@
+// Age-bound the digest's `failed` exception reason (issue #499 follow-up).
+//
+// The 0038 `routine_exceptions` view surfaces any ENABLED routine whose LAST run
+// failed, with NO age bound — the intent being "unresolved until fixed/retired".
+// For a SCHEDULED routine that is self-clearing: the next fire produces a newer
+// non-failed `last_run_status` and the routine drops out of the digest.
+//
+// But a routine that CANNOT auto-produce a newer run — a chat/ad-hoc-triggered
+// routine (e.g. `planning-triage`), or one whose only history is an orphaned run
+// that died at start — has NO path to a fresher `last_run_status`. Its single
+// stale `failed` row then pins the routine in `routine_exceptions` FOREVER, so
+// the zero-LLM digest re-emits the same "N failed — needs a look" line on every
+// Heartbeat cycle. The status CHECK constraint on `workflow_executions`
+// (running|suspended|completed|failed) has no terminal "cancelled/dismissed"
+// value, so the stale row can't even be honestly reclassified in place — the
+// failure is genuinely unresolvable through data alone. Observed live
+// 2026-08-14: `planning-triage` re-flagged every cycle off a single 2026-07-08
+// orphan (a mis-triggered run that died at start; its real task shipped
+// separately) — a standing per-cycle attention tax on a non-actionable red.
+//
+// Fix: bound the DIGEST's `failed` reason to failures whose last run is within
+// the last 30 days. The digest is explicitly the "anti-token-burn, exceptions-
+// ONLY, worth-a-glance" surface (see 0038 header) — a failure older than 30 days
+// with no newer run is no longer news worth re-surfacing every cycle. This bounds
+// ONLY the digest views; the full truth (failed_count, history, success_rate) is
+// untouched in `routine_scorecard` / `routine_report`, so nothing is hidden from
+// anyone who looks — only the every-cycle re-nag stops. 30 days keeps a WEEKLY
+// routine's failure visible across ~4 more fire opportunities to self-heal, while
+// letting truly stale / non-re-runnable failures age out of the noise. `zombie`
+// (a stuck `running` row) and `new` (created <24h) reasons are deliberately left
+// unbounded — a stuck job and a freshly-armed routine are always actionable.
+//
+// Follow-up (not this migration): a first-class terminal status (add 'cancelled'
+// to the status CHECK) + a `resolve`/`dismiss` verb would give an EXPLICIT
+// retire path, superseding the age heuristic. Tracked for a later cycle.
+//
+// Views only — CREATE OR REPLACE over the 0038 definitions; additive and fully
+// reversible (`down` restores the unbounded 0038 views). No data touched.
+
+export const up = `
+  -- ── Exceptions: age-bound the failed reason (30-day digest window) ──────────
+  CREATE OR REPLACE VIEW routine_exceptions AS
+  SELECT
+    s.routine_slug,
+    s.routine_name,
+    s.authored_by,
+    s.status,
+    s.enabled,
+    s.fire_count,
+    s.failed_count,
+    s.zombie_count,
+    s.last_run_at,
+    s.last_run_status,
+    s.created_at,
+    ARRAY_REMOVE(ARRAY[
+      CASE WHEN s.last_run_status = 'failed'
+                AND s.last_run_at > NOW() - INTERVAL '30 days'   THEN 'failed'  END,
+      CASE WHEN s.zombie_count > 0                               THEN 'zombie'  END,
+      CASE WHEN s.created_at > NOW() - INTERVAL '24 hours'       THEN 'new'     END
+    ], NULL) AS reasons
+  FROM routine_scorecard s
+  WHERE s.enabled
+    AND (
+         (s.last_run_status = 'failed' AND s.last_run_at > NOW() - INTERVAL '30 days')
+      OR s.zombie_count > 0
+      OR s.created_at > NOW() - INTERVAL '24 hours'
+    );
+
+  -- ── Summary: header failed_count matches the bounded exceptions ─────────────
+  CREATE OR REPLACE VIEW routine_digest_summary AS
+  SELECT
+    COUNT(*)                                                        AS total_routines,
+    COUNT(*) FILTER (WHERE enabled)                                 AS enabled_count,
+    COUNT(*) FILTER (
+      WHERE enabled AND last_run_status = 'failed'
+        AND last_run_at > NOW() - INTERVAL '30 days')               AS failed_count,
+    COUNT(*) FILTER (WHERE enabled AND zombie_count > 0)            AS zombie_count,
+    COUNT(*) FILTER (
+      WHERE enabled AND created_at > NOW() - INTERVAL '24 hours')   AS new_count
+  FROM routine_scorecard;
+`;
+
+// Restore the unbounded 0038 definitions.
+export const down = `
+  CREATE OR REPLACE VIEW routine_exceptions AS
+  SELECT
+    s.routine_slug,
+    s.routine_name,
+    s.authored_by,
+    s.status,
+    s.enabled,
+    s.fire_count,
+    s.failed_count,
+    s.zombie_count,
+    s.last_run_at,
+    s.last_run_status,
+    s.created_at,
+    ARRAY_REMOVE(ARRAY[
+      CASE WHEN s.last_run_status = 'failed'                        THEN 'failed'  END,
+      CASE WHEN s.zombie_count > 0                                  THEN 'zombie'  END,
+      CASE WHEN s.created_at > NOW() - INTERVAL '24 hours'          THEN 'new'     END
+    ], NULL) AS reasons
+  FROM routine_scorecard s
+  WHERE s.enabled
+    AND (
+         s.last_run_status = 'failed'
+      OR s.zombie_count > 0
+      OR s.created_at > NOW() - INTERVAL '24 hours'
+    );
+
+  CREATE OR REPLACE VIEW routine_digest_summary AS
+  SELECT
+    COUNT(*)                                                        AS total_routines,
+    COUNT(*) FILTER (WHERE enabled)                                 AS enabled_count,
+    COUNT(*) FILTER (WHERE enabled AND last_run_status = 'failed')  AS failed_count,
+    COUNT(*) FILTER (WHERE enabled AND zombie_count > 0)            AS zombie_count,
+    COUNT(*) FILTER (
+      WHERE enabled AND created_at > NOW() - INTERVAL '24 hours')   AS new_count
+  FROM routine_scorecard;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -33,6 +33,7 @@ import { up as up_0041, down as down_0041 } from './0041_add_trigram_index_to_ob
 import { up as up_0042, down as down_0042 } from './0042_create_rules_table';
 import { up as up_0043, down as down_0043 } from './0043_create_agent_jobs_table';
 import { up as up_0044, down as down_0044 } from './0044_create_work_items_tables';
+import { up as up_0045, down as down_0045 } from './0045_bound_stale_routine_digest_failures';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -66,4 +67,5 @@ export const migrationsRegistry = [
   { name: '0042_create_rules_table',                        up: up_0042, down: down_0042 },
   { name: '0043_create_agent_jobs_table',                   up: up_0043, down: down_0043 },
   { name: '0044_create_work_items_tables',                   up: up_0044, down: down_0044 },
+  { name: '0045_bound_stale_routine_digest_failures',        up: up_0045, down: down_0045 },
 ] as const;


### PR DESCRIPTION
## What
Age-bounds the routine **digest**'s `failed` reason to the last **30 days**, so a stale failure on a routine that can't auto-produce a newer run stops re-nagging Heartbeat every cycle.

## Why (found live 2026-08-14)
`routine_exceptions` (migration 0038) surfaces any enabled routine whose **last** run failed — with **no age bound**. Scheduled routines self-clear on their next fire. But a **chat/ad-hoc-triggered** routine (e.g. `planning-triage`) — or one whose only history is an **orphaned run that died at start** — can never produce a fresher `last_run_status`, so one stale `failed` row pins it in the zero-LLM digest **forever**, re-emitting the same *"N failed — needs a look"* line every autonomous cycle.

The `workflow_executions` status CHECK (`running|suspended|completed|failed`) has **no** terminal cancelled/dismissed value, so the row can't even be honestly reclassified in place — the failure is genuinely unresolvable through data alone.

Concretely: `planning-triage` has been re-flagged every cycle off a single **2026-07-08** orphan (a mis-triggered run that died at start; its real task shipped in commit `0e814213b`). A permanent false red = a per-cycle attention tax.

## Fix
Migration **0045** — `CREATE OR REPLACE` over the two 0038 views:
- Bounds **only the digest** `failed` reason/count to `last_run_at > NOW() - INTERVAL '30 days'`.
- `zombie` (stuck `running`) and `new` (<24h) reasons stay **unbounded** — always actionable.
- The **full truth** (`failed_count`, history, `success_rate`) is untouched in `routine_scorecard` / `routine_report` — nothing is hidden, only the every-cycle re-nag stops.
- 30 days keeps a **weekly** routine's failure visible across ~4 more self-heal chances.

## Verification
- Bounded predicate run read-only against the **live DB**: drops the 37-day-old `planning-triage` failure while still surfacing the two legitimately-`new` routines — and any failure **within** 30 days still surfaces (no real signal lost).
- `tsc --noEmit` clean; new file lint-clean; views-only, additive, **fully reversible** (`down` restores the unbounded 0038 views — no data touched).

## Gate
Reaches the live digest only on **rebuild + DB migrate**. Do **not** merge/rebuild without Jonathon.

## Follow-up
A first-class terminal status (`'cancelled'`) + a `resolve`/`dismiss` verb would give an explicit *retire* path superseding this age heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)