### PR TITLE
test(heartbeat): guard continuous-operator prompt against pick-one/STOP regression

### DIFF
--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -23,4 +23,26 @@ describe('heartbeatPrompt', () => {
     // Unassigned work is claimed by self-assigning into the lane.
     expect(heartbeatPrompt).toContain('self-assign');
   });
+
+  // Regression guard for #587: Jonathon rejected the "pick one task, make one
+  // move, STOP" cycle ceiling (#581) and required a continuous operator that
+  // works the whole portfolio per wake. PR #581 proved this framing can be
+  // reintroduced, so pin the corrected language and forbid the rejected phrasing.
+  it('frames heartbeat as a continuous operator, not a one-task-per-cycle worker', () => {
+    // Positive: the continuous-operator guarantee must be present.
+    expect(heartbeatPrompt).toContain('not a one-task worker');
+    expect(heartbeatPrompt).toContain('does not cap you at one item per wake');
+    expect(heartbeatPrompt).toContain('Never end a wake idle');
+
+    // Negative: the rejected pick-one / one-move / STOP ceiling must not return.
+    // Matchers are tuned to #581's signature ("Cycle Budget" section header,
+    // "pick exactly ONE task", "make ONE ... move", "one item per cycle") and
+    // deliberately do NOT trip on legit language kept in the prompt: "pick the
+    // top open task", "One task per decision", "does not cap you at one item per wake".
+    expect(heartbeatPrompt).not.toContain('Cycle Budget');
+    expect(heartbeatPrompt).not.toMatch(/pick exactly one/i);
+    expect(heartbeatPrompt).not.toMatch(/make one\b[^.]*\bmove/i);
+    expect(heartbeatPrompt).not.toMatch(/one[- ]move budget/i);
+    expect(heartbeatPrompt).not.toMatch(/one item per cycle/i);
+  });
 });


### PR DESCRIPTION
## What
Adds a regression test pinning the **continuous-operator** framing of the Heartbeat prompt (`prompts/heartbeat.ts`) that #587 established.

## Why
Jonathon rejected the "pick one task, make one move, STOP" cycle ceiling. PR #581 encoded that framing and was closed unmerged; #587 replaced it with continuous-operator language ("not a one-task worker … does not cap you at one item per wake"). Nothing guarded that language at the file level — #581 proved it can be reintroduced. This test makes a regression fail CI instead of silently shipping.

## The test asserts
- **Positive:** `not a one-task worker`, `does not cap you at one item per wake`, `Never end a wake idle` are present.
- **Negative:** the #581 signature cannot return — no `Cycle Budget` header, no `pick exactly one`, no `make one … move`, no `one-move budget`, no `one item per cycle`.

Matchers were verified to (a) trip on #581-style phrasing and (b) leave legit language untouched (`pick the top open task`, `One task per decision`, `does not cap you at one item per wake`).

## Verification
`npx jest heartbeatPrompt.test.ts` → 3/3 pass on `main`. Guard-validity checked: all four negative matchers catch the rejected #581 text.

Additive, test-only, does not gate the pending Desktop rebuild. Relates to grbz / #587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)