### PR TITLE
[DRAFT] Episodic memory writer half — rebased onto main + tests (#518)

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/KnowledgeGraphModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/KnowledgeGraphModel.ts
@@ -44,6 +44,42 @@ export interface UpsertKnowledgeNodeInput {
   merged_into?: string | null;
 }
 
+/** One encoded node the Scribe (#518) asks to persist. */
+export interface EpisodeNodeInput {
+  title:      string;
+  summary?:   string;
+  detail?:    string | null;
+  aliases?:   string[];
+  node_type?: string;
+}
+
+/** A fully-encoded completed episode, written atomically by writeEpisode. */
+export interface WriteEpisodeInput {
+  /** Origin: 'chat' | 'heartbeat' | 'sub-agent' | ... — stored as node source. */
+  source?:   string;
+  /** Project/epic anchor the episode belongs_to (resolved+reused, else created). */
+  project?:  EpisodeNodeInput | null;
+  /** The event node — "what happened". Always created new. Required. */
+  event:     EpisodeNodeInput;
+  /** Lesson nodes — "what we learned" — linked learned_from the episode. */
+  lessons?:  EpisodeNodeInput[];
+  /** Blocker nodes — linked blocked_by the episode. */
+  blockers?: EpisodeNodeInput[];
+  /** Entities/concepts seen — resolved+reused, else created — linked mentioned_in. */
+  entities?: EpisodeNodeInput[];
+  /** Co-occurring surface-form pairs to Hebbian-reinforce (related_to). */
+  reinforcePairs?: [string, string][];
+}
+
+export interface WriteEpisodeResult {
+  episodeId:    string;
+  createdNodes: number;
+  reusedNodes:  number;
+  linksCreated: number;
+  reinforced:   number;
+  nodeIds:      string[];
+}
+
 export interface AliasResolutionRecord {
   node_id:   string;
   title:     string;
@@ -463,5 +499,201 @@ export class KnowledgeGraphModel {
       [id],
     );
     return (result.rowCount ?? 0) > 0;
+  }
+
+  /** Normalize a surface form to a stable slug (mirrors the SQL norm_alias). */
+  private static normSlug(s: string): string {
+    return (s || '')
+      .normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase().replace(/[^a-z0-9#]+/g, '');
+  }
+
+  /**
+   * Scribe encoder (#518) — persist one completed episode atomically.
+   *
+   * Contract (matches the issue):
+   *  1. Resolve project + entities via the same alias resolution recall uses;
+   *     reuse any match with sim ≥ 0.85 instead of creating a duplicate.
+   *  2. Create the event node ("what happened"), plus lesson/blocker nodes and
+   *     any unmatched entities.
+   *  3. Alias every observed surface form.
+   *  4. Link: event `belongs_to` the project anchor; lessons `learned_from` the
+   *     event; blockers `blocked_by` the event; entities `mentioned_in` the
+   *     event. Every NEW node gets ≥1 edge (orphans are a write-side bug).
+   *  5. Hebbian: for each co-occurring resolved pair, ensure a `related_to`
+   *     edge then reinforce it (strength += 0.2×(1−strength), bump fire_count).
+   *
+   * Resolution (reads) runs first; all writes run in ONE transaction with
+   * link_count bumps. Never hard-deletes.
+   */
+  static async writeEpisode(input: WriteEpisodeInput): Promise<WriteEpisodeResult> {
+    const REUSE_SIM = 0.85;
+    const rand = (n: number) => Math.random().toString(36).slice(2, 2 + n);
+    const slugId = (prefix: string, title: string) => {
+      const s = KnowledgeGraphModel.normSlug(title);
+      return `${ prefix }_${ s || rand(8) }`;
+    };
+
+    if (!input?.event?.title?.trim()) {
+      throw new Error('writeEpisode: event.title is required');
+    }
+
+    // ── Phase 1: resolution (reads, pre-transaction) ─────────────────────
+    // Reuse an existing node when the strongest alias match clears the bar.
+    const resolveReuse = async(node: EpisodeNodeInput): Promise<string | null> => {
+      const terms = [node.title, ...(node.aliases ?? [])].map(t => (t || '').trim()).filter(Boolean);
+      if (terms.length === 0) return null;
+      const rows = await KnowledgeGraphModel.resolveAliases(terms);
+      return rows[0] && rows[0].sim >= REUSE_SIM ? rows[0].node_id : null;
+    };
+
+    interface PlannedNode { id: string; node: EpisodeNodeInput; type: string; isNew: boolean }
+    const planned: PlannedNode[] = [];
+    const reuseByTermNorm = new Map<string, string>(); // surface-form -> node id (for reinforce)
+
+    const registerTerms = (node: EpisodeNodeInput, id: string) => {
+      for (const t of [node.title, ...(node.aliases ?? [])]) {
+        const n = KnowledgeGraphModel.normSlug(t);
+        if (n) reuseByTermNorm.set(n, id);
+      }
+    };
+
+    let projectId: string | null = null;
+    if (input.project?.title?.trim()) {
+      const reused = await resolveReuse(input.project);
+      projectId = reused ?? slugId('kn', input.project.title);
+      planned.push({ id: projectId, node: input.project, type: input.project.node_type || 'project', isNew: !reused });
+      registerTerms(input.project, projectId);
+    }
+
+    // Event is always a fresh fact.
+    const eventId = `evt_${ Date.now() }_${ rand(6) }`;
+    planned.push({ id: eventId, node: input.event, type: 'event', isNew: true });
+    registerTerms(input.event, eventId);
+
+    const usedIds = new Set<string>([eventId, ...(projectId ? [projectId] : [])]);
+    const freshFactId = (prefix: string, title: string) => {
+      let id = slugId(prefix, title);
+      while (usedIds.has(id)) id = `${ id }_${ rand(3) }`;
+      usedIds.add(id);
+      return id;
+    };
+
+    const lessonIds: string[] = [];
+    for (const l of input.lessons ?? []) {
+      if (!l?.title?.trim()) continue;
+      const id = freshFactId('les', l.title);
+      lessonIds.push(id);
+      planned.push({ id, node: l, type: l.node_type || 'lesson', isNew: true });
+      registerTerms(l, id);
+    }
+
+    const blockerIds: string[] = [];
+    for (const b of input.blockers ?? []) {
+      if (!b?.title?.trim()) continue;
+      const id = freshFactId('blk', b.title);
+      blockerIds.push(id);
+      planned.push({ id, node: b, type: b.node_type || 'blocker', isNew: true });
+      registerTerms(b, id);
+    }
+
+    const entityIds: string[] = [];
+    for (const e of input.entities ?? []) {
+      if (!e?.title?.trim()) continue;
+      const reused = await resolveReuse(e);
+      const id = reused ?? slugId('kn', e.title);
+      if (usedIds.has(id)) { entityIds.push(id); continue; } // de-dupe within episode
+      usedIds.add(id);
+      entityIds.push(id);
+      planned.push({ id, node: e, type: e.node_type || 'entity', isNew: !reused });
+      registerTerms(e, id);
+    }
+
+    // Resolve reinforce pairs to node ids (this-episode nodes or committed ones).
+    const pairPlan: [string, string][] = [];
+    for (const [a, b] of input.reinforcePairs ?? []) {
+      const ida = reuseByTermNorm.get(KnowledgeGraphModel.normSlug(a)) ?? (await resolveReuse({ title: a }));
+      const idb = reuseByTermNorm.get(KnowledgeGraphModel.normSlug(b)) ?? (await resolveReuse({ title: b }));
+      if (ida && idb && ida !== idb) pairPlan.push([ida, idb]);
+    }
+
+    // ── Phase 2: writes (single transaction) ─────────────────────────────
+    return postgresClient.transaction(async(client) => {
+      let createdNodes = 0;
+      let reusedNodes = 0;
+      let linksCreated = 0;
+      let reinforced = 0;
+
+      for (const p of planned) {
+        await client.query(
+          `INSERT INTO ${ KnowledgeGraphModel.NODES_TABLE }
+             (id, node_type, title, summary, detail, source)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           ON CONFLICT (id) DO UPDATE SET
+             summary = CASE WHEN EXCLUDED.summary <> '' THEN EXCLUDED.summary ELSE ${ KnowledgeGraphModel.NODES_TABLE }.summary END,
+             detail  = COALESCE(EXCLUDED.detail, ${ KnowledgeGraphModel.NODES_TABLE }.detail),
+             updated_at = now()`,
+          [p.id, p.type, p.node.title, p.node.summary ?? '', p.node.detail ?? null, input.source ?? null],
+        );
+        if (p.isNew) createdNodes++; else reusedNodes++;
+
+        // Alias every observed surface form.
+        for (const alias of [p.node.title, ...(p.node.aliases ?? [])]) {
+          if (!alias?.trim()) continue;
+          await client.query(
+            `INSERT INTO ${ KnowledgeGraphModel.ALIASES_TABLE } (alias, alias_norm, node_id)
+             VALUES ($1, norm_alias($1), $2)
+             ON CONFLICT (alias_norm, node_id) DO UPDATE SET alias = EXCLUDED.alias`,
+            [alias, p.id],
+          );
+        }
+      }
+
+      // linkOnce: insert (or keep) an edge; bump link_count only on true insert.
+      const linkOnce = async(src: string, dst: string, rel: string, strength = 0.5) => {
+        if (src === dst) return;
+        const { rows } = await client.query<{ was_inserted: boolean }>(
+          `INSERT INTO ${ KnowledgeGraphModel.LINKS_TABLE } (src_id, dst_id, relation_type, strength)
+           VALUES ($1, $2, $3, $4)
+           ON CONFLICT (src_id, dst_id, relation_type) DO UPDATE SET strength = ${ KnowledgeGraphModel.LINKS_TABLE }.strength
+           RETURNING (xmax = 0) AS was_inserted`,
+          [src, dst, rel, strength],
+        );
+        if (rows[0]?.was_inserted) {
+          linksCreated++;
+          await client.query(
+            `UPDATE ${ KnowledgeGraphModel.NODES_TABLE } SET link_count = link_count + 1, updated_at = now() WHERE id IN ($1, $2)`,
+            [src, dst],
+          );
+        }
+      };
+
+      if (projectId) await linkOnce(eventId, projectId, 'belongs_to', 0.6);
+      for (const id of lessonIds) await linkOnce(id, eventId, 'learned_from', 0.6);
+      for (const id of blockerIds) await linkOnce(eventId, id, 'blocked_by', 0.6);
+      for (const id of entityIds) await linkOnce(id, eventId, 'mentioned_in', 0.5);
+
+      // Hebbian reinforcement of co-occurring resolved pairs.
+      for (const [a, b] of pairPlan) {
+        await linkOnce(a, b, 'related_to', 0.3);
+        const { rows } = await client.query<{ ok: boolean }>(
+          `UPDATE ${ KnowledgeGraphModel.LINKS_TABLE }
+           SET strength = strength + 0.2 * (1 - strength), fire_count = fire_count + 1, last_fired_at = now()
+           WHERE src_id = $1 AND dst_id = $2 AND relation_type = 'related_to'
+           RETURNING true AS ok`,
+          [a, b],
+        );
+        if (rows[0]?.ok) reinforced++;
+      }
+
+      return {
+        episodeId: eventId,
+        createdNodes,
+        reusedNodes,
+        linksCreated,
+        reinforced,
+        nodeIds: planned.map(p => p.id),
+      };
+    });
   }
 }

--- a/pkg/rancher-desktop/agent/database/models/__tests__/KnowledgeGraphModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/KnowledgeGraphModel.test.ts
@@ -279,4 +279,116 @@ describe('KnowledgeGraphModel', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ id: 'issue-517', activation: 1, hop: 0 });
   });
