### PR TITLE
feat(projects,heartbeat): unified activity feed + workboard-native Heartbeat

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -90,9 +90,32 @@ export interface WorkCommentRecord {
   archived:   boolean;
 }
 
-export interface WorkActivityRecord extends WorkCommentRecord {
-  task_title:    string;
-  task_status:   string;
+export type WorkActivityKind =
+  | 'comment'
+  | 'task_created'
+  | 'task_updated'
+  | 'task_moved'
+  | 'epic_created'
+  | 'epic_updated'
+  | 'project_created'
+  | 'project_updated';
+
+/**
+ * A single row in the unified Projects activity feed. Rows are synthesized from
+ * comments plus the created_at / last_moved_at / updated_at timestamps on
+ * projects, epics and tasks — there is no separate audit table, so each item
+ * contributes at most one row per event kind (its most recent create/move/edit).
+ */
+export interface WorkActivityRecord {
+  id:            string;               // unique per feed row (kind-prefixed for non-comments)
+  kind:          WorkActivityKind;
+  activity_at:   string;               // the moment this event happened (sort key)
+  created_at:    string;               // alias of activity_at, kept for renderers that format it
+  body:          string | null;        // comment text; null for lifecycle events
+  author:        string | null;        // comment author; null for lifecycle events
+  task_id:       string | null;        // null for epic/project-level events
+  task_title:    string | null;
+  task_status:   string;               // status of the subject item (task, or epic/project)
   task_priority: string;
   project_id:    string;
   project_title: string;
@@ -901,44 +924,131 @@ export class WorkItemsModel {
     );
   }
 
+  /**
+   * Unified reverse-chronological activity feed for the Projects area: comments,
+   * newly created tasks/epics/projects, status/board moves, and metadata edits —
+   * newest first. Synthesized via UNION over the work tables' timestamp columns
+   * (no audit table), so each item yields at most one row per event kind.
+   *
+   * Bind params: $1 = projectId (or null = all), $2 = author filter (or null),
+   * $3 = row limit. The author filter only applies to comments; when set, the
+   * lifecycle events (which have no recorded actor) are excluded.
+   */
   static async listRecentActivity(opts: ListActivityOpts = {}): Promise<WorkActivityRecord[]> {
-    const conds = [
-      'c.archived = false',
-      't.archived = false',
-      'p.archived = false',
-    ];
-    const values: any[] = [];
-    let idx = 1;
-    if (opts.projectId) {
-      conds.push(`t.project_id = $${ idx++ }`);
-      values.push(opts.projectId);
-    }
-    if (opts.author) {
-      conds.push(`LOWER(COALESCE(c.author, '')) = LOWER($${ idx++ })`);
-      values.push(opts.author);
-    }
+    const { PROJECTS, EPICS, TASKS, COMMENTS } = WorkItemsModel;
+    const projectId = opts.projectId ?? null;
+    const author = opts.author ?? null;
     const limit = Math.min(Math.max(1, opts.limit ?? 80), 200);
-    values.push(limit);
 
     return postgresClient.query<WorkActivityRecord>(
-      `SELECT
-          c.*,
-          t.title AS task_title,
-          t.status AS task_status,
-          t.priority AS task_priority,
-          p.id AS project_id,
-          p.title AS project_title,
-          p.slug AS project_slug,
-          e.id AS epic_id,
-          e.title AS epic_title
-        FROM ${ WorkItemsModel.COMMENTS } c
-        JOIN ${ WorkItemsModel.TASKS } t ON t.id = c.task_id
-        JOIN ${ WorkItemsModel.PROJECTS } p ON p.id = t.project_id
-        LEFT JOIN ${ WorkItemsModel.EPICS } e ON e.id = t.epic_id AND e.archived = false
-        WHERE ${ conds.join(' AND ') }
-        ORDER BY c.created_at DESC
-        LIMIT $${ idx }`,
-      values,
+      `WITH activity AS (
+        -- comments (and Heartbeat cycle notes)
+        SELECT
+          c.id          AS id,
+          'comment'     AS kind,
+          c.created_at  AS activity_at,
+          c.body        AS body,
+          c.author      AS author,
+          t.id          AS task_id,
+          t.title       AS task_title,
+          t.status      AS task_status,
+          t.priority    AS task_priority,
+          p.id          AS project_id,
+          p.title       AS project_title,
+          p.slug        AS project_slug,
+          e.id          AS epic_id,
+          e.title       AS epic_title
+        FROM ${ COMMENTS } c
+        JOIN ${ TASKS } t    ON t.id = c.task_id
+        JOIN ${ PROJECTS } p ON p.id = t.project_id
+        LEFT JOIN ${ EPICS } e ON e.id = t.epic_id AND e.archived = false
+        WHERE c.archived = false AND t.archived = false AND p.archived = false
+          AND ($1::text IS NULL OR t.project_id = $1)
+          AND ($2::text IS NULL OR LOWER(COALESCE(c.author, '')) = LOWER($2))
+
+        UNION ALL
+        -- task created
+        SELECT 'tc:' || t.id, 'task_created', t.created_at, NULL, NULL,
+               t.id, t.title, t.status, t.priority,
+               p.id, p.title, p.slug, e.id, e.title
+        FROM ${ TASKS } t
+        JOIN ${ PROJECTS } p ON p.id = t.project_id
+        LEFT JOIN ${ EPICS } e ON e.id = t.epic_id AND e.archived = false
+        WHERE t.archived = false AND p.archived = false AND $2::text IS NULL
+          AND ($1::text IS NULL OR t.project_id = $1)
+
+        UNION ALL
+        -- task status / board move
+        SELECT 'tm:' || t.id, 'task_moved', t.last_moved_at, NULL, NULL,
+               t.id, t.title, t.status, t.priority,
+               p.id, p.title, p.slug, e.id, e.title
+        FROM ${ TASKS } t
+        JOIN ${ PROJECTS } p ON p.id = t.project_id
+        LEFT JOIN ${ EPICS } e ON e.id = t.epic_id AND e.archived = false
+        WHERE t.archived = false AND p.archived = false AND $2::text IS NULL
+          AND t.last_moved_at IS DISTINCT FROM t.created_at
+          AND ($1::text IS NULL OR t.project_id = $1)
+
+        UNION ALL
+        -- task metadata edit (distinct from its create and move)
+        SELECT 'tu:' || t.id, 'task_updated', t.updated_at, NULL, NULL,
+               t.id, t.title, t.status, t.priority,
+               p.id, p.title, p.slug, e.id, e.title
+        FROM ${ TASKS } t
+        JOIN ${ PROJECTS } p ON p.id = t.project_id
+        LEFT JOIN ${ EPICS } e ON e.id = t.epic_id AND e.archived = false
+        WHERE t.archived = false AND p.archived = false AND $2::text IS NULL
+          AND t.updated_at IS NOT NULL
+          AND t.updated_at IS DISTINCT FROM t.created_at
+          AND t.updated_at IS DISTINCT FROM t.last_moved_at
+          AND ($1::text IS NULL OR t.project_id = $1)
+
+        UNION ALL
+        -- epic created
+        SELECT 'ec:' || e.id, 'epic_created', e.created_at, NULL, NULL,
+               NULL, NULL, e.status, e.priority,
+               p.id, p.title, p.slug, e.id, e.title
+        FROM ${ EPICS } e
+        JOIN ${ PROJECTS } p ON p.id = e.project_id
+        WHERE e.archived = false AND p.archived = false AND $2::text IS NULL
+          AND ($1::text IS NULL OR e.project_id = $1)
+
+        UNION ALL
+        -- epic updated / moved
+        SELECT 'eu:' || e.id, 'epic_updated', GREATEST(e.updated_at, e.last_moved_at), NULL, NULL,
+               NULL, NULL, e.status, e.priority,
+               p.id, p.title, p.slug, e.id, e.title
+        FROM ${ EPICS } e
+        JOIN ${ PROJECTS } p ON p.id = e.project_id
+        WHERE e.archived = false AND p.archived = false AND $2::text IS NULL
+          AND GREATEST(e.updated_at, e.last_moved_at) IS DISTINCT FROM e.created_at
+          AND ($1::text IS NULL OR e.project_id = $1)
+
+        UNION ALL
+        -- project created
+        SELECT 'pc:' || p.id, 'project_created', p.created_at, NULL, NULL,
+               NULL, NULL, p.status, p.priority,
+               p.id, p.title, p.slug, NULL, NULL
+        FROM ${ PROJECTS } p
+        WHERE p.archived = false AND $2::text IS NULL
+          AND ($1::text IS NULL OR p.id = $1)
+
+        UNION ALL
+        -- project updated / moved
+        SELECT 'pu:' || p.id, 'project_updated', GREATEST(p.updated_at, p.last_moved_at), NULL, NULL,
+               NULL, NULL, p.status, p.priority,
+               p.id, p.title, p.slug, NULL, NULL
+        FROM ${ PROJECTS } p
+        WHERE p.archived = false AND $2::text IS NULL
+          AND GREATEST(p.updated_at, p.last_moved_at) IS DISTINCT FROM p.created_at
+          AND ($1::text IS NULL OR p.id = $1)
+      )
+      SELECT *, activity_at AS created_at
+      FROM activity
+      WHERE activity_at IS NOT NULL
+      ORDER BY activity_at DESC
+      LIMIT $3`,
+      [projectId, author, limit],
     );
   }
 

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkItemsModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkItemsModel.test.ts
@@ -18,12 +18,12 @@ describe('WorkItemsModel', () => {
   it('lists recent activity with project and author filters in stable parameter order', async() => {
     (postgresClient as any).query = jest.fn(() => Promise.resolve([{
       id:             'comment-1',
+      kind:           'comment',
+      activity_at:    '2026-08-17T16:00:00.000Z',
+      created_at:     '2026-08-17T16:00:00.000Z',
       task_id:        'task-1',
       body:           'Moved the operator task forward.',
       author:         'Heartbeat',
-      created_at:     '2026-08-17T16:00:00.000Z',
-      updated_at:     null,
-      archived:       false,
       task_title:     'Improve workboard continuity',
       task_status:    'in_progress',
       task_priority:  'high',
@@ -40,8 +40,9 @@ describe('WorkItemsModel', () => {
       limit:     12,
     });
 
+    // Unified feed: params are always bound in [projectId, author, limit] order.
     expect(postgresClient.query).toHaveBeenCalledWith(
-      expect.stringContaining('JOIN work_tasks t ON t.id = c.task_id'),
+      expect.stringContaining('UNION ALL'),
       ['project-1', 'heartbeat', 12],
     );
     expect(postgresClient.query).toHaveBeenCalledWith(
@@ -49,6 +50,7 @@ describe('WorkItemsModel', () => {
       ['project-1', 'heartbeat', 12],
     );
     expect(rows[0]).toMatchObject({
+      kind:          'comment',
       task_title:    'Improve workboard continuity',
       project_title: 'Sulla Desktop',
     });
@@ -60,15 +62,16 @@ describe('WorkItemsModel', () => {
     await WorkItemsModel.listRecentActivity({ limit: 500 });
     await WorkItemsModel.listRecentActivity({ limit: 0 });
 
+    // projectId/author default to null; limit is clamped to [1, 200].
     expect(postgresClient.query).toHaveBeenNthCalledWith(
       1,
       expect.any(String),
-      [200],
+      [null, null, 200],
     );
     expect(postgresClient.query).toHaveBeenNthCalledWith(
       2,
       expect.any(String),
-      [1],
+      [null, null, 1],
     );
   });
 });

--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -13,4 +13,14 @@ describe('heartbeatPrompt', () => {
     expect(heartbeatPrompt).toContain('exec');
     expect(heartbeatPrompt).toContain('sulla <category>/<tool>');
   });
+
+  it('boots from the heartbeat lane and retires the markdown state file', () => {
+    // The workboard is the only work-state store; HEARTBEAT_STATE.md is dead.
+    expect(heartbeatPrompt).toContain('HEARTBEAT_STATE.md');
+    expect(heartbeatPrompt).toContain('RETIRED');
+    // First action pulls the heartbeat-assigned lane, not a file read.
+    expect(heartbeatPrompt).toContain('"assignee":"heartbeat"');
+    // Unassigned work is claimed by self-assigning into the lane.
+    expect(heartbeatPrompt).toContain('self-assign');
+  });
 });

--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -63,11 +63,25 @@ do not already name the exact tool, call 'browse_tools' (or
 'exec' as 'sulla <category>/<tool> '<json>'' so vault auth, routing, and audit
 hooks stay inside the platform.
 
+## Boot From Your Lane — the workboard is your only memory
+
+Your work-state lives in ONE place: the Postgres workboard behind the Projects view ('sulla work/*'). There is no state file. **HEARTBEAT_STATE.md, PLAYBOOK.md, LEDGER.md and every per-cycle markdown log are RETIRED** — do not read them, do not write them, do not recreate them. If recall or an old note points you at one, ignore it; the file is a tombstone that just redirects here. Anything worth remembering across cycles goes in a task comment or a task's status, never a markdown scratchpad.
+
+**First action of every cycle** (before any 'ls', any file read): pull your lane.
+
+'sulla work/list_work_items {"assignee":"heartbeat","include_done":false}'
+
+That list — tasks assigned to **heartbeat** — is your queue. You, your Human, or any Sulla graph can put work in it by setting a task's assignee to 'heartbeat'. Then:
+
+- **Lane has work** → take the top item (respect priority, then oldest). Flip it to 'in_progress' and go.
+- **Lane is empty** → pick the top open task from the operator-platform project (or the highest-priority project that has actionable work), **self-assign it** ('sulla work/update_task {"id":"…","assignee":"heartbeat","status":"in_progress"}'), and ship its next inch. Self-assigning is how you claim work into your lane — do it every time you pick up an unassigned task.
+- **Board is genuinely empty** → create the next project/epic/task from identity goals, assign it to heartbeat, and ship the first inch.
+
 ## The Lane Portfolio — There Is Always Work
 
 Pick ONE item per cycle, from the highest lane that has an actionable item. If a lane is walled, drop down — never end a cycle idle:
 
-1. **Ship** — the top open task on the workboard ('sulla work/list_work_items' / the injected '<work_report>'). Filter by your lane (Heartbeat = owner/assignee 'heartbeat' or the operator-platform project). Read the project/epic, find what's done, do the smallest concrete step that moves it. Not a plan for a plan — the next buildable thing. If the board is empty, create the next project/epic/task from identity goals and ship the first inch — that IS the cycle's artifact.
+1. **Ship** — the top open task in your lane ('sulla work/list_work_items {"assignee":"heartbeat"}' / the injected '<work_report>'). Read the project/epic, find what's done, do the smallest concrete step that moves it. Not a plan for a plan — the next buildable thing. Claim unassigned work by self-assigning it to heartbeat first. If the board is empty, create the next project/epic/task from identity goals and ship the first inch — that IS the cycle's artifact.
 2. **Verify** — resourceful QA on your Human's products (as recorded in the ledger and 'identity/business/'). Don't checklist — hunt: exercise states (loading/empty/error/overflow), interactions (click, type, submit), watch network for 4xx/5xx, diff shared components across pages, force the breakpoints. File real bugs to GitHub with repro + screenshot. One focused target per cycle, rotating.
 3. **Unblock** — re-scan tasks with 'status=blocked' or 'status=parked' ('sulla work/list_work_items {"status":"blocked"}'). Has any gate opened (answer arrived on your channel, dependency landed, workaround appeared)? Close out what you can — comment the resolution and flip status back to 'todo' / 'in_progress'.
 4. **Polish** — maintenance, docs, memory/observation hygiene, small papercuts you noticed while doing other work.
@@ -120,7 +134,7 @@ You are part of a network of agents communicating over WebSocket channels. Befor
 
 **Memory:** when you learn something durable (a decision, a gotcha, a convention), record it via the observation tools so future cycles inherit it. Prune what's stale.
 
-**Bookkeeping (every cycle):** write the outcome back to the workboard. 'update_task' / 'update_epic' / 'update_project' for status/priority/assignee; 'add_task_comment' for what shipped and what's next. A cycle that changes nothing on the board was an observer cycle. The work tables are the ONE work-state store — no parallel markdown status files, no LEDGER.md pick-path. Filesystem '~/sulla/projects/<slug>/PROJECT.md' is a PRD, not the agenda. The Projects view and the first-turn standup read these tables — write enough detail for an informed conversation.
+**Bookkeeping (every cycle):** write the outcome back to the workboard. 'update_task' / 'update_epic' / 'update_project' for status/priority/assignee; 'add_task_comment' for what shipped and what's next. A cycle that changes nothing on the board was an observer cycle. The work tables are the ONE work-state store — **no HEARTBEAT_STATE.md, no LEDGER.md, no parallel markdown status file of any name.** Those are retired; the task you moved + the comment you left ARE your state for next cycle. Filesystem '~/sulla/projects/<slug>/PROJECT.md' is a PRD (the spec), not the agenda. The Projects view and the first-turn standup read these tables — write enough detail for an informed conversation.
 
 ## Voice — the Jarvis Standard
 
@@ -150,8 +164,8 @@ You MUST end with exactly one wrapper:
 
 ## Cycle Shape (summary)
 
-1. Read context (agents block, recall, '<work_report>' / 'sulla work/list_work_items'). Answer incoming messages first.
-2. Pick ONE item from the highest actionable lane. Commit to it — no project-bouncing.
+1. Boot from your lane: 'sulla work/list_work_items {"assignee":"heartbeat"}' (+ agents block, recall, '<work_report>'). No state file. Answer incoming messages first.
+2. Pick ONE item from the highest actionable lane; self-assign it to heartbeat if it isn't already. Commit to it — no project-bouncing.
 3. Execute through the Unblock Ladder; stage to the irreversible edge.
 4. Verify your work like a skeptic.
 5. Bookkeep (ledger write-back + PRD). Self-audit. Ship the artifact. Status line = outcome.

--- a/pkg/rancher-desktop/pages/ProjectsHome.vue
+++ b/pkg/rancher-desktop/pages/ProjectsHome.vue
@@ -183,7 +183,7 @@
                     </button>
                   </div>
                 </div>
-                <p>{{ shortName(sel) }} · latest comments and cycle notes from the workboard.</p>
+                <p>{{ shortName(sel) }} · newest first — comments, new tasks &amp; epics, status and metadata changes.</p>
               </div>
               <div v-if="activityLoading && !activity.length" class="ph-state">Loading recent activity…</div>
               <div v-else-if="!activity.length" class="ph-state">No activity has been recorded for this project yet.</div>
@@ -193,17 +193,19 @@
                   :key="item.id"
                   type="button"
                   class="ph-activity"
+                  :class="{ 'is-event': item.kind !== 'comment' }"
                   @click="openActivityTask(item)"
                 >
-                  <span class="ph-activity-dot" :class="{ hb: isHeartbeatAuthor(item.author), human: item.author === 'human' }" />
+                  <span class="ph-activity-dot" :class="{ hb: isHeartbeatAuthor(item.author), human: item.author === 'human', event: item.kind !== 'comment' }" />
                   <span class="ph-activity-body">
                     <span class="ph-activity-meta">
-                      <b>{{ item.author || 'agent' }}</b>
-                      <span>{{ shortDate(item.created_at) }}</span>
+                      <span class="ph-activity-kind" :class="'k-' + item.kind">{{ activityKindLabel(item.kind) }}</span>
+                      <b>{{ activityActor(item) }}</b>
+                      <span>{{ shortDate(item.activity_at) }}</span>
                       <span v-if="item.epic_title">{{ item.epic_title }}</span>
                     </span>
-                    <span class="ph-activity-task" v-html="cleanTitle(item.task_title)" />
-                    <span class="ph-activity-text">{{ item.body }}</span>
+                    <span class="ph-activity-task" v-html="cleanTitle(activityTitle(item))" />
+                    <span class="ph-activity-text">{{ activityText(item) }}</span>
                   </span>
                   <span class="ph-tag" :class="{ wait: item.task_status === 'blocked' }">{{ statusLabel(item.task_status) }}</span>
                 </button>
@@ -266,7 +268,13 @@
           </div>
           <div>
             <label class="ph-fl">Assignee</label>
-            <input v-model="taskDraft.assignee" class="ph-in" placeholder="unassigned">
+            <select v-model="taskDraft.assignee" class="ph-in">
+              <option value="">unassigned</option>
+              <option v-for="a in ASSIGNEES" :key="a.value" :value="a.value">{{ a.label }}</option>
+              <option v-if="taskDraft.assignee && !isKnownAssignee(taskDraft.assignee)" :value="taskDraft.assignee">
+                {{ taskDraft.assignee }}
+              </option>
+            </select>
           </div>
         </div>
 
@@ -406,6 +414,17 @@ const activityLoading = ref(false);
 
 const STATUSES = ['backlog', 'todo', 'in_progress', 'blocked', 'done', 'cancelled'];
 const PRIORITIES = ['critical', 'high', 'medium', 'low'];
+// Canonical assignees. Values are the exact lowercase tokens the workboard and
+// the Heartbeat lane filter match on — 'heartbeat' is what routes work into the
+// autonomous agent's queue, so it must stay lowercase and spelled this way.
+const ASSIGNEES = [
+  { value: 'heartbeat', label: 'Heartbeat (autonomous)' },
+  { value: 'sulla', label: 'Sulla' },
+  { value: 'human', label: 'Human' },
+];
+function isKnownAssignee(a: string): boolean {
+  return ASSIGNEES.some(x => x.value === a);
+}
 
 onMounted(() => {
   load().catch((err) => {
@@ -673,10 +692,55 @@ async function openTaskDrawer(t: WorkTaskRecord): Promise<void> {
 }
 
 async function openActivityTask(item: WorkActivityRecord): Promise<void> {
+  if (!item.task_id) return;
   const task = sel.value?.epics
     .flatMap(epic => epic.tasks)
     .find(t => t.id === item.task_id);
   if (task) await openTaskDrawer(task);
+}
+
+const ACTIVITY_KIND_LABELS: Record<WorkActivityRecord['kind'], string> = {
+  comment:          'Comment',
+  task_created:     'New task',
+  task_updated:     'Task edited',
+  task_moved:       'Status',
+  epic_created:     'New epic',
+  epic_updated:     'Epic edited',
+  project_created:  'New project',
+  project_updated:  'Project edited',
+};
+
+function activityKindLabel(kind: WorkActivityRecord['kind']): string {
+  return ACTIVITY_KIND_LABELS[kind] ?? 'Activity';
+}
+
+/** Who did it: comments carry an author; lifecycle events have no recorded actor. */
+function activityActor(item: WorkActivityRecord): string {
+  if (item.author) return item.author;
+  return item.kind === 'comment' ? 'agent' : 'workboard';
+}
+
+/** The headline for a row — the subject item's title, whatever level it lives at. */
+function activityTitle(item: WorkActivityRecord): string {
+  if (item.task_title) return item.task_title;
+  if (item.epic_title) return item.epic_title;
+  return item.project_title;
+}
+
+/** Body text: real comment bodies, or a short synthesized description for lifecycle events. */
+function activityText(item: WorkActivityRecord): string {
+  if (item.kind === 'comment') return item.body ?? '';
+  const status = statusLabel(item.task_status);
+  switch (item.kind) {
+  case 'task_created': return 'Task added to the workboard.';
+  case 'task_moved': return `Moved to ${ status }.`;
+  case 'task_updated': return 'Task details updated.';
+  case 'epic_created': return 'Epic created.';
+  case 'epic_updated': return `Epic updated · ${ status }.`;
+  case 'project_created': return 'Project created.';
+  case 'project_updated': return `Project updated · ${ status }.`;
+  default: return '';
+  }
 }
 
 function openNewTask(epicId: string): void {
@@ -996,6 +1060,11 @@ async function confirmArchiveEpic(e: EpicWithTasks): Promise<void> {
 .ph-activity-dot { width: 13px; height: 13px; border-radius: 50%; margin-top: 5px; background: var(--ptext3); border: 3px solid var(--pbg); position: relative; z-index: 1; }
 .ph-activity-dot.hb { background: var(--pacc); box-shadow: 0 0 0 3px var(--pacc-soft); }
 .ph-activity-dot.human { background: var(--pgreen); }
+.ph-activity-dot.event { background: var(--pbg); border-color: var(--ptext3); }
+.ph-activity-kind { display: inline-block; padding: 1px 6px; border-radius: 4px; background: var(--psurf2); color: var(--ptext2); border: 1px solid var(--pborder); font-weight: 600; letter-spacing: 0.05em; }
+.ph-activity-kind.k-comment { background: var(--pacc-soft); color: var(--pacc); border-color: transparent; }
+.ph-activity-kind.k-task_created, .ph-activity-kind.k-epic_created, .ph-activity-kind.k-project_created { color: var(--pgreen); }
+.ph-activity.is-event .ph-activity-text { color: var(--ptext3); font-style: italic; }
 .ph-activity-body { min-width: 0; display: flex; flex-direction: column; gap: 5px; padding-bottom: 2px; }
 .ph-activity-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-family: var(--pmono); font-size: 10.5px; color: var(--ptext3); text-transform: uppercase; letter-spacing: 0.06em; }
 .ph-activity-meta b { color: var(--pacc); font-weight: 600; }


### PR DESCRIPTION
Unifies the Projects **Activity** tab into a reverse-chron feed (comments, new tasks/epics/projects, status moves, metadata edits) via a UNION over the work tables — no new table/migration.

Adds a first-class **assignee picker** (Heartbeat / Sulla / Human) to the task drawer so the human or any Sulla graph can route work into Heartbeats lane in one click.

**Retires HEARTBEAT_STATE.md**: the autonomous playbook now boots from its `assignee=heartbeat` lane, self-assigns claimed work, and treats the workboard (task status + comments) as its only cross-cycle memory.

Validation: heartbeat prompt + WorkItemsModel tests pass (4/4); zero net-new lint errors on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)