### PR TITLE
fix(model-provider): restart self-heal for stranded subconscious model/provider pair (u4IL)

### DIFF
--- a/pkg/rancher-desktop/agent/services/ModelProviderService.ts
+++ b/pkg/rancher-desktop/agent/services/ModelProviderService.ts
@@ -311,6 +311,56 @@ class ModelProviderService {
     return !modelId || modelId === 'fast' || modelId === 'balanced' || modelId === 'powerful';
   }
 
+  /**
+   * Decide whether a concrete subconscious model id is stranded — i.e. it names a
+   * model its provider does not offer, the inconsistent pair (e.g. provider=codex /
+   * id=grok-4.6) that drives the recurring subconscious drift.
+   *
+   * Fail-safe by construction — only returns true when we can POSITIVELY prove the
+   * mismatch. It never resets when:
+   *  - the id is provider-agnostic ('', or a fast/balanced/powerful tier), or
+   *  - the provider's model list is unknown/empty (a dynamic provider whose catalog
+   *    could not be loaded — resetting there would wipe a legitimately-chosen model).
+   * This is the landmine guard: a blanket "reset if not in list" would clobber a valid
+   * concrete selection whenever the catalog fetch transiently fails.
+   */
+  private modelIsStrandedForProvider(modelId: string, providerModelIds: string[]): boolean {
+    if (this.isProviderAgnosticModelId(modelId)) return false; // no provider affinity — never stranded
+    if (providerModelIds.length === 0) return false; // catalog unknown — cannot prove mismatch, keep
+    return !providerModelIds.includes(modelId); // concrete id the provider does not offer → stranded
+  }
+
+  /**
+   * Restart self-heal for the subconscious slot. setSubconsciousProvider() only clears a
+   * stranded override when the PROVIDER changes; the reported drift keeps the provider
+   * unchanged (stays codex) while a stale concrete id (grok-4.6) survives in the DB and is
+   * reloaded verbatim on every boot. This reconciles the loaded pair once at init: if the
+   * concrete id is provably not offered by the current provider, reset it to '' (provider
+   * default) so the pair is consistent and stops being re-broadcast into the settings UI.
+   * Runs after the DB load; no-ops on any error so a bad reconcile never blocks startup.
+   */
+  private async reconcileSubconsciousModel(): Promise<void> {
+    const modelId = this.state.subconsciousModelId;
+    if (this.isProviderAgnosticModelId(modelId)) return; // fast path — nothing concrete to reconcile
+
+    let providerModelIds: string[] = [];
+    try {
+      const models = await this.getModelsForProvider(this.state.subconsciousProvider);
+      providerModelIds = models.map(m => m.id);
+    } catch {
+      return; // could not load the provider catalog — fail safe, leave the id untouched
+    }
+
+    if (this.modelIsStrandedForProvider(modelId, providerModelIds)) {
+      console.warn(
+        `[ModelProviderService] Stranded subconscious model '${ modelId }' is not offered by ` +
+        `provider '${ this.state.subconsciousProvider }' — resetting to provider default`,
+      );
+      this.state.subconsciousModelId = '';
+      await SullaSettingsModel.set('subconsciousModelId', '', 'string');
+    }
+  }
+
   async setHeartbeatModelId(modelId: string): Promise<void> {
     this.state.heartbeatModelId = modelId;
     await SullaSettingsModel.set('heartbeatModelId', modelId, 'string');
@@ -357,6 +407,12 @@ class ModelProviderService {
     this.state.heartbeatModelId = await SullaSettingsModel.get('heartbeatModelId', 'fast');
     this.state.subconsciousModelId = await SullaSettingsModel.get('subconsciousModelId', 'fast');
     this.state.modelMode = 'remote';
+
+    // Self-heal a stranded subconscious model/provider pair loaded from the DB (e.g.
+    // provider=codex left with a concrete grok-4.6 id). setSubconsciousProvider only
+    // clears this on a provider change; reconcile here so it also heals on restart when
+    // the provider is unchanged — the acceptance criterion for this slot.
+    await this.reconcileSubconsciousModel();
 
     // Load active model from the provider's integration form values
     try {

--- a/pkg/rancher-desktop/agent/services/__tests__/ModelProviderService.subconsciousDrift.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/ModelProviderService.subconsciousDrift.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Restart self-heal for the recurring subconscious model drift.
+ *
+ * The bug (task u4IL): `subconsciousModelId` keeps reverting to a grok id
+ * (e.g. grok-4.6) while `subconsciousProvider` stays codex. setSubconsciousProvider()
+ * only clears a stranded override when the PROVIDER changes, so a stale concrete id
+ * survives every restart (loadStateFromDB reloaded it verbatim) and gets re-broadcast
+ * into the settings UI, which re-persists it and clobbers manual repairs.
+ *
+ * These tests pin the fix: on load, an inconsistent provider/model pair self-heals to
+ * the provider default (''), while a *valid* concrete selection and any pair whose
+ * catalog cannot be proven are left untouched (the landmine guard — never wipe a
+ * legitimately-chosen model on a transient catalog miss).
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const getSettingMock: any = jest.fn();
+const setSettingMock: any = jest.fn(() => Promise.resolve());
+const getFormValuesMock: any = jest.fn(() => Promise.resolve([]));
+
+jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
+  SullaSettingsModel: {
+    get: getSettingMock,
+    set: setSettingMock,
+  },
+}));
+jest.unstable_mockModule('../IntegrationService', () => ({
+  getIntegrationService: () => ({
+    getFormValues: getFormValuesMock,
+  }),
+}));
+jest.unstable_mockModule('../../integrations/catalog', () => ({
+  integrations: {},
+}));
+
+async function makeService(): Promise<any> {
+  const { getModelProviderService } = await import('../ModelProviderService');
+  const svc: any = getModelProviderService();
+  // Reset the singleton's in-memory state between tests.
+  svc.state = {
+    primaryProvider:      'codex',
+    secondaryProvider:    'codex',
+    heartbeatProvider:    'codex',
+    subconsciousProvider: 'codex',
+    activeModelId:        '',
+    modelMode:            'remote',
+    secondaryModelId:     '',
+    heartbeatModelId:     'codex',
+    subconsciousModelId:  'codex',
+  };
+  return svc;
+}
+
+describe('ModelProviderService — subconscious drift self-heal', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks(); // singleton service — undo prior spyOn(getModelsForProvider)
+    getSettingMock.mockReset();
+    setSettingMock.mockReset();
+    setSettingMock.mockImplementation(() => Promise.resolve());
+    getFormValuesMock.mockReset();
+    getFormValuesMock.mockImplementation(() => Promise.resolve([]));
+  });
+
+  describe('modelIsStrandedForProvider (pure decision)', () => {
+    it('flags a concrete id the provider does not offer as stranded', async() => {
+      const svc = await makeService();
+      // The exact reported pair: provider=codex offers codex/gpt-* but NOT grok-4.6.
+      expect(svc.modelIsStrandedForProvider('grok-4.6', ['codex', 'gpt-5.3-codex', 'gpt-5-codex'])).toBe(true);
+    });
+
+    it('keeps a concrete id the provider DOES offer (valid selection)', async() => {
+      const svc = await makeService();
+      // Landmine case: provider=grok legitimately offers grok-4.6 — must NOT be wiped.
+      expect(svc.modelIsStrandedForProvider('grok-4.6', ['grok-4.6', 'grok-3'])).toBe(false);
+      // The 'auto' sentinel id equals the provider id and is in-list.
+      expect(svc.modelIsStrandedForProvider('codex', ['codex', 'gpt-5.3-codex'])).toBe(false);
+    });
+
+    it('never flags provider-agnostic ids (empty / tier names)', async() => {
+      const svc = await makeService();
+      for (const id of ['', 'fast', 'balanced', 'powerful']) {
+        expect(svc.modelIsStrandedForProvider(id, ['codex'])).toBe(false);
+      }
+    });
+
+    it('fails safe when the provider catalog is unknown/empty (no proof of mismatch)', async() => {
+      const svc = await makeService();
+      // A dynamic provider whose catalog could not be loaded — resetting here would
+      // clobber a legitimate choice, so we must keep it.
+      expect(svc.modelIsStrandedForProvider('grok-4.6', [])).toBe(false);
+    });
+  });
+
+  describe('reconcileSubconsciousModel', () => {
+    it('resets the stranded codex/grok-4.6 pair to the provider default and persists it', async() => {
+      const svc = await makeService();
+      svc.state.subconsciousProvider = 'codex';
+      svc.state.subconsciousModelId = 'grok-4.6';
+      jest.spyOn(svc, 'getModelsForProvider').mockResolvedValue([
+        { id: 'codex', name: 'Auto' }, { id: 'gpt-5.3-codex', name: 'GPT-5.3 Codex' },
+      ]);
+
+      await svc.reconcileSubconsciousModel();
+
+      expect(svc.state.subconsciousModelId).toBe('');
+      expect(setSettingMock).toHaveBeenCalledWith('subconsciousModelId', '', 'string');
+    });
+
+    it('leaves a valid concrete selection untouched and does not write settings', async() => {
+      const svc = await makeService();
+      svc.state.subconsciousProvider = 'grok';
+      svc.state.subconsciousModelId = 'grok-4.6';
+      jest.spyOn(svc, 'getModelsForProvider').mockResolvedValue([
+        { id: 'grok-4.6', name: 'Grok 4.6' }, { id: 'grok-3', name: 'Grok 3' },
+      ]);
+
+      await svc.reconcileSubconsciousModel();
+
+      expect(svc.state.subconsciousModelId).toBe('grok-4.6');
+      expect(setSettingMock).not.toHaveBeenCalled();
+    });
+
+    it('does not touch an agnostic id (no catalog lookup needed)', async() => {
+      const svc = await makeService();
+      svc.state.subconsciousProvider = 'codex';
+      svc.state.subconsciousModelId = '';
+      const spy = jest.spyOn(svc, 'getModelsForProvider');
+
+      await svc.reconcileSubconsciousModel();
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(setSettingMock).not.toHaveBeenCalled();
+    });
+
+    it('fails safe on a catalog fetch error (keeps the id, no write)', async() => {
+      const svc = await makeService();
+      svc.state.subconsciousProvider = 'grok';
+      svc.state.subconsciousModelId = 'grok-4.6';
+      jest.spyOn(svc, 'getModelsForProvider').mockRejectedValue(new Error('vault not ready'));
+
+      await svc.reconcileSubconsciousModel();
+
+      expect(svc.state.subconsciousModelId).toBe('grok-4.6');
+      expect(setSettingMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loadStateFromDB (end-to-end self-heal on restart)', () => {
+    it('heals a stranded pair reloaded from the DB', async() => {
+      const svc = await makeService();
+      const db: Record<string, string> = {
+        primaryProvider:      'codex',
+        secondaryProvider:    'codex',
+        heartbeatProvider:    'codex',
+        subconsciousProvider: 'codex',
+        secondaryModelId:     '',
+        heartbeatModelId:     'codex',
+        subconsciousModelId:  'grok-4.6', // the stranded id reloaded verbatim
+        remoteModel:          '',
+      };
+      getSettingMock.mockImplementation((key: string, def: string) =>
+        Promise.resolve(key in db ? db[key] : def));
+      jest.spyOn(svc, 'getModelsForProvider').mockResolvedValue([
+        { id: 'codex', name: 'Auto' }, { id: 'gpt-5.3-codex', name: 'GPT-5.3 Codex' },
+      ]);
+
+      await svc.loadStateFromDB();
+
+      expect(svc.state.subconsciousModelId).toBe('');
+      expect(setSettingMock).toHaveBeenCalledWith('subconsciousModelId', '', 'string');
+    });
+  });
+});


### PR DESCRIPTION
## Problem (task u4IL)

The recurring subconscious model drift — `subconsciousModelId` reverts to a grok id (e.g. `grok-4.6`) while `subconsciousProvider` stays `codex` — survives restarts, so manual `settings_set` repairs never stick.

**Why the merged fix (#577) is insufficient:** `setSubconsciousProvider()` clears a stranded concrete override only when the **provider changes**. The reported scenario keeps the provider unchanged (`codex`), so the reset never fires. On boot, `loadStateFromDB()` reloads the stale `grok-4.6` verbatim; `ModelProviderService` holds it as authoritative in-memory state and re-broadcasts it, and (with the settings UI open) it gets re-persisted — clobbering the repair. Restart just reloads the stranded pair.

This is the residual gap confirmed in the task's root-cause trace (comment `[Lsad]`), which the merged fix does not cover.

## Fix (Part A — restart self-heal)

Add `reconcileSubconsciousModel()`, run once at the end of `loadStateFromDB()`. If the loaded concrete id is **provably not offered** by the current provider, reset it to `''` (provider default) so the pair is consistent and stops being re-broadcast. This directly satisfies the task's acceptance criterion: *"survives without manual repair across a restart / defaults to codex."*

### Landmine guard (the one thing to get right)
A naive "reset if not in the provider's list" would wipe a *legitimately-chosen* concrete model (e.g. `provider=grok, id=grok-4.6` is valid) whenever the catalog fetch transiently fails. `modelIsStrandedForProvider()` is fail-safe by construction — it only returns `true` when the mismatch is **positively proven**:
- provider-agnostic ids (`''`, `fast`/`balanced`/`powerful`) → never stranded
- empty/unknown provider catalog → keep (cannot prove mismatch)
- catalog fetch throws → keep (no-op, never blocks startup)

## Tests

`ModelProviderService.subconsciousDrift.test.ts` — 9 unit tests, all green:
- the exact reported pair `codex` / `grok-4.6` → reset + persisted `''`
- landmine cases: valid concrete selection kept, empty catalog kept, agnostic id skipped (no catalog lookup), catalog fetch error kept
- end-to-end `loadStateFromDB()` self-heal on a stranded pair reloaded from the DB

Adds no new lint violations. Diff is +56 lines in the service plus the new test file.

## Scope / follow-up

Deliberately **Part A only** (restart self-heal), which is the acceptance-critical piece. Part B from the root-cause design (make out-of-band `settings_set` repairs stick live *without* a restart, via an in-memory refresh on settings-changed) is more invasive to the in-memory-source-of-truth design and is not part of the stated acceptance — left as a documented follow-up.

**Final live acceptance** (toggle-and-restart proof in the running app) remains gated on the same Desktop rebuild/restart as the rest of the lane; this PR makes the logic verifiable now via unit tests.

Task: u4IL. Companion to merged #577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