+
+  it('writeEpisode rejects a missing event.title without opening a transaction', async() => {
+    (postgresClient as any).transaction = jest.fn();
+    (postgresClient as any).query = jest.fn();
+
+    await expect(KnowledgeGraphModel.writeEpisode({ event: { title: '   ' } } as any))
+      .rejects.toThrow('writeEpisode: event.title is required');
+    expect(postgresClient.transaction).not.toHaveBeenCalled();
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('writeEpisode creates event/project/lesson/blocker/entity and Hebbian-reinforces a pair in one transaction', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([])); // resolveAliases → no reuse
+
+    const client: any = {
+      query: jest.fn((sql: string) => {
+        if (sql.includes('INSERT INTO knowledge_nodes')) return Promise.resolve({ rows: [] });
+        if (sql.includes('INSERT INTO node_aliases')) return Promise.resolve({ rows: [] });
+        if (sql.includes('INSERT INTO node_links')) return Promise.resolve({ rows: [{ was_inserted: true }] });
+        if (sql.includes('UPDATE knowledge_nodes')) return Promise.resolve({ rows: [] });
+        if (sql.includes("relation_type = 'related_to'")) return Promise.resolve({ rows: [{ ok: true }] });
+        return Promise.resolve({ rows: [] });
+      }),
+    };
+    (postgresClient as any).transaction = jest.fn((callback: any) => Promise.resolve(callback(client)));
+
+    const result = await KnowledgeGraphModel.writeEpisode({
+      source:  'heartbeat',
+      project: { title: 'Sulla Desktop', aliases: ['sulla-desktop'] },
+      event:   { title: 'Rebased episodic scribe onto main', summary: 'Writer half now sits on d6eed29ea.' },
+      lessons: [{ title: 'Rebase isolated worktrees, never the dirty primary checkout' }],
+      blockers: [{ title: 'Primary checkout is dirty on feat/projects-workboard' }],
+      entities: [{ title: 'EpisodicScribe' }],
+      reinforcePairs: [['Sulla Desktop', 'EpisodicScribe']],
+    });
+
+    expect(postgresClient.transaction).toHaveBeenCalledTimes(1);
+    expect(result.createdNodes).toBe(5); // project + event + lesson + blocker + entity
+    expect(result.reusedNodes).toBe(0);
+    expect(result.linksCreated).toBe(5); // belongs_to, learned_from, blocked_by, mentioned_in, related_to
+    expect(result.reinforced).toBe(1);
+    expect(result.episodeId).toMatch(/^evt_/);
+    expect(result.nodeIds).toHaveLength(5);
+
+    const inserts = client.query.mock.calls.filter((c: any[]) => String(c[0]).includes('INSERT INTO knowledge_nodes'));
+    expect(inserts).toHaveLength(5);
+    const types = inserts.map((c: any[]) => c[1][1]).sort();
+    expect(types).toEqual(['blocker', 'entity', 'event', 'lesson', 'project']);
+    expect(inserts.some((c: any[]) => c[1][5] === 'heartbeat')).toBe(true);
+
+    const rels = client.query.mock.calls
+      .filter((c: any[]) => String(c[0]).includes('INSERT INTO node_links'))
+      .map((c: any[]) => c[1][2])
+      .sort();
+    expect(rels).toEqual(['belongs_to', 'blocked_by', 'learned_from', 'mentioned_in', 'related_to']);
+  });
+
+  it('writeEpisode reuses a project whose alias sim is ≥ 0.85 and still creates a fresh event', async() => {
+    (postgresClient as any).query = jest.fn((_sql: string, params: any[]) => {
+      const terms: string[] = params?.[0] ?? [];
+      if (terms.some((t: string) => /sulla desktop/i.test(t))) {
+        return Promise.resolve([{
+          node_id: 'kn_sulladesktop', title: 'Sulla Desktop', node_type: 'project',
+          alias: 'Sulla Desktop', match: 'exact', sim: 0.97,
+        }]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const client: any = {
+      query: jest.fn((sql: string) => {
+        if (sql.includes('INSERT INTO node_links')) return Promise.resolve({ rows: [{ was_inserted: true }] });
+        return Promise.resolve({ rows: [] });
+      }),
+    };
+    (postgresClient as any).transaction = jest.fn((callback: any) => Promise.resolve(callback(client)));
+
+    const result = await KnowledgeGraphModel.writeEpisode({
+      project: { title: 'Sulla Desktop' },
+      event:   { title: 'Cycle shipped the scribe rebase' },
+    });
+
+    expect(result.createdNodes).toBe(1); // event only
+    expect(result.reusedNodes).toBe(1);  // project
+    expect(result.nodeIds).toContain('kn_sulladesktop');
+    expect(result.episodeId).not.toBe('kn_sulladesktop');
+    expect(result.linksCreated).toBe(1); // event belongs_to reused project
+  });
+
+  it('writeEpisode does not reuse a fuzzy match below the 0.85 bar', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([{
+      node_id: 'kn_other', title: 'Sulla Mobile', node_type: 'project',
+      alias: 'Sulla', match: 'fuzzy', sim: 0.62,
+    }]));
+
+    const client: any = {
+      query: jest.fn((sql: string) => {
+        if (sql.includes('INSERT INTO node_links')) return Promise.resolve({ rows: [{ was_inserted: true }] });
+        return Promise.resolve({ rows: [] });
+      }),
+    };
+    (postgresClient as any).transaction = jest.fn((callback: any) => Promise.resolve(callback(client)));
+
+    const result = await KnowledgeGraphModel.writeEpisode({
+      project: { title: 'Sulla Desktop' },
+      event:   { title: 'Did not collide with Sulla Mobile' },
+    });
+
+    expect(result.createdNodes).toBe(2);
+    expect(result.reusedNodes).toBe(0);
+    expect(result.nodeIds).not.toContain('kn_other');
+  });
 });

