### PR TITLE
feat(heartbeat): enforce cycle-budget, escalation ladder & anti-noise rule in prompt (grbz code half)

### DIFF
--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -14,6 +14,24 @@ describe('heartbeatPrompt', () => {
     expect(heartbeatPrompt).toContain('sulla <category>/<tool>');
   });
 
+  it('enforces the one-move cycle budget, escalation ladder, and anti-noise rule', () => {
+    // Cycle budget: pick one task, make one concrete move, verify, bookkeep, stop.
+    expect(heartbeatPrompt).toContain('## Cycle Budget & Escalation');
+    expect(heartbeatPrompt).toContain('Pick ONE task');
+    expect(heartbeatPrompt).toContain('Make ONE concrete, artifact-producing move');
+    // Exceed-budget => write the exact next action and resume from the comment, not chat memory.
+    expect(heartbeatPrompt).toContain('Exceed budget?');
+    expect(heartbeatPrompt).toContain('resume next cycle from that comment');
+    // Escalation: reroute before parking; park only irreversible/gated decisions.
+    expect(heartbeatPrompt).toContain('Escalation ladder');
+    // Anti-noise: no status-only comments; advance a different unblocked task instead.
+    expect(heartbeatPrompt).toContain('### Anti-Noise Rule');
+    expect(heartbeatPrompt).toContain('Never post a status-only comment when nothing changed');
+    expect(heartbeatPrompt).toContain('advance a different unblocked task');
+    // Resume-from-state digest trailer.
+    expect(heartbeatPrompt).toContain('--- HB-DIGEST v1 ---');
+  });
+
   it('boots from the heartbeat lane and retires the markdown state file', () => {
     // The workboard is the only work-state store; HEARTBEAT_STATE.md is dead.
     expect(heartbeatPrompt).toContain('HEARTBEAT_STATE.md');

--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -92,6 +92,36 @@ Pick ONE item per cycle, from the highest lane that has an actionable item. If a
 
 Every cycle ends with a **named artifact**: a commit, a pushed branch, an opened PR, a filed issue, a written/updated doc, a closed parked item, or a recorded verified fact with its evidence trail. A status update is not an artifact. If the cycle is ending and there's no artifact, do a Polish-lane task now.
 
+## Cycle Budget & Escalation
+
+A cycle is a **fixed budget**, not an open-ended session. Spend it the same way every time:
+
+1. **Pick ONE task** from the highest actionable lane. Do not scan unrelated projects — the '<work_report>' and your lane list already tell you what's actionable. Bouncing between projects burns the budget before any move lands.
+2. **Make ONE concrete, artifact-producing move** on it (see the Artifact-per-Cycle Contract). One inch that ships beats three inches half-explored.
+3. **Verify** the move like a skeptic (re-read/re-run/re-fetch).
+4. **Bookkeep** — write the outcome back to the task ('add_task_comment' + 'update_task'), then **STOP**.
+
+**Exceed budget?** If the move is bigger than one cycle, don't sprawl: commit the reversible progress, write the *exact* next action into a task comment, and resume next cycle from that comment. The comment — not chat memory — is how the next cycle continues where you left off.
+
+**Escalation ladder for a stuck task** (in order — never skip to the top):
+- **Reroute** to a different path to the same outcome (Unblock Ladder step 4).
+- **Park** only a genuinely irreversible/Jonathon-gated decision: 'status=parked' (or 'blocked' while a live gate holds) with a one-line 'rec:' recommendation. Move to another unblocked task the same cycle — parking is not ending the cycle.
+
+### Anti-Noise Rule
+
+**Never post a status-only comment when nothing changed.** A comment that re-states the same state as last cycle ("still blocked on rebuild", "gate unchanged") is noise, not an artifact — it does not satisfy the Artifact-per-Cycle Contract. If the only thing you have to say is "no change", that is the signal to **advance a different unblocked task instead** (Lane Portfolio lanes 2 and 4 are never blocked). Re-verify a known gate at most once per cycle, and only when a change would alter what you do next; a bookkeeping comment must record something that actually moved.
+
+End every workboard/cycle comment with a compact digest trailer so the next cycle can resume from state alone:
+
+'''
+--- HB-DIGEST v1 ---
+STATE: <what is true now / what shipped this cycle>
+BLOCKED: <live gate, or "none">
+NEXT: <exact next action for the following cycle>
+CHECKED: <what you verified as ground truth this cycle>
+--- /HB-DIGEST ---
+'''
+
 ## Parked Decisions Queue
 
 Parked decisions are work tasks with 'status=parked' (or 'blocked' while a gate is live). One task per decision. Put the recommendation, default, staged artifact, and unblock-check in the task description or a comment ('sulla work/add_task_comment', author 'sulla'):


### PR DESCRIPTION
## What

Bakes the **grbz** cycle-budget / escalation / anti-noise policy — previously living only in recall observation `AhkF` — directly into the heartbeat autonomous prompt (`heartbeat.ts`) so it is **structurally enforced every cycle**, not just when recall happens to surface it.

New `## Cycle Budget & Escalation` section:
- **One-move budget**: pick ONE task → make ONE concrete artifact-producing move → verify → bookkeep → STOP. No scanning unrelated projects.
- **Exceed-budget path**: commit reversible progress, write the *exact* next action into a task comment, resume from that comment (not chat memory).
- **Escalation ladder**: reroute before parking; park only irreversible/Jonathon-gated decisions, and advance another unblocked task the same cycle.
- **Anti-Noise Rule**: never post a status-only comment when nothing changed — advance a different unblocked task instead; re-verify a known gate at most once per cycle.
- **HB-DIGEST v1** resume-from-state trailer convention documented so the next cycle can continue from state alone.

## Why

grbz acceptance: *"no cycle burns time scanning unrelated projects or producing status-only notifications."* This was delivered as a "convention half" via observation `AhkF`, with the code half deferred **only** because stacking rebuild-gated PRs onto an unbuilt pile (#573/#577/#579/#580) had low marginal value. That pile is now 100% merged to main with zero open PRs, so the deferral rationale is void and this ships the code half cleanly off `origin/main`.

## Test

Extends `heartbeatPrompt.test.ts` with invariant assertions for the new section. Focused run green:

```
PASS pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
  ✓ keeps the autonomous loop anchored to the bundled docs and live tool catalog
  ✓ enforces the one-move cycle budget, escalation ladder, and anti-noise rule
  ✓ boots from the heartbeat lane and retires the markdown state file
Tests: 3 passed, 3 total
```

`git diff --check` clean; prompt-only + test change (2 files, +48).

## Gate

Behavioral effect requires the standard Sulla Desktop **rebuild + restart** to reach the running binary (same gate as the merged heartbeat pile). Until then the policy remains enforced behaviorally via recall observation `AhkF`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
