### PR TITLE
fix: stop subconscious model drift when subconscious provider changes

### DIFF
--- a/pkg/rancher-desktop/agent/services/ModelProviderService.ts
+++ b/pkg/rancher-desktop/agent/services/ModelProviderService.ts
@@ -285,9 +285,30 @@ class ModelProviderService {
   }
 
   async setSubconsciousProvider(providerId: string): Promise<void> {
+    const changed = providerId !== this.state.subconsciousProvider;
     this.state.subconsciousProvider = providerId;
     await SullaSettingsModel.set('subconsciousProvider', providerId, 'string');
+
+    // When the provider changes, a concrete model-id override left over from the
+    // previous provider is now stranded — e.g. subconsciousProvider moves grok→codex
+    // while subconsciousModelId is still 'grok-4.6'. That inconsistent pair is the
+    // source of the recurring subconscious model drift: every full-state broadcast
+    // re-pushes the stale id into the settings UI, which re-persists it and clobbers
+    // any manual repair. Reset the override to '' (use the new provider's default) so
+    // the model always stays consistent with its provider. Tier names
+    // (fast/balanced/powerful) and '' are provider-agnostic, so leave those intact.
+    if (changed && !this.isProviderAgnosticModelId(this.state.subconsciousModelId)) {
+      this.state.subconsciousModelId = '';
+      await SullaSettingsModel.set('subconsciousModelId', '', 'string');
+    }
+
     await this.broadcastChange();
+  }
+
+  /** True when the model id carries no provider affinity: empty (use provider default)
+   *  or a dynamic tier name that resolves against whatever provider is active. */
+  private isProviderAgnosticModelId(modelId: string): boolean {
+    return !modelId || modelId === 'fast' || modelId === 'balanced' || modelId === 'powerful';
   }
 
   async setHeartbeatModelId(modelId: string): Promise<void> {

--- a/pkg/rancher-desktop/pages/LanguageModelSettings.vue
+++ b/pkg/rancher-desktop/pages/LanguageModelSettings.vue
@@ -263,7 +263,10 @@ export default defineComponent({
     },
 
     // Watch secondary model override
-    async secondaryModelId(newId: string) {
+    async secondaryModelId(newId: string, oldId: string) {
+      // Skip no-op re-syncs: handleProviderStateChanged re-assigns this from the
+      // service's broadcast state, which would otherwise fire a redundant persist.
+      if (newId === oldId) return;
       try {
         await ipcRenderer.invoke('model-provider:set-secondary-model', newId);
       } catch (err) {
@@ -286,7 +289,11 @@ export default defineComponent({
     },
 
     // Watch subconscious model override
-    async subconsciousModelId(newId: string) {
+    async subconsciousModelId(newId: string, oldId: string) {
+      // Skip no-op re-syncs: handleProviderStateChanged re-assigns this from the
+      // service's broadcast state, which would otherwise fire a redundant persist
+      // and could re-pin a stale model id (source of the subconscious model drift).
+      if (newId === oldId) return;
       try {
         await ipcRenderer.invoke('model-provider:set-subconscious-model', newId);
       } catch (err) {


### PR DESCRIPTION
## Problem
`subconsciousModelId` keeps reverting to a stale grok model id (e.g. `grok-4.6`) while `subconsciousProvider` is `codex`. Manual `settings_set` repairs do not stick (repaired 3x on 2026-08-17). Task: heartbeat `u4IL`.

## Root cause
The **only** DB writer of `subconsciousModelId` is `LanguageModelSettings.vue`'s watcher → IPC `model-provider:set-subconscious-model` → `ModelProviderService.setSubconsciousModelId`. The subconscious *resolution* path (`languagemodels/index.ts`) is read-only, and `grok-4.6` is not a code literal anywhere — it is a live-discovered grok model id. So there is no autonomous backend rewriter.

The drift is a stranded-override loop:
1. Operator moves `subconsciousProvider` grok→codex. `setSubconsciousProvider` **never reset** `subconsciousModelId`, leaving the inconsistent pair `provider=codex, model=grok-4.6`.
2. `ModelProviderService` holds that pair in authoritative in-memory state and re-broadcasts it on every provider change.
3. `handleProviderStateChanged` re-assigns `this.subconsciousModelId` from the broadcast, and the `subconsciousModelId` watcher had **no `newId===oldId` guard**, so it re-persists the stale id — clobbering any raw-DB repair.
4. A restart just reloads the stranded pair from the DB, so it never self-heals.

> Note: this corrects the earlier task hypothesis that `selectModel` cascades the write. Current `selectModel` (ModelProviderService.ts:252-266) only writes `primaryProvider`/`activeModelId`; lines 300-301 are the correctly-scoped `setSubconsciousModelId` setter (line numbers had shifted).

## Fix
- **ModelProviderService.setSubconsciousProvider**: when the provider changes, clear a *stranded concrete* `subconsciousModelId` to `''` (use the new provider default). Tier names (`fast`/`balanced`/`powerful`) and `''` are provider-agnostic and left intact. This keeps model consistent with provider and, because the DB is written to `''`, it survives a restart.
- **LanguageModelSettings.vue**: add `newId===oldId` guards to the `secondaryModelId` and `subconsciousModelId` watchers (matching the existing provider watchers) so broadcast re-syncs no longer fire redundant re-persists.

## Verification
- Static: the stranded pair can no longer be created (reset on provider change) and can no longer be re-persisted on echo (guarded watchers).
- Runtime proof across restart is pending the operator rebuild+restart flow (heartbeat cannot rebuild the binary). Acceptance step "survives a restart" should be confirmed after the next rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
