### PR TITLE
fix(tabs): give Projects (and Agents) a proper tab title

### DIFF
--- a/pkg/rancher-desktop/composables/useBrowserTabs.ts
+++ b/pkg/rancher-desktop/composables/useBrowserTabs.ts
@@ -346,6 +346,8 @@ export function useBrowserTabs() {
     labs:         'Labs',
     'file-editor': 'Editor',
     terminal:     'Terminal',
+    agents:       'Agents',
+    projects:     'Projects',
   };
 
   function createTab(url = 'about:blank', opts?: { mode?: BrowserTabMode }): BrowserTab {

--- a/pkg/rancher-desktop/pages/BrowserTab.vue
+++ b/pkg/rancher-desktop/pages/BrowserTab.vue
@@ -351,6 +351,7 @@ const MODE_TITLES: Record<BrowserTabMode, string> = {
   labs:          'Labs',
   'file-editor': 'Editor',
   terminal:      'Terminal',
+  agents:        'Agents',
   projects:      'Projects',
 };
 


### PR DESCRIPTION
The `MODE_TITLES` map in `useBrowserTabs.ts` (used by `createTab` and the `open_tab` agent tool) was missing the `projects` and `agents` keys, so opening the Projects board fell through to `|| "New Tab"` and the tab read **New Tab** instead of **Projects**. The incomplete `Record<BrowserTabMode,string>` slipped through because the Electron webpack build transpiles without type-checking.

Completes both title maps (useBrowserTabs.ts + BrowserTab.vue) so all 17 tab modes resolve a proper title. 3 lines, zero net-new lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)