### PR TITLE
Teach Heartbeat to fan out Projects tasks

### DIFF
--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -78,6 +78,18 @@ describe('heartbeatPrompt', () => {
     expect(heartbeatPrompt).toContain("never write Redis 'sulla_settings' directly");
   });
 
+  it('dispatches multiple actionable Projects tasks through sub-agents with worktree isolation', () => {
+    expect(heartbeatPrompt).toContain('## Parallel Projects Dispatch');
+    expect(heartbeatPrompt).toContain('up to **10** ungated tasks');
+    expect(heartbeatPrompt).toContain("one asynchronous 'spawn_agent' call");
+    expect(heartbeatPrompt).toContain('one sub-agent per task');
+    expect(heartbeatPrompt).toContain("'parallel:true', 'async:true'");
+    expect(heartbeatPrompt).toContain('isolated git worktree');
+    expect(heartbeatPrompt).toContain('sulla github/git_worktree');
+    expect(heartbeatPrompt).toContain('sulla github/git_push');
+    expect(heartbeatPrompt).toContain('check_agent_jobs');
+  });
+
   // Regression guard for #587: Jonathon rejected the "pick one task, make one
   // move, STOP" cycle ceiling (#581) and required a continuous operator that
   // works the whole portfolio per wake. PR #581 proved this framing can be

--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -36,6 +36,14 @@ The test is the Two-Door Rule applied on the sub-agent's behalf: **reversible �
 
 Standard: *decide it the way a trusted chief of staff would.* Chiefs of staff don't relay reversible questions upward — they decide, act, and report. Bouncing a sub-agent's reversible decision to Jonathon is the failure mode this whole system exists to prevent. One blocked sub-agent must never cascade into a blocked heartbeat.
 
+## Parallel Projects Dispatch — Fan Out Real Work
+
+When Projects shows multiple actionable tasks, you are the dispatcher, not the bottleneck. Select up to **10** ungated tasks at a time and launch them with one asynchronous 'spawn_agent' call: one sub-agent per task, 'parallel:true', 'async:true'. Do this before settling into solo execution when the queue has independent work.
+
+Each delegated task prompt must include the task id/title, project/epic context, exact acceptance criteria, required Projects bookkeeping ('author:"heartbeat"' comments and 'actor:"heartbeat"' status updates), and a hard instruction to work in an isolated git worktree for code changes. For code tasks, the sub-agent must use 'sulla github/git_worktree' (or verified existing worktree state) to create/use a task-specific worktree and branch before editing, then push its feature branch via 'sulla github/git_push' and stop at the PR/merge gate.
+
+Do not delegate ambiguity bombs. If a task needs a small reversible choice to become executable, decide it first and include the decision in the sub-agent prompt. If a task is irreversible/high-blast, stage the reversible 90% yourself or dispatch only that reversible slice. Track the returned jobId, keep operating on other work, and use 'check_agent_jobs' only as the fallback/history read if the wake does not arrive.
+
 ## Priority Override
 
 If there are incoming messages on your channel from another agent or your Human, **respond to them first** before picking up lane work. Use 'send_notification_to_human' to surface your reply if it's for your Human.

--- a/pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts
@@ -23,6 +23,10 @@ export const HEARTBEAT_REQUIRED_PHRASES = [
   'Unblock Ladder',
   'Two-Door Rule',
   'You Are the Decider for Your Sub-Agents',
+  'Parallel Projects Dispatch',
+  'up to **10** ungated tasks',
+  'one sub-agent per task',
+  'isolated git worktree',
   'The Prospector',
   'Artifact-per-Cycle',
   // Stability covenant: the prompt is frozen — heartbeat may not tweak itself.


### PR DESCRIPTION
## Summary
- add a Parallel Projects Dispatch section to the heartbeat operator prompt
- instruct Heartbeat to launch up to 10 actionable Projects tasks via one async parallel spawn_agent call
- require one sub-agent per task and isolated git worktree/branch handling for code changes
- pin the new behavior in heartbeat prompt tests and runtime required phrases

## Verification
- node_modules/.bin/cross-env BROWSERSLIST_IGNORE_OLD_DATA=1 node --experimental-vm-modules node_modules/jest/bin/jest.js pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts pkg/rancher-desktop/agent/prompts/__tests__/heartbeatInvariants.test.ts
- Result: 2 suites passed, 16 tests passed

## Notes
This is a user-directed capability-gap change under the prompt freeze: Jonathon explicitly requested Heartbeat dispatch up to 10 sub-agents, one per task, each in its own worktree for code work. Merge/rebuild remains human-gated.