### PR TITLE
heartbeat: freeze the operator prompt — stability covenant + full-doctrine invariants

### DIFF
--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatInvariants.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatInvariants.test.ts
@@ -23,6 +23,15 @@ describe('checkHeartbeatPromptInvariants', () => {
     expect(result.missing).toContain('Never end a wake idle');
   });
 
+  it('fails when the operator doctrine or freeze covenant is stripped from a deployed prompt', () => {
+    for (const phrase of ['Two-Door Rule', 'The Prospector', 'This Prompt Is Frozen']) {
+      const stripped = heartbeatPrompt.split(phrase).join('');
+      const result = checkHeartbeatPromptInvariants(stripped);
+      expect(result.ok).toBe(false);
+      expect(result.missing).toContain(phrase);
+    }
+  });
+
   it('fails when a #581 STOP-ceiling phrase reappears', () => {
     const reverted = `${ heartbeatPrompt }\n\n## Cycle Budget & Escalation\nPick ONE task, make one move, then STOP.`;
     const result = checkHeartbeatPromptInvariants(reverted);

--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -65,6 +65,19 @@ describe('heartbeatPrompt', () => {
     }
   });
 
+  // Stability covenant: Jonathon declared the operator prompt nailed down.
+  // Heartbeat must not generate prompt-tweak churn; edits require verified
+  // evidence (capability gap / invariant regression / authority defect) and
+  // ship as a parked DECISION task for Jonathon — never a self-modification.
+  it('carries the prompt-freeze covenant so heartbeat stops tweaking itself', () => {
+    expect(heartbeatPrompt).toContain('## Prompt Stability — This Prompt Is Frozen');
+    expect(heartbeatPrompt).toContain('Never self-modify this prompt');
+    expect(heartbeatPrompt).toContain('never treat "the prompt could be better" as evidence');
+    // The freeze extends to the operator's own switch and settings store.
+    expect(heartbeatPrompt).toContain("never flip 'heartbeatEnabled'");
+    expect(heartbeatPrompt).toContain("never write Redis 'sulla_settings' directly");
+  });
+
   // Regression guard for #587: Jonathon rejected the "pick one task, make one
   // move, STOP" cycle ceiling (#581) and required a continuous operator that
   // works the whole portfolio per wake. PR #581 proved this framing can be

--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -171,6 +171,12 @@ First-person, brief, confident, anticipatory. Outcomes, not process. Warm, a lit
 
 Your status line at cycle end = the artifact + what's staged next.
 
+## Prompt Stability — This Prompt Is Frozen
+
+This prompt is the nailed-down operator contract. It is stable by design: churn in your own operating instructions is a defect, not an improvement. Do not propose, file, draft, or implement changes to the heartbeat prompt, its invariants, or its guard tests unless you hold verified evidence of one of exactly three things: (a) a capability gap that blocked real shipped work, (b) a regression against the runtime invariants, or (c) an authority-boundary defect — you were permitted something gated, or gated from something permitted. Even then, the change is a DECISION/GATED task: attach the evidence, park it for Jonathon, and move on. Never self-modify this prompt, and never treat "the prompt could be better" as evidence.
+
+The same freeze covers your own switch: never flip 'heartbeatEnabled', and never write Redis 'sulla_settings' directly — settings flow through 'sulla settings_get' / 'settings_set' only, and the heartbeat toggle belongs to Jonathon alone.
+
 ## Cycle Self-Audit (run before ending, every cycle)
 
 1. Did I produce a named artifact this cycle? If no → do a Polish task now.

--- a/pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts
@@ -14,9 +14,19 @@
 
 /** Phrases the deployed continuous-operator heartbeat prompt MUST contain. */
 export const HEARTBEAT_REQUIRED_PHRASES = [
+  // Continuous-operator posture (#587): whole-portfolio work, no per-wake cap.
   'not a one-task worker',
   'does not cap you at one item per wake',
   'Never end a wake idle',
+  // Operator doctrine sections — each header is load-bearing; a deployed prompt
+  // missing any of these has been truncated or reverted, not merely reworded.
+  'Unblock Ladder',
+  'Two-Door Rule',
+  'You Are the Decider for Your Sub-Agents',
+  'The Prospector',
+  'Artifact-per-Cycle',
+  // Stability covenant: the prompt is frozen — heartbeat may not tweak itself.
+  'This Prompt Is Frozen',
 ] as const;
 
 /**


### PR DESCRIPTION
## Why
Jonathon declared the Heartbeat operator prompt **nailed down** — no more system-generated tweaking. This is the lock-in PR: it makes the freeze part of the prompt itself and widens the runtime invariants so the entire operator doctrine is pinned, then the prompt is frozen.

## What
- **`heartbeat.ts`** — new `## Prompt Stability — This Prompt Is Frozen` section: prompt churn is a defect; edits require verified evidence of a capability gap, invariant regression, or authority-boundary defect, and ship only as a parked DECISION task for Jonathon. Never self-modify. Freeze extends to `heartbeatEnabled` and direct Redis `sulla_settings` writes.
- **`heartbeatInvariants.ts`** — `HEARTBEAT_REQUIRED_PHRASES` widened from 3 phrases to the full doctrine: Unblock Ladder, Two-Door Rule, sub-agent Decider, Prospector, Artifact-per-Cycle, and the freeze covenant. A deployed prompt missing any of these now self-reports as stale/reverted on every wake.
- **Guard suites** — new tests pin the covenant text and verify stripped-doctrine prompts fail the runtime check.

## Verification
- `test:unit:jest` on both guard suites: **15/15 green** (heartbeatPrompt.test.ts, heartbeatInvariants.test.ts)
- `git diff --check` clean

## Notes
- Takes effect at the next Desktop rebuild/restart, same gate as the merged #583–#594 prompt queue.
- After this merges: prompt edits are frozen per the covenant — verified defects only, via parked DECISION tasks.