### PR TITLE
heartbeat: lane-health STALE counts comment-only progress (xoV6 residual)

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -80,6 +80,14 @@ export interface WorkTaskRecord {
   last_moved_by: string | null;
   completed_at:  string | null;
   archived:      boolean;
+  /**
+   * Computed by listTasks() only — MAX(created_at) of the task's live comments,
+   * or null when it has none. Not a stored column, so plain SELECT * paths omit
+   * it (hence optional). Lets lane-health treat comment-only progress as
+   * activity: a task actively commented but held at a stable in_progress status
+   * stops false-flagging STALE, since add_task_comment does not bump last_moved_at.
+   */
+  latest_comment_at?: string | null;
 }
 
 export interface WorkCommentRecord {
@@ -902,7 +910,16 @@ export class WorkItemsModel {
     const limit = opts.limit ?? 50;
     values.push(limit);
     return postgresClient.query<WorkTaskRecord>(
-      `SELECT * FROM ${ WorkItemsModel.TASKS }
+      // latest_comment_at: newest live comment per task, so lane-health can treat
+      // comment-only progress as activity (add_task_comment does not bump
+      // last_moved_at). Correlated subquery keyed on the task id — no table alias
+      // needed, so the WHERE/ORDER BY on bare columns are untouched; backed by
+      // idx_work_task_comments_task, one indexed lookup per returned row.
+      `SELECT *, (
+          SELECT MAX(c.created_at) FROM ${ WorkItemsModel.COMMENTS } c
+           WHERE c.task_id = ${ WorkItemsModel.TASKS }.id AND c.archived = false
+        ) AS latest_comment_at
+        FROM ${ WorkItemsModel.TASKS }
         WHERE ${ conds.join(' AND ') }
         ORDER BY ${ PRIORITY_RANK }, due_at ASC NULLS LAST, last_moved_at ASC, position ASC
         LIMIT $${ idx }`,

--- a/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
@@ -840,10 +840,19 @@ export class HeartbeatNode extends BaseNode {
     }
 
     // 2. Stale in_progress — resume or park with a status change + comment.
+    //    Staleness is measured from the LATEST activity, not just last_moved_at:
+    //    add_task_comment does not bump last_moved_at, so a leaf task actively
+    //    progressed by comments at a stable in_progress status would otherwise
+    //    false-flag every cycle. latest_comment_at (from listTasks) captures that.
     for (const task of leafInProgress) {
-      const movedMs = Date.parse(task.last_moved_at);
-      if (!Number.isFinite(movedMs)) continue;
-      const ageHours = Math.floor((nowMs - movedMs) / 3_600_000);
+      const movedMs   = Date.parse(task.last_moved_at);
+      const commentMs = task.latest_comment_at ? Date.parse(task.latest_comment_at) : NaN;
+      const activityMs = Math.max(
+        Number.isFinite(movedMs) ? movedMs : -Infinity,
+        Number.isFinite(commentMs) ? commentMs : -Infinity,
+      );
+      if (!Number.isFinite(activityMs)) continue;
+      const ageHours = Math.floor((nowMs - activityMs) / 3_600_000);
       if (ageHours >= STALE_IN_PROGRESS_HOURS) {
         lines.push(`- STALE: task ${ this.escapeXmlText(task.id) } "${ this.escapeXmlText(task.title) }" has sat in_progress ~${ ageHours }h with no movement. Resume it now, or add a comment and set status (blocked/todo) explaining the pause.`);
       }

--- a/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
@@ -573,6 +573,42 @@ describe('HeartbeatNode lane-health digest (Sw8c)', () => {
     expect(digest).toContain('child2');
     expect(digest).not.toContain('parent1');
   });
+
+  it('does NOT flag a leaf task as STALE when a recent comment progressed it (last_moved_at stale)', async() => {
+    const recentIso = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1h ago
+    listTasksMock
+      .mockResolvedValueOnce([ // single in_progress leaf: old last_moved_at but freshly commented
+        { id: 'task1', project_id: 'proj1', title: 'Comment-progressed', parent_id: null,
+          last_moved_at: staleIso, latest_comment_at: recentIso },
+      ])
+      .mockResolvedValueOnce([]) // blocked
+      .mockResolvedValueOnce([ // lane-drift probe — nothing off-lane
+        { id: 'task1', project_id: 'proj1', title: 'Comment-progressed', parent_id: null,
+          last_moved_at: staleIso, latest_comment_at: recentIso },
+      ]);
+
+    const node = await makeNode();
+    const digest = await node.buildLaneHealthDigest({ projectId: 'proj1' });
+
+    // last_moved_at is ancient, but the fresh comment counts as activity.
+    expect(digest).not.toContain('STALE');
+    expect(digest).toBe('');
+  });
+
+  it('still flags a leaf STALE when BOTH last_moved_at and latest_comment_at are old', async() => {
+    listTasksMock
+      .mockResolvedValueOnce([
+        { id: 'task1', project_id: 'proj1', title: 'Truly forgotten', parent_id: null,
+          last_moved_at: staleIso, latest_comment_at: staleIso },
+      ])
+      .mockResolvedValueOnce([]) // blocked
+      .mockResolvedValueOnce([]); // lane-drift probe
+
+    const node = await makeNode();
+    const digest = await node.buildLaneHealthDigest({ projectId: 'proj1' });
+
+    expect(digest).toContain('STALE: task task1');
+  });
 });
 
 describe('HeartbeatNode next-action digest (S75N)', () => {


### PR DESCRIPTION
Closes the deferred residual from #579 (lane-health finding #1, general case).

**Problem.** A leaf task actively progressed by comments but held at a stable `in_progress` status still false-flagged `STALE` in `buildLaneHealthDigest` every cycle, because `add_task_comment` does not bump `last_moved_at`. The #579 fix only excluded *parent* tasks; leaf comment-only threads (e.g. grbz/Di0x during a long gate) remained victims.

**Fix (read-path only — no change to `last_moved_at` semantics, no touch to the comment-write path):**
- `WorkItemsModel.listTasks` now exposes a computed `latest_comment_at` (`MAX(created_at)` of the task's live comments) via a correlated subquery keyed on the task id. No table alias, so the existing `WHERE`/`ORDER BY` on bare columns are untouched; backed by `idx_work_task_comments_task` (one indexed lookup per returned row, limit 50).
- `buildLaneHealthDigest` measures staleness from `max(last_moved_at, latest_comment_at)`, so comment-only progress counts as activity.

This is the lower-risk of the two approaches the #579 author flagged (the other — bumping `last_moved_at` on comment insert — would change the field's meaning for every consumer).

**Tests:** +2 in `HeartbeatNode.workContext.test.ts` (leaf freshly commented but old `last_moved_at` -> not STALE; both old -> still STALE). `HeartbeatNode.workContext` 19/19, `WorkItemsModel` 3/3 via `node --experimental-vm-modules`.

Live effect shares the same rebuild gate as the rest of the lane; the code + tests stand on their own.

Generated with Claude Code