### PR TITLE
feat(heartbeat): lane-health recovery digest (stale/duplicate/drift)

### DIFF
--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -804,8 +804,8 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
    * Also drops first-turn synthetic carrier messages once emptied.
    */
   protected stripInjectedContextBlocks(state: BaseThreadState): void {
-    const BLOCK_RE = /\n*<(episodic_context|recall_context|observation_context|conversation_recall_context|security_context|unstuck_context|routine_digest)>[\s\S]*?<\/\1>/g;
-    const MARKER_RE = /<(?:episodic_context|recall_context|observation_context|conversation_recall_context|security_context|unstuck_context|routine_digest)>/;
+    const BLOCK_RE = /\n*<(episodic_context|recall_context|observation_context|conversation_recall_context|security_context|unstuck_context|routine_digest|lane_health)>[\s\S]*?<\/\1>/g;
+    const MARKER_RE = /<(?:episodic_context|recall_context|observation_context|conversation_recall_context|security_context|unstuck_context|routine_digest|lane_health)>/;
 
     for (const msg of state.messages) {
       if (msg.role !== 'assistant') continue;

--- a/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
@@ -733,14 +733,26 @@ export class HeartbeatNode extends BaseNode {
 
     const lines: string[] = [];
 
-    // 1. Duplicate active — advance one, park the rest.
-    if (laneInProgress.length > 1) {
-      const ids = laneInProgress.map(task => this.escapeXmlText(task.id)).join(', ');
-      lines.push(`- DUPLICATE ACTIVE: ${ laneInProgress.length } tasks are in_progress at once (${ ids }). Advance ONE; for the others add a comment and move them back to todo or blocked so the lane keeps a single active thread.`);
+    // A parent task legitimately stays in_progress while its subtasks are
+    // worked, and add_task_comment does not bump last_moved_at — so parents
+    // otherwise false-flag both DUPLICATE ACTIVE (inflated count) and STALE
+    // (comment-only progress reads as "no movement") every cycle. Exclude any
+    // in-lane task that is the parent of another in-lane in_progress task from
+    // those two checks; drift + blocked backlog still consider every task.
+    const inProgressParentIds = new Set(
+      laneInProgress.map(task => task.parent_id).filter(Boolean),
+    );
+    const leafInProgress = laneInProgress.filter(task => !inProgressParentIds.has(task.id));
+
+    // 1. Duplicate active — advance one, park the rest. Count leaf threads only;
+    //    a parent + its single active subtask is the healthy case, not a dupe.
+    if (leafInProgress.length > 1) {
+      const ids = leafInProgress.map(task => this.escapeXmlText(task.id)).join(', ');
+      lines.push(`- DUPLICATE ACTIVE: ${ leafInProgress.length } tasks are in_progress at once (${ ids }). Advance ONE; for the others add a comment and move them back to todo or blocked so the lane keeps a single active thread.`);
     }
 
     // 2. Stale in_progress — resume or park with a status change + comment.
-    for (const task of laneInProgress) {
+    for (const task of leafInProgress) {
       const movedMs = Date.parse(task.last_moved_at);
       if (!Number.isFinite(movedMs)) continue;
       const ageHours = Math.floor((nowMs - movedMs) / 3_600_000);

--- a/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
@@ -33,6 +33,10 @@ const AGENT_CONTINUE_XML_REGEX = /<AGENT_CONTINUE>([\s\S]*?)<\/AGENT_CONTINUE>/i
 const STATUS_REPORT_XML_REGEX = /<STATUS_REPORT>([\s\S]*?)<\/STATUS_REPORT>/i;
 const NEEDS_USER_INPUT_REGEX = /Needs user input:\s*(yes|no)/i;
 const HEARTBEAT_OPERATOR_PROJECT_SLUG = 'goal-operator-transition';
+// An in_progress task untouched for this many hours is treated as stale and
+// surfaced by the lane-health digest (task Sw8c) so Heartbeat resumes or parks
+// it instead of silently leaving it hanging.
+const STALE_IN_PROGRESS_HOURS = 6;
 
 interface HeartbeatWorkboardSnapshot {
   taskId:       string;
@@ -157,6 +161,26 @@ export class HeartbeatNode extends BaseNode {
       if (routineDigest) {
         const digestBlock = `\n\n<routine_digest>\n${ routineDigest }\n</routine_digest>`;
         this.mergeHeartbeatContextBlock(state, digestBlock, 'routine_digest');
+      }
+    }
+
+    // Inject the deterministic, zero-LLM lane-health advisory (task Sw8c):
+    // stale in_progress, duplicate active tasks, and lane drift into
+    // non-Operator projects. Only emits when something needs attention, so a
+    // healthy lane collapses to nothing. Fresh cycles only, and any failure
+    // (e.g. tables not migrated) must never break the cycle — skip silently.
+    if (!isToolCallLoop) {
+      let laneHealth = '';
+      try {
+        const reportOpts = (state.metadata as any).heartbeatReportOpts
+          ?? await this.resolveHeartbeatWorkReportOpts();
+        laneHealth = await this.buildLaneHealthDigest(reportOpts);
+      } catch (err) {
+        console.warn(`[HeartbeatNode] Lane-health digest skipped: ${ (err as Error).message }`);
+      }
+      if (laneHealth) {
+        const laneBlock = `\n\n<lane_health>\n${ laneHealth }\n</lane_health>`;
+        this.mergeHeartbeatContextBlock(state, laneBlock, 'lane_health');
       }
     }
 
@@ -514,6 +538,7 @@ export class HeartbeatNode extends BaseNode {
     try {
       const { buildWorkReport } = await import('../prompts/workReport');
       const reportOpts = await this.resolveHeartbeatWorkReportOpts();
+      (state.metadata as any).heartbeatReportOpts = reportOpts;
       const report = await buildWorkReport({ ...reportOpts, nextLimit: 12 });
       if (!report) return;
 
@@ -684,6 +709,64 @@ export class HeartbeatNode extends BaseNode {
     return this.escapeXmlText(value)
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&apos;');
+  }
+
+  /**
+   * Deterministic, zero-LLM lane-health advisory (task Sw8c). Detects three
+   * failure modes each cycle and returns a compact corrective note — or ''
+   * when the lane is healthy so nothing is injected:
+   *   1. Duplicate active — more than one in_progress task fractures focus.
+   *   2. Stale in_progress — a task untouched for STALE_IN_PROGRESS_HOURS
+   *      should be resumed or parked with a status change.
+   *   3. Lane drift — heartbeat-assigned in_progress work outside the Operator
+   *      Platform project, which Heartbeat must hand back, not advance.
+   * Also lists in-lane blocked tasks so blockers get re-verified before new
+   * work starts. Never throws — the caller guards, but callers elsewhere may
+   * rely on the empty-string contract.
+   */
+  private async buildLaneHealthDigest(reportOpts: { projectId?: string; assignee?: string }): Promise<string> {
+    const nowMs = Date.now();
+    const [laneInProgress, laneBlocked] = await Promise.all([
+      WorkItemsModel.listTasks({ ...reportOpts, status: 'in_progress', limit: 50 }),
+      WorkItemsModel.listTasks({ ...reportOpts, status: 'blocked', limit: 50 }),
+    ]);
+
+    const lines: string[] = [];
+
+    // 1. Duplicate active — advance one, park the rest.
+    if (laneInProgress.length > 1) {
+      const ids = laneInProgress.map(task => this.escapeXmlText(task.id)).join(', ');
+      lines.push(`- DUPLICATE ACTIVE: ${ laneInProgress.length } tasks are in_progress at once (${ ids }). Advance ONE; for the others add a comment and move them back to todo or blocked so the lane keeps a single active thread.`);
+    }
+
+    // 2. Stale in_progress — resume or park with a status change + comment.
+    for (const task of laneInProgress) {
+      const movedMs = Date.parse(task.last_moved_at);
+      if (!Number.isFinite(movedMs)) continue;
+      const ageHours = Math.floor((nowMs - movedMs) / 3_600_000);
+      if (ageHours >= STALE_IN_PROGRESS_HOURS) {
+        lines.push(`- STALE: task ${ this.escapeXmlText(task.id) } "${ this.escapeXmlText(task.title) }" has sat in_progress ~${ ageHours }h with no movement. Resume it now, or add a comment and set status (blocked/todo) explaining the pause.`);
+      }
+    }
+
+    // 3. Blocked backlog — re-verify blockers before starting new work.
+    if (laneBlocked.length) {
+      const ids = laneBlocked.map(task => this.escapeXmlText(task.id)).join(', ');
+      lines.push(`- BLOCKED (${ laneBlocked.length }): ${ ids }. Re-check each blocker is still real before picking up anything new; resume if it cleared, otherwise leave a fresh blocker note.`);
+    }
+
+    // 4. Lane drift — heartbeat in_progress work outside the Operator lane.
+    if (reportOpts.projectId) {
+      const heartbeatInProgress = await WorkItemsModel.listTasks({ assignee: 'heartbeat', status: 'in_progress', limit: 50 });
+      const offLane = heartbeatInProgress.filter(task => task.project_id !== reportOpts.projectId);
+      if (offLane.length) {
+        const refs = offLane.map(task => `${ this.escapeXmlText(task.id) } (project ${ this.escapeXmlText(task.project_id) })`).join(', ');
+        lines.push(`- LANE DRIFT: ${ offLane.length } heartbeat task(s) in_progress OUTSIDE the Operator Platform lane — ${ refs }. Operator Platform is your only lane; do NOT advance Farm/ERP/other-project work unless it was explicitly assigned to you. Add a corrective comment and hand it back.`);
+      }
+    }
+
+    if (lines.length === 0) return '';
+    return ['Operator lane health — resolve these before picking up new work:', ...lines].join('\n');
   }
 
   private async resolveHeartbeatWorkReportOpts(): Promise<{ projectId?: string; assignee?: string }> {

--- a/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
@@ -531,4 +531,46 @@ describe('HeartbeatNode lane-health digest (Sw8c)', () => {
     // Only two queries — no third heartbeat-assignee probe.
     expect(listTasksMock).toHaveBeenCalledTimes(2);
   });
+
+  it('excludes a parent task from DUPLICATE ACTIVE and STALE (parent + one subtask is healthy)', async() => {
+    listTasksMock
+      .mockResolvedValueOnce([ // in_progress — a long-lived parent plus its single active, fresh subtask
+        { id: 'parent1', project_id: 'proj1', title: 'Parent epic-ish task', parent_id: null, last_moved_at: staleIso },
+        { id: 'child1', project_id: 'proj1', title: 'Active subtask', parent_id: 'parent1', last_moved_at: nowIso },
+      ])
+      .mockResolvedValueOnce([]) // blocked
+      .mockResolvedValueOnce([ // heartbeat in_progress (lane-drift probe) — nothing off-lane
+        { id: 'parent1', project_id: 'proj1', title: 'Parent epic-ish task', parent_id: null, last_moved_at: staleIso },
+        { id: 'child1', project_id: 'proj1', title: 'Active subtask', parent_id: 'parent1', last_moved_at: nowIso },
+      ]);
+
+    const node = await makeNode();
+    const digest = await node.buildLaneHealthDigest({ projectId: 'proj1' });
+
+    // Parent + one fresh child is the normal case: no duplicate, and the
+    // comment-only-progressed parent must NOT be reported stale.
+    expect(digest).not.toContain('DUPLICATE ACTIVE');
+    expect(digest).not.toContain('STALE');
+    expect(digest).toBe('');
+  });
+
+  it('still flags two leaf subtasks in_progress as DUPLICATE ACTIVE (parent excluded from the count)', async() => {
+    listTasksMock
+      .mockResolvedValueOnce([ // in_progress — parent plus TWO active leaf subtasks
+        { id: 'parent1', project_id: 'proj1', title: 'Parent', parent_id: null, last_moved_at: staleIso },
+        { id: 'child1', project_id: 'proj1', title: 'Leaf one', parent_id: 'parent1', last_moved_at: nowIso },
+        { id: 'child2', project_id: 'proj1', title: 'Leaf two', parent_id: 'parent1', last_moved_at: nowIso },
+      ])
+      .mockResolvedValueOnce([]) // blocked
+      .mockResolvedValueOnce([]); // heartbeat in_progress (lane-drift probe)
+
+    const node = await makeNode();
+    const digest = await node.buildLaneHealthDigest({ projectId: 'proj1' });
+
+    // Two real active threads → duplicate, but counted as 2 (leaves), not 3.
+    expect(digest).toContain('DUPLICATE ACTIVE: 2 tasks');
+    expect(digest).toContain('child1');
+    expect(digest).toContain('child2');
+    expect(digest).not.toContain('parent1');
+  });
 });

--- a/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
@@ -464,3 +464,71 @@ describe('HeartbeatNode workboard context injection', () => {
     });
   });
 });
+
+describe('HeartbeatNode lane-health digest (Sw8c)', () => {
+  const nowIso = new Date().toISOString();
+  const staleIso = '2020-01-01T00:00:00.000Z';
+
+  beforeEach(() => {
+    listTasksMock.mockReset();
+  });
+
+  it('returns empty when the lane is healthy (single fresh in_progress, nothing off-lane)', async() => {
+    listTasksMock
+      .mockResolvedValueOnce([ // in_progress in-lane
+        { id: 'task1', project_id: 'proj1', title: 'Active', last_moved_at: nowIso },
+      ])
+      .mockResolvedValueOnce([]) // blocked in-lane
+      .mockResolvedValueOnce([ // heartbeat in_progress (lane-drift probe)
+        { id: 'task1', project_id: 'proj1', title: 'Active', last_moved_at: nowIso },
+      ]);
+
+    const node = await makeNode();
+    const digest = await node.buildLaneHealthDigest({ projectId: 'proj1' });
+
+    expect(digest).toBe('');
+  });
+
+  it('flags duplicate active, stale in_progress, blocked backlog, and lane drift', async() => {
+    listTasksMock
+      .mockResolvedValueOnce([ // in_progress in-lane — two at once, one stale
+        { id: 'taskA', project_id: 'proj1', title: 'Fresh work', last_moved_at: nowIso },
+        { id: 'taskB', project_id: 'proj1', title: 'Forgotten work', last_moved_at: staleIso },
+      ])
+      .mockResolvedValueOnce([ // blocked in-lane
+        { id: 'blk1', project_id: 'proj1', title: 'Waiting', last_moved_at: nowIso },
+      ])
+      .mockResolvedValueOnce([ // heartbeat in_progress across all projects
+        { id: 'taskA', project_id: 'proj1', title: 'Fresh work', last_moved_at: nowIso },
+        { id: 'off1', project_id: 'farm', title: 'Farm drift', last_moved_at: nowIso },
+      ]);
+
+    const node = await makeNode();
+    const digest = await node.buildLaneHealthDigest({ projectId: 'proj1' });
+
+    expect(digest).toContain('DUPLICATE ACTIVE: 2 tasks');
+    expect(digest).toContain('taskA');
+    expect(digest).toContain('STALE: task taskB');
+    expect(digest).toContain('BLOCKED (1): blk1');
+    expect(digest).toContain('LANE DRIFT: 1 heartbeat task');
+    expect(digest).toContain('off1 (project farm)');
+    // The in-lane fresh task must NOT be reported as drift.
+    expect(digest).not.toContain('taskA (project proj1)');
+  });
+
+  it('skips the lane-drift probe when scoped by assignee only (no projectId)', async() => {
+    listTasksMock
+      .mockResolvedValueOnce([ // in_progress
+        { id: 'task1', project_id: 'proj1', title: 'Stale one', last_moved_at: staleIso },
+      ])
+      .mockResolvedValueOnce([]); // blocked
+
+    const node = await makeNode();
+    const digest = await node.buildLaneHealthDigest({ assignee: 'heartbeat' });
+
+    expect(digest).toContain('STALE: task task1');
+    expect(digest).not.toContain('LANE DRIFT');
+    // Only two queries — no third heartbeat-assignee probe.
+    expect(listTasksMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## What
Deterministic, zero-LLM **lane-health advisory** injected into each fresh Heartbeat cycle (task `Sw8c`, parent `o8SF`). Surfaces the failure modes Heartbeat has been hitting by hand — before it picks up new work.

Detects and reports:
- **Duplicate active** — >1 `in_progress` task in the Operator lane (advance one, park the rest)
- **Stale in_progress** — a task untouched for ≥6h (resume or park with a status change + comment)
- **Blocked backlog** — in-lane blocked tasks to re-verify before starting new work
- **Lane drift** — heartbeat-assigned `in_progress` work *outside* the Operator Platform project (hand it back, do not advance Farm/ERP/other-project work unless explicitly assigned)

Healthy lanes emit **nothing**, so the block costs almost nothing.

## How
- New `HeartbeatNode.buildLaneHealthDigest()` — queries in-lane `in_progress`/`blocked` plus a heartbeat-assignee drift probe (skipped when scoped by assignee only). All XML-escaped.
- Injected via `mergeHeartbeatContextBlock` as `<lane_health>`; `BaseNode.stripInjectedContextBlocks` now strips it too so it replaces rather than accumulates across turns/tool-loops.
- Report opts resolved for the work report are stashed on metadata and reused to avoid a second project query.
- Failures are swallowed — a digest error never breaks a cycle.

## Tests
Focused Jest `HeartbeatNode.workContext.test.ts` → **10/10 pass** (7 existing + 3 new: healthy→empty, all-four-signals, assignee-only skips drift probe). `git diff --check` clean.

## Acceptance (Sw8c)
Each cycle now checks Operator in_progress/blocked first, flags drift into non-Operator projects, and hands the model a corrective note. Gated on the same operator rebuild+restart as the rest of the lane to reach the running binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)