### PR TITLE
fix(episodic): persist episode provenance anchors

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/KnowledgeGraphModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/KnowledgeGraphModel.ts
@@ -53,10 +53,27 @@ export interface EpisodeNodeInput {
   node_type?: string;
 }
 
+export interface EpisodeMetadataInput {
+  projectId?:           string | null;
+  epicId?:              string | null;
+  taskId?:              string | null;
+  repo?:                string | null;
+  decision?:            string | null;
+  artifact?:            string | null;
+  artifacts?:           string[];
+  timestamp?:           string | null;
+  sourceConversation?:  string | null;
+  sourceConversationId?: string | null;
+  commitSha?:           string | null;
+  githubIssue?:         string | null;
+}
+
 /** A fully-encoded completed episode, written atomically by writeEpisode. */
 export interface WriteEpisodeInput {
   /** Origin: 'chat' | 'heartbeat' | 'sub-agent' | ... — stored as node source. */
   source?:   string;
+  /** Durable provenance/trace metadata for later operator recall. */
+  metadata?: EpisodeMetadataInput;
   /** Project/epic anchor the episode belongs_to (resolved+reused, else created). */
   project?:  EpisodeNodeInput | null;
   /** The event node — "what happened". Always created new. Required. */
@@ -548,6 +565,11 @@ export class KnowledgeGraphModel {
     };
 
     interface PlannedNode { id: string; node: EpisodeNodeInput; type: string; isNew: boolean }
+    const normalizedMetadata = KnowledgeGraphModel.normalizeEpisodeMetadata(input.metadata);
+    const metadataEntities = KnowledgeGraphModel.metadataEntities(normalizedMetadata);
+    const metadataPairs = KnowledgeGraphModel.metadataReinforcePairs(normalizedMetadata);
+    const eventNode = KnowledgeGraphModel.eventWithMetadata(input.event, normalizedMetadata);
+
     const planned: PlannedNode[] = [];
     const reuseByTermNorm = new Map<string, string>(); // surface-form -> node id (for reinforce)
 
@@ -568,8 +590,8 @@ export class KnowledgeGraphModel {
 
     // Event is always a fresh fact.
     const eventId = `evt_${ Date.now() }_${ rand(6) }`;
-    planned.push({ id: eventId, node: input.event, type: 'event', isNew: true });
-    registerTerms(input.event, eventId);
+    planned.push({ id: eventId, node: eventNode, type: 'event', isNew: true });
+    registerTerms(eventNode, eventId);
 
     const usedIds = new Set<string>([eventId, ...(projectId ? [projectId] : [])]);
     const freshFactId = (prefix: string, title: string) => {
@@ -598,7 +620,7 @@ export class KnowledgeGraphModel {
     }
 
     const entityIds: string[] = [];
-    for (const e of input.entities ?? []) {
+    for (const e of [...(input.entities ?? []), ...metadataEntities]) {
       if (!e?.title?.trim()) continue;
       const reused = await resolveReuse(e);
       const id = reused ?? slugId('kn', e.title);
@@ -611,7 +633,7 @@ export class KnowledgeGraphModel {
 
     // Resolve reinforce pairs to node ids (this-episode nodes or committed ones).
     const pairPlan: [string, string][] = [];
-    for (const [a, b] of input.reinforcePairs ?? []) {
+    for (const [a, b] of [...(input.reinforcePairs ?? []), ...metadataPairs]) {
       const ida = reuseByTermNorm.get(KnowledgeGraphModel.normSlug(a)) ?? (await resolveReuse({ title: a }));
       const idb = reuseByTermNorm.get(KnowledgeGraphModel.normSlug(b)) ?? (await resolveReuse({ title: b }));
       if (ida && idb && ida !== idb) pairPlan.push([ida, idb]);
@@ -695,5 +717,85 @@ export class KnowledgeGraphModel {
         nodeIds: planned.map(p => p.id),
       };
     });
+  }
+
+  private static normalizeEpisodeMetadata(metadata: EpisodeMetadataInput | undefined): EpisodeMetadataInput | undefined {
+    if (!metadata || typeof metadata !== 'object') return undefined;
+    const cleanString = (value: unknown): string | null => {
+      if (value == null) return null;
+      const trimmed = String(value).trim();
+      return trimmed || null;
+    };
+    const cleanStringList = (value: unknown): string[] => {
+      if (!Array.isArray(value)) return [];
+      return Array.from(new Set(value.map(cleanString).filter((v): v is string => Boolean(v))));
+    };
+
+    const normalized: EpisodeMetadataInput = {
+      projectId:            cleanString(metadata.projectId),
+      epicId:               cleanString(metadata.epicId),
+      taskId:               cleanString(metadata.taskId),
+      repo:                 cleanString(metadata.repo),
+      decision:             cleanString(metadata.decision),
+      artifact:             cleanString(metadata.artifact),
+      artifacts:            cleanStringList(metadata.artifacts),
+      timestamp:            cleanString(metadata.timestamp),
+      sourceConversation:   cleanString(metadata.sourceConversation),
+      sourceConversationId: cleanString(metadata.sourceConversationId),
+      commitSha:            cleanString(metadata.commitSha),
+      githubIssue:          cleanString(metadata.githubIssue),
+    };
+
+    return Object.values(normalized).some(value => Array.isArray(value) ? value.length > 0 : Boolean(value))
+      ? normalized
+      : undefined;
+  }
+
+  private static eventWithMetadata(event: EpisodeNodeInput, metadata: EpisodeMetadataInput | undefined): EpisodeNodeInput {
+    if (!metadata) return event;
+    const compactMetadata = Object.fromEntries(
+      Object.entries(metadata).filter(([, value]) => Array.isArray(value) ? value.length > 0 : Boolean(value)),
+    );
+    const metadataLine = `Episode metadata: ${ JSON.stringify(compactMetadata) }`;
+    const detail = [event.detail?.trim(), metadataLine].filter(Boolean).join('\n\n');
+
+    return { ...event, detail };
+  }
+
+  private static metadataEntities(metadata: EpisodeMetadataInput | undefined): EpisodeNodeInput[] {
+    if (!metadata) return [];
+    const entities: EpisodeNodeInput[] = [];
+
+    const push = (title: string | null | undefined, nodeType: string, summary: string, aliases: string[] = []) => {
+      const cleanTitle = title?.trim();
+      if (!cleanTitle) return;
+      entities.push({
+        title:     cleanTitle,
+        summary,
+        aliases:   Array.from(new Set([cleanTitle, ...aliases].map(a => a.trim()).filter(Boolean))),
+        node_type: nodeType,
+      });
+    };
+
+    push(metadata.taskId, 'task', 'Workboard task associated with this episode.', metadata.taskId ? [`task ${ metadata.taskId }`, `work task ${ metadata.taskId }`] : []);
+    push(metadata.epicId, 'epic', 'Workboard epic associated with this episode.', metadata.epicId ? [`epic ${ metadata.epicId }`] : []);
+    push(metadata.projectId, 'project', 'Workboard project associated with this episode.', metadata.projectId ? [`project ${ metadata.projectId }`] : []);
+    push(metadata.repo, 'repo', 'Repository touched or inspected during this episode.');
+    push(metadata.githubIssue, 'issue', 'GitHub issue or PR associated with this episode.');
+    push(metadata.commitSha, 'commit', 'Commit associated with this episode.');
+    push(metadata.sourceConversationId ?? metadata.sourceConversation, 'conversation', 'Source conversation for this episode.');
+    for (const artifact of [metadata.artifact, ...(metadata.artifacts ?? [])]) {
+      push(artifact, 'artifact', 'Artifact produced, inspected, or updated during this episode.');
+    }
+
+    return entities;
+  }
+
+  private static metadataReinforcePairs(metadata: EpisodeMetadataInput | undefined): [string, string][] {
+    if (!metadata?.taskId) return [];
+    return [metadata.repo, metadata.githubIssue, metadata.commitSha, metadata.sourceConversationId, metadata.artifact, ...(metadata.artifacts ?? [])]
+      .map(value => value?.trim())
+      .filter((value): value is string => Boolean(value))
+      .map(value => [metadata.taskId as string, value] as [string, string]);
   }
 }

--- a/pkg/rancher-desktop/agent/database/models/__tests__/KnowledgeGraphModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/KnowledgeGraphModel.test.ts
@@ -336,6 +336,57 @@ describe('KnowledgeGraphModel', () => {
     expect(rels).toEqual(['belongs_to', 'blocked_by', 'learned_from', 'mentioned_in', 'related_to']);
   });
 
+  it('writeEpisode stores provenance metadata and mirrors recall anchors', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([])); // resolveAliases → no reuse
+
+    const client: any = {
+      query: jest.fn((sql: string) => {
+        if (sql.includes('INSERT INTO node_links')) return Promise.resolve({ rows: [{ was_inserted: true }] });
+        if (sql.includes("relation_type = 'related_to'")) return Promise.resolve({ rows: [{ ok: true }] });
+        return Promise.resolve({ rows: [] });
+      }),
+    };
+    (postgresClient as any).transaction = jest.fn((callback: any) => Promise.resolve(callback(client)));
+
+    const result = await KnowledgeGraphModel.writeEpisode({
+      source:   'heartbeat',
+      metadata: {
+        projectId:            'trXJ',
+        epicId:               'iK4o',
+        taskId:               'Yrn7',
+        repo:                 '/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop',
+        artifact:             'pkg/rancher-desktop/agent/database/models/KnowledgeGraphModel.ts',
+        timestamp:            '2026-08-17T13:25:00.000Z',
+        sourceConversationId: 'conv_heartbeat_1786973100000',
+        commitSha:            'abc1234',
+        githubIssue:          '#518',
+      },
+      project: { title: 'Sulla Desktop' },
+      event:   { title: 'Verified episodic memory write and recall', summary: 'Metadata anchors were made durable.' },
+    });
+
+    expect(result.createdNodes).toBe(10); // project + event + 8 metadata anchors
+
+    const nodeInserts = client.query.mock.calls.filter((c: any[]) => String(c[0]).includes('INSERT INTO knowledge_nodes'));
+    const eventInsert = nodeInserts.find((c: any[]) => c[1][1] === 'event');
+    expect(eventInsert?.[1][4]).toContain('"taskId":"Yrn7"');
+    expect(eventInsert?.[1][4]).toContain('"sourceConversationId":"conv_heartbeat_1786973100000"');
+
+    const insertedTitles = nodeInserts.map((c: any[]) => c[1][2]);
+    expect(insertedTitles).toEqual(expect.arrayContaining([
+      'Yrn7',
+      '/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop',
+      'pkg/rancher-desktop/agent/database/models/KnowledgeGraphModel.ts',
+      'conv_heartbeat_1786973100000',
+      '#518',
+    ]));
+
+    const aliases = client.query.mock.calls
+      .filter((c: any[]) => String(c[0]).includes('INSERT INTO node_aliases'))
+      .map((c: any[]) => c[1][0]);
+    expect(aliases).toEqual(expect.arrayContaining(['task Yrn7', 'work task Yrn7', 'epic iK4o', 'project trXJ']));
+  });
+
   it('writeEpisode reuses a project whose alias sim is ≥ 0.85 and still creates a fresh event', async() => {
     (postgresClient as any).query = jest.fn((_sql: string, params: any[]) => {
       const terms: string[] = params?.[0] ?? [];

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -547,13 +547,19 @@ Read the WHOLE completed conversation and produce ONE episode:
   services, files, issue numbers. Give each its surface forms as aliases.
 - **reinforcePairs**: pairs of entities/terms that co-occurred meaningfully,
   so their association strengthens over time.
+- **metadata**: when available, include durable provenance such as taskId,
+  projectId, epicId, repo, decision, artifact(s), timestamp, sourceConversationId,
+  commitSha, and githubIssue. These fields are how future Heartbeat/operator
+  loops land back on a specific task, repo, artifact, or decision.
 
 ## How to work (fast, ≤2 rounds)
 
 1. Extract the salient surface forms (entities, project, key nouns).
 2. Call \`episodic_resolve\` ONCE with all of them so you know what already
    exists (write-side dedup mirrors read-side recall). Reuse those names.
-3. Call \`episodic_write_episode\` EXACTLY ONCE with the full encoding. It
+3. Call \`episodic_write_episode\` EXACTLY ONCE with the full encoding. Include
+   the \`metadata\` object from the episode metadata block when values are present.
+   It
    handles dedup, aliasing, linking, and reinforcement atomically — you just
    supply good content. Every entity you name should also appear in a
    reinforcePair or be a project/lesson so nothing is orphaned.
@@ -563,8 +569,39 @@ Read the WHOLE completed conversation and produce ONE episode:
 - Encode only what actually happened in THIS conversation. Never invent facts,
   outcomes, or entities that weren't discussed.
 - Summaries are the product — specific and self-contained beats vague.
+- Preserve source ids and artifact paths in metadata instead of burying them
+  only in prose.
 - Do not store secrets, credentials, or tokens.
 - One \`episodic_write_episode\` call, then finish. Output nothing else.`;
+
+function buildEpisodeMetadataInstruction(parentState: BaseThreadState): string {
+  const metadata = (parentState.metadata || {}) as Record<string, any>;
+  const values: Record<string, string> = {};
+  const set = (key: string, value: unknown) => {
+    if (value == null) return;
+    const trimmed = String(value).trim();
+    if (trimmed) values[key] = trimmed;
+  };
+
+  set('sourceConversationId', metadata.threadId || metadata.conversationId);
+  set('taskId', metadata.heartbeatSelectedTaskId);
+  set('workflowNodeId', metadata.workflowNodeId);
+  set('workflowParentChannel', metadata.workflowParentChannel);
+  set('parentWsChannel', metadata.wsChannel);
+  set('timestamp', new Date().toISOString());
+
+  if (Object.keys(values).length === 0) {
+    return 'The conversation above just completed. Encode it into ONE episode: resolve the entities, then make exactly one episodic_write_episode call with the event, project, lessons, blockers, entities, and reinforce pairs. Encode only what actually happened.';
+  }
+
+  return [
+    'The conversation above just completed. Encode it into ONE episode: resolve the entities, then make exactly one episodic_write_episode call with the event, project, lessons, blockers, entities, reinforce pairs, and metadata. Encode only what actually happened.',
+    '',
+    '<episode_metadata>',
+    JSON.stringify(values, null, 2),
+    '</episode_metadata>',
+  ].join('\n');
+}
 
 // ── Heartbeat-specific memory recall ──────────────────────────────────────
 
@@ -1407,7 +1444,7 @@ export const GraphRegistry = {
     const state = await buildSubconsciousState({
       systemPrompt:           EPISODIC_SCRIBE_PROMPT,
       tools:                  EPISODIC_SCRIBE_TOOLS,
-      userMessage:            'The conversation above just completed. Encode it into ONE episode: resolve the entities, then make exactly one episodic_write_episode call with the event, project, lessons, blockers, entities, and reinforce pairs. Encode only what actually happened.',
+      userMessage:            buildEpisodeMetadataInstruction(parentState),
       messages:               [...parentState.messages],
       // Wide window — the Scribe mines the whole episode for facts, like the
       // observation writer. The summarizer has already compacted anything older.

--- a/pkg/rancher-desktop/agent/tools/episodic/episodic_recall.ts
+++ b/pkg/rancher-desktop/agent/tools/episodic/episodic_recall.ts
@@ -5,7 +5,12 @@ const DEFAULT_LIMIT = 12;
 
 function cleanTerms(terms: unknown): string[] {
   if (!Array.isArray(terms)) return [];
-  return Array.from(new Set(terms.map(String).map(t => t.trim()).filter(Boolean))).slice(0, 8);
+  return Array.from(new Set(
+    terms
+      .filter((term): term is string => typeof term === 'string')
+      .map(t => t.trim())
+      .filter(Boolean),
+  )).slice(0, 8);
 }
 
 function cleanLimit(value: unknown): number {
@@ -23,7 +28,9 @@ export function formatEpisodicContext(rows: SpreadActivationRecord[]): string {
     const summary = (row.summary || '').trim();
     const activation = Number(row.activation ?? 0).toFixed(3);
     const hop = Number(row.hop ?? 0);
-    const body = summary ? `${ title } — ${ summary }` : title;
+    const detail = (row.detail || '').replace(/\s+/g, ' ').trim();
+    const detailSuffix = detail ? ` | ${ detail.slice(0, 360) }${ detail.length > 360 ? '…' : '' }` : '';
+    const body = summary ? `${ title } — ${ summary }${ detailSuffix }` : `${ title }${ detailSuffix }`;
 
     return `[${ type }] ${ body } (id: ${ row.id }, activation: ${ activation }, hop: ${ hop })`;
   }).join('\n');

--- a/pkg/rancher-desktop/agent/tools/episodic/episodic_write_episode.ts
+++ b/pkg/rancher-desktop/agent/tools/episodic/episodic_write_episode.ts
@@ -1,4 +1,4 @@
-import { KnowledgeGraphModel, type EpisodeNodeInput, type WriteEpisodeInput } from '../../database/models/KnowledgeGraphModel';
+import { KnowledgeGraphModel, type EpisodeMetadataInput, type EpisodeNodeInput, type WriteEpisodeInput } from '../../database/models/KnowledgeGraphModel';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -35,6 +35,50 @@ export class EpisodicWriteEpisodeWorker extends BaseTool {
     return raw.map(r => this.normNode(r)).filter((n): n is EpisodeNodeInput => n != null);
   }
 
+  private normMetadata(raw: any): EpisodeMetadataInput | undefined {
+    if (!raw || typeof raw !== 'object') return undefined;
+    const str = (...keys: string[]) => {
+      for (const key of keys) {
+        const value = raw[key];
+        if (value == null) continue;
+        const trimmed = String(value).trim();
+        if (trimmed) return trimmed;
+      }
+      return undefined;
+    };
+    const list = (...keys: string[]) => {
+      const values: string[] = [];
+      for (const key of keys) {
+        const rawValue = raw[key];
+        const parts = Array.isArray(rawValue) ? rawValue : rawValue ? [rawValue] : [];
+        for (const part of parts) {
+          const trimmed = String(part).trim();
+          if (trimmed) values.push(trimmed);
+        }
+      }
+      return Array.from(new Set(values));
+    };
+
+    const metadata: EpisodeMetadataInput = {
+      projectId:            str('projectId', 'project_id'),
+      epicId:               str('epicId', 'epic_id'),
+      taskId:               str('taskId', 'task_id'),
+      repo:                 str('repo', 'repository'),
+      decision:             str('decision'),
+      artifact:             str('artifact'),
+      artifacts:            list('artifacts'),
+      timestamp:            str('timestamp', 'time'),
+      sourceConversation:   str('sourceConversation', 'source_conversation'),
+      sourceConversationId: str('sourceConversationId', 'source_conversation_id', 'conversationId', 'conversation_id'),
+      commitSha:            str('commitSha', 'commit_sha'),
+      githubIssue:          str('githubIssue', 'github_issue'),
+    };
+
+    return Object.values(metadata).some(value => Array.isArray(value) ? value.length > 0 : Boolean(value))
+      ? metadata
+      : undefined;
+  }
+
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const event = this.normNode(input.event);
     if (!event) {
@@ -56,6 +100,7 @@ export class EpisodicWriteEpisodeWorker extends BaseTool {
 
     const payload: WriteEpisodeInput = {
       source:         input.source != null ? String(input.source) : undefined,
+      metadata:       this.normMetadata(input.metadata),
       project:        this.normNode(input.project),
       event,
       lessons:        this.normList(input.lessons),

--- a/pkg/rancher-desktop/agent/tools/episodic/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/episodic/manifests.ts
@@ -33,6 +33,7 @@ export const episodicToolManifests: ToolManifest[] = [
     category:    'memory',
     schemaDef:   {
       source:  { type: 'string', optional: true, description: "Episode origin: 'chat', 'heartbeat', or 'sub-agent'." },
+      metadata: { type: 'object', optional: true, description: 'Durable provenance for recall: { projectId?, epicId?, taskId?, repo?, decision?, artifact?, artifacts?, timestamp?, sourceConversationId?, commitSha?, githubIssue? }. These fields are stored on the event and mirrored as graph anchors where useful.' },
       project: { type: 'object', optional: true, description: 'The project/epic this episode belongs to: { title, aliases?: string[] }. Resolved+reused if it already exists.' },
       event:   { type: 'object', description: 'REQUIRED. The "what happened" node: { title, summary, detail?, aliases?: string[] }. Summary is written to be read cold months later.' },
       lessons: { type: 'array', optional: true, items: { type: 'object' }, description: 'What we learned: [{ title, summary, detail? }] — linked learned_from the event.' },


### PR DESCRIPTION
## What changed
- Adds optional episodic episode metadata for project/epic/task/repo/artifact/timestamp/source conversation provenance.
- Stores metadata on the event detail and mirrors key fields as graph entities/aliases so future recall can land on task ids, repo paths, artifacts, commits, issues, and source conversations.
- Updates the scribe prompt/user message to pass available source metadata, and recall formatting to include event detail.

## Verification
- PASS: `BROWSERSLIST_IGNORE_OLD_DATA=1 node --experimental-vm-modules node_modules/jest/bin/jest.js pkg/rancher-desktop/agent/database/models/__tests__/KnowledgeGraphModel.test.ts pkg/rancher-desktop/agent/tools/episodic/__tests__/episodic_recall.test.ts --runInBand`
- LIVE CHECK: current running binary can write/recall a Yrn7 episode, but ignores the new metadata field until this branch is merged/rebuilt.
- LIMIT: full `tsc --noEmit` in Lima OOMed at 4GB; host lint via `exechost` hit the tool timeout before returning a verdict.

## Gate
Draft until Jonathon is ready to fold it into the operator rebuild pile.