### PR TITLE
Disable Claude Code built-in task/todo list (one PM system: Projects)

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -212,7 +212,15 @@ export class ClaudeCodeService extends BaseLanguageModel {
       '--dangerously-skip-permissions',
       // Disable Claude's built-in AskUserQuestion — see runClaude for why it
       // routes through the sulla-native MCP tool instead.
-      '--disallowedTools', 'AskUserQuestion',
+      //
+      // Also disable Claude Code's built-in task/todo list (TaskCreate /
+      // TaskUpdate / TaskList / TaskGet, and legacy TodoWrite / TodoRead). It
+      // is a parallel, ephemeral project-management surface that competes with
+      // Sulla Projects. Agents track all work in Projects via `sulla project/*`
+      // (Postgres) — there must be exactly one task system, not a second
+      // in-memory to-do list. NOTE: TaskOutput / TaskStop are background-process
+      // controls (not the to-do list) and stay enabled.
+      '--disallowedTools', 'AskUserQuestion TaskCreate TaskUpdate TaskList TaskGet TodoWrite TodoRead',
     ];
     // stream-json input lets the process boot before the prompt exists (the
     // prompt is fed as a JSON user message on stdin by the caller).


### PR DESCRIPTION
## What
Disables Claude Code's built-in **task/todo list** (`TaskCreate` / `TaskUpdate` / `TaskList` / `TaskGet`, plus legacy `TodoWrite` / `TodoRead`) for all Sulla agents by adding them to `ClaudeCodeService`'s `--disallowedTools`.

## Why
That to-do list is injected by the `claude` runtime (v2.1.172), not by Sulla. It's an **ephemeral, in-memory** task tracker that shows up in the agent's thinking stream as *"Using TaskUpdate"* and even nudges agents (via an auto-reminder) to use it — a **second, parallel PM surface** competing with Sulla Projects.

There must be exactly one task system: **Sulla Projects via `sulla project/*`** (Postgres). Routing the built-in list into Projects isn't viable (it's a per-turn scratchpad; forcing every step into durable `work_tasks` rows would pollute the board), so we disable it — the same pattern already used for the built-in `AskUserQuestion` (routed to the sulla-native MCP tool).

## Scope / safety
- One-line change to the existing `--disallowedTools` arg (space-separated list; verified `claude --help` accepts that form).
- **`TaskOutput` / `TaskStop` are NOT disabled** — those are background-process controls (bash/agent tasks), not the to-do list.
- Does not touch sub-agent spawning (`Agent`) or any Sulla CLI tool.
- Affects all agents (Heartbeat/Workbench/desktop) after rebuild+restart.

## Related
Resolves the open decision-rule in `~/sulla/identity/agent/decision-rules.md` ("if `TaskUpdate` is a parallel PM system, remove it and route references through the Projects CLI catalog"). Complements #582 (work→project terminology rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)