### PR TITLE
heartbeat: runtime self-check of continuous-operator prompt invariants

### DIFF
--- a/pkg/rancher-desktop/agent/prompts/SystemPromptBuilder.ts
+++ b/pkg/rancher-desktop/agent/prompts/SystemPromptBuilder.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ChatMode } from '../controllers/ChatController';
+import { checkHeartbeatPromptInvariants, type HeartbeatInvariantResult } from './heartbeatInvariants';
 
 // ============================================================================
 // Types
@@ -84,6 +85,12 @@ export interface BuiltPrompt {
   anthropicSystem?: AnthropicSystemBlock[];
   /** Which sections were included in the build */
   includedSections: string[];
+  /**
+   * Heartbeat-only: runtime invariant check of the composed prompt — confirms
+   * the deployed continuous-operator wording is present and the #581 STOP-ceiling
+   * framing is absent. Undefined for non-heartbeat builds. See heartbeatInvariants.
+   */
+  heartbeatInvariants?: HeartbeatInvariantResult;
 }
 
 export interface AnthropicSystemBlock {
@@ -268,7 +275,25 @@ class SystemPromptBuilderImpl {
       }
     }
 
-    return { text, anthropicSystem, includedSections };
+    // Heartbeat self-verification: on the autonomous wake path, confirm the
+    // DEPLOYED prompt still carries the continuous-operator invariants. A stale
+    // binary running reverted prompt code (e.g. PR #581's pick-one/STOP ceiling)
+    // passes the source-level tests on main but fails here at runtime — turning
+    // the manual "rebuild + eyeball the live prompt" gate into an automatic
+    // signal. Non-throwing: we only surface the failure.
+    let heartbeatInvariants: HeartbeatInvariantResult | undefined;
+    if (ctx.isHeartbeat) {
+      heartbeatInvariants = checkHeartbeatPromptInvariants(text);
+      if (!heartbeatInvariants.ok) {
+        console.error(
+          '[SystemPromptBuilder] Heartbeat prompt invariant FAILURE — deployed prompt is stale or reverted. '
+          + 'Rebuild/restart Sulla Desktop to load the continuous-operator prompt.',
+          { missing: heartbeatInvariants.missing, forbidden: heartbeatInvariants.forbidden },
+        );
+      }
+    }
+
+    return { text, anthropicSystem, includedSections, heartbeatInvariants };
   }
 }
 

--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatInvariants.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatInvariants.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { heartbeatPrompt } from '../heartbeat';
+import {
+  HEARTBEAT_FORBIDDEN_PHRASES,
+  HEARTBEAT_REQUIRED_PHRASES,
+  checkHeartbeatPromptInvariants,
+} from '../heartbeatInvariants';
+import { SystemPromptBuilder, type PromptBuildContext } from '../SystemPromptBuilder';
+
+describe('checkHeartbeatPromptInvariants', () => {
+  it('passes on the real continuous-operator heartbeat prompt', () => {
+    const result = checkHeartbeatPromptInvariants(heartbeatPrompt);
+    expect(result.ok).toBe(true);
+    expect(result.missing).toEqual([]);
+    expect(result.forbidden).toEqual([]);
+  });
+
+  it('fails when a required continuous-operator phrase is missing (stale/reverted prompt)', () => {
+    const stripped = heartbeatPrompt.split('Never end a wake idle').join('');
+    const result = checkHeartbeatPromptInvariants(stripped);
+    expect(result.ok).toBe(false);
+    expect(result.missing).toContain('Never end a wake idle');
+  });
+
+  it('fails when a #581 STOP-ceiling phrase reappears', () => {
+    const reverted = `${ heartbeatPrompt }\n\n## Cycle Budget & Escalation\nPick ONE task, make one move, then STOP.`;
+    const result = checkHeartbeatPromptInvariants(reverted);
+    expect(result.ok).toBe(false);
+    expect(result.forbidden).toEqual(expect.arrayContaining(['Cycle Budget', 'Pick ONE', 'make one move']));
+  });
+
+  it('matches forbidden phrases case-insensitively', () => {
+    const result = checkHeartbeatPromptInvariants('the operator has a cycle budget of one item per cycle');
+    expect(result.ok).toBe(false);
+    expect(result.forbidden).toEqual(expect.arrayContaining(['Cycle Budget', 'one item per cycle']));
+  });
+
+  it('exposes the canonical phrase lists as non-empty', () => {
+    expect(HEARTBEAT_REQUIRED_PHRASES.length).toBeGreaterThan(0);
+    expect(HEARTBEAT_FORBIDDEN_PHRASES.length).toBeGreaterThan(0);
+  });
+});
+
+describe('SystemPromptBuilder heartbeat invariant wiring', () => {
+  const baseCtx = (overrides: Partial<PromptBuildContext>): PromptBuildContext => ({
+    mode:                  'full',
+    agentId:               'sulla-desktop',
+    agentConfig:           null,
+    provider:              'openai', // non-anthropic keeps the assertion focused on `text`
+    chatMode:              'text',
+    trustLevel:            'trusted',
+    isSubAgent:            false,
+    isHeartbeat:           true,
+    wsChannel:             'heartbeat',
+    toolMode:              'slim',
+    templateVars:          {},
+    agentSectionOverrides: new Map(),
+    excludeSections:       new Set(),
+    basePrompt:            '',
+    ...overrides,
+  });
+
+  it('attaches a passing invariant result for a healthy heartbeat build', async () => {
+    SystemPromptBuilder.register('heartbeat', () => ({
+      id:             'heartbeat',
+      content:        heartbeatPrompt,
+      priority:       110,
+      cacheStability: 'stable',
+    }), ['full']);
+
+    const built = await SystemPromptBuilder.build(baseCtx({}));
+    expect(built.heartbeatInvariants?.ok).toBe(true);
+  });
+
+  it('flags a stale/reverted heartbeat build', async () => {
+    SystemPromptBuilder.register('heartbeat', () => ({
+      id:             'heartbeat',
+      content:        'stale prompt with a Cycle Budget: pick exactly one task and STOP.',
+      priority:       110,
+      cacheStability: 'stable',
+    }), ['full']);
+
+    const built = await SystemPromptBuilder.build(baseCtx({}));
+    expect(built.heartbeatInvariants?.ok).toBe(false);
+    expect(built.heartbeatInvariants?.forbidden).toContain('Cycle Budget');
+  });
+
+  it('skips the invariant check for non-heartbeat builds', async () => {
+    SystemPromptBuilder.register('heartbeat', () => null, ['full']);
+
+    const built = await SystemPromptBuilder.build(baseCtx({ isHeartbeat: false }));
+    expect(built.heartbeatInvariants).toBeUndefined();
+  });
+});

--- a/pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts
@@ -1,0 +1,64 @@
+/**
+ * Runtime invariants for the Heartbeat autonomous ("continuous operator") prompt.
+ *
+ * Build-time tests (heartbeatPrompt.test.ts and PR #588) guard the prompt SOURCE
+ * on main. They cannot catch a *stale deployed binary* running reverted prompt
+ * code — the exact failure mode PR #581 introduced, and the reason the grbz/o8SF
+ * lane keeps gating a human "rebuild Desktop + eyeball the live prompt" step.
+ *
+ * This module lets the running process verify its OWN composed system prompt on
+ * every heartbeat wake (see SystemPromptBuilder.build). If the deployed prompt is
+ * stale or reverted, the check fails at runtime and the process self-reports it —
+ * turning the manual live-acceptance gate into an automatic signal.
+ */
+
+/** Phrases the deployed continuous-operator heartbeat prompt MUST contain. */
+export const HEARTBEAT_REQUIRED_PHRASES = [
+  'not a one-task worker',
+  'does not cap you at one item per wake',
+  'Never end a wake idle',
+] as const;
+
+/**
+ * #581-signature phrases that must NEVER reappear — the pick-one / do-one / STOP
+ * cycle-ceiling framing Jonathon explicitly rejected. Matched case-insensitively.
+ */
+export const HEARTBEAT_FORBIDDEN_PHRASES = [
+  'Cycle Budget',
+  'Pick ONE',
+  'pick exactly one',
+  'make one move',
+  'one move per',
+  'one item per cycle',
+] as const;
+
+export interface HeartbeatInvariantResult {
+  /** True when every required phrase is present and no forbidden phrase appears. */
+  ok:        boolean;
+  /** Required phrases that were NOT found (stale/reverted prompt). */
+  missing:   string[];
+  /** Forbidden phrases that WERE found (STOP-ceiling framing reintroduced). */
+  forbidden: string[];
+}
+
+/**
+ * Check a composed system-prompt string against the continuous-operator
+ * invariants. Pure and side-effect free.
+ *
+ * Required phrases are matched exactly (the wording is load-bearing); forbidden
+ * phrases are matched case-insensitively so casing tricks can't slip a STOP
+ * ceiling past the guard.
+ */
+export function checkHeartbeatPromptInvariants(promptText: string): HeartbeatInvariantResult {
+  const haystack = promptText || '';
+  const lower = haystack.toLowerCase();
+
+  const missing = HEARTBEAT_REQUIRED_PHRASES.filter(phrase => !haystack.includes(phrase));
+  const forbidden = HEARTBEAT_FORBIDDEN_PHRASES.filter(phrase => lower.includes(phrase.toLowerCase()));
+
+  return {
+    ok: missing.length === 0 && forbidden.length === 0,
+    missing,
+    forbidden,
+  };
+}


### PR DESCRIPTION
## What

Adds a **runtime** self-check that the deployed Heartbeat prompt still carries the continuous-operator invariants — on every heartbeat wake, not just at build time.

## Why

Build-time tests (`heartbeatPrompt.test.ts`, PR #588) guard the prompt **source** on `main`. They cannot catch a **stale deployed binary** running reverted prompt code — the exact failure mode PR #581 introduced. That gap is why the operator lane (grbz / o8SF / W16D) keeps gating a manual *"rebuild Desktop + eyeball the live prompt"* acceptance step: nothing in the running app confirms the correct prompt is actually live.

## How

- `heartbeatInvariants.ts` — `checkHeartbeatPromptInvariants(text)` (pure): asserts the 3 required continuous-operator phrases are present and the 6 #581 pick-one/STOP-ceiling signatures are absent (forbidden matched case-insensitively).
- `SystemPromptBuilder.build()` — on `ctx.isHeartbeat`, verifies the **composed** prompt, logs a clear error on failure, and exposes the result on `BuiltPrompt.heartbeatInvariants`. **Non-throwing.**

Net effect: live acceptance becomes an **automatic, self-reporting** signal. A stale/reverted deploy surfaces itself on the next wake instead of needing a human eyeball.

## Tests

8 unit tests (pure checker + `build()` wiring: healthy / stale / non-heartbeat). The `pkg/rancher-desktop/agent/prompts` suite passes 10/10 locally.

## Notes

- Complements #588 (build-time) — different layer, different file, no overlap.
- Canonical phrase lists live here; #588 can later import them to converge on one source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