--- a/pkg/rancher-desktop/agent/middleware/EpisodicScribe.ts
+++ b/pkg/rancher-desktop/agent/middleware/EpisodicScribe.ts
@@ -1,0 +1,78 @@
+/**
+ * EpisodicScribe — the WRITE side of episodic memory (#518).
+ *
+ * Fires fire-and-forget when a conversation (episode) completes — from the
+ * Graph.ts completion hook, covering all three sources (heartbeat cycles,
+ * sub-agents, human desktop chats). Reads the whole episode and encodes it into
+ * knowledge-graph nodes/aliases/links so the Recall agent has something to land
+ * on. Mirrors the observation-writer lifecycle: fire-and-forget, soft-archive
+ * only, never blocks the turn.
+ *
+ * Gating lives here (and at the hook) so chit-chat mints nothing:
+ *   - Skip subconscious threads entirely (no recursion — the Scribe must never
+ *     fire on Scribe/Recall/summarizer runs).
+ *   - Work floor: only encode episodes with real work (≥1 tool call OR
+ *     ≥ MIN_MESSAGES messages).
+ */
+
+import { GraphRegistry } from '../services/GraphRegistry';
+
+import type { BaseThreadState } from '../nodes/Graph';
+
+/** Below this message count AND with no tool calls, an episode is chit-chat. */
+const MIN_MESSAGES = 4;
+
+/** A subconscious thread never triggers the Scribe (matches issue #518). */
+export function isSubconsciousThread(threadId: unknown): boolean {
+  return typeof threadId === 'string' && threadId.startsWith('subconscious_');
+}
+
+/** True when the episode carries enough real work to be worth encoding. */
+export function meetsEpisodeWorkFloor(state: BaseThreadState): boolean {
+  const messages = (state.messages ?? []) as any[];
+
+  let realMessages = 0;
+  let toolCalls = 0;
+  for (const m of messages) {
+    if (m?.role !== 'user' && m?.role !== 'assistant') continue;
+    if ((m?.metadata as any)?.source === 'subconscious') continue;
+    realMessages++;
+    if (Array.isArray(m.content) && m.content.some((b: any) => b?.type === 'tool_use')) toolCalls++;
+  }
+
+  return toolCalls >= 1 || realMessages >= MIN_MESSAGES;
+}
+
+/**
+ * Run the Scribe over a completed episode. Fire-and-forget — callers must NOT
+ * await this on the turn's critical path; it writes to the graph via tools and
+ * never mutates the parent state.
+ */
+export async function runEpisodicScribe(state: BaseThreadState): Promise<void> {
+  const startTime = Date.now();
+  const threadId = (state.metadata as any)?.threadId;
+
+  // Guard 1: never recurse on subconscious runs.
+  if (isSubconsciousThread(threadId)) return;
+
+  // Guard 2: work floor — chit-chat mints nothing.
+  if (!meetsEpisodeWorkFloor(state)) {
+    console.log(`[EpisodicScribe] Skipped — below work floor | threadId: ${ threadId }`);
+    return;
+  }
+
+  try {
+    const { graph, state: subState, threadId: scribeThreadId } = await GraphRegistry.createEpisodicScribe(state);
+    console.log(`[EpisodicScribe] Started | episode: ${ threadId } | scribe: ${ scribeThreadId }`);
+
+    await graph.execute(subState, 'subconscious', { maxIterations: 10 });
+
+    const agentMeta = (subState.metadata as any).agent || {};
+    const toolCalls = subState.messages.filter((m: any) =>
+      Array.isArray(m.content) && m.content.some((b: any) => b?.type === 'tool_use'),
+    ).length;
+    console.log(`[EpisodicScribe] Completed in ${ Date.now() - startTime }ms | tool_calls: ${ toolCalls }, status: ${ agentMeta.status }`);
+  } catch (error) {
+    console.error(`[EpisodicScribe] Failed in ${ Date.now() - startTime }ms:`, error instanceof Error ? error.message : error);
+  }
+}

--- a/pkg/rancher-desktop/agent/middleware/__tests__/EpisodicScribe.test.ts
+++ b/pkg/rancher-desktop/agent/middleware/__tests__/EpisodicScribe.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+
+import {
+  isSubconsciousThread,
+  meetsEpisodeWorkFloor,
+  runEpisodicScribe,
+} from '../EpisodicScribe';
+
+jest.mock('../../services/GraphRegistry', () => ({
+  GraphRegistry: {
+    createEpisodicScribe: jest.fn(),
+  },
+}));
+
+import { GraphRegistry } from '../../services/GraphRegistry';
+
+function msg(role: string, content: any, extra: Record<string, any> = {}) {
+  return { role, content, ...extra };
+}
+
+describe('EpisodicScribe gates', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('isSubconsciousThread matches the subconscious_ prefix only', () => {
+    expect(isSubconsciousThread('subconscious_abc')).toBe(true);
+    expect(isSubconsciousThread('heartbeat')).toBe(false);
+    expect(isSubconsciousThread(null)).toBe(false);
+    expect(isSubconsciousThread(12)).toBe(false);
+  });
+
+  it('meetsEpisodeWorkFloor is true when any real message carries a tool_use', () => {
+    const state: any = {
+      messages: [
+        msg('user', 'hi'),
+        msg('assistant', [{ type: 'tool_use', name: 'read_file', id: '1' }]),
+      ],
+    };
+    expect(meetsEpisodeWorkFloor(state)).toBe(true);
+  });
+
+  it('meetsEpisodeWorkFloor is true at ≥4 real user/assistant messages even without tools', () => {
+    const state: any = {
+      messages: [
+        msg('user', 'one'),
+        msg('assistant', 'two'),
+        msg('user', 'three'),
+        msg('assistant', 'four'),
+      ],
+    };
+    expect(meetsEpisodeWorkFloor(state)).toBe(true);
+  });
+
+  it('meetsEpisodeWorkFloor ignores subconscious-sourced messages and chit-chat', () => {
+    const state: any = {
+      messages: [
+        msg('user', 'hey', { metadata: { source: 'subconscious' } }),
+        msg('assistant', 'ok', { metadata: { source: 'subconscious' } }),
+        msg('user', 'hi'),
+        msg('assistant', 'hello'),
+        msg('system', 'noise'),
+      ],
+    };
+    expect(meetsEpisodeWorkFloor(state)).toBe(false);
+  });
+
+  it('runEpisodicScribe returns without launching a scribe on a subconscious thread', async() => {
+    await runEpisodicScribe({
+      messages: [msg('user', 'a'), msg('assistant', [{ type: 'tool_use', name: 'x', id: '1' }])],
+      metadata: { threadId: 'subconscious_scribe' },
+    } as any);
+    expect(GraphRegistry.createEpisodicScribe).not.toHaveBeenCalled();
+  });
+
+  it('runEpisodicScribe returns without launching a scribe below the work floor', async() => {
+    await runEpisodicScribe({
+      messages: [msg('user', 'hi'), msg('assistant', 'hey')],
+      metadata: { threadId: 'sulla-desktop' },
+    } as any);
+    expect(GraphRegistry.createEpisodicScribe).not.toHaveBeenCalled();
+  });
+
+  it('runEpisodicScribe launches the scribe graph when the floor is met', async() => {
+    const execute = jest.fn(async(..._args: any[]) => undefined);
+    (GraphRegistry.createEpisodicScribe as any).mockResolvedValue({
+      graph:    { execute },
+      state:    { metadata: { agent: { status: 'done' } }, messages: [] },
+      threadId: 'subconscious_scribe_1',
+    });
+
+    await runEpisodicScribe({
+      messages: [
+        msg('user', 'one'),
+        msg('assistant', [{ type: 'tool_use', name: 'read_file', id: '1' }]),
+      ],
+      metadata: { threadId: 'sulla-desktop' },
+    } as any);
+
+    expect(GraphRegistry.createEpisodicScribe).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledWith(expect.anything(), 'subconscious', { maxIterations: 10 });
+  });
+});

--- a/pkg/rancher-desktop/agent/nodes/Graph.ts
+++ b/pkg/rancher-desktop/agent/nodes/Graph.ts
@@ -516,6 +516,20 @@ export class Graph<TState = BaseThreadState> {
       });
       // Clear stopReason after sending
       (state as any).metadata.stopReason = null;
+
+      // ── Episodic Scribe (#518) — write side of episodic memory ──
+      // Fire-and-forget when a real episode completes (any source). Skipped
+      // when the agent is only pausing for the user (episode isn't done) and
+      // on subconscious threads (no recursion — the Scribe must never fire on
+      // Scribe/Recall/summarizer runs). Dynamic import breaks the
+      // Graph → GraphRegistry → EpisodicScribe require cycle. Never throws
+      // into the graph path; the runner enforces its own work-floor gate.
+      const episodeThreadId = (state as any).metadata.threadId;
+      if (!waitingForUser && typeof episodeThreadId === 'string' && !episodeThreadId.startsWith('subconscious_')) {
+        void import('../middleware/EpisodicScribe')
+          .then(m => m.runEpisodicScribe(state as unknown as BaseThreadState))
+          .catch(err => console.error('[EpisodicScribe] launch failed:', err instanceof Error ? err.message : err));
+      }
     }
 
     // Restore previous reentry flag so nested reentries unwind correctly

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -60,6 +60,12 @@ const EPISODIC_RECALL_TOOLS: string[] = [
   'episodic_recall',
 ];
 
