### PR TITLE
fix(agent): recover from provider failures

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/providerRecovery.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/providerRecovery.test.ts
@@ -1,0 +1,58 @@
+import { classifyLLMFailure, redactLLMFailureMessage, sameLLMRoute } from '../providerRecovery';
+
+describe('providerRecovery', () => {
+  it('classifies quota and weekly-limit failures as fallbackable provider failures', () => {
+    expect(classifyLLMFailure(new Error('HTTP 402 Grok Build usage balance exhausted'))).toMatchObject({
+      kind:            'quota',
+      retryPrimary:    false,
+      fallbackAllowed: true,
+    });
+
+    expect(classifyLLMFailure(new Error('Claude weekly limit reached'))).toMatchObject({
+      kind:            'quota',
+      retryPrimary:    false,
+      fallbackAllowed: true,
+    });
+  });
+
+  it('classifies process and stream failures as retryable before fallback', () => {
+    expect(classifyLLMFailure(new Error('Codex app-server event stream lag dropped events'))).toMatchObject({
+      kind:            'unavailable',
+      retryPrimary:    true,
+      fallbackAllowed: true,
+    });
+
+    expect(classifyLLMFailure(new Error('codex exited with code null'))).toMatchObject({
+      kind:            'unavailable',
+      retryPrimary:    true,
+      fallbackAllowed: true,
+    });
+  });
+
+  it('treats aborts as controlled interruptions, not provider fallbacks', () => {
+    const err = new Error('Chat operation aborted');
+    (err as any).name = 'AbortError';
+
+    expect(classifyLLMFailure(err)).toMatchObject({
+      kind:            'interrupted',
+      retryPrimary:    false,
+      fallbackAllowed: false,
+    });
+  });
+
+  it('redacts provider secrets from failure messages', () => {
+    expect(redactLLMFailureMessage('bad key sk-proj-abcdefghijklmnopqrstuvwxyz123456')).toBe('bad key [redacted]');
+  });
+
+  it('detects duplicate provider/model fallback routes', () => {
+    expect(sameLLMRoute(
+      { provider: 'OpenAI Codex', model: 'codex' },
+      { provider: 'openai codex', model: 'CODEX' },
+    )).toBe(true);
+
+    expect(sameLLMRoute(
+      { provider: 'OpenAI Codex', model: 'codex' },
+      { provider: 'OpenAI', model: 'gpt-5' },
+    )).toBe(false);
+  });
+});

