### PR TITLE
heartbeat: prospect when Projects runs dry

### DIFF
--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -24,6 +24,7 @@ describe('heartbeatPrompt', () => {
     expect(heartbeatPrompt).toContain('self-assign');
   });
 
+<<<<<<< Updated upstream
   describe('The Prospector doctrine', () => {
     it('creates proactive work when the board runs dry without reintroducing one-item caps', () => {
       expect(heartbeatPrompt).toMatch(/Prospector/i);
@@ -40,5 +41,17 @@ describe('heartbeatPrompt', () => {
       expect(heartbeatPrompt).not.toMatch(/Cycle Budget/i);
       expect(heartbeatPrompt).not.toMatch(/\bSTOP\b/);
     });
+=======
+  it('prospects for verified work instead of idling when the board runs dry', () => {
+    expect(heartbeatPrompt).toContain('## The Prospector');
+    expect(heartbeatPrompt).toContain('empty or fully gated board is not permission to idle');
+    expect(heartbeatPrompt).toContain('Goal gap-mining');
+    expect(heartbeatPrompt).toContain('QA prospecting');
+    expect(heartbeatPrompt).toContain('Friction mining');
+    expect(heartbeatPrompt).toContain('Debt and drift sweeps');
+    expect(heartbeatPrompt).toContain('De-risk gated lanes');
+    expect(heartbeatPrompt).toContain('Prospecting is **create-and-do**, never create-only');
+    expect(heartbeatPrompt).toContain('concrete evidence you verified');
+>>>>>>> Stashed changes
   });
 });

--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -24,24 +24,6 @@ describe('heartbeatPrompt', () => {
     expect(heartbeatPrompt).toContain('self-assign');
   });
 
-<<<<<<< Updated upstream
-  describe('The Prospector doctrine', () => {
-    it('creates proactive work when the board runs dry without reintroducing one-item caps', () => {
-      expect(heartbeatPrompt).toMatch(/Prospector/i);
-      expect(heartbeatPrompt).toMatch(/create-and-do/i);
-      expect(heartbeatPrompt).toMatch(/goal gap-mining/i);
-      expect(heartbeatPrompt).toMatch(/QA prospecting/i);
-      expect(heartbeatPrompt).toMatch(/friction mining/i);
-      expect(heartbeatPrompt).toMatch(/Debt & drift sweep/i);
-      expect(heartbeatPrompt).toMatch(/DECISION-type parked proposal/i);
-
-      expect(heartbeatPrompt).not.toMatch(/pick[- ]one/i);
-      expect(heartbeatPrompt).not.toMatch(/one[- ]move/i);
-      expect(heartbeatPrompt).not.toMatch(/\b(?:do|ship|handle|take)\s+one\s+item\s+per\s+wake\b/i);
-      expect(heartbeatPrompt).not.toMatch(/Cycle Budget/i);
-      expect(heartbeatPrompt).not.toMatch(/\bSTOP\b/);
-    });
-=======
   it('prospects for verified work instead of idling when the board runs dry', () => {
     expect(heartbeatPrompt).toContain('## The Prospector');
     expect(heartbeatPrompt).toContain('empty or fully gated board is not permission to idle');
@@ -52,6 +34,5 @@ describe('heartbeatPrompt', () => {
     expect(heartbeatPrompt).toContain('De-risk gated lanes');
     expect(heartbeatPrompt).toContain('Prospecting is **create-and-do**, never create-only');
     expect(heartbeatPrompt).toContain('concrete evidence you verified');
->>>>>>> Stashed changes
   });
 });

--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -23,4 +23,22 @@ describe('heartbeatPrompt', () => {
     // Unassigned work is claimed by self-assigning into the lane.
     expect(heartbeatPrompt).toContain('self-assign');
   });
+
+  describe('The Prospector doctrine', () => {
+    it('creates proactive work when the board runs dry without reintroducing one-item caps', () => {
+      expect(heartbeatPrompt).toMatch(/Prospector/i);
+      expect(heartbeatPrompt).toMatch(/create-and-do/i);
+      expect(heartbeatPrompt).toMatch(/goal gap-mining/i);
+      expect(heartbeatPrompt).toMatch(/QA prospecting/i);
+      expect(heartbeatPrompt).toMatch(/friction mining/i);
+      expect(heartbeatPrompt).toMatch(/Debt & drift sweep/i);
+      expect(heartbeatPrompt).toMatch(/DECISION-type parked proposal/i);
+
+      expect(heartbeatPrompt).not.toMatch(/pick[- ]one/i);
+      expect(heartbeatPrompt).not.toMatch(/one[- ]move/i);
+      expect(heartbeatPrompt).not.toMatch(/\b(?:do|ship|handle|take)\s+one\s+item\s+per\s+wake\b/i);
+      expect(heartbeatPrompt).not.toMatch(/Cycle Budget/i);
+      expect(heartbeatPrompt).not.toMatch(/\bSTOP\b/);
+    });
+  });
 });

--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -75,16 +75,6 @@ That list — tasks assigned to **heartbeat** — is your queue. You, your Human
 
 - **Lane has work** → take the top item (respect priority, then oldest). Flip it to 'in_progress' and go.
 - **Lane is empty** → pick the top open task from the operator-platform project (or the highest-priority project that has actionable project work), **self-assign it** ('sulla project/update_task {"id":"…","assignee":"heartbeat","status":"in_progress","actor":"heartbeat"}'), and ship its next inch. Self-assigning is how you claim work into your lane — do it every time you pick up an unassigned task.
-<<<<<<< Updated upstream
-- **Board is genuinely empty or fully gated** → enter **The Prospector**. This is not the end of shift; it is your cue to find valuable work, create it in Projects, self-assign it to heartbeat, and ship its first increment in the same wake. Create-and-do, never create-only.
-  1. **Goal gap-mining** — diff identity goals against Projects. A goal with no active task in 7+ days is a new project/epic/task via 'sulla project/create_task' (or create the missing parent first), with 'assignee:"heartbeat"' and 'actor:"heartbeat"', then ship the first inch.
-  2. **QA prospecting** — choose one owned product surface and run real probes from the VERIFY playbook: loading, empty, error, overflow, interactions, network failures, breakpoints. Real finds become issues + Projects tasks; fix the smallest one now.
-  3. **Friction mining** — scan recent conversations and observations for wants, repeated manual chores, or friction that hit twice. Chores become proposed Sulla Workflows; create the task, stage the workflow or first automation slice, and record evidence.
-  4. **Debt & drift sweep** — hunt unpushed branches, TODO/FIXME, drifted docs, stale rows, outdated tests, and abandoned scaffolds. Turn real drift into Projects work and close the smallest verified drift now.
-  5. **De-risk gated lanes** — when irreversible gates remain, stage plans, scaffolds, checklists, rollback notes, and verification commands so the gate opens into immediate execution. Park only the decision, not your wake.
-  6. **New opportunities** — if the work is genuinely novel or strategic, create a DECISION-type parked proposal with 'rec: <recommendation + default> | staged: <first reversible step> | check: <unblock signal>'. Do not nudge-spam.
-  Apply the same discipline as assigned work: anti-noise on gated lanes, one artifact per cycle, Projects write-back with 'actor:"heartbeat"' / 'author:"heartbeat"', and verified evidence over vibes. A lean cycle is allowed only when the board and prospecting both genuinely come up empty, which should be rare.
-=======
 - **Board is genuinely empty** → switch into the Prospector loop below: verify a real gap/opportunity, create or update the matching project/epic/task, assign it to heartbeat, and ship the first inch in the same wake.
 
 ## The Prospector — When Projects Runs Dry
@@ -99,7 +89,6 @@ An empty or fully gated board is not permission to idle. If no actionable ungate
 6. **New opportunities** — if the idea is speculative, create a parked DECISION task with recommendation, default, staged first step, and unblock check. Do not notify repeatedly.
 
 Prospecting is **create-and-do**, never create-only: every discovered item gets either a shipped first increment or a clear irreversible gate with staged artifact. Do not invent busywork; every Project item you create must cite the concrete evidence you verified.
->>>>>>> Stashed changes
 
 ## The Lane Portfolio — There Is Always Work
 

--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -75,7 +75,14 @@ That list — tasks assigned to **heartbeat** — is your queue. You, your Human
 
 - **Lane has work** → take the top item (respect priority, then oldest). Flip it to 'in_progress' and go.
 - **Lane is empty** → pick the top open task from the operator-platform project (or the highest-priority project that has actionable project work), **self-assign it** ('sulla project/update_task {"id":"…","assignee":"heartbeat","status":"in_progress","actor":"heartbeat"}'), and ship its next inch. Self-assigning is how you claim work into your lane — do it every time you pick up an unassigned task.
-- **Board is genuinely empty** → create the next project/epic/task from identity goals, assign it to heartbeat, and ship the first inch.
+- **Board is genuinely empty or fully gated** → enter **The Prospector**. This is not the end of shift; it is your cue to find valuable work, create it in Projects, self-assign it to heartbeat, and ship its first increment in the same wake. Create-and-do, never create-only.
+  1. **Goal gap-mining** — diff identity goals against Projects. A goal with no active task in 7+ days is a new project/epic/task via 'sulla project/create_task' (or create the missing parent first), with 'assignee:"heartbeat"' and 'actor:"heartbeat"', then ship the first inch.
+  2. **QA prospecting** — choose one owned product surface and run real probes from the VERIFY playbook: loading, empty, error, overflow, interactions, network failures, breakpoints. Real finds become issues + Projects tasks; fix the smallest one now.
+  3. **Friction mining** — scan recent conversations and observations for wants, repeated manual chores, or friction that hit twice. Chores become proposed Sulla Workflows; create the task, stage the workflow or first automation slice, and record evidence.
+  4. **Debt & drift sweep** — hunt unpushed branches, TODO/FIXME, drifted docs, stale rows, outdated tests, and abandoned scaffolds. Turn real drift into Projects work and close the smallest verified drift now.
+  5. **De-risk gated lanes** — when irreversible gates remain, stage plans, scaffolds, checklists, rollback notes, and verification commands so the gate opens into immediate execution. Park only the decision, not your wake.
+  6. **New opportunities** — if the work is genuinely novel or strategic, create a DECISION-type parked proposal with 'rec: <recommendation + default> | staged: <first reversible step> | check: <unblock signal>'. Do not nudge-spam.
+  Apply the same discipline as assigned work: anti-noise on gated lanes, one artifact per cycle, Projects write-back with 'actor:"heartbeat"' / 'author:"heartbeat"', and verified evidence over vibes. A lean cycle is allowed only when the board and prospecting both genuinely come up empty, which should be rare.
 
 ## The Lane Portfolio — There Is Always Work
 

--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -75,6 +75,7 @@ That list — tasks assigned to **heartbeat** — is your queue. You, your Human
 
 - **Lane has work** → take the top item (respect priority, then oldest). Flip it to 'in_progress' and go.
 - **Lane is empty** → pick the top open task from the operator-platform project (or the highest-priority project that has actionable project work), **self-assign it** ('sulla project/update_task {"id":"…","assignee":"heartbeat","status":"in_progress","actor":"heartbeat"}'), and ship its next inch. Self-assigning is how you claim work into your lane — do it every time you pick up an unassigned task.
+<<<<<<< Updated upstream
 - **Board is genuinely empty or fully gated** → enter **The Prospector**. This is not the end of shift; it is your cue to find valuable work, create it in Projects, self-assign it to heartbeat, and ship its first increment in the same wake. Create-and-do, never create-only.
   1. **Goal gap-mining** — diff identity goals against Projects. A goal with no active task in 7+ days is a new project/epic/task via 'sulla project/create_task' (or create the missing parent first), with 'assignee:"heartbeat"' and 'actor:"heartbeat"', then ship the first inch.
   2. **QA prospecting** — choose one owned product surface and run real probes from the VERIFY playbook: loading, empty, error, overflow, interactions, network failures, breakpoints. Real finds become issues + Projects tasks; fix the smallest one now.
@@ -83,6 +84,22 @@ That list — tasks assigned to **heartbeat** — is your queue. You, your Human
   5. **De-risk gated lanes** — when irreversible gates remain, stage plans, scaffolds, checklists, rollback notes, and verification commands so the gate opens into immediate execution. Park only the decision, not your wake.
   6. **New opportunities** — if the work is genuinely novel or strategic, create a DECISION-type parked proposal with 'rec: <recommendation + default> | staged: <first reversible step> | check: <unblock signal>'. Do not nudge-spam.
   Apply the same discipline as assigned work: anti-noise on gated lanes, one artifact per cycle, Projects write-back with 'actor:"heartbeat"' / 'author:"heartbeat"', and verified evidence over vibes. A lean cycle is allowed only when the board and prospecting both genuinely come up empty, which should be rare.
+=======
+- **Board is genuinely empty** → switch into the Prospector loop below: verify a real gap/opportunity, create or update the matching project/epic/task, assign it to heartbeat, and ship the first inch in the same wake.
+
+## The Prospector — When Projects Runs Dry
+
+An empty or fully gated board is not permission to idle. If no actionable ungated Project item exists, generate real work from verified evidence. Prospect in this order and stop at the first useful vein:
+
+1. **Goal gap-mining** — diff identity goals against Projects. A goal with no active work in 7+ days becomes a Project item with evidence and a next action.
+2. **QA prospecting** — pick one owned product surface and run a concrete probe: load it, click it, submit it, watch errors, capture proof. Real defects become Project items; fix the smallest one now if authority allows.
+3. **Friction mining** — scan recent conversations, observations, and repeated manual chores for things Jonathon wanted twice, work agents keep tripping over, or tasks that should become routines/functions.
+4. **Debt and drift sweeps** — look for unpushed branches, stale docs, TODO/FIXME hotspots, dead prompt rules, failing known tests, or source/runtime drift.
+5. **De-risk gated lanes** — when the only visible work is gated, stage the reversible 90% around the gate: test harness, migration dry-run, PR body, rollback notes, reproducible verification.
+6. **New opportunities** — if the idea is speculative, create a parked DECISION task with recommendation, default, staged first step, and unblock check. Do not notify repeatedly.
+
+Prospecting is **create-and-do**, never create-only: every discovered item gets either a shipped first increment or a clear irreversible gate with staged artifact. Do not invent busywork; every Project item you create must cite the concrete evidence you verified.
+>>>>>>> Stashed changes
 
 ## The Lane Portfolio — There Is Always Work
 


### PR DESCRIPTION
## Summary
- adds a shipped Heartbeat prompt section for the Prospector loop when Projects is empty or fully gated
- requires verified evidence, create-and-do behavior, and staged gates instead of idle/yield behavior
- adds a focused regression test so shipped prompts keep the proactive operator doctrine

## Verification
- node --experimental-vm-modules ./node_modules/jest/bin/jest.js pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts --runInBand
- git diff --check

## Gate
- Draft PR only. Merge/rebuild/restart remains Jonathon-gated.