+/** Episodic Scribe (#518): resolve entities for dedup, then write the episode. */
+const EPISODIC_SCRIBE_TOOLS: string[] = [
+  'episodic_resolve',        // Read-side dedup: check what already exists before encoding
+  'episodic_write_episode',  // Persist the encoded episode atomically (call once)
+];
+
 /** Observation Writer: write/archive observations and update identity files */
 const OBSERVATION_AGENT_TOOLS: string[] = [
   'add_observational_memory',     // Insert or update an observation row
@@ -521,6 +527,44 @@ AGENT_DONE.
 
 After the tool returns, emit only the tool's episodic context payload inside
 AGENT_DONE. If the tool returns an empty context, emit an empty AGENT_DONE.`;
+
+const EPISODIC_SCRIBE_PROMPT = `You are the SCRIBE — the write side of episodic memory. A conversation just
+completed. Your job is to distill it into durable knowledge-graph facts so the
+Recall agent can land on them later. You run fire-and-forget; nobody is waiting.
+
+## What to encode
+
+Read the WHOLE completed conversation and produce ONE episode:
+
+- **event** (required): "what happened" — the outcome of this conversation in a
+  few sentences. Write the summary to be read COLD months from now, with no
+  other context: name the concrete result, decisions, and where things landed.
+- **project**: the project/epic this belongs to (e.g. "Sulla Desktop",
+  "Reborn Exteriors"), with any aliases. Omit only if genuinely none applies.
+- **lessons**: durable things learned ("what we learned") — 0 to a few.
+- **blockers**: anything that blocked progress — 0 to a few.
+- **entities**: the concrete nouns that appeared — projects, features, people,
+  services, files, issue numbers. Give each its surface forms as aliases.
+- **reinforcePairs**: pairs of entities/terms that co-occurred meaningfully,
+  so their association strengthens over time.
+
+## How to work (fast, ≤2 rounds)
+
+1. Extract the salient surface forms (entities, project, key nouns).
+2. Call \`episodic_resolve\` ONCE with all of them so you know what already
+   exists (write-side dedup mirrors read-side recall). Reuse those names.
+3. Call \`episodic_write_episode\` EXACTLY ONCE with the full encoding. It
+   handles dedup, aliasing, linking, and reinforcement atomically — you just
+   supply good content. Every entity you name should also appear in a
+   reinforcePair or be a project/lesson so nothing is orphaned.
+
+## Rules
+
+- Encode only what actually happened in THIS conversation. Never invent facts,
+  outcomes, or entities that weren't discussed.
+- Summaries are the product — specific and self-contained beats vague.
+- Do not store secrets, credentials, or tokens.
+- One \`episodic_write_episode\` call, then finish. Output nothing else.`;
 
 // ── Heartbeat-specific memory recall ──────────────────────────────────────
 
@@ -1341,6 +1385,36 @@ export const GraphRegistry = {
       contextWindow:          12,
       parentAbortSignal:      (parentState.metadata as any).options?.abort,
       agentLabel:             'episodic-recall',
+      parentWsChannel:        String(parentState.metadata.wsChannel || ''),
+      parentConversationId:   (parentState.metadata as any).threadId || (parentState.metadata as any).conversationId,
+      workflowNodeId:         (parentState.metadata as any).workflowNodeId,
+      workflowParentChannel:  (parentState.metadata as any).workflowParentChannel,
+    });
+    return { graph, state, threadId: state.metadata.threadId };
+  },
+
+  /**
+   * Create an Episodic Scribe graph (#518) — the WRITE side of episodic memory.
+   * Fires fire-and-forget when a conversation completes; reads the whole episode
+   * and encodes it into knowledge-graph nodes/aliases/links via
+   * episodic_write_episode. Populates the graph the Recall agent reads from.
+   */
+  createEpisodicScribe: async function(parentState: BaseThreadState): Promise<{
+    graph:    Graph<BaseThreadState>;
+    state:    BaseThreadState;
+    threadId: string;
+  }> {
+    const graph = createSubconsciousGraph();
+    const state = await buildSubconsciousState({
+      systemPrompt:           EPISODIC_SCRIBE_PROMPT,
+      tools:                  EPISODIC_SCRIBE_TOOLS,
+      userMessage:            'The conversation above just completed. Encode it into ONE episode: resolve the entities, then make exactly one episodic_write_episode call with the event, project, lessons, blockers, entities, and reinforce pairs. Encode only what actually happened.',
+      messages:               [...parentState.messages],
+      // Wide window — the Scribe mines the whole episode for facts, like the
+      // observation writer. The summarizer has already compacted anything older.
+      contextWindow:          40,
+      parentAbortSignal:      (parentState.metadata as any).options?.abort,
+      agentLabel:             'episodic-scribe',
       parentWsChannel:        String(parentState.metadata.wsChannel || ''),
       parentConversationId:   (parentState.metadata as any).threadId || (parentState.metadata as any).conversationId,
       workflowNodeId:         (parentState.metadata as any).workflowNodeId,

--- a/pkg/rancher-desktop/agent/tools/episodic/episodic_write_episode.ts
+++ b/pkg/rancher-desktop/agent/tools/episodic/episodic_write_episode.ts
@@ -1,0 +1,81 @@
+import { KnowledgeGraphModel, type EpisodeNodeInput, type WriteEpisodeInput } from '../../database/models/KnowledgeGraphModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * EpisodicWriteEpisode (#518) — persist one completed episode to the knowledge
+ * graph. The Scribe agent encodes what happened, then calls this ONCE. All
+ * writes are atomic (single transaction) with resolve-and-reuse dedup, alias
+ * capture, linking (every new node gets ≥1 edge), and Hebbian reinforcement of
+ * co-occurring pairs. See KnowledgeGraphModel.writeEpisode for the contract.
+ */
+export class EpisodicWriteEpisodeWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  private normNode(raw: any): EpisodeNodeInput | null {
+    if (!raw) return null;
+    // Accept either a string ("just a title") or a full object.
+    if (typeof raw === 'string') {
+      const title = raw.trim();
+      return title ? { title } : null;
+    }
+    const title = String(raw.title ?? '').trim();
+    if (!title) return null;
+    return {
+      title,
+      summary:   raw.summary != null ? String(raw.summary) : undefined,
+      detail:    raw.detail != null ? String(raw.detail) : undefined,
+      aliases:   Array.isArray(raw.aliases) ? raw.aliases.map(String).filter(Boolean) : undefined,
+      node_type: raw.node_type != null ? String(raw.node_type) : undefined,
+    };
+  }
+
+  private normList(raw: any): EpisodeNodeInput[] {
+    if (!Array.isArray(raw)) return [];
+    return raw.map(r => this.normNode(r)).filter((n): n is EpisodeNodeInput => n != null);
+  }
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const event = this.normNode(input.event);
+    if (!event) {
+      return { successBoolean: false, responseString: 'episodic_write_episode requires an "event" with a non-empty title ("what happened").' };
+    }
+
+    // Reinforce pairs: accept [[a,b],...] or [{a,b}/{from,to}/{src,dst}].
+    const reinforcePairs: [string, string][] = [];
+    if (Array.isArray(input.reinforcePairs)) {
+      for (const p of input.reinforcePairs) {
+        if (Array.isArray(p) && p[0] && p[1]) reinforcePairs.push([String(p[0]), String(p[1])]);
+        else if (p && typeof p === 'object') {
+          const a = p.a ?? p.from ?? p.src;
+          const b = p.b ?? p.to ?? p.dst;
+          if (a && b) reinforcePairs.push([String(a), String(b)]);
+        }
+      }
+    }
+
+    const payload: WriteEpisodeInput = {
+      source:         input.source != null ? String(input.source) : undefined,
+      project:        this.normNode(input.project),
+      event,
+      lessons:        this.normList(input.lessons),
+      blockers:       this.normList(input.blockers),
+      entities:       this.normList(input.entities),
+      reinforcePairs,
+    };
+
+    try {
+      const r = await KnowledgeGraphModel.writeEpisode(payload);
+      return {
+        successBoolean: true,
+        responseString:
+          `Episode written: ${ r.episodeId }\n` +
+          `nodes: ${ r.createdNodes } created, ${ r.reusedNodes } reused\n` +
+          `edges: ${ r.linksCreated } created, ${ r.reinforced } reinforced\n` +
+          `nodeIds: ${ r.nodeIds.join(', ') }`,
+      };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to write episode: ${ err?.message ?? String(err) }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/episodic/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/episodic/manifests.ts
@@ -1,7 +1,5 @@
 import type { ToolManifest } from '../registry';
 
-const notImplemented = (issue: '#517' | '#518') => () => Promise.reject(new Error(`not implemented until ${ issue }`));
-
 export const episodicToolManifests: ToolManifest[] = [
   {
     name:        'episodic_resolve',
@@ -31,14 +29,18 @@ export const episodicToolManifests: ToolManifest[] = [
   },
   {
     name:        'episodic_write_episode',
-    description: 'Write encoded episode nodes, aliases, and links to episodic memory. Declared for Phase 3.',
+    description: 'Persist ONE completed episode to the knowledge graph. Call once, at the end of encoding. Writes are atomic: the project anchor and entities are resolved and reused if they already exist (no duplicates); the event node plus lessons/blockers/new entities are created; every observed surface form becomes an alias; edges are created (event belongs_to project, lessons learned_from event, blockers blocked_by event, entities mentioned_in event) so no node is orphaned; and co-occurring pairs are Hebbian-reinforced. Provide the richest encoding you can — this is how the graph grows.',
     category:    'memory',
     schemaDef:   {
-      nodes:    { type: 'array', optional: true, items: { type: 'object' }, description: 'Encoded knowledge nodes.' },
-      links:    { type: 'array', optional: true, items: { type: 'object' }, description: 'Encoded node links.' },
-      resolved: { type: 'array', optional: true, items: { type: 'object' }, description: 'Previously resolved node matches.' },
+      source:  { type: 'string', optional: true, description: "Episode origin: 'chat', 'heartbeat', or 'sub-agent'." },
+      project: { type: 'object', optional: true, description: 'The project/epic this episode belongs to: { title, aliases?: string[] }. Resolved+reused if it already exists.' },
+      event:   { type: 'object', description: 'REQUIRED. The "what happened" node: { title, summary, detail?, aliases?: string[] }. Summary is written to be read cold months later.' },
+      lessons: { type: 'array', optional: true, items: { type: 'object' }, description: 'What we learned: [{ title, summary, detail? }] — linked learned_from the event.' },
+      blockers: { type: 'array', optional: true, items: { type: 'object' }, description: 'Blockers hit: [{ title, summary }] — linked blocked_by the event.' },
+      entities: { type: 'array', optional: true, items: { type: 'object' }, description: 'Entities/concepts/people/services seen: [{ title, aliases?: string[], node_type? }] — resolved+reused, linked mentioned_in the event.' },
+      reinforcePairs: { type: 'array', optional: true, items: { type: 'array', items: { type: 'string' } }, description: 'Pairs of surface forms that co-occurred, e.g. [["Sulla Desktop","episodic memory"]] — each pair gets a reinforced related_to edge.' },
     },
     operationTypes: ['create', 'update'],
-    loader:         notImplemented('#518'),
+    loader:         () => import('./episodic_write_episode'),
   },
 ];


### PR DESCRIPTION
**Supersedes #567.** Same rescue, now rebased onto current `main` (`d6eed29ea`) with the schema-reconcile caveat closed and two test commits locking the writer contract.

**Not part of the #560–#566 one-pass gate.** Do not fold this into GATE-MERGE-BRIEFING.md. Merge after the 7-PR rebuild, or independently if you want the writer half live sooner — it is additive (no migration; uses the already-shipped `0029` knowledge-graph tables).

## Why this exists
`main` ships the *recall* half (`episodic_recall` / `episodic_resolve`) but nothing writes the store. This branch is the *writer* half: a fire-and-forget Scribe that encodes a completed episode into `knowledge_nodes` / `node_aliases` / `node_links` so recall has something to land on.

The original commit (`563e0814c`, 2026-08-04) sat local-only for 10 days. Heartbeat rescued it as DRAFT #567 on the un-rebased branch (~71 commits behind). This cycle finished the rebase in the isolated worktree (`sulla-desktop-integration-episodic-memory`) and added the contract tests.

## What landed (3 commits on `d6eed29ea`)
1. `de22b935f` feat(episodic): EpisodicScribe middleware + `episodic_write_episode` + `KnowledgeGraphModel.writeEpisode` + Graph.ts completion hook + GraphRegistry.createEpisodicScribe
2. `8b91a5f3a` test(episodic): lock Scribe work-floor + no-recursion gates
3. `77a7d594d` test(episodic): cover writeEpisode reuse bar, edges, Hebbian reinforce

Tip: `77a7d594d`.

## Schema reconcile — CLOSED
Live PG already has `knowledge_nodes` / `node_aliases` / `node_links` from migration `0029`. `writeEpisode` columns + constraints match the live schema (id/node_type/title/summary/detail/source, alias_norm via `norm_alias()`, unique `(src_id,dst_id,relation_type)`, `fire_count`/`last_fired_at` for Hebbian). No new migration. Observations table (0028) is a separate lane — this does not touch it.

## Contract (locked by tests, 20/20 green)
- Subconscious threads (`threadId` starts with `subconscious_`) never launch a scribe (no recursion).
- Work floor: skip unless ≥1 `tool_use` OR ≥4 real user/assistant messages. Chit-chat mints nothing.
- `writeEpisode` rejects empty `event.title` without opening a transaction.
- One transaction creates project/event/lesson/blocker/entity + the five relation types (`belongs_to`, `learned_from`, `blocked_by`, `mentioned_in`, `related_to`).
- Reuse an existing project at alias sim ≥ 0.85; still mint a fresh event. Refuse a fuzzy match below the bar.

## Why a new branch (not a force-push of #567)
`sulla github/git_push force:true` emits a bare `--force-with-lease` against an HTTPS URL (not the named `origin` remote), so git has no tracking ref to lease against and always rejects with `stale info`. Pushing the rebased tip to a new branch is the reversible, never-lose-code path. Old rescue branch `feat/episodic-scribe-518` @ `563e0814c` stays on origin as the historical rescue; #567 will be closed as superseded.

## Verify
```
NODE_PATH=/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop/node_modules \
  /Users/jonathonbyrdziak/Sites/sulla/sulla-desktop/node_modules/.bin/jest \
  --config /Users/jonathonbyrdziak/Sites/sulla/sulla-desktop/jest.config.js \
  pkg/rancher-desktop/agent/middleware/__tests__/EpisodicScribe.test.ts \
  pkg/rancher-desktop/agent/database/models/__tests__/KnowledgeGraphModel.test.ts
# 20/20 passed (2026-08-14 20:4x)
```

Rebuild+restart still required for the writer to fire in the running binary. Do not merge into the #560–#566 one-pass set.