--- a/pkg/rancher-desktop/agent/languagemodels/providerRecovery.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/providerRecovery.ts
@@ -1,0 +1,126 @@
+export type LLMFailureKind =
+  | 'auth'
+  | 'quota'
+  | 'rate_limit'
+  | 'timeout'
+  | 'unavailable'
+  | 'empty'
+  | 'interrupted'
+  | 'unknown';
+
+export interface LLMFailureRecovery {
+  kind:            LLMFailureKind;
+  retryPrimary:    boolean;
+  fallbackAllowed: boolean;
+  userMessage:     string;
+}
+
+const SECRET_PATTERNS = [
+  /\bsk-[A-Za-z0-9_-]{8,}\b/g,
+  /\bsk-proj-[A-Za-z0-9_-]{8,}\b/g,
+  /\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/g,
+];
+
+export function redactLLMFailureMessage(value: unknown): string {
+  let text = value instanceof Error ? value.message : String(value ?? '');
+  for (const pattern of SECRET_PATTERNS) {
+    text = text.replace(pattern, '[redacted]');
+  }
+  return text;
+}
+
+export function classifyLLMFailure(error: unknown): LLMFailureRecovery {
+  const name = (error as any)?.name;
+  const message = redactLLMFailureMessage(error);
+  const lower = `${ name || '' } ${ message }`.toLowerCase();
+
+  if (name === 'AbortError' || lower.includes('aborted') || lower.includes('aborterror')) {
+    return {
+      kind:            'interrupted',
+      retryPrimary:    false,
+      fallbackAllowed: false,
+      userMessage:     'The prior model run was interrupted.',
+    };
+  }
+
+  if (/\b401\b/.test(lower) || lower.includes('unauthorized') || lower.includes('invalid api key')) {
+    return {
+      kind:            'auth',
+      retryPrimary:    false,
+      fallbackAllowed: true,
+      userMessage:     'The selected model provider rejected its credentials.',
+    };
+  }
+
+  if (/\b402\b/.test(lower) || lower.includes('balance exhausted') || lower.includes('usage balance') || lower.includes('weekly limit')) {
+    return {
+      kind:            'quota',
+      retryPrimary:    false,
+      fallbackAllowed: true,
+      userMessage:     'The selected model provider is out of usable quota.',
+    };
+  }
+
+  if (/\b429\b/.test(lower) || lower.includes('rate limit') || lower.includes('too many requests')) {
+    return {
+      kind:            'rate_limit',
+      retryPrimary:    true,
+      fallbackAllowed: true,
+      userMessage:     'The selected model provider is rate limited.',
+    };
+  }
+
+  if (lower.includes('timeout') || lower.includes('timed out') || lower.includes('etimedout')) {
+    return {
+      kind:            'timeout',
+      retryPrimary:    true,
+      fallbackAllowed: true,
+      userMessage:     'The selected model provider timed out.',
+    };
+  }
+
+  if (
+    lower.includes('no response') ||
+    lower.includes('empty response') ||
+    lower.includes('returned empty') ||
+    lower.includes('no extractable prompt')
+  ) {
+    return {
+      kind:            'empty',
+      retryPrimary:    true,
+      fallbackAllowed: true,
+      userMessage:     'The selected model provider returned no usable response.',
+    };
+  }
+
+  if (
+    lower.includes('event stream') ||
+    lower.includes('dropped event') ||
+    lower.includes('stream lag') ||
+    lower.includes('exited with code null') ||
+    lower.includes('econnreset') ||
+    lower.includes('econnrefused') ||
+    lower.includes('network') ||
+    lower.includes('service unavailable') ||
+    /\b5\d\d\b/.test(lower)
+  ) {
+    return {
+      kind:            'unavailable',
+      retryPrimary:    true,
+      fallbackAllowed: true,
+      userMessage:     'The selected model provider was temporarily unavailable.',
+    };
+  }
+
+  return {
+    kind:            'unknown',
+    retryPrimary:    false,
+    fallbackAllowed: true,
+    userMessage:     'The selected model provider failed.',
+  };
+}
+
+export function sameLLMRoute(a: { provider: string; model: string }, b: { provider: string; model: string }): boolean {
+  return a.provider.trim().toLowerCase() === b.provider.trim().toLowerCase() &&
+    a.model.trim().toLowerCase() === b.model.trim().toLowerCase();
+}

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -6,19 +6,18 @@ import { ToolExecutor } from '../controllers/ToolExecutor';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { getAgentOverrideService, getPrimaryService, getSecondaryService, getSubconsciousService } from '../languagemodels';
 import { BaseLanguageModel, ChatMessage, NormalizedResponse, FinishReason, type StreamCallbacks } from '../languagemodels/BaseLanguageModel';
+import { classifyLLMFailure, redactLLMFailureMessage, sameLLMRoute } from '../languagemodels/providerRecovery';
+import { SystemPromptBuilder, type PromptBuildContext, type AgentConfig, type AnthropicSystemBlock } from '../prompts/SystemPromptBuilder';
+import { INTEGRATIONS_INSTRUCTIONS_BLOCK } from '../prompts/environment';
 import { throwIfAborted } from '../services/AbortService';
 import { parseJson } from '../services/JsonParseService';
 import { getWebSocketClientService } from '../services/WebSocketClientService';
 import { toolRegistry } from '../tools/registry';
 import { stripProtocolTags, stripProtocolTagsStreaming } from '../utils/stripProtocolTags';
 import { resolveSullaProjectsDir, resolveSullaSkillsDir, resolveSullaAgentsDir, resolveSullaCodebaseDir, findAgentDir, resolveSullaHomeDir, resolveSullaDocsDir } from '../utils/sullaPaths';
-import { INTEGRATIONS_INSTRUCTIONS_BLOCK } from '../prompts/environment';
 
 import type { BaseThreadState, NodeResult } from './Graph';
 import type { StreamContext } from '../controllers/Extractor';
-
-import { SystemPromptBuilder, type PromptBuildContext, type AgentConfig, type AnthropicSystemBlock } from '../prompts/SystemPromptBuilder';
-
 import type { WebSocketMessageHandler } from '../services/WebSocketClientService';
 import type { ToolResult, ThreadState } from '../types';
 import '../prompts/sections/index'; // Register all sections on import
@@ -557,9 +556,8 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
         bumpStateVersion:      (state) => this.bumpStateVersion(state),
       });
       // Wire live currentNodeRunContext via property descriptor
-      const self = this;
       Object.defineProperty(this._toolExecutor['ctx'], 'currentNodeRunContext', {
-        get() { return self.currentNodeRunContext },
+        get:          () => this.currentNodeRunContext,
         configurable: true,
       });
     }
@@ -1220,63 +1218,138 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
 
       return reply;
     } catch (err) {
-      if ((err as any)?.name === 'AbortError') throw err;
+      const initialRecovery = classifyLLMFailure(err);
+      if (initialRecovery.kind === 'interrupted') throw err;
 
       const primaryName = this.llm.getProviderName?.() || 'primary';
       const primaryId = this.llm.getModel?.() || '';
-      const errMsg = err instanceof Error ? err.message : String(err);
-      console.warn(`[${ this.name }:BaseNode] Primary LLM failed (${ primaryName }):`, errMsg);
+      let lastErr = err;
+      let lastErrMsg = redactLLMFailureMessage(err);
+      let recovery = initialRecovery;
+      console.warn(
+        `[${ this.name }:BaseNode] Primary LLM failed ` +
+        `(provider=${ primaryName }, model=${ primaryId || '(default)' }, kind=${ recovery.kind }): ${ lastErrMsg }`,
+      );
 
-      // Never silently swap models out from under the user — when they pick a
-      // specific provider they want to know it failed, not get an answer from
-      // a different model pretending to be the same assistant. Fallback only
-      // runs when the primary is a generic/unselected provider.
-      const explicitPrimary = primaryId === 'claude-code' || primaryName === 'Claude Code' ||
-        primaryId === 'codex' || primaryName === 'OpenAI Codex';
-      if (explicitPrimary) {
-        throw new Error(`${ primaryName } failed: ${ errMsg }`);
-      }
-
-      // Fallback to secondary provider — only if it's healthy
-      try {
-        const secondary = await getSecondaryService();
-        await secondary.initialize();
-        if (secondary.isAvailable()) {
-          const secondaryName = secondary.getProviderName?.() || secondary.getModel();
-          console.warn(`[${ this.name }:BaseNode] Falling back to secondary provider (${ secondaryName }) — primary ${ primaryName } failed`);
-          const chatMessages = messages.filter(msg =>
-            ['system', 'user', 'assistant'].includes(msg.role),
+      if (recovery.retryPrimary) {
+        try {
+          console.warn(
+            `[${ this.name }:BaseNode] Retrying primary provider once ` +
+            `(provider=${ primaryName }, model=${ primaryId || '(default)' }, kind=${ recovery.kind })`,
           );
-          const reply = await secondary.chat(chatMessages, {
-            signal:      state.metadata?.options?.abort?.signal,
-            temperature: options.temperature,
+          const retryMessages = this.buildReducedRetryMessages(messages);
+          const retryReply = await this.llm.chat(retryMessages, {
             maxTokens:   options.maxTokens,
             format:      options.format,
+            temperature: options.temperature,
+            signal:      state.metadata?.options?.abort?.signal,
+            tools:       llmTools,
             conversationId,
             nodeName,
           });
-          if (reply) {
-            // Annotate the reply so downstream UI can badge it as a fallback.
-            (reply.metadata as any).fallback_used = true;
-            (reply.metadata as any).fallback_from = primaryName;
-            (reply.metadata as any).fallback_to = secondaryName;
-            this.appendResponse(state, reply.content, reply.metadata.rawProviderContent);
-            return reply;
+          if (retryReply && (retryReply.content?.trim() || retryReply.metadata.tool_calls?.length)) {
+            (retryReply.metadata as any).retry_used = true;
+            (retryReply.metadata as any).retry_provider = primaryName;
+            (retryReply.metadata as any).retry_model = primaryId;
+            (retryReply.metadata as any).retry_reason = recovery.kind;
+            this.appendResponse(state, retryReply.content, retryReply.metadata.rawProviderContent);
+            return retryReply;
           }
-        } else {
-          console.warn(`[${ this.name }:BaseNode] Secondary provider not available — skipping fallback`);
+          throw new Error(`LLM returned empty response on provider retry (model=${ primaryId || this.llm.getModel() }, provider=${ primaryName })`);
+        } catch (retryErr) {
+          const retryRecovery = classifyLLMFailure(retryErr);
+          if (retryRecovery.kind === 'interrupted') throw retryErr;
+          lastErr = retryErr;
+          lastErrMsg = redactLLMFailureMessage(retryErr);
+          recovery = retryRecovery;
+          console.warn(
+            `[${ this.name }:BaseNode] Primary retry failed ` +
+            `(provider=${ primaryName }, model=${ primaryId || '(default)' }, kind=${ recovery.kind }): ${ lastErrMsg }`,
+          );
         }
-      } catch (fallbackErr) {
-        if ((fallbackErr as any)?.name === 'AbortError') throw fallbackErr;
-        console.error(`[${ this.name }:BaseNode] Secondary provider fallback failed:`, fallbackErr);
+      }
+
+      // Fallback to secondary provider. Health check failures are logged, but
+      // the call is still attempted because provider health probes often test
+      // a different endpoint than chat completion.
+      if (recovery.fallbackAllowed) {
+        try {
+          const secondary = await getSecondaryService();
+          const secondaryName = secondary.getProviderName?.() || secondary.getModel();
+          const secondaryModel = secondary.getModel?.() || '';
+          const sameRoute = sameLLMRoute(
+            { provider: primaryName, model: primaryId },
+            { provider: secondaryName, model: secondaryModel },
+          );
+
+          if (sameRoute) {
+            console.warn(
+              `[${ this.name }:BaseNode] Secondary provider matches failed primary ` +
+              `(provider=${ secondaryName }, model=${ secondaryModel || '(default)' }) — skipping fallback`,
+            );
+          } else {
+            const initialized = await secondary.initialize();
+            if (!initialized || !secondary.isAvailable()) {
+              console.warn(
+                `[${ this.name }:BaseNode] Secondary provider did not pass health check ` +
+                `(provider=${ secondaryName }, model=${ secondaryModel || '(default)' }) — attempting fallback call anyway`,
+              );
+            }
+            console.warn(
+              `[${ this.name }:BaseNode] Falling back to secondary provider ` +
+              `(from=${ primaryName }/${ primaryId || '(default)' }, to=${ secondaryName }/${ secondaryModel || '(default)' }, reason=${ recovery.kind })`,
+            );
+            const chatMessages = messages.filter(msg =>
+              ['system', 'user', 'assistant'].includes(msg.role),
+            );
+            const reply = await secondary.chat(chatMessages, {
+              signal:      state.metadata?.options?.abort?.signal,
+              temperature: options.temperature,
+              maxTokens:   options.maxTokens,
+              format:      options.format,
+              tools:       llmTools,
+              conversationId,
+              nodeName,
+            });
+            if (reply && (reply.content?.trim() || reply.metadata.tool_calls?.length)) {
+            // Annotate the reply so downstream UI can badge it as a fallback.
+              (reply.metadata as any).fallback_used = true;
+              (reply.metadata as any).fallback_from = primaryName;
+              (reply.metadata as any).fallback_to = secondaryName;
+              (reply.metadata as any).fallback_reason = recovery.kind;
+              (reply.metadata as any).failed_model = primaryId;
+              (reply.metadata as any).fallback_model = secondaryModel;
+              this.appendResponse(state, reply.content, reply.metadata.rawProviderContent);
+              return reply;
+            }
+            throw new Error(`Secondary provider returned empty response (provider=${ secondaryName }, model=${ secondaryModel || '(default)' })`);
+          }
+        } catch (fallbackErr) {
+          const fallbackRecovery = classifyLLMFailure(fallbackErr);
+          if (fallbackRecovery.kind === 'interrupted') throw fallbackErr;
+          lastErr = fallbackErr;
+          lastErrMsg = redactLLMFailureMessage(fallbackErr);
+          console.error(`[${ this.name }:BaseNode] Secondary provider fallback failed (${ fallbackRecovery.kind }):`, lastErrMsg);
+        }
       }
 
       // Propagate the error so the chat UI can display it to the user
-      throw new Error(`[${ this.name }] LLM provider failed: ${ errMsg }`);
+      throw new Error(
+        `[${ this.name }] LLM provider recovery failed: ${ recovery.userMessage } ` +
+        `Tried ${ primaryName }/${ primaryId || '(default)' }` +
+        `${ recovery.fallbackAllowed ? ' and the configured fallback provider' : '' }. ` +
+        `Last error: ${ redactLLMFailureMessage(lastErr) || lastErrMsg }`,
+      );
     } finally {
       this.currentNodeRunContext = previousRunContext;
       (state.metadata as any).__toolAccessPolicy = previousToolAccessPolicy;
     }
+  }
+
+  private buildReducedRetryMessages(messages: ChatMessage[]): ChatMessage[] {
+    const systemMsgs = messages.filter(m => m.role === 'system');
+    const recentMsgs = messages.filter(m => m.role !== 'system').slice(-3);
+    return [...systemMsgs, ...recentMsgs];
   }
 
   private buildToolAccessPolicyForCall(options: LLMCallOptions) {
@@ -1358,7 +1431,7 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
   /**
      * Helper method to respond gracefully when abort is detected
      */
-  protected async handleAbort(state: BaseThreadState, message?: string): Promise<void> {
+  protected handleAbort(state: BaseThreadState, message?: string): void {
     const abortMessage = message || "OK, I'm stopping everything. What do you need me to do?";
     this.wsChatMessage(state, abortMessage, 'assistant', 'progress');
   }
@@ -1369,7 +1442,7 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
      * When present and containing tool_use blocks, the native content array is stored directly
      * so buildRequestBody can pass it through as-is on subsequent turns.
      */
-  protected async appendResponse(state: BaseThreadState, content: string, rawProviderContent?: any): Promise<void> {
+  protected appendResponse(state: BaseThreadState, content: string, rawProviderContent?: any): void {
     const contentStr = typeof content === 'string' ? content : JSON.stringify(content);
     const normalizedContent = stripProtocolTags(contentStr);
 
@@ -1708,7 +1781,7 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     state:    BaseThreadState,
     content:  string,
     role:     'assistant' | 'system' = 'assistant',
-    kind    = 'progress',
+    kind = 'progress',
     extras?: Record<string, unknown>,
     // Wire type. Defaults to 'assistant_message' (the primary orchestration
     // path — flips graphRunning on the frontend). Subconscious agents

--- a/pkg/rancher-desktop/agent/nodes/__tests__/BaseNode.providerRecovery.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/BaseNode.providerRecovery.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const primaryChatStreamMock: any = jest.fn();
+const primaryChatMock: any = jest.fn();
+const secondaryChatMock: any = jest.fn();
+
+const primaryService = {
+  getContextWindow: jest.fn(() => 100_000),
+  getModel:         jest.fn(() => 'claude-code'),
+  getProviderName:  jest.fn(() => 'Claude Code'),
+  chatStream:       primaryChatStreamMock,
+  chat:             primaryChatMock,
+};
+
+const secondaryService = {
+  getModel:        jest.fn(() => 'gpt-5'),
+  getProviderName: jest.fn(() => 'OpenAI'),
+  initialize:      jest.fn(async() => true),
+  isAvailable:     jest.fn(() => true),
+  chat:            secondaryChatMock,
+};
+
+jest.unstable_mockModule('../../languagemodels', () => ({
+  getAgentOverrideService: jest.fn(async() => null),
+  getPrimaryService:       jest.fn(async() => primaryService),
+  getSecondaryService:     jest.fn(async() => secondaryService),
+  getSubconsciousService:  jest.fn(async() => primaryService),
+}));
+
+jest.unstable_mockModule('../../controllers/ChatController', () => ({
+  ChatController: class MockChatController {
+    private mode = 'text';
+
+    setMode(mode: string) { this.mode = mode }
+    getMode() { return this.mode }
+    buildContext() { return {} }
+    reset() {}
+    processChunk(token: string) { return token }
+    processComplete(content: string, metadata: any) {
+      return { content, metadata };
+    }
+    processNonVoiceSpeak() {}
+  },
+}));
+
+jest.unstable_mockModule('../../controllers/ToolExecutor', () => ({
+  ToolExecutor: class MockToolExecutor {
+    ctx: any;
+
+    constructor(ctx: any) {
+      this.ctx = ctx;
+    }
+
+    buildToolAccessPolicyForCall() {
+      return {};
+    }
+
+    async filterLLMToolsByAccessPolicy(tools: any[]) {
+      return { tools };
+    }
+  },
+}));
+
+jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
+  SullaSettingsModel: {
+    get: jest.fn(async(_key: string, fallback: any) => fallback),
+    set: jest.fn(async() => undefined),
+  },
+}));
+
+jest.unstable_mockModule('../../services/JsonParseService', () => ({
+  parseJson: jest.fn((value: string) => JSON.parse(value)),
+}));
+
+jest.unstable_mockModule('../../services/WebSocketClientService', () => ({
+  getWebSocketClientService: jest.fn(() => ({
+    send: jest.fn(),
+  })),
+}));
+
+jest.unstable_mockModule('../../tools/registry', () => ({
+  toolRegistry: {
+    convertToolToLLM:          jest.fn(async() => null),
+    getSlimPrimaryLLMTools:    jest.fn(async() => []),
+    getLLMToolsFor:            jest.fn(async() => []),
+    getToolsByCategory:        jest.fn(async() => []),
+    getToolNamesForCategory:   jest.fn(() => []),
+    getToolNames:              jest.fn(() => []),
+    getNativeToolDefinitions:  jest.fn(() => new Map()),
+  },
+}));
+
+describe('BaseNode provider recovery', () => {
+  beforeEach(() => {
+    primaryChatStreamMock.mockReset();
+    primaryChatMock.mockReset();
+    secondaryChatMock.mockReset();
+
+    primaryChatStreamMock.mockRejectedValue(new Error('Codex app-server event stream lag dropped events'));
+    primaryChatMock.mockRejectedValue(new Error('codex exited with code null'));
+    secondaryChatMock.mockResolvedValue({
+      content:  'fallback response ok',
+      metadata: {
+        rawProviderContent: 'fallback response ok',
+      },
+    });
+  });
+
+  it('retries a recoverable primary failure, then appends successful secondary fallback metadata', async() => {
+    const { BaseNode } = await import('../BaseNode');
+
+    class TestNode extends BaseNode<any> {
+      async execute(state: any) {
+        const reply = await this.normalizedChat(state, 'System prompt', { disableTools: true });
+        return { state, decision: { type: 'end' as const }, response: reply?.content ?? '' };
+      }
+    }
+
+    const state: any = {
+      messages: [
+        { role: 'user', content: 'Please answer.' },
+      ],
+      metadata: {
+        threadId:  'test-thread',
+        wsChannel: 'test-channel',
+        options:   {},
+      },
+    };
+
+    const node = new TestNode('test-node', 'TestNode');
+    const result = await node.execute(state);
+
+    expect(primaryChatStreamMock).toHaveBeenCalledTimes(1);
+    expect(primaryChatMock).toHaveBeenCalledTimes(1);
+    expect(secondaryChatMock).toHaveBeenCalledTimes(1);
+    expect(result.response).toBe('fallback response ok');
+
+    const assistantMessage = state.messages[state.messages.length - 1];
+    expect(assistantMessage).toMatchObject({
+      role:    'assistant',
+      content: 'fallback response ok',
+    });
+
+    const fallbackReply = secondaryChatMock.mock.results[0].value;
+    await expect(fallbackReply).resolves.toMatchObject({
+      metadata: {
+        fallback_used:   true,
+        fallback_from:   'Claude Code',
+        fallback_to:     'OpenAI',
+        fallback_reason: 'unavailable',
+        failed_model:    'claude-code',
+        fallback_model:  'gpt-5',
+      },
+    });
+  });
+});

--- a/pkg/rancher-desktop/agent/services/BackendGraphWebSocketService.ts
+++ b/pkg/rancher-desktop/agent/services/BackendGraphWebSocketService.ts
@@ -286,6 +286,10 @@ export class BackendGraphWebSocketService {
     const threadId = threadIdFromMsg || nextThreadId();
 
     let state: AgentGraphState | undefined;
+    const abortKey = this.abortKey(channelId, threadId);
+    let runAbort: AbortService | undefined;
+
+    const isCurrentRun = () => this.activeAborts.get(abortKey) === runAbort;
 
     try {
       const result = await GraphRegistry.getOrCreateAgentGraph(agentId, threadId) as { graph: any; state: AgentGraphState };
@@ -306,16 +310,20 @@ export class BackendGraphWebSocketService {
       // tabs sharing the same WebSocket channel can run in parallel.
       // Rapid double-sends from the same tab still get coalesced because
       // they share a thread id.
-      const abortKey = this.abortKey(channelId, threadId);
       const prior = this.activeAborts.get(abortKey);
       if (prior) {
-        try { prior.abort(); } catch { /* already aborted */ }
+        try {
+          prior.abort();
+        } catch {
+          // already aborted
+        }
         this.activeAborts.delete(abortKey);
       }
 
       // Create abort service for this run.
       // Set state first so stop_run can't race between activeAborts and state.
       const abort = new AbortService();
+      runAbort = abort;
       state.metadata.options.abort = abort;
       this.activeAborts.set(abortKey, abort);
 
@@ -374,9 +382,12 @@ export class BackendGraphWebSocketService {
       await graph.execute(state, startNode);
     } catch (err: any) {
       if (err?.name === 'AbortError' && state) {
-        // Cleanly aborted by user — mark cycle complete so graph won't restart
-        state.metadata.cycleComplete = true;
-        state.metadata.waitingForUser = true;
+        // Cleanly aborted by user. If a newer run superseded this one, leave
+        // the shared thread state alone so the new run is not poisoned.
+        if (isCurrentRun()) {
+          state.metadata.cycleComplete = true;
+          state.metadata.waitingForUser = true;
+        }
       } else if (err?.name !== 'AbortError') {
         console.error(`[BackendGraphWS] Agent execution FAILED on ${ channelId }:`, err);
         this.emitMessage(channelId, 'assistant_message', {
@@ -386,7 +397,9 @@ export class BackendGraphWebSocketService {
         });
       }
     } finally {
-      this.activeAborts.delete(this.abortKey(channelId, threadId));
+      if (isCurrentRun()) {
+        this.activeAborts.delete(abortKey);
+      }
     }
   }
 
@@ -418,7 +431,7 @@ export class BackendGraphWebSocketService {
   // Calendar handling (unchanged)
   // ------------------------------------------------------------------
 
-  private async handleCalendarMessage(msg: WebSocketMessage): Promise<void> {
+  private handleCalendarMessage(msg: WebSocketMessage): void {
     const calendarMsg = msg as CalendarWebSocketMessage;
 
     if (!calendarMsg || typeof calendarMsg.type !== 'string') {

--- a/pkg/rancher-desktop/agent/services/FrontendGraphWebSocketService.ts
+++ b/pkg/rancher-desktop/agent/services/FrontendGraphWebSocketService.ts
@@ -175,9 +175,17 @@ export class FrontendGraphWebSocketService {
 
     // Create a fresh AbortService for this run and wire it into state.
     // Set state first so stop_run can't race between activeAbort and state.
+    if (this.activeAbort) {
+      try {
+        this.activeAbort.abort();
+      } catch {
+        // already aborted
+      }
+    }
     const abort = new AbortService();
     state.metadata.options.abort = abort;
     this.activeAbort = abort;
+    const isCurrentRun = () => this.activeAbort === abort;
 
     // Always refresh model context from current settings so existing threads
     // follow the currently selected frontend model/provider.
@@ -246,9 +254,11 @@ export class FrontendGraphWebSocketService {
       await graph.execute(state, startNode);
     } catch (err: any) {
       if (err.name === 'AbortError') {
-        state.metadata.cycleComplete = true;
-        state.metadata.waitingForUser = true;
-        this.emitSystemMessage('Execution stopped.', threadId);
+        if (isCurrentRun()) {
+          state.metadata.cycleComplete = true;
+          state.metadata.waitingForUser = true;
+          this.emitSystemMessage('Execution stopped.', threadId);
+        }
       } else {
         console.error('[FrontendGraphWS] Error:', err?.message);
         this.emitSystemMessage(`Error: ${ err.message || String(err) }`, threadId);
@@ -258,7 +268,9 @@ export class FrontendGraphWebSocketService {
       state.metadata.consecutiveSameNode = 0;
       state.metadata.iterations = 0;
       (state.metadata as any).agentLoopCount = 0;
-      this.activeAbort = null;
+      if (isCurrentRun()) {
+        this.activeAbort = null;
+      }
 
       // Persist thread state so it survives page reloads
       saveThreadState(state).catch(err => console.warn('[FrontendGraphWS] Failed to save thread state:', err));
@@ -282,9 +294,17 @@ export class FrontendGraphWebSocketService {
 
     // Create a fresh AbortService for this run.
     // Set state first so stop_run can't race between activeAbort and state.
+    if (this.activeAbort) {
+      try {
+        this.activeAbort.abort();
+      } catch {
+        // already aborted
+      }
+    }
     const abort = new AbortService();
     state.metadata.options.abort = abort;
     this.activeAbort = abort;
+    const isCurrentRun = () => this.activeAbort === abort;
 
     try {
       // Reset loop counters so the graph can run another full set of cycles
@@ -298,9 +318,11 @@ export class FrontendGraphWebSocketService {
       await graph.execute(state, 'agent');
     } catch (err: any) {
       if (err.name === 'AbortError') {
-        state.metadata.cycleComplete = true;
-        state.metadata.waitingForUser = true;
-        this.emitSystemMessage('Execution stopped.', threadId ?? undefined);
+        if (isCurrentRun()) {
+          state.metadata.cycleComplete = true;
+          state.metadata.waitingForUser = true;
+          this.emitSystemMessage('Execution stopped.', threadId ?? undefined);
+        }
       } else {
         console.error('[FrontendGraphWS] Continue error:', err?.message);
         this.emitSystemMessage(`Error: ${ err.message || String(err) }`, threadId ?? undefined);
@@ -309,7 +331,9 @@ export class FrontendGraphWebSocketService {
       state.metadata.consecutiveSameNode = 0;
       state.metadata.iterations = 0;
       (state.metadata as any).agentLoopCount = 0;
-      this.activeAbort = null;
+      if (isCurrentRun()) {
+        this.activeAbort = null;
+      }
 
       // Persist thread state so it survives page reloads
       saveThreadState(state).catch(err => console.warn('[FrontendGraphWS] Failed to save thread state:', err));

--- a/pkg/rancher-desktop/agent/services/__tests__/BackendGraphWebSocketService.abortRace.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/BackendGraphWebSocketService.abortRace.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import type { AbortService } from '../AbortService';
+
+interface Deferred<T = void> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject:  (reason?: unknown) => void;
+}
+
+function deferred<T = void>(): Deferred<T> {
+  let resolveFn!: Deferred<T>['resolve'];
+  let rejectFn!: Deferred<T>['reject'];
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+
+  return { promise, resolve: resolveFn, reject: rejectFn };
+}
+
+const sendMock: any = jest.fn();
+const executeMock: any = jest.fn();
+const state: any = {
+  metadata: { options: {} },
+  messages: [],
+};
+
+jest.unstable_mockModule('../WebSocketClientService', () => ({
+  getWebSocketClientService: jest.fn(() => ({
+    connect:   jest.fn(),
+    onMessage: jest.fn(() => jest.fn()),
+    send:      sendMock,
+  })),
+}));
+
+jest.unstable_mockModule('../SchedulerService', () => ({
+  getSchedulerService: jest.fn(() => ({
+    cancelEvent:     jest.fn(),
+    scheduleEvent:   jest.fn(),
+    rescheduleEvent: jest.fn(),
+  })),
+}));
+
+jest.unstable_mockModule('../GraphRegistry', () => ({
+  GraphRegistry: {
+    getOrCreateAgentGraph: jest.fn(() => Promise.resolve({
+      graph: { execute: executeMock },
+      state,
+    })),
+    delete: jest.fn(),
+  },
+  getAgentIdForTrigger: jest.fn(() => Promise.resolve('sulla-desktop')),
+  nextThreadId:         jest.fn(() => 'thread-generated'),
+  nextMessageId:        jest.fn(() => `msg-${ state.messages.length + 1 }`),
+}));
+
+jest.unstable_mockModule('../ActiveAgentsRegistry', () => ({
+  getActiveAgentsRegistry: jest.fn(() => ({
+    register:   jest.fn(() => Promise.resolve(undefined)),
+    deregister: jest.fn(() => Promise.resolve(undefined)),
+  })),
+}));
+
+jest.unstable_mockModule('../../utils/sullaPaths', () => ({
+  resolveAllAgentsDirs: jest.fn(() => []),
+  resolveSullaLogsDir:  jest.fn(() => '/tmp'),
+}));
+
+describe('BackendGraphWebSocketService interruption ownership', () => {
+  it('does not let an aborted superseded run delete the newer run abort handle', async() => {
+    const { BackendGraphWebSocketService } = await import('../BackendGraphWebSocketService');
+    const svc: any = new BackendGraphWebSocketService();
+    const firstStarted = deferred<AbortService>();
+    const firstMayFinish = deferred();
+    const secondStarted = deferred<AbortService>();
+    let firstAbort: AbortService | undefined;
+    let secondAbort: AbortService | undefined;
+
+    executeMock.mockImplementationOnce(async(runState: any) => {
+      firstAbort = runState.metadata.options.abort;
+      if (!firstAbort) throw new Error('first run did not receive an AbortService');
+      firstStarted.resolve(firstAbort);
+      await new Promise<void>((resolve) => {
+        firstAbort?.signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      await firstMayFinish.promise;
+      throw new DOMException('Operation aborted', 'AbortError');
+    });
+
+    executeMock.mockImplementationOnce(async(runState: any) => {
+      secondAbort = runState.metadata.options.abort;
+      if (!secondAbort) throw new Error('second run did not receive an AbortService');
+      secondStarted.resolve(secondAbort);
+      await new Promise<void>((resolve) => {
+        secondAbort?.signal.addEventListener('abort', () => resolve(), { once: true });
+      });
+      throw new DOMException('Operation aborted', 'AbortError');
+    });
+
+    const firstRun = svc.dispatchToAgent('sulla-desktop', 'sulla-desktop', 'first', 'thread-1');
+    const activeFirstAbort = await firstStarted.promise;
+    expect(activeFirstAbort.aborted).toBe(false);
+
+    const secondRun = svc.dispatchToAgent('sulla-desktop', 'sulla-desktop', 'second', 'thread-1');
+    const activeSecondAbort = await secondStarted.promise;
+
+    expect(firstAbort?.aborted).toBe(true);
+    expect(activeSecondAbort.aborted).toBe(false);
+    expect(svc.activeAborts.get('sulla-desktop|thread-1')).toBe(activeSecondAbort);
+
+    firstMayFinish.resolve();
+    await firstRun;
+
+    expect(svc.activeAborts.get('sulla-desktop|thread-1')).toBe(activeSecondAbort);
+
+    await svc.handleChannelMessage('sulla-desktop', 'sulla-desktop', {
+      type:      'stop_run',
+      data:      { threadId: 'thread-1' },
+      timestamp: Date.now(),
+    });
+    await secondRun;
+
+    expect(secondAbort?.aborted).toBe(true);
+    expect(svc.activeAborts.has('sulla-desktop|thread-1')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed
- Adds a central provider-recovery classifier for quota, auth, rate-limit, timeout, empty-response, stream/process, and interruption failures.
- Updates BaseNode so recoverable primary failures retry once, then fall back to a distinct configured secondary provider even when the primary is Claude Code or Codex.
- Redacts provider secrets in recovery logs/errors and annotates retry/fallback metadata for UI/log evidence.

## Verification
- PASS: focused ESLint on BaseNode + providerRecovery helper/test in the original checkout.
- PASS: providerRecovery Jest test, 5/5, in VM and host original checkout.
- PASS: git diff --check.

## Notes
- Full-project tsc is red on existing baseline dependency/UI type errors unrelated to this patch; focused lint/test are green.
- No rebuild/restart performed.