### PR TITLE
fix(heartbeat): lane-health staleness counts comment-only progress (xoV6)

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -937,6 +937,29 @@ export class WorkItemsModel {
   }
 
   /**
+   * Latest (non-archived) comment timestamp per task, for the given task ids, in
+   * a single grouped query. Used by lane-health staleness: add_task_comment does
+   * NOT bump the task's last_moved_at, so a task actively progressed via comments
+   * would otherwise read as "no movement" and false-flag as stale every cycle.
+   * Returns a Map keyed by task id; tasks with no comments are simply absent.
+   */
+  static async latestCommentAtByTask(taskIds: string[]): Promise<Map<string, string>> {
+    const out = new Map<string, string>();
+    if (!taskIds.length) return out;
+    const rows = await postgresClient.query<{ task_id: string; latest_comment_at: string }>(
+      `SELECT task_id, MAX(created_at) AS latest_comment_at
+         FROM ${ WorkItemsModel.COMMENTS }
+        WHERE archived = false AND task_id = ANY($1)
+        GROUP BY task_id`,
+      [taskIds],
+    );
+    for (const row of rows) {
+      if (row.latest_comment_at) out.set(row.task_id, row.latest_comment_at);
+    }
+    return out;
+  }
+
+  /**
    * Unified reverse-chronological activity feed for the Projects area: comments,
    * newly created tasks/epics/projects, status/board moves, and metadata edits —
    * newest first. Synthesized via UNION over the project tables' timestamp columns

--- a/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
@@ -840,12 +840,25 @@ export class HeartbeatNode extends BaseNode {
     }
 
     // 2. Stale in_progress — resume or park with a status change + comment.
+    //    add_task_comment does NOT bump last_moved_at, so a leaf task actively
+    //    progressed via comments (a status held steady while work continues)
+    //    would false-flag as stale every cycle. Measure staleness from the LATEST
+    //    of last_moved_at and the most recent comment, so comment-only progress
+    //    counts as movement.
+    const latestCommentAt = await WorkItemsModel.latestCommentAtByTask(
+      leafInProgress.map(task => task.id),
+    );
     for (const task of leafInProgress) {
-      const movedMs = Date.parse(task.last_moved_at);
-      if (!Number.isFinite(movedMs)) continue;
-      const ageHours = Math.floor((nowMs - movedMs) / 3_600_000);
+      const movedMs   = Date.parse(task.last_moved_at);
+      const commentMs = Date.parse(latestCommentAt.get(task.id) ?? '');
+      const lastActivityMs = Math.max(
+        Number.isFinite(movedMs)   ? movedMs   : -Infinity,
+        Number.isFinite(commentMs) ? commentMs : -Infinity,
+      );
+      if (!Number.isFinite(lastActivityMs)) continue;
+      const ageHours = Math.floor((nowMs - lastActivityMs) / 3_600_000);
       if (ageHours >= STALE_IN_PROGRESS_HOURS) {
-        lines.push(`- STALE: task ${ this.escapeXmlText(task.id) } "${ this.escapeXmlText(task.title) }" has sat in_progress ~${ ageHours }h with no movement. Resume it now, or add a comment and set status (blocked/todo) explaining the pause.`);
+        lines.push(`- STALE: task ${ this.escapeXmlText(task.id) } "${ this.escapeXmlText(task.title) }" has sat in_progress ~${ ageHours }h with no movement or comment. Resume it now, or add a comment and set status (blocked/todo) explaining the pause.`);
       }
     }
 

--- a/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
@@ -8,6 +8,7 @@ const getProjectMock: any = jest.fn();
 const getEpicMock: any = jest.fn();
 const getTaskMock: any = jest.fn();
 const listCommentsMock: any = jest.fn();
+const latestCommentAtByTaskMock: any = jest.fn();
 
 jest.unstable_mockModule('../BaseNode', () => ({
   BaseNode: class MockBaseNode {
@@ -27,6 +28,7 @@ jest.unstable_mockModule('../../database/models/WorkItemsModel', () => ({
     getEpic:      getEpicMock,
     getTask:      getTaskMock,
     listComments: listCommentsMock,
+    latestCommentAtByTask: latestCommentAtByTaskMock,
   },
 }));
 
@@ -69,6 +71,8 @@ describe('HeartbeatNode Projects context injection', () => {
     getEpicMock.mockReset();
     getTaskMock.mockReset();
     listCommentsMock.mockReset();
+    latestCommentAtByTaskMock.mockReset();
+    latestCommentAtByTaskMock.mockResolvedValue(new Map());
 
     ensureTablesMock.mockResolvedValue(undefined);
     buildProjectReportMock.mockResolvedValue('# Project report\n\n## Next up\n- [critical] Hydrate me (id task1)');
@@ -471,6 +475,8 @@ describe('HeartbeatNode lane-health digest (Sw8c)', () => {
 
   beforeEach(() => {
     listTasksMock.mockReset();
+    latestCommentAtByTaskMock.mockReset();
+    latestCommentAtByTaskMock.mockResolvedValue(new Map());
   });
 
   it('returns empty when the lane is healthy (single fresh in_progress, nothing off-lane)', async() => {
@@ -572,6 +578,40 @@ describe('HeartbeatNode lane-health digest (Sw8c)', () => {
     expect(digest).toContain('child1');
     expect(digest).toContain('child2');
     expect(digest).not.toContain('parent1');
+  });
+
+  it('does not flag a leaf task as STALE when a recent comment postdates last_moved_at (xoV6)', async() => {
+    listTasksMock
+      .mockResolvedValueOnce([ // in_progress — one leaf, stale by last_moved_at alone
+        { id: 'task1', project_id: 'proj1', title: 'Progressed via comments', parent_id: null, last_moved_at: staleIso },
+      ])
+      .mockResolvedValueOnce([]) // blocked
+      .mockResolvedValueOnce([ // heartbeat in_progress (lane-drift probe)
+        { id: 'task1', project_id: 'proj1', title: 'Progressed via comments', parent_id: null, last_moved_at: staleIso },
+      ]);
+    // A fresh comment counts as movement — staleness uses GREATEST(last_moved_at, latest comment).
+    latestCommentAtByTaskMock.mockResolvedValue(new Map([['task1', nowIso]]));
+
+    const node = await makeNode();
+    const digest = await node.buildLaneHealthDigest({ projectId: 'proj1' });
+
+    expect(digest).not.toContain('STALE');
+    expect(digest).toBe('');
+  });
+
+  it('still flags a leaf task as STALE when its latest comment is also old (xoV6)', async() => {
+    listTasksMock
+      .mockResolvedValueOnce([
+        { id: 'task1', project_id: 'proj1', title: 'Truly abandoned', parent_id: null, last_moved_at: staleIso },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    latestCommentAtByTaskMock.mockResolvedValue(new Map([['task1', staleIso]]));
+
+    const node = await makeNode();
+    const digest = await node.buildLaneHealthDigest({ projectId: 'proj1' });
+
+    expect(digest).toContain('STALE: task task1');
   });
 });
 


### PR DESCRIPTION
## What
Closes the remaining defect in **xoV6** (P2 lane-health false-positives). `buildLaneHealthDigest` flagged a leaf `in_progress` task as STALE after 6h using `last_moved_at` alone. `add_task_comment` does **not** bump `last_moved_at`, so a task actively progressed via comments (status held steady while work continues) false-flagged STALE every cycle — e.g. parent-class tasks were already excluded, but any commented-not-moved leaf still tripped it.

## Fix
- New `WorkItemsModel.latestCommentAtByTask(taskIds)` — one grouped query (`MAX(created_at) ... GROUP BY task_id`, uses the existing `(task_id, archived, created_at)` index).
- Staleness now measures from `GREATEST(last_moved_at, latest comment)`, so comment-only progress counts as movement. No change to `last_moved_at` semantics or the activity feed (option a from the task, not the invasive last_moved_at bump).
- Defect #2 (parent inflating DUPLICATE/STALE) was already handled via leaf-filtering; this completes defect #1.

## Tests
`HeartbeatNode.workContext.test.ts` — 19/19 green via the canonical ESM invocation (`node --experimental-vm-modules .../jest.js`). Added two cases: recent comment on a moved-long-ago task is NOT stale; a task whose latest comment is also old still IS stale. All existing lane-health/parent-exclusion tests unchanged.

Gate note: like the other stacked heartbeat PRs, live effect needs the pending Desktop rebuild/restart. Not auto-merging (gated repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)