### PR TITLE
heartbeat: add task-type execution playbooks to autonomous prompt

### DIFF
--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -23,4 +23,33 @@ describe('heartbeatPrompt', () => {
     // Unassigned work is claimed by self-assigning into the lane.
     expect(heartbeatPrompt).toContain('self-assign');
   });
+
+  it('carries task-type execution playbooks that select a checklist without capping items per wake', () => {
+    expect(heartbeatPrompt).toContain('## Task-Type Playbooks');
+    // Every playbook type is present.
+    for (const type of [
+      'VERIFY / QA',
+      'ROOT-CAUSE',
+      'IMPLEMENT / CODE + PR',
+      'E2E / ACCEPTANCE',
+      'CLEANUP / CURATE',
+      'DECISION / GATED',
+    ]) {
+      expect(heartbeatPrompt).toContain(type);
+    }
+    // The playbook picks HOW to execute, never how many — it must not reintroduce a one-item cap.
+    expect(heartbeatPrompt).toContain('does **not** cap');
+    expect(heartbeatPrompt).toContain('never a stop signal');
+    // Gated/decision work parks and moves on rather than ending the wake.
+    expect(heartbeatPrompt).toContain('Parking one decision never ends the wake');
+    // The one-per-cycle throttle removed in #587 must stay gone from the prompt.
+    for (const banned of [
+      'pick exactly one',
+      'make one move',
+      'one item per cycle',
+      'Cycle Budget',
+    ]) {
+      expect(heartbeatPrompt).not.toContain(banned);
+    }
+  });
 });

--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -88,6 +88,17 @@ You are an **operator**, not a one-task worker. Work continuously across the por
 
 "Everything is blocked" is false by construction — lanes 2 and 4 are never blocked.
 
+## Task-Type Playbooks — Match the Checklist to the Work
+
+Read each task's type and run the matching checklist. This chooses *how* you execute the item in front of you — it does **not** cap *how many* items you work. There is no one-item-per-wake limit (see The Lane Portfolio); the playbook is an execution pattern, never a stop signal. When a task's type is ambiguous, default to the closest match and note the choice.
+
+- **VERIFY / QA** → run a concrete probe against the running thing, capture the evidence (command output, screenshot, network trace, row count), and record the verified fact with its trail. No probe, no verification — never mark something verified from inference or from a report alone.
+- **ROOT-CAUSE** → establish ground truth first, form **one** hypothesis, run **one** probe to confirm or kill it, and record the finding *before* writing any fix. Fixing before the cause is pinned is a guess wearing a diff.
+- **IMPLEMENT / CODE + PR** → focused branch, the smallest change that moves the task, a focused test plus a diff-check, then push the branch and open the PR via 'sulla github/*'. Never auto-merge a gated repo — stage to the PR edge and let your Human gate the merge.
+- **E2E / ACCEPTANCE** → exercise the real end-to-end loop (not a unit stand-in) and produce a reproducible proof artifact of the pass/fail. Acceptance without proof isn't acceptance.
+- **CLEANUP / CURATE** → search active *and* archived first, update in place instead of duplicating, soft-archive the stale, and sync identity/outcomes when the change warrants it.
+- **DECISION / GATED** → the only type that parks: record recommendation + default + staged artifact + unblock-check on the task ('status=parked', author 'heartbeat'), then move to the next unblocked valuable item. Parking one decision never ends the wake.
+
 ## Artifact-per-Cycle Contract
 
 Every cycle ends with a **named artifact**: a commit, a pushed branch, an opened PR, a filed issue, a written/updated doc, a closed parked item, or a recorded verified fact with its evidence trail. A status update is not an artifact. If the cycle is ending and there's no artifact, do a Polish-lane task now.


### PR DESCRIPTION
## What
Adds a **Task-Type Playbooks** section to the Heartbeat autonomous prompt (`prompts/heartbeat.ts`) that selects the right execution checklist by task type:

- **VERIFY / QA** — concrete probe + captured evidence; never verify from inference/report
- **ROOT-CAUSE** — ground truth → one hypothesis → one probe → record finding *before* fixing
- **IMPLEMENT / CODE + PR** — focused branch, focused test + diff-check, push PR via `sulla github/*`, never auto-merge a gated repo
- **E2E / ACCEPTANCE** — real end-to-end loop + reproducible proof artifact
- **CLEANUP / CURATE** — search active + archived first, update in place, soft-archive stale, sync identity/outcomes
- **DECISION / GATED** — the only type that parks (rec + default + staged + unblock-check), then move to the next unblocked item

## Why this is safe re: #587
The section explicitly states the playbook chooses **how** to execute an item, **never how many** — there is no one-item-per-wake limit. It does not reintroduce the pick-one/do-one/STOP throttle removed in #587. `DECISION/GATED` parking never ends the wake.

## Guard
Extends `__tests__/heartbeatPrompt.test.ts` with a regression test asserting every playbook type is present, the no-cap wording holds (`does **not** cap`, `never a stop signal`, `Parking one decision never ends the wake`), and the #581-style signatures (`pick exactly one`, `make one move`, `one item per cycle`, `Cycle Budget`) stay absent.

3/3 pass via `node --experimental-vm-modules node_modules/jest/bin/jest.js` (the ESM-safe invocation; a raw `jest <file>` gives a false-RED).

Closes Di0x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)