### PR TITLE
System Prompt: DB-backed editable sections + staged AI-edit approval

### DIFF
--- a/pkg/rancher-desktop/agent/database/DatabaseManager.ts
+++ b/pkg/rancher-desktop/agent/database/DatabaseManager.ts
@@ -55,6 +55,16 @@ export class DatabaseManager {
     // Settings are ready to be used in seeding
     await this.runSeeders();
 
+    // Seed the editable system-prompt sections from their baked native
+    // fallbacks (write-only-if-absent; honors is_customized). Non-fatal —
+    // the section factories remain the runtime fallback if this fails.
+    try {
+      const { SystemPromptSectionModel } = await import('@pkg/agent/database/models/SystemPromptSectionModel');
+      await SystemPromptSectionModel.seedDefaults();
+    } catch (error) {
+      console.warn('[DB] SystemPromptSectionModel.seedDefaults() failed:', error);
+    }
+
     // Warm skills registry cache
     try {
       await skillsRegistry.initialize();

--- a/pkg/rancher-desktop/agent/database/migrations/0048_create_system_prompt_sections_table.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0048_create_system_prompt_sections_table.ts
@@ -1,0 +1,53 @@
+/**
+ * Migration 0048 — Create system prompt sections table.
+ *
+ * Backs the editable CORE of the agent system prompt. Each identity file
+ * (soul, user, environment, agents, heartbeat) becomes one row here, plus
+ * any custom sections the human adds from the Language Model Settings →
+ * System Prompt UI.
+ *
+ * THREE-LAYER RESOLUTION (highest wins):
+ *   1. agent-specific physical file  (~/sulla/agents/<id>/*.md)  — per-agent override
+ *   2. DB row                        (this table)                — editable global core
+ *   3. baked-in native fallback      (soul.ts, bundled *.md)     — ships with app, SEEDS the row
+ *
+ * SCHEMA-ONLY (per the no-user-data-in-migrations rule — see 0042): this
+ * migration creates the table and nothing else. The canonical rows are
+ * seeded at runtime from the baked native fallbacks by
+ * SystemPromptSectionModel.seedDefaults(), invoked from the database
+ * bootstrap. Seeding at runtime (not here) keeps the baked fallback the
+ * single source of truth and lets `is_customized` govern upstream drift.
+ *
+ * Columns:
+ *   is_builtin     — one of the canonical identity rows (resettable, not deletable).
+ *                    Custom user-added sections are false (fully deletable).
+ *   is_generated   — body is produced at runtime (e.g. `environment`); shown
+ *                    read-only in the UI, DB content is ignored at compile time.
+ *   is_customized  — flipped true the first time the human edits the row. Frozen
+ *                    rows are never overwritten when a newer app ships an updated
+ *                    baked default; untouched rows follow upstream.
+ *   priority / cache_stability — govern placement + KV-cache tier for CUSTOM rows
+ *                    (builtin rows keep their registered section's priority/tier).
+ */
+
+export const up = `
+  CREATE TABLE IF NOT EXISTS sulla_system_prompt_sections (
+    id              TEXT        PRIMARY KEY,
+    title           TEXT        NOT NULL,
+    content         TEXT        NOT NULL DEFAULT '',
+    priority        INTEGER     NOT NULL DEFAULT 100,
+    enabled         BOOLEAN     NOT NULL DEFAULT true,
+    cache_stability TEXT        NOT NULL DEFAULT 'stable',
+    is_builtin      BOOLEAN     NOT NULL DEFAULT false,
+    is_generated    BOOLEAN     NOT NULL DEFAULT false,
+    is_customized   BOOLEAN     NOT NULL DEFAULT false,
+    source          TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_sulla_sps_enabled_priority
+    ON sulla_system_prompt_sections (enabled, priority, id);
+`;
+
+export const down = `DROP TABLE IF EXISTS sulla_system_prompt_sections CASCADE;`;

--- a/pkg/rancher-desktop/agent/database/migrations/0049_create_system_prompt_section_edits_table.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0049_create_system_prompt_section_edits_table.ts
@@ -1,0 +1,36 @@
+/**
+ * Migration 0049 — Create system prompt section edits (staged proposals) table.
+ *
+ * Human-in-the-loop guardrail for AI-authored prompt changes. Agents NEVER write
+ * a sulla_system_prompt_sections row directly — they stage a proposal here, and
+ * the human approves / edits / denies it from Language Model Settings → System
+ * Prompt. Only on approval is the proposed content copied into the live row.
+ *
+ * status:      pending | approved | denied | superseded
+ *   - superseded: an older pending proposal for the same section, retired when a
+ *     newer proposal for that section is approved (keeps history without ambiguity).
+ * base_content: snapshot of the row's content at propose time — used to render an
+ *   accurate diff and to detect when the live row drifted after the proposal.
+ *
+ * SCHEMA-ONLY (per the no-user-data-in-migrations rule — see 0042/0048).
+ */
+
+export const up = `
+  CREATE TABLE IF NOT EXISTS sulla_system_prompt_section_edits (
+    id               TEXT        PRIMARY KEY,
+    section_id       TEXT        NOT NULL,
+    proposed_content TEXT        NOT NULL,
+    base_content     TEXT        NOT NULL DEFAULT '',
+    rationale        TEXT,
+    status           TEXT        NOT NULL DEFAULT 'pending',
+    proposed_by      TEXT,
+    reviewed_by      TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    reviewed_at      TIMESTAMPTZ
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_sulla_sps_edits_pending
+    ON sulla_system_prompt_section_edits (status, section_id, created_at DESC);
+`;
+
+export const down = `DROP TABLE IF EXISTS sulla_system_prompt_section_edits CASCADE;`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -36,6 +36,8 @@ import { up as up_0044, down as down_0044 } from './0044_create_work_items_table
 import { up as up_0045, down as down_0045 } from './0045_bound_stale_routine_digest_failures';
 import { up as up_0046, down as down_0046 } from './0046_create_heartbeat_run_audit_table';
 import { up as up_0047, down as down_0047 } from './0047_add_work_task_actor';
+import { up as up_0048, down as down_0048 } from './0048_create_system_prompt_sections_table';
+import { up as up_0049, down as down_0049 } from './0049_create_system_prompt_section_edits_table';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -72,4 +74,6 @@ export const migrationsRegistry = [
   { name: '0045_bound_stale_routine_digest_failures',        up: up_0045, down: down_0045 },
   { name: '0046_create_heartbeat_run_audit_table',            up: up_0046, down: down_0046 },
   { name: '0047_add_work_task_actor',                          up: up_0047, down: down_0047 },
+  { name: '0048_create_system_prompt_sections_table',          up: up_0048, down: down_0048 },
+  { name: '0049_create_system_prompt_section_edits_table',      up: up_0049, down: down_0049 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/SystemPromptSectionEditModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/SystemPromptSectionEditModel.ts
@@ -1,0 +1,190 @@
+/**
+ * SystemPromptSectionEditModel — staged, human-approved edits to the editable
+ * system-prompt sections (see SystemPromptSectionModel / migration 0049).
+ *
+ * The guardrail: agents may only PROPOSE a change here. The proposed content is
+ * inert until a human approves it in Language Model Settings → System Prompt, at
+ * which point it is copied into the live sulla_system_prompt_sections row. The
+ * prompt builder never reads this table, so a pending proposal can never affect
+ * any agent's compiled prompt.
+ *
+ * Main-process only (imports postgresClient); the renderer reaches it via the
+ * `system-prompt-edits:*` IPC handlers in main/sullaEvents.ts.
+ */
+import { postgresClient } from '../PostgresClient';
+
+import { SystemPromptSectionModel, type SystemPromptSectionRecord } from './SystemPromptSectionModel';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export type EditStatus = 'pending' | 'approved' | 'denied' | 'superseded';
+
+export interface SectionEditRecord {
+  id:               string;
+  section_id:       string;
+  proposed_content: string;
+  base_content:     string;
+  rationale:        string | null;
+  status:           EditStatus;
+  proposed_by:      string | null;
+  reviewed_by:      string | null;
+  created_at:       string;
+  reviewed_at:      string | null;
+}
+
+export interface ProposeEditInput {
+  section_id:       string;
+  proposed_content: string;
+  rationale?:       string;
+  proposed_by?:     string;
+}
+
+// ── Tiny-ID generator (matches RulesModel/observations) ────────────────
+
+function generateTinyId(): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let id = '';
+  for (let i = 0; i < 6; i++) id += chars.charAt(Math.floor(Math.random() * chars.length));
+  return id;
+}
+
+// ── Model ──────────────────────────────────────────────────────────────
+
+export class SystemPromptSectionEditModel {
+  private static readonly TABLE = 'sulla_system_prompt_section_edits';
+
+  static async ensureTable(): Promise<void> {
+    try {
+      await postgresClient.query(`
+        CREATE TABLE IF NOT EXISTS ${ SystemPromptSectionEditModel.TABLE } (
+          id               TEXT        PRIMARY KEY,
+          section_id       TEXT        NOT NULL,
+          proposed_content TEXT        NOT NULL,
+          base_content     TEXT        NOT NULL DEFAULT '',
+          rationale        TEXT,
+          status           TEXT        NOT NULL DEFAULT 'pending',
+          proposed_by      TEXT,
+          reviewed_by      TEXT,
+          created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+          reviewed_at      TIMESTAMPTZ
+        )
+      `);
+      await postgresClient.query(`
+        CREATE INDEX IF NOT EXISTS idx_sulla_sps_edits_pending
+          ON ${ SystemPromptSectionEditModel.TABLE } (status, section_id, created_at DESC)
+      `);
+    } catch (err) {
+      console.error('[SystemPromptSectionEditModel] Failed to ensure table:', err);
+    }
+  }
+
+  // ──────────────────────────────────────────────
+  // Propose — the ONLY write agents are allowed
+  // ──────────────────────────────────────────────
+
+  /**
+   * Stage a proposed edit for a section. Snapshots the section's current content
+   * as base_content so the diff stays accurate even if the live row drifts. Only
+   * valid for an existing section id — returns null otherwise.
+   */
+  static async propose(input: ProposeEditInput): Promise<SectionEditRecord | null> {
+    const section = await SystemPromptSectionModel.getById(input.section_id);
+    if (!section) return null;
+
+    const rows = await postgresClient.query<SectionEditRecord>(
+      `INSERT INTO ${ SystemPromptSectionEditModel.TABLE }
+         (id, section_id, proposed_content, base_content, rationale, status, proposed_by)
+       VALUES ($1, $2, $3, $4, $5, 'pending', $6)
+       RETURNING *`,
+      [
+        generateTinyId(),
+        input.section_id,
+        input.proposed_content,
+        section.content,
+        input.rationale ?? null,
+        input.proposed_by ?? null,
+      ],
+    );
+    return rows[0] ?? null;
+  }
+
+  // ──────────────────────────────────────────────
+  // Reads
+  // ──────────────────────────────────────────────
+
+  static async listPending(): Promise<SectionEditRecord[]> {
+    return postgresClient.query<SectionEditRecord>(
+      `SELECT * FROM ${ SystemPromptSectionEditModel.TABLE }
+       WHERE status = 'pending' ORDER BY created_at ASC`,
+    );
+  }
+
+  static async getById(id: string): Promise<SectionEditRecord | null> {
+    const rows = await postgresClient.query<SectionEditRecord>(
+      `SELECT * FROM ${ SystemPromptSectionEditModel.TABLE } WHERE id = $1 LIMIT 1`,
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  /** History for one section (any status), newest first. */
+  static async listBySection(sectionId: string, limit = 50): Promise<SectionEditRecord[]> {
+    return postgresClient.query<SectionEditRecord>(
+      `SELECT * FROM ${ SystemPromptSectionEditModel.TABLE }
+       WHERE section_id = $1 ORDER BY created_at DESC LIMIT $2`,
+      [sectionId, limit],
+    );
+  }
+
+  // ──────────────────────────────────────────────
+  // Review actions
+  // ──────────────────────────────────────────────
+
+  /**
+   * Approve a pending proposal: copy its content (or the human's amended version
+   * via `finalContent` — "edit & approve") into the live section row, mark the
+   * proposal approved, and supersede any other pending proposals for the same
+   * section. Returns the updated section row + the approved edit, or null.
+   */
+  static async approve(
+    id: string,
+    opts: { finalContent?: string; reviewed_by?: string } = {},
+  ): Promise<{ section: SystemPromptSectionRecord | null; edit: SectionEditRecord } | null> {
+    const edit = await SystemPromptSectionEditModel.getById(id);
+    if (!edit || edit.status !== 'pending') return null;
+
+    const content = opts.finalContent ?? edit.proposed_content;
+
+    // Apply to the live row (flips is_customized in SystemPromptSectionModel.update).
+    const section = await SystemPromptSectionModel.update(edit.section_id, { content });
+
+    const rows = await postgresClient.query<SectionEditRecord>(
+      `UPDATE ${ SystemPromptSectionEditModel.TABLE }
+         SET status = 'approved', reviewed_by = $2, reviewed_at = now(),
+             proposed_content = $3
+       WHERE id = $1 RETURNING *`,
+      [id, opts.reviewed_by ?? 'human', content],
+    );
+
+    // Retire any other still-pending proposals for the same section.
+    await postgresClient.query(
+      `UPDATE ${ SystemPromptSectionEditModel.TABLE }
+         SET status = 'superseded', reviewed_at = now()
+       WHERE section_id = $1 AND status = 'pending' AND id <> $2`,
+      [edit.section_id, id],
+    );
+
+    return { section, edit: rows[0] ?? edit };
+  }
+
+  /** Deny a pending proposal without touching the live row. */
+  static async deny(id: string, opts: { reviewed_by?: string } = {}): Promise<SectionEditRecord | null> {
+    const rows = await postgresClient.query<SectionEditRecord>(
+      `UPDATE ${ SystemPromptSectionEditModel.TABLE }
+         SET status = 'denied', reviewed_by = $2, reviewed_at = now()
+       WHERE id = $1 AND status = 'pending' RETURNING *`,
+      [id, opts.reviewed_by ?? 'human'],
+    );
+    return rows[0] ?? null;
+  }
+}

--- a/pkg/rancher-desktop/agent/database/models/SystemPromptSectionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/SystemPromptSectionModel.ts
@@ -1,0 +1,275 @@
+/**
+ * SystemPromptSectionModel — the editable CORE of the agent system prompt.
+ *
+ * Each identity/system-prompt row (soul, user, environment, agents, heartbeat,
+ * plus any custom sections the human adds) lives here as one row. This is
+ * layer 2 of the three-layer resolution (see migration 0048):
+ *
+ *   1. agent-specific physical file  (~/sulla/agents/<id>/*.md)  — per-agent override
+ *   2. DB row                        (this table)                — editable global core
+ *   3. baked-in native fallback      (systemPromptSectionDefaults / factories)
+ *
+ * Seeding is write-only-if-absent and honors `is_customized`: a fresh app that
+ * ships an improved baked default updates only rows the human never touched.
+ *
+ * DUAL-STORE NOTE: reads and writes ONLY Postgres — no Redis hash. Main-process
+ * only (imports postgresClient); the renderer reaches it via the
+ * `system-prompt:*` IPC handlers in main/sullaEvents.ts.
+ */
+import {
+  BUILTIN_SECTION_IDS,
+  getSystemPromptSectionDefault,
+  SYSTEM_PROMPT_SECTION_DEFAULTS,
+} from '@pkg/agent/prompts/systemPromptSectionDefaults';
+
+import { postgresClient } from '../PostgresClient';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface SystemPromptSectionRecord {
+  id:              string;
+  title:           string;
+  content:         string;
+  priority:        number;
+  enabled:         boolean;
+  cache_stability: string;
+  is_builtin:      boolean;
+  is_generated:    boolean;
+  is_customized:   boolean;
+  source:          string | null;
+  created_at:      string;
+  updated_at:      string | null;
+}
+
+export interface AddSectionInput {
+  id:              string;
+  title:           string;
+  content?:        string;
+  priority?:       number;
+  enabled?:        boolean;
+  cache_stability?: string;
+  source?:         string;
+}
+
+export interface UpdateSectionInput {
+  title?:          string;
+  content?:        string;
+  priority?:       number;
+  enabled?:        boolean;
+  cache_stability?: string;
+}
+
+// ── Model ──────────────────────────────────────────────────────────────
+
+export class SystemPromptSectionModel {
+  private static readonly TABLE = 'sulla_system_prompt_sections';
+
+  // ──────────────────────────────────────────────
+  // Table bootstrap (idempotent) — mirrors migration 0048
+  // ──────────────────────────────────────────────
+
+  static async ensureTable(): Promise<void> {
+    try {
+      await postgresClient.query(`
+        CREATE TABLE IF NOT EXISTS ${ SystemPromptSectionModel.TABLE } (
+          id              TEXT        PRIMARY KEY,
+          title           TEXT        NOT NULL,
+          content         TEXT        NOT NULL DEFAULT '',
+          priority        INTEGER     NOT NULL DEFAULT 100,
+          enabled         BOOLEAN     NOT NULL DEFAULT true,
+          cache_stability TEXT        NOT NULL DEFAULT 'stable',
+          is_builtin      BOOLEAN     NOT NULL DEFAULT false,
+          is_generated    BOOLEAN     NOT NULL DEFAULT false,
+          is_customized   BOOLEAN     NOT NULL DEFAULT false,
+          source          TEXT,
+          created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+          updated_at      TIMESTAMPTZ
+        )
+      `);
+      await postgresClient.query(`
+        CREATE INDEX IF NOT EXISTS idx_sulla_sps_enabled_priority
+          ON ${ SystemPromptSectionModel.TABLE } (enabled, priority, id)
+      `);
+    } catch (err) {
+      console.error('[SystemPromptSectionModel] Failed to ensure table:', err);
+    }
+  }
+
+  // ──────────────────────────────────────────────
+  // Seeding — write-only-if-absent, honors is_customized
+  // ──────────────────────────────────────────────
+
+  /**
+   * Seed the canonical builtin rows from the baked native fallbacks. Idempotent:
+   *   - A row that does not yet exist is inserted from its shipped default.
+   *   - An existing row the human HAS edited (is_customized = true) is never
+   *     touched — their edits win over upstream improvements.
+   *   - An existing builtin row the human has NOT edited follows upstream: its
+   *     content/title/priority are refreshed from the (possibly newer) default.
+   * Custom user-added rows are never affected.
+   */
+  static async seedDefaults(): Promise<void> {
+    await SystemPromptSectionModel.ensureTable();
+
+    for (const def of SYSTEM_PROMPT_SECTION_DEFAULTS) {
+      try {
+        const content = await def.resolveContent();
+        const existing = await SystemPromptSectionModel.getById(def.id);
+
+        if (!existing) {
+          await postgresClient.query(
+            `INSERT INTO ${ SystemPromptSectionModel.TABLE }
+               (id, title, content, priority, enabled, cache_stability,
+                is_builtin, is_generated, is_customized, source)
+             VALUES ($1, $2, $3, $4, $5, $6, true, $7, false, 'baked-default')
+             ON CONFLICT (id) DO NOTHING`,
+            [def.id, def.title, content, def.priority, def.enabledByDefault, def.cacheStability, def.isGenerated],
+          );
+          continue;
+        }
+
+        // Refresh untouched builtin rows from the (possibly updated) shipped
+        // default; leave customized rows and the enabled flag alone.
+        if (existing.is_builtin && !existing.is_customized) {
+          await postgresClient.query(
+            `UPDATE ${ SystemPromptSectionModel.TABLE }
+               SET content = $2, title = $3, priority = $4,
+                   is_generated = $5, cache_stability = $6, updated_at = now()
+             WHERE id = $1 AND is_customized = false`,
+            [def.id, content, def.title, def.priority, def.isGenerated, def.cacheStability],
+          );
+        }
+      } catch (err) {
+        console.error(`[SystemPromptSectionModel] seedDefaults failed for '${ def.id }':`, err);
+      }
+    }
+  }
+
+  // ──────────────────────────────────────────────
+  // Reads
+  // ──────────────────────────────────────────────
+
+  /** All rows, compiled-order (priority asc, id tiebreak). */
+  static async list(): Promise<SystemPromptSectionRecord[]> {
+    return postgresClient.query<SystemPromptSectionRecord>(
+      `SELECT * FROM ${ SystemPromptSectionModel.TABLE } ORDER BY priority ASC, id ASC`,
+    );
+  }
+
+  /** Enabled rows only — what the builder layers into the compiled prompt. */
+  static async listEnabled(): Promise<SystemPromptSectionRecord[]> {
+    return postgresClient.query<SystemPromptSectionRecord>(
+      `SELECT * FROM ${ SystemPromptSectionModel.TABLE }
+       WHERE enabled = true ORDER BY priority ASC, id ASC`,
+    );
+  }
+
+  static async getById(id: string): Promise<SystemPromptSectionRecord | null> {
+    const rows = await postgresClient.query<SystemPromptSectionRecord>(
+      `SELECT * FROM ${ SystemPromptSectionModel.TABLE } WHERE id = $1 LIMIT 1`,
+      [id],
+    );
+    return rows[0] ?? null;
+  }
+
+  // ──────────────────────────────────────────────
+  // Writes
+  // ──────────────────────────────────────────────
+
+  /** Add a NEW custom section (is_builtin = false, fully deletable). */
+  static async addCustom(input: AddSectionInput): Promise<SystemPromptSectionRecord> {
+    const rows = await postgresClient.query<SystemPromptSectionRecord>(
+      `INSERT INTO ${ SystemPromptSectionModel.TABLE }
+         (id, title, content, priority, enabled, cache_stability,
+          is_builtin, is_generated, is_customized, source)
+       VALUES ($1, $2, $3, $4, $5, $6, false, false, true, $7)
+       RETURNING *`,
+      [
+        input.id,
+        input.title,
+        input.content ?? '',
+        input.priority ?? 100,
+        input.enabled ?? true,
+        input.cache_stability ?? 'stable',
+        input.source ?? 'user',
+      ],
+    );
+    return rows[0];
+  }
+
+  /**
+   * Update mutable fields. Any CONTENT edit flips is_customized = true so future
+   * seedDefaults() runs never clobber the human's version.
+   */
+  static async update(id: string, changes: UpdateSectionInput): Promise<SystemPromptSectionRecord | null> {
+    const setClauses: string[] = ['updated_at = now()'];
+    const values: any[] = [];
+    let idx = 1;
+
+    const assign = (col: string, val: any) => {
+      setClauses.push(`${ col } = $${ idx++ }`);
+      values.push(val);
+    };
+
+    if (changes.title           !== undefined) assign('title', changes.title);
+    if (changes.priority        !== undefined) assign('priority', changes.priority);
+    if (changes.enabled         !== undefined) assign('enabled', changes.enabled);
+    if (changes.cache_stability !== undefined) assign('cache_stability', changes.cache_stability);
+    if (changes.content         !== undefined) {
+      assign('content', changes.content);
+      setClauses.push('is_customized = true');
+    }
+
+    if (setClauses.length === 1) return null; // nothing to update
+    values.push(id);
+
+    const rows = await postgresClient.query<SystemPromptSectionRecord>(
+      `UPDATE ${ SystemPromptSectionModel.TABLE } SET ${ setClauses.join(', ') }
+       WHERE id = $${ idx } RETURNING *`,
+      values,
+    );
+    return rows[0] ?? null;
+  }
+
+  /** Toggle a section on/off without editing its content. */
+  static async setEnabled(id: string, enabled: boolean): Promise<boolean> {
+    const result = await postgresClient.queryWithResult(
+      `UPDATE ${ SystemPromptSectionModel.TABLE } SET enabled = $2, updated_at = now()
+       WHERE id = $1`,
+      [id, enabled],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Restore a builtin row to its shipped default content and clear the
+   * customized flag. No-op for custom rows (they have no baked default).
+   */
+  static async resetToDefault(id: string): Promise<SystemPromptSectionRecord | null> {
+    const def = getSystemPromptSectionDefault(id);
+    if (!def) return null; // not a builtin — nothing to reset to
+
+    const content = await def.resolveContent();
+    const rows = await postgresClient.query<SystemPromptSectionRecord>(
+      `UPDATE ${ SystemPromptSectionModel.TABLE }
+         SET content = $2, title = $3, priority = $4, is_generated = $5,
+             cache_stability = $6, is_customized = false, updated_at = now()
+       WHERE id = $1 RETURNING *`,
+      [id, content, def.title, def.priority, def.isGenerated, def.cacheStability],
+    );
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Delete a CUSTOM section. Builtin rows are protected — they can be disabled
+   * or reset but never deleted (returns false without touching the row).
+   */
+  static async remove(id: string): Promise<boolean> {
+    if (BUILTIN_SECTION_IDS.has(id)) return false;
+    const result = await postgresClient.queryWithResult(
+      `DELETE FROM ${ SystemPromptSectionModel.TABLE } WHERE id = $1 AND is_builtin = false`,
+      [id],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+}

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -4,10 +4,11 @@ import path from 'node:path'; // used by enrichPrompt for active_projects_file
 import { ChatController, type ChatMode } from '../controllers/ChatController';
 import { ToolExecutor } from '../controllers/ToolExecutor';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
+import { SystemPromptSectionModel } from '../database/models/SystemPromptSectionModel';
 import { getAgentOverrideService, getPrimaryService, getSecondaryService, getSubconsciousService } from '../languagemodels';
 import { BaseLanguageModel, ChatMessage, NormalizedResponse, FinishReason, type StreamCallbacks } from '../languagemodels/BaseLanguageModel';
 import { classifyLLMFailure, redactLLMFailureMessage, sameLLMRoute } from '../languagemodels/providerRecovery';
-import { SystemPromptBuilder, type PromptBuildContext, type AgentConfig, type AnthropicSystemBlock } from '../prompts/SystemPromptBuilder';
+import { SystemPromptBuilder, type PromptBuildContext, type DbPromptSection, type AgentConfig, type AnthropicSystemBlock } from '../prompts/SystemPromptBuilder';
 import { INTEGRATIONS_INSTRUCTIONS_BLOCK } from '../prompts/environment';
 import { throwIfAborted } from '../services/AbortService';
 import { parseJson } from '../services/JsonParseService';
@@ -686,6 +687,32 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
       ? 'slim'
       : 'full';
 
+    // Load the DB-backed system-prompt sections — the editable CORE layer that
+    // sits BENEATH each agent's .md overrides and ABOVE the baked factories.
+    // Enabled rows become dbSections; a disabled row excludes its section.
+    // Non-fatal: if the DB is empty or unreachable the baked factories are used.
+    let dbSections: Map<string, DbPromptSection> | undefined;
+    try {
+      const rows = await SystemPromptSectionModel.list();
+      if (rows.length) {
+        dbSections = new Map<string, DbPromptSection>();
+        for (const row of rows) {
+          if (!row.enabled) {
+            excludeSections.add(row.id);
+            continue;
+          }
+          dbSections.set(row.id, {
+            content:        row.content,
+            priority:       row.priority,
+            cacheStability: (row.cache_stability as DbPromptSection['cacheStability']) || 'stable',
+            isGenerated:    row.is_generated,
+          });
+        }
+      }
+    } catch (err) {
+      console.warn('[BaseNode] Could not load system prompt sections from DB; using baked factories:', err);
+    }
+
     // Build prompt context
     const buildCtx: PromptBuildContext = {
       mode,
@@ -701,6 +728,7 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
       templateVars,
       agentSectionOverrides,
       excludeSections,
+      dbSections,
       basePrompt:           basePrompt || '',
     };
 

--- a/pkg/rancher-desktop/agent/prompts/SystemPromptBuilder.ts
+++ b/pkg/rancher-desktop/agent/prompts/SystemPromptBuilder.ts
@@ -64,8 +64,31 @@ export interface PromptBuildContext {
   agentSectionOverrides: Map<string, string>;
   /** Sections to exclude entirely (from config.yaml exclude_sections) */
   excludeSections:       Set<string>;
+  /**
+   * DB-backed system-prompt sections (SystemPromptSectionModel), keyed by id —
+   * the editable CORE layer. Enabled rows only. For a REGISTERED section id the
+   * content replaces the baked factory content (unless an agent .md override is
+   * present, which still wins, or the section is generated — see isGenerated).
+   * A row whose id has no registered factory is injected as a NEW section using
+   * its own priority/cacheStability. Optional: when undefined (empty/unreachable
+   * DB, or a caller/test that doesn't set it) the baked factories are used.
+   */
+  dbSections?:           Map<string, DbPromptSection>;
   /** Base prompt passed by the caller (node-specific content) */
   basePrompt:            string;
+}
+
+/** A DB-backed section row projected into the build context. */
+export interface DbPromptSection {
+  content:        string;
+  priority:       number;
+  cacheStability: 'stable' | 'semi-stable' | 'dynamic';
+  /**
+   * The section's body is partly runtime-generated (e.g. `environment`). Its
+   * factory composes the DB content (static preamble) with the live tail, so
+   * the builder does NOT blindly replace it — the factory reads dbSections itself.
+   */
+  isGenerated:    boolean;
 }
 
 export interface AgentConfig {
@@ -194,14 +217,45 @@ class SystemPromptBuilderImpl {
         continue;
       }
 
-      // Call the factory
+      // Call the factory ONCE. It enforces mode/gating (e.g. the heartbeat
+      // section returns null unless ctx.isHeartbeat) — a null result means the
+      // section is off for this build, and the DB must NOT resurrect it.
+      let section: PromptSection | null = null;
       try {
-        const section = await reg.factory(ctx);
-        if (section && section.content?.trim()) {
-          builtSections.push(section);
-        }
+        section = await reg.factory(ctx);
       } catch (err) {
         console.error(`[SystemPromptBuilder] Section "${ id }" failed:`, err);
+        continue;
+      }
+      if (!section) continue;
+
+      // Layer 2: DB row content replaces the baked factory content, keeping the
+      // factory's priority/cacheStability. Generated sections (isGenerated) are
+      // left as-is — their factory already composed the DB static preamble with
+      // the live runtime tail (it reads ctx.dbSections directly).
+      const dbRow = ctx.dbSections?.get(id);
+      if (dbRow && !dbRow.isGenerated && dbRow.content?.trim()) {
+        builtSections.push({ ...section, content: dbRow.content });
+      } else if (section.content?.trim()) {
+        builtSections.push(section);
+      }
+    }
+
+    // Inject CUSTOM DB sections — enabled rows whose id has no registered
+    // factory (e.g. `user` and any user-added sections). Full/local modes only;
+    // disabled rows are already absent from ctx.dbSections and excluded ids are
+    // skipped. Registered ids were handled in the loop above.
+    if (ctx.dbSections && (ctx.mode === 'full' || ctx.mode === 'local')) {
+      for (const [id, row] of ctx.dbSections) {
+        if (this.sections.has(id)) continue;
+        if (ctx.excludeSections.has(id)) continue;
+        if (!row.content?.trim()) continue;
+        builtSections.push({
+          id,
+          content:        row.content,
+          priority:       row.priority,
+          cacheStability: row.cacheStability,
+        });
       }
     }
 

--- a/pkg/rancher-desktop/agent/prompts/sections/environment.ts
+++ b/pkg/rancher-desktop/agent/prompts/sections/environment.ts
@@ -7,14 +7,13 @@
  */
 import type { PromptBuildContext, PromptSection } from '../SystemPromptBuilder';
 
-export function buildEnvironmentSection(ctx: PromptBuildContext): PromptSection | null {
-  if (ctx.mode !== 'full') return null;
-
-  const integrationsIndex = ctx.templateVars['{{integrations_index}}'] || '';
-  const integrationsInstructions = ctx.templateVars['{{integrations_instructions}}'] || '';
-  const installedExtensions = ctx.templateVars['{{installed_extensions}}'] || '';
-
-  let content = `# Response Formatting
+/**
+ * The STATIC, editable half of the environment section. This is the baked
+ * default seeded into the `environment` DB row (see systemPromptSectionDefaults).
+ * At compile time the runtime-generated tail (installed extensions, integrations)
+ * is appended after whatever the DB row / factory supplies here.
+ */
+export const ENVIRONMENT_STATIC_PREAMBLE = `# Response Formatting
 
 For visual content (reports, statistics, dashboards, charts, tables, widgets): wrap your entire response in \`<html>...</html>\` tags. The chat UI renders it as HTML.
 
@@ -25,9 +24,29 @@ Aesthetic: dark mode only, steel blue accent on dark backgrounds, noir cinematic
 For notifications: use \`notify_user\` via the Tools API when the user is not looking at the chat.
 For simple text: use markdown.`;
 
-  if (installedExtensions) {
-    content += `\n\n${ installedExtensions }`;
-  }
+/**
+ * Build ONLY the runtime-generated tail of the environment section — the live
+ * installed-extensions / integrations data. Exposed so the settings UI can show
+ * the human exactly what gets injected (read-only preview) without duplicating
+ * the assembly logic.
+ */
+export function buildEnvironmentDynamic(ctx: PromptBuildContext): string {
+  const installedExtensions = ctx.templateVars['{{installed_extensions}}'] || '';
+  return installedExtensions ? installedExtensions : '';
+}
+
+export function buildEnvironmentSection(ctx: PromptBuildContext): PromptSection | null {
+  if (ctx.mode !== 'full') return null;
+
+  // Static preamble comes from the editable DB row when present, else the baked
+  // default. The runtime-generated tail (installed extensions, etc.) is always
+  // appended after it — this is why `environment` is flagged is_generated and
+  // the builder does not blindly replace it.
+  const dbStatic = ctx.dbSections?.get('environment')?.content;
+  const staticPart = dbStatic && dbStatic.trim() ? dbStatic : ENVIRONMENT_STATIC_PREAMBLE;
+
+  const dynamic = buildEnvironmentDynamic(ctx);
+  const content = dynamic ? `${ staticPart }\n\n${ dynamic }` : staticPart;
 
   return {
     id:             'environment',

--- a/pkg/rancher-desktop/agent/prompts/systemPromptSectionDefaults.ts
+++ b/pkg/rancher-desktop/agent/prompts/systemPromptSectionDefaults.ts
@@ -1,0 +1,129 @@
+/**
+ * System Prompt Section Defaults — the baked-in native fallbacks.
+ *
+ * This is the SINGLE canonical source for the shipped default content of every
+ * editable identity/system-prompt row. It is used in two places:
+ *   1. SystemPromptSectionModel.seedDefaults() — seeds a fresh DB (write-only-
+ *      if-absent, never clobbering the human's edits), and
+ *   2. "Reset to default" in the UI — restores a row to its shipped content.
+ *
+ * THREE-LAYER RESOLUTION (highest wins), see migration 0048:
+ *   1. agent-specific physical file  (~/sulla/agents/<id>/*.md)
+ *   2. DB row                        (sulla_system_prompt_sections)  ← seeded from here
+ *   3. baked-in native fallback      (THIS FILE / the section factories)
+ *
+ * Because the section factories (soul.ts, environment.ts, heartbeat.ts, …) stay
+ * intact, they remain the ultimate runtime fallback if the DB is empty/unreachable.
+ * This module exists so the SEED and the RESET pull from one authoritative place.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { resolveSullaDocsDir } from '@pkg/agent/utils/sullaPaths';
+
+import { heartbeatPrompt } from './heartbeat';
+import { ENVIRONMENT_STATIC_PREAMBLE } from './sections/environment';
+import { SOUL_CONTENT } from './sections/soul';
+
+export type CacheStability = 'stable' | 'semi-stable' | 'dynamic';
+
+export interface SystemPromptSectionDefault {
+  /** Section id — matches a registered prompt-section id where one exists. */
+  id:              string;
+  /** Human-facing label shown in the System Prompt settings UI. */
+  title:           string;
+  /** Sort order in the compiled prompt (mirrors the registered section priority). */
+  priority:        number;
+  cacheStability:  CacheStability;
+  /**
+   * The body is (partly) produced at runtime — e.g. `environment` appends live
+   * installed-extension/integration data. The stored content is the editable
+   * STATIC preamble; the generated tail is shown read-only in the UI and
+   * appended by the section factory at compile time.
+   */
+  isGenerated:     boolean;
+  /** Whether the section is enabled (injected) by default on a fresh seed. */
+  enabledByDefault: boolean;
+  /** Resolve the baked default content. Async because some read bundled files. */
+  resolveContent:  () => Promise<string> | string;
+}
+
+/**
+ * Read a bundled sulla-docs markdown file. Best-effort: returns '' if the file
+ * cannot be resolved so a packaging hiccup never blocks DB seeding.
+ */
+function readBundledDoc(...segments: string[]): string {
+  try {
+    const file = path.join(resolveSullaDocsDir(), ...segments);
+    return fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    console.warn('[SystemPromptSectionDefaults] could not read bundled doc', segments.join('/'), err);
+    return '';
+  }
+}
+
+/**
+ * The canonical identity rows, seeded on first boot. Ordering here is display
+ * order; `priority` governs compiled-prompt placement.
+ *
+ * `agents` ships DISABLED: it is reference documentation (not part of the
+ * compiled prompt today), so enabling it injects a large doc into every prompt.
+ * The human can opt it in from the UI.
+ */
+export const SYSTEM_PROMPT_SECTION_DEFAULTS: SystemPromptSectionDefault[] = [
+  {
+    id:               'user',
+    title:            'User',
+    priority:         15,
+    cacheStability:   'stable',
+    isGenerated:      false,
+    enabledByDefault: true,
+    // Seeded empty — freeform notes about the human. The name itself stays in
+    // the botName / primaryUserName settings shown at the top of the panel.
+    resolveContent:   () => '',
+  },
+  {
+    id:               'soul',
+    title:            'Soul',
+    priority:         20,
+    cacheStability:   'stable',
+    isGenerated:      false,
+    enabledByDefault: true,
+    resolveContent:   () => SOUL_CONTENT,
+  },
+  {
+    id:               'environment',
+    title:            'Environment',
+    priority:         50,
+    cacheStability:   'stable',
+    isGenerated:      true, // live installed-extensions / integrations tail appended at runtime
+    enabledByDefault: true,
+    resolveContent:   () => ENVIRONMENT_STATIC_PREAMBLE,
+  },
+  {
+    id:               'agents',
+    title:            'Agents',
+    priority:         90,
+    cacheStability:   'stable',
+    isGenerated:      false,
+    enabledByDefault: false, // reference doc — opt-in so it doesn't bloat every prompt
+    resolveContent:   () => readBundledDoc('tools', 'agents.md'),
+  },
+  {
+    id:               'heartbeat',
+    title:            'Heartbeat',
+    priority:         110,
+    cacheStability:   'stable',
+    isGenerated:      false,
+    enabledByDefault: true,
+    resolveContent:   () => heartbeatPrompt,
+  },
+];
+
+/** Look up a single default by id. */
+export function getSystemPromptSectionDefault(id: string): SystemPromptSectionDefault | undefined {
+  return SYSTEM_PROMPT_SECTION_DEFAULTS.find(d => d.id === id);
+}
+
+/** The set of canonical (builtin) ids — used to guard delete/reset semantics. */
+export const BUILTIN_SECTION_IDS = new Set(SYSTEM_PROMPT_SECTION_DEFAULTS.map(d => d.id));

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -164,6 +164,85 @@ export function initSullaEvents(): void {
   });
 
   // ─────────────────────────────────────────────────────────────
+  // System Prompt sections — DB-backed editable core of the agent
+  // system prompt (see SystemPromptSectionModel / migration 0048).
+  // ─────────────────────────────────────────────────────────────
+
+  ipcMainProxy.handle('system-prompt:list', async() => {
+    const { SystemPromptSectionModel } = await import('@pkg/agent/database/models/SystemPromptSectionModel');
+
+    return SystemPromptSectionModel.list();
+  });
+
+  ipcMainProxy.handle('system-prompt:update', async(_event: unknown, id: string, changes: any) => {
+    const { SystemPromptSectionModel } = await import('@pkg/agent/database/models/SystemPromptSectionModel');
+
+    return SystemPromptSectionModel.update(id, changes);
+  });
+
+  ipcMainProxy.handle('system-prompt:reset', async(_event: unknown, id: string) => {
+    const { SystemPromptSectionModel } = await import('@pkg/agent/database/models/SystemPromptSectionModel');
+
+    return SystemPromptSectionModel.resetToDefault(id);
+  });
+
+  ipcMainProxy.handle('system-prompt:add', async(_event: unknown, input: any) => {
+    const { SystemPromptSectionModel } = await import('@pkg/agent/database/models/SystemPromptSectionModel');
+
+    return SystemPromptSectionModel.addCustom(input);
+  });
+
+  ipcMainProxy.handle('system-prompt:remove', async(_event: unknown, id: string) => {
+    const { SystemPromptSectionModel } = await import('@pkg/agent/database/models/SystemPromptSectionModel');
+
+    return SystemPromptSectionModel.remove(id);
+  });
+
+  // Read-only preview of the runtime-generated tail for a generated section
+  // (currently just `environment` → live installed-extensions block).
+  ipcMainProxy.handle('system-prompt:preview-generated', async(_event: unknown, id: string) => {
+    if (id !== 'environment') return '';
+    try {
+      const { SullaSettingsModel } = await import('@pkg/agent/database/models/SullaSettingsModel');
+      // installed_extensions is assembled and cached as a setting the prompt
+      // builder consumes; surface it verbatim so the human sees what ships.
+      return await SullaSettingsModel.get('installedExtensionsBlock', '') || '';
+    } catch (err) {
+      console.warn('[system-prompt:preview-generated] failed:', err);
+      return '';
+    }
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // System Prompt EDITS — staged, human-approved proposals. Agents
+  // propose; the human approves/edits/denies here (see migration 0049).
+  // ─────────────────────────────────────────────────────────────
+
+  ipcMainProxy.handle('system-prompt-edits:list-pending', async() => {
+    const { SystemPromptSectionEditModel } = await import('@pkg/agent/database/models/SystemPromptSectionEditModel');
+
+    return SystemPromptSectionEditModel.listPending();
+  });
+
+  ipcMainProxy.handle('system-prompt-edits:propose', async(_event: unknown, input: any) => {
+    const { SystemPromptSectionEditModel } = await import('@pkg/agent/database/models/SystemPromptSectionEditModel');
+
+    return SystemPromptSectionEditModel.propose(input);
+  });
+
+  ipcMainProxy.handle('system-prompt-edits:approve', async(_event: unknown, id: string, finalContent?: string) => {
+    const { SystemPromptSectionEditModel } = await import('@pkg/agent/database/models/SystemPromptSectionEditModel');
+
+    return SystemPromptSectionEditModel.approve(id, { finalContent, reviewed_by: 'human' });
+  });
+
+  ipcMainProxy.handle('system-prompt-edits:deny', async(_event: unknown, id: string) => {
+    const { SystemPromptSectionEditModel } = await import('@pkg/agent/database/models/SystemPromptSectionEditModel');
+
+    return SystemPromptSectionEditModel.deny(id, { reviewed_by: 'human' });
+  });
+
+  // ─────────────────────────────────────────────────────────────
   // Labs — experimental feature launchers
   // ─────────────────────────────────────────────────────────────
 

--- a/pkg/rancher-desktop/pages/LanguageModelSettings.vue
+++ b/pkg/rancher-desktop/pages/LanguageModelSettings.vue
@@ -17,10 +17,35 @@ import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 const navItems = [
   { id: 'overview', name: 'Overview' },
   { id: 'models', name: 'Models' },
-  { id: 'claude-code', name: 'Claude Code (deprecated)' },
-  { id: 'soul', name: 'Soul' },
+  { id: 'system-prompt', name: 'System Prompt' },
   { id: 'heartbeat', name: 'Heartbeat' },
 ];
+
+// Shape of a system-prompt section row returned by the `system-prompt:*` IPC.
+interface SystemPromptSectionRow {
+  id:            string;
+  title:         string;
+  content:       string;
+  priority:      number;
+  enabled:       boolean;
+  is_builtin:    boolean;
+  is_generated:  boolean;
+  is_customized: boolean;
+}
+
+// A staged, AI-proposed edit awaiting human review (`system-prompt-edits:*`).
+interface SectionEditRow {
+  id:               string;
+  section_id:       string;
+  proposed_content: string;
+  base_content:     string;
+  rationale:        string | null;
+  status:           string;
+  proposed_by:      string | null;
+  created_at:       string;
+}
+
+type DiffLine = { type: 'ctx' | 'add' | 'del'; text: string };
 
 export default defineComponent({
   name: 'language-model-settings',
@@ -76,6 +101,22 @@ export default defineComponent({
       botName:         'Sulla',
       primaryUserName: '',
 
+      // System Prompt tab — DB-backed editable sections (master → detail)
+      systemPromptSections: [] as SystemPromptSectionRow[],
+      selectedSectionId:    '' as string,   // '' = list view; id = detail view
+      sectionDraft:         '' as string,   // working copy of the open section's content
+      envGeneratedPreview:  '' as string,   // read-only runtime-generated tail for `environment`
+      loadingSections:      false,
+      savingSection:        false,
+      sectionError:         '' as string,
+
+      // Staged AI-proposed edits awaiting review (approve / edit / deny)
+      pendingEdits:         [] as SectionEditRow[],
+      reviewingEditId:      '' as string,   // '' = not reviewing; id = review view
+      editApproveMode:      false,          // false = diff view, true = amend-before-approve
+      editApproveDraft:     '' as string,
+      reviewError:          '' as string,
+
       // Default prompts for reset
       soulPromptDefault:      soulPrompt,
       heartbeatPromptDefault: heartbeatPrompt,
@@ -91,22 +132,6 @@ export default defineComponent({
       savingSettings:         false,
       // Guard flag to prevent feedback loop between primaryProvider watcher and IPC handler
       _suppressProviderWatch: false,
-
-      // Claude Code auth
-      claudeAuthMode:      'none' as 'none' | 'api-key' | 'oauth',
-      claudeApiKey:        '',
-      claudeOAuthToken:    '',
-      claudeApiKeyVisible: false,
-      claudeSaving:        false,
-      claudeOAuthRunning:  false,
-      claudeOAuthStatus:   'Starting...',
-      claudeOAuthError:    '',
-      claudeOAuthUrl:      '',
-      claudeOAuthCode:     '',
-
-      // Deprecated legacy-credentials panel — collapsed by default now that
-      // the Integrations page is the primary path.
-      showLegacyClaudeCreds: false,
     };
   },
 
@@ -144,6 +169,28 @@ export default defineComponent({
 
       return model?.description || '';
     },
+    selectedSection(): SystemPromptSectionRow | null {
+      return this.systemPromptSections.find(s => s.id === this.selectedSectionId) || null;
+    },
+    reviewingEdit(): SectionEditRow | null {
+      return this.pendingEdits.find(e => e.id === this.reviewingEditId) || null;
+    },
+    reviewingEditSection(): SystemPromptSectionRow | null {
+      const e = this.reviewingEdit;
+      return e ? (this.systemPromptSections.find(s => s.id === e.section_id) || null) : null;
+    },
+    reviewingEditIndex(): number {
+      return this.pendingEdits.findIndex(e => e.id === this.reviewingEditId);
+    },
+    pendingCountBySection(): Record<string, number> {
+      const counts: Record<string, number> = {};
+      for (const e of this.pendingEdits) counts[e.section_id] = (counts[e.section_id] || 0) + 1;
+      return counts;
+    },
+    reviewDiff(): DiffLine[] {
+      const e = this.reviewingEdit;
+      return e ? this.diffLines(e.base_content, e.proposed_content) : [];
+    },
   },
 
   async mounted() {
@@ -155,9 +202,6 @@ export default defineComponent({
     });
 
     this.activeMode = await SullaSettingsModel.get('activeMode', 'remote');
-
-    // Load Claude Code credentials
-    await this.loadClaudeCredentials();
 
     // Listen for state changes from ModelProviderService (source of truth)
     ipcRenderer.on('model-provider:state-changed', this.handleProviderStateChanged);
@@ -232,6 +276,10 @@ export default defineComponent({
 
     // Load model lists for all three provider slots
     await this.loadSlotModels();
+
+    // Load DB-backed system prompt sections + any staged AI edits for review
+    await this.loadSystemPromptSections();
+    await this.loadPendingEdits();
 
     ipcRenderer.send('dialog/ready');
   },
@@ -643,123 +691,6 @@ export default defineComponent({
       }
     },
 
-    async startClaudeOAuth() {
-      this.claudeOAuthError = '';
-      this.claudeOAuthStatus = 'Starting claude setup-token in the VM...';
-      this.claudeOAuthUrl = '';
-      this.claudeOAuthCode = '';
-      this.claudeOAuthRunning = true;
-
-      const onProgress = (_event: unknown, text: string) => {
-        const trimmed = text.trim();
-        if (trimmed) this.claudeOAuthStatus = trimmed.split('\n').pop() || this.claudeOAuthStatus;
-      };
-      const onUrl = (_event: unknown, url: string) => {
-        this.claudeOAuthUrl = url;
-        this.claudeOAuthStatus = 'Sign in in your browser, then paste the code below.';
-      };
-      ipcRenderer.on('claude-oauth:progress', onProgress);
-      ipcRenderer.on('claude-oauth:url', onUrl);
-
-      try {
-        const result = await ipcRenderer.invoke('claude-oauth:start');
-        if (result.token) {
-          this.claudeOAuthToken = result.token;
-          await ipcRenderer.invoke('sulla-settings-set', 'claudeOAuthToken', result.token, 'string');
-          await ipcRenderer.invoke('sulla-settings-set', 'claudeApiKey', '', 'string');
-          this.claudeApiKey = '';
-          this.claudeOAuthStatus = 'Signed in';
-        } else if (result.error) {
-          this.claudeOAuthError = result.error;
-        }
-      } catch (err: any) {
-        this.claudeOAuthError = err?.message || 'OAuth flow failed';
-      } finally {
-        ipcRenderer.removeListener('claude-oauth:progress', onProgress);
-        ipcRenderer.removeListener('claude-oauth:url', onUrl);
-        this.claudeOAuthRunning = false;
-        this.claudeOAuthUrl = '';
-      }
-    },
-
-    async submitClaudeOAuthCode() {
-      const code = this.claudeOAuthCode.trim();
-      if (!code) return;
-      try {
-        // Send the code followed by newline to feed the CLI's stdin
-        await ipcRenderer.invoke('claude-oauth:send-input', code + '\r');
-        this.claudeOAuthCode = '';
-        this.claudeOAuthStatus = 'Code submitted, waiting for token...';
-      } catch (err) {
-        console.warn('Failed to submit OAuth code:', err);
-      }
-    },
-
-    async copyAuthUrl() {
-      const { clipboard } = require('electron');
-      if (this.claudeOAuthUrl) {
-        clipboard.writeText(this.claudeOAuthUrl);
-        this.claudeOAuthStatus = 'URL copied to clipboard. Paste it into your browser.';
-      }
-    },
-
-    async cancelClaudeOAuth() {
-      try {
-        await ipcRenderer.invoke('claude-oauth:cancel');
-      } catch { /* ignore */ }
-      this.claudeOAuthRunning = false;
-      this.claudeOAuthStatus = 'Starting...';
-      this.claudeOAuthUrl = '';
-      this.claudeOAuthCode = '';
-    },
-
-    async disconnectClaudeOAuth() {
-      this.claudeOAuthToken = '';
-      await ipcRenderer.invoke('sulla-settings-set', 'claudeOAuthToken', '', 'string');
-    },
-
-    async saveClaudeCredentials() {
-      this.claudeSaving = true;
-      try {
-        if (this.claudeAuthMode === 'api-key' && this.claudeApiKey) {
-          await ipcRenderer.invoke('sulla-settings-set', 'claudeApiKey', this.claudeApiKey, 'string');
-          await ipcRenderer.invoke('sulla-settings-set', 'claudeOAuthToken', '', 'string');
-        } else if (this.claudeAuthMode === 'oauth' && this.claudeOAuthToken) {
-          await ipcRenderer.invoke('sulla-settings-set', 'claudeOAuthToken', this.claudeOAuthToken.trim(), 'string');
-          await ipcRenderer.invoke('sulla-settings-set', 'claudeApiKey', '', 'string');
-        }
-        console.log('[LM Settings] Claude credentials saved');
-      } catch (err) {
-        console.error('Failed to save Claude credentials:', err);
-      } finally {
-        this.claudeSaving = false;
-      }
-    },
-
-
-    async loadClaudeCredentials() {
-      try {
-        const apiKey = await ipcRenderer.invoke('sulla-settings-get', 'claudeApiKey', '');
-        const oauthToken = await ipcRenderer.invoke('sulla-settings-get', 'claudeOAuthToken', '');
-        this.claudeApiKey = apiKey || '';
-        this.claudeOAuthToken = oauthToken || '';
-        if (oauthToken) {
-          this.claudeAuthMode = 'oauth';
-        } else if (apiKey) {
-          this.claudeAuthMode = 'api-key';
-        } else {
-          this.claudeAuthMode = 'none';
-        }
-        // If legacy creds are present, expand the legacy panel automatically
-        // so the user can see they're still active.
-        if (this.claudeApiKey || this.claudeOAuthToken) {
-          this.showLegacyClaudeCreds = true;
-        }
-      } catch {
-        // Settings not available yet
-      }
-    },
-
     openExternal(url: string) {
       const { shell } = require('electron');
       shell.openExternal(url);
@@ -816,6 +747,215 @@ export default defineComponent({
         console.error('[LM Settings] Error in writeExperimentalSettings:', err);
         throw err;
       }
+    },
+
+    // ── System Prompt tab (DB-backed sections) ──────────────────────────
+    async loadSystemPromptSections() {
+      this.loadingSections = true;
+      this.sectionError = '';
+      try {
+        this.systemPromptSections = await ipcRenderer.invoke('system-prompt:list') || [];
+      } catch (err) {
+        console.error('[LM Settings] Failed to load system prompt sections:', err);
+        this.sectionError = 'Could not load system prompt sections.';
+      } finally {
+        this.loadingSections = false;
+      }
+    },
+
+    async openSection(id: string) {
+      const section = this.systemPromptSections.find(s => s.id === id);
+      if (!section) return;
+      this.selectedSectionId = id;
+      this.sectionDraft = section.content;
+      this.sectionError = '';
+      this.envGeneratedPreview = '';
+      // For generated sections (e.g. environment) fetch the live read-only tail.
+      if (section.is_generated) {
+        try {
+          this.envGeneratedPreview = await ipcRenderer.invoke('system-prompt:preview-generated', id) || '';
+        } catch (err) {
+          console.warn('[LM Settings] Failed to load generated preview for', id, err);
+        }
+      }
+    },
+
+    closeSection() {
+      this.selectedSectionId = '';
+      this.sectionDraft = '';
+      this.envGeneratedPreview = '';
+    },
+
+    async saveSection() {
+      if (!this.selectedSection || this.savingSection) return;
+      this.savingSection = true;
+      this.sectionError = '';
+      try {
+        const updated = await ipcRenderer.invoke('system-prompt:update', this.selectedSection.id, { content: this.sectionDraft });
+        if (updated) this.applyUpdatedSection(updated);
+      } catch (err) {
+        console.error('[LM Settings] Failed to save section:', err);
+        this.sectionError = 'Failed to save this section.';
+      } finally {
+        this.savingSection = false;
+      }
+    },
+
+    async toggleSection(section: SystemPromptSectionRow) {
+      try {
+        const updated = await ipcRenderer.invoke('system-prompt:update', section.id, { enabled: !section.enabled });
+        if (updated) this.applyUpdatedSection(updated);
+      } catch (err) {
+        console.error('[LM Settings] Failed to toggle section:', err);
+      }
+    },
+
+    async resetSection(section: SystemPromptSectionRow) {
+      try {
+        const updated = await ipcRenderer.invoke('system-prompt:reset', section.id);
+        if (updated) {
+          this.applyUpdatedSection(updated);
+          if (this.selectedSectionId === section.id) this.sectionDraft = updated.content;
+        }
+      } catch (err) {
+        console.error('[LM Settings] Failed to reset section:', err);
+      }
+    },
+
+    async addSection() {
+      const title = String(window.prompt('New section title (e.g. Business Context):') || '').trim();
+      if (!title) return;
+      const id = title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+      if (!id) return;
+      try {
+        const created = await ipcRenderer.invoke('system-prompt:add', { id, title, priority: 100 });
+        if (created) {
+          await this.loadSystemPromptSections();
+          this.openSection(created.id);
+        }
+      } catch (err) {
+        console.error('[LM Settings] Failed to add section:', err);
+        this.sectionError = 'Could not add section (id may already exist).';
+      }
+    },
+
+    async deleteSection(section: SystemPromptSectionRow) {
+      if (section.is_builtin) return; // builtin rows can be disabled/reset, not deleted
+      if (!window.confirm(`Delete the "${ section.title }" section? This cannot be undone.`)) return;
+      try {
+        await ipcRenderer.invoke('system-prompt:remove', section.id);
+        if (this.selectedSectionId === section.id) this.closeSection();
+        await this.loadSystemPromptSections();
+      } catch (err) {
+        console.error('[LM Settings] Failed to delete section:', err);
+      }
+    },
+
+    // Merge an updated row back into the in-memory list without a full reload.
+    applyUpdatedSection(updated: SystemPromptSectionRow) {
+      const idx = this.systemPromptSections.findIndex(s => s.id === updated.id);
+      if (idx !== -1) this.systemPromptSections.splice(idx, 1, updated);
+    },
+
+    sectionSnippet(content: string): string {
+      const oneLine = String(content || '').replace(/\s+/g, ' ').trim();
+      return oneLine.length > 90 ? `${ oneLine.slice(0, 90) }…` : (oneLine || 'Empty');
+    },
+
+    // ── Staged AI edits: review queue ──────────────────────────────────
+    async loadPendingEdits() {
+      try {
+        this.pendingEdits = await ipcRenderer.invoke('system-prompt-edits:list-pending') || [];
+      } catch (err) {
+        console.error('[LM Settings] Failed to load pending edits:', err);
+      }
+    },
+
+    sectionTitle(sectionId: string): string {
+      return this.systemPromptSections.find(s => s.id === sectionId)?.title || sectionId;
+    },
+
+    openReview(editId: string) {
+      const edit = this.pendingEdits.find(e => e.id === editId);
+      if (!edit) return;
+      this.reviewingEditId = editId;
+      this.editApproveMode = false;
+      this.editApproveDraft = edit.proposed_content;
+      this.reviewError = '';
+      // Leave any open section editor — the review takes over the panel.
+      this.selectedSectionId = '';
+    },
+
+    openFirstPendingForSection(sectionId: string) {
+      const edit = this.pendingEdits.find(e => e.section_id === sectionId);
+      if (edit) this.openReview(edit.id);
+    },
+
+    closeReview() {
+      this.reviewingEditId = '';
+      this.editApproveMode = false;
+      this.editApproveDraft = '';
+      this.reviewError = '';
+    },
+
+    // After a review action, jump to the next pending edit or exit the queue.
+    advanceReviewQueue() {
+      const next = this.pendingEdits[0];
+      if (next) this.openReview(next.id);
+      else this.closeReview();
+    },
+
+    async approveEdit() {
+      const edit = this.reviewingEdit;
+      if (!edit) return;
+      this.reviewError = '';
+      try {
+        const finalContent = this.editApproveMode ? this.editApproveDraft : undefined;
+        await ipcRenderer.invoke('system-prompt-edits:approve', edit.id, finalContent);
+        await Promise.all([this.loadSystemPromptSections(), this.loadPendingEdits()]);
+        this.advanceReviewQueue();
+      } catch (err) {
+        console.error('[LM Settings] Failed to approve edit:', err);
+        this.reviewError = 'Failed to approve this change.';
+      }
+    },
+
+    async denyEdit() {
+      const edit = this.reviewingEdit;
+      if (!edit) return;
+      this.reviewError = '';
+      try {
+        await ipcRenderer.invoke('system-prompt-edits:deny', edit.id);
+        await this.loadPendingEdits();
+        this.advanceReviewQueue();
+      } catch (err) {
+        console.error('[LM Settings] Failed to deny edit:', err);
+        this.reviewError = 'Failed to deny this change.';
+      }
+    },
+
+    // Compact LCS line diff (base → proposed). Prompts are at most a few hundred
+    // lines, so the O(n*m) table is negligible.
+    diffLines(base: string, proposed: string): DiffLine[] {
+      const a = String(base || '').split('\n');
+      const b = String(proposed || '').split('\n');
+      const n = a.length;
+      const m = b.length;
+      const dp: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+      for (let i = n - 1; i >= 0; i--) {
+        for (let j = m - 1; j >= 0; j--) {
+          dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+        }
+      }
+      const out: DiffLine[] = [];
+      let i = 0;
+      let j = 0;
+      while (i < n && j < m) {
+        if (a[i] === b[j]) { out.push({ type: 'ctx', text: a[i] }); i++; j++; } else if (dp[i + 1][j] >= dp[i][j + 1]) { out.push({ type: 'del', text: a[i] }); i++; } else { out.push({ type: 'add', text: b[j] }); j++; }
+      }
+      while (i < n) { out.push({ type: 'del', text: a[i] }); i++; }
+      while (j < m) { out.push({ type: 'add', text: b[j] }); j++; }
+      return out;
     },
 
     closeWindow() {
@@ -1122,49 +1262,301 @@ export default defineComponent({
           </div>
         </div>
 
-        <!-- Soul Tab -->
+        <!-- System Prompt Tab -->
         <div
-          v-if="currentNav === 'soul'"
-          class="tab-content"
+          v-if="currentNav === 'system-prompt'"
+          class="tab-content sp-tab"
         >
-          <h2>Soul</h2>
-          <p class="description">
-            Configure the agent's identity and system prompt. The bot name and user name will be prefixed to the soul prompt.
-          </p>
+          <!-- REVIEW VIEW — a staged AI-proposed edit -->
+          <template v-if="reviewingEdit">
+            <div class="sp-detail-bar">
+              <span
+                class="sp-back"
+                @click="closeReview"
+              >‹ Back to sections</span>
+              <span class="sp-detail-bar-spacer" />
+              <span
+                v-if="pendingEdits.length > 1"
+                class="sp-detail-meta"
+              >{{ reviewingEditIndex + 1 }} of {{ pendingEdits.length }}</span>
+            </div>
 
-          <div
-            class="form-group"
-            style="margin-bottom: 1.5rem;"
-          >
-            <label class="form-label">Bot Name</label>
-            <input
-              v-model="botName"
-              type="text"
-              class="text-input"
-              placeholder="Sulla"
-              style="max-width: 400px;"
-            >
-            <p class="setting-description">
-              The name of the AI assistant (default: Sulla)
-            </p>
-          </div>
+            <div class="sp-detail-head">
+              <h2>{{ sectionTitle(reviewingEdit.section_id) }}</h2>
+              <span class="sp-detail-meta">proposed edit · staged, not live</span>
+            </div>
+            <div class="sp-review-by">
+              Proposed by <strong>{{ reviewingEdit.proposed_by || 'an agent' }}</strong>
+              <span v-if="reviewingEdit.created_at"> · {{ reviewingEdit.created_at }}</span>
+            </div>
 
-          <div
-            class="form-group"
-            style="margin-bottom: 2rem;"
-          >
-            <label class="form-label">Your Human's Name</label>
-            <input
-              v-model="primaryUserName"
-              type="text"
-              class="text-input"
-              placeholder="Enter your name (optional)"
-              style="max-width: 400px;"
+            <div
+              v-if="reviewingEdit.rationale"
+              class="sp-rationale"
             >
-            <p class="setting-description">
-              Your name (optional) - helps personalize interactions
+              <div class="sp-rationale-label">WHY THIS CHANGE</div>
+              <div class="sp-rationale-body">{{ reviewingEdit.rationale }}</div>
+            </div>
+
+            <!-- Diff (default) or amend-before-approve editor -->
+            <template v-if="!editApproveMode">
+              <div class="sp-list-header">PROPOSED CHANGES</div>
+              <div class="sp-diff">
+                <div
+                  v-for="(line, i) in reviewDiff"
+                  :key="i"
+                  class="sp-diff-line"
+                  :class="'sp-diff-' + line.type"
+                >
+                  <span class="sp-diff-gutter">{{ line.type === 'add' ? '+' : (line.type === 'del' ? '−' : '') }}</span>
+                  <span class="sp-diff-text">{{ line.text || ' ' }}</span>
+                </div>
+              </div>
+            </template>
+            <template v-else>
+              <div class="sp-list-header">AMEND BEFORE APPROVING</div>
+              <textarea
+                v-model="editApproveDraft"
+                class="sp-editor"
+                spellcheck="false"
+              />
+            </template>
+
+            <div
+              v-if="reviewError"
+              class="activation-error"
+            >
+              {{ reviewError }}
+            </div>
+
+            <div class="sp-detail-actions">
+              <button
+                class="btn sp-approve-btn"
+                @click="approveEdit"
+              >
+                ✓ {{ editApproveMode ? 'Approve amended' : 'Approve & apply' }}
+              </button>
+              <button
+                class="btn role-secondary"
+                @click="editApproveMode = !editApproveMode"
+              >
+                {{ editApproveMode ? 'View diff' : 'Edit & approve' }}
+              </button>
+              <button
+                class="btn sp-deny-btn"
+                @click="denyEdit"
+              >
+                Deny
+              </button>
+              <span class="sp-detail-bar-spacer" />
+              <span class="sp-review-note">Approving writes this into the live prompt.</span>
+            </div>
+          </template>
+
+          <!-- LIST VIEW -->
+          <template v-else-if="!selectedSectionId">
+            <h2>System Prompt</h2>
+            <p class="description">
+              The compiled system prompt for every Sulla agent. Each row is editable raw markdown, seeded from the shipped defaults. Agent-specific <code>.md</code> files still override these per-agent.
             </p>
-          </div>
+
+            <!-- Staged AI edits awaiting review -->
+            <div
+              v-if="pendingEdits.length"
+              class="sp-review-banner"
+            >
+              <span class="sp-review-banner-icon">⏳</span>
+              <div class="sp-review-banner-text">
+                <div class="sp-review-banner-title">
+                  {{ pendingEdits.length }} proposed edit{{ pendingEdits.length === 1 ? '' : 's' }} awaiting your review
+                </div>
+                <div class="sp-review-banner-sub">Staged by Sulla — nothing is live until you approve.</div>
+              </div>
+              <button
+                class="btn sp-review-banner-btn"
+                @click="openReview(pendingEdits[0].id)"
+              >
+                Review
+              </button>
+            </div>
+
+            <!-- Identity fields -->
+            <div class="sp-identity">
+              <div class="form-group">
+                <label class="form-label">Sulla's Name</label>
+                <input
+                  v-model="botName"
+                  type="text"
+                  class="text-input"
+                  placeholder="Sulla"
+                >
+              </div>
+              <div class="form-group">
+                <label class="form-label">Human's Name</label>
+                <input
+                  v-model="primaryUserName"
+                  type="text"
+                  class="text-input"
+                  placeholder="Your name (optional)"
+                >
+              </div>
+            </div>
+
+            <div class="sp-list-header">
+              SECTIONS · compiled top → bottom by priority
+            </div>
+
+            <div
+              v-if="sectionError"
+              class="activation-error"
+            >
+              {{ sectionError }}
+            </div>
+
+            <div class="sp-list">
+              <div
+                v-for="section in systemPromptSections"
+                :key="section.id"
+                class="sp-row"
+                :class="{ 'sp-row--disabled': !section.enabled }"
+                @click="openSection(section.id)"
+              >
+                <span class="sp-grip">⋮⋮</span>
+                <div class="sp-row-main">
+                  <div class="sp-row-title">
+                    {{ section.title }}
+                    <span
+                      v-if="pendingCountBySection[section.id]"
+                      class="sp-badge sp-badge--pending"
+                      @click.stop="openFirstPendingForSection(section.id)"
+                    >● {{ pendingCountBySection[section.id] }} proposed</span>
+                    <span
+                      v-if="section.is_generated"
+                      class="sp-badge sp-badge--warn"
+                    >partly generated</span>
+                    <span
+                      v-if="section.id === 'heartbeat'"
+                      class="sp-badge sp-badge--dim"
+                    >heartbeat agent only</span>
+                  </div>
+                  <div class="sp-row-snippet">
+                    {{ sectionSnippet(section.content) }}
+                  </div>
+                </div>
+                <span
+                  v-if="section.is_builtin"
+                  class="sp-badge sp-badge--accent"
+                >builtin</span>
+                <span
+                  v-else
+                  class="sp-badge sp-badge--custom"
+                >custom</span>
+                <label
+                  class="switch"
+                  @click.stop
+                >
+                  <input
+                    type="checkbox"
+                    :checked="section.enabled"
+                    @change="toggleSection(section)"
+                  >
+                  <span class="slider" />
+                </label>
+                <span class="sp-chevron">›</span>
+              </div>
+            </div>
+
+            <div class="sp-list-actions">
+              <button
+                class="btn role-primary"
+                @click="addSection"
+              >
+                + Add section
+              </button>
+            </div>
+          </template>
+
+          <!-- DETAIL VIEW -->
+          <template v-else-if="selectedSection">
+            <div class="sp-detail-bar">
+              <span
+                class="sp-back"
+                @click="closeSection"
+              >‹ All sections</span>
+              <span class="sp-detail-bar-spacer" />
+              <span
+                v-if="selectedSection.is_builtin"
+                class="sp-badge sp-badge--accent"
+              >builtin</span>
+              <span
+                v-else
+                class="sp-badge sp-badge--custom"
+              >custom</span>
+              <button
+                v-if="selectedSection.is_builtin"
+                class="btn role-secondary sp-mini-btn"
+                @click="resetSection(selectedSection)"
+              >
+                Reset to default
+              </button>
+              <button
+                v-else
+                class="btn role-secondary sp-mini-btn"
+                @click="deleteSection(selectedSection)"
+              >
+                Delete
+              </button>
+              <label class="switch">
+                <input
+                  type="checkbox"
+                  :checked="selectedSection.enabled"
+                  @change="toggleSection(selectedSection)"
+                >
+                <span class="slider" />
+              </label>
+            </div>
+
+            <div class="sp-detail-head">
+              <h2>{{ selectedSection.title }}</h2>
+              <span class="sp-detail-meta">
+                {{ selectedSection.id }} · priority {{ selectedSection.priority }}
+                <template v-if="selectedSection.is_customized"> · customized</template>
+              </span>
+            </div>
+
+            <textarea
+              v-model="sectionDraft"
+              class="sp-editor"
+              spellcheck="false"
+              placeholder="Raw markdown for this section…"
+            />
+
+            <!-- Read-only runtime-generated tail (environment, etc.) -->
+            <div
+              v-if="selectedSection.is_generated"
+              class="sp-generated"
+            >
+              <div class="sp-generated-label">🔒 RUNTIME-GENERATED · appended live, read-only</div>
+              <pre class="sp-generated-body">{{ envGeneratedPreview || 'Nothing generated right now (e.g. no installed extensions).' }}</pre>
+            </div>
+
+            <div
+              v-if="sectionError"
+              class="activation-error"
+            >
+              {{ sectionError }}
+            </div>
+
+            <div class="sp-detail-actions">
+              <button
+                class="btn role-primary"
+                :disabled="savingSection"
+                @click="saveSection"
+              >
+                {{ savingSection ? 'Saving…' : 'Save' }}
+              </button>
+            </div>
+          </template>
         </div>
 
         <!-- Heartbeat Tab -->
@@ -1257,179 +1649,6 @@ export default defineComponent({
             <p class="setting-description">
               Subconscious agents (memory recall, observation, unstuck research) run in the background and need a fast tool-emitting chat model. "Use Primary Provider" mirrors your main provider. Avoid autonomous models like Claude Code here — they over-invest in quick recall tasks.
             </p>
-          </div>
-        </div>
-
-        <!-- Claude Code Tab -->
-        <div
-          v-if="currentNav === 'claude-code'"
-          class="tab-content"
-        >
-          <h2>Claude Code <span class="claude-deprecated-badge">Deprecated</span></h2>
-          <div class="claude-deprecation-banner">
-            <p>
-              <strong>Claude Code sign-in has moved to Integrations.</strong>
-              Connect via <em>Integrations → Claude Code</em>. Credentials now live in
-              the encrypted vault and propagate through the Integration service, so
-              the same account works everywhere without writing to SullaSettingsModel.
-            </p>
-            <p>
-              This tab stays available while we validate the new path. It will be
-              removed once the Integrations flow is confirmed stable.
-            </p>
-          </div>
-
-          <!-- Legacy credentials — collapsed by default; only show if the user
-               explicitly expands or legacy credentials already exist. -->
-          <div class="setting-group claude-legacy">
-            <button
-              type="button"
-              class="btn role-secondary"
-              @click="showLegacyClaudeCreds = !showLegacyClaudeCreds"
-            >
-              {{ showLegacyClaudeCreds ? 'Hide legacy credentials' : 'Show legacy credentials (deprecated)' }}
-            </button>
-          </div>
-
-          <div v-if="showLegacyClaudeCreds">
-            <p class="description claude-legacy-warning">
-              These fields still write to <code>SullaSettingsModel</code>. They continue
-              to work as a fallback, but new connections should go through
-              <em>Integrations → Claude Code</em>.
-            </p>
-
-          <!-- Auth Mode Selection -->
-          <div class="setting-group">
-            <label class="setting-label">Authentication Method</label>
-            <div class="claude-auth-buttons">
-              <button
-                class="btn"
-                :class="claudeAuthMode === 'api-key' ? 'role-primary' : 'role-secondary'"
-                @click="claudeAuthMode = 'api-key'"
-              >
-                API Key
-              </button>
-              <button
-                class="btn"
-                :class="claudeAuthMode === 'oauth' ? 'role-primary' : 'role-secondary'"
-                @click="claudeAuthMode = 'oauth'"
-              >
-                Claude Max (OAuth)
-              </button>
-            </div>
-            <p class="setting-description">
-              Use an API key for pay-per-token billing, or sign in with your Claude Max/Pro subscription.
-            </p>
-          </div>
-
-          <!-- API Key Input -->
-          <div
-            v-if="claudeAuthMode === 'api-key'"
-            class="setting-group"
-          >
-            <label class="setting-label">Anthropic API Key</label>
-            <div class="claude-input-row">
-              <input
-                v-model="claudeApiKey"
-                :type="claudeApiKeyVisible ? 'text' : 'password'"
-                class="input-field claude-input-field"
-                placeholder="sk-ant-..."
-              >
-              <button
-                class="btn role-secondary"
-                @click="claudeApiKeyVisible = !claudeApiKeyVisible"
-              >
-                {{ claudeApiKeyVisible ? 'Hide' : 'Show' }}
-              </button>
-            </div>
-            <p class="setting-description">
-              Get your API key from
-              <a
-                href="#"
-                @click.prevent="openExternal('https://console.anthropic.com/settings/keys')"
-              >console.anthropic.com</a>
-            </p>
-          </div>
-
-          <!-- OAuth Sign-In -->
-          <div
-            v-if="claudeAuthMode === 'oauth'"
-            class="setting-group"
-          >
-            <label class="setting-label">Claude Max / Pro Subscription</label>
-            <p class="setting-description claude-oauth-instructions">
-              Sign in with your Anthropic account to use your Claude Max or Pro subscription.
-              We'll open a browser window for you to authorize.
-            </p>
-            <button
-              v-if="!claudeOAuthToken && !claudeOAuthRunning"
-              class="btn role-primary"
-              @click="startClaudeOAuth"
-            >
-              Sign in with Claude
-            </button>
-            <div
-              v-if="claudeOAuthRunning"
-              class="claude-oauth-progress-container"
-            >
-              <p class="setting-description">
-                {{ claudeOAuthStatus }}
-              </p>
-              <button
-                class="btn role-secondary"
-                @click="cancelClaudeOAuth"
-              >
-                Cancel
-              </button>
-            </div>
-            <div
-              v-if="claudeOAuthToken && !claudeOAuthRunning"
-              class="claude-oauth-signed-in"
-            >
-              <span class="claude-status-dot" />
-              <span class="setting-description claude-status-text">Signed in</span>
-              <button
-                class="btn role-secondary"
-                @click="disconnectClaudeOAuth"
-              >
-                Sign out
-              </button>
-            </div>
-            <p
-              v-if="claudeOAuthError"
-              class="setting-description claude-oauth-error"
-            >
-              {{ claudeOAuthError }}
-            </p>
-          </div>
-
-          <!-- Save Button (API key only) -->
-          <div
-            v-if="claudeAuthMode === 'api-key'"
-            class="setting-group"
-          >
-            <button
-              class="btn role-primary"
-              :disabled="claudeSaving"
-              @click="saveClaudeCredentials"
-            >
-              {{ claudeSaving ? 'Saving...' : 'Save API Key' }}
-            </button>
-          </div>
-
-          <!-- Status -->
-          <div
-            v-if="claudeAuthMode !== 'none' && (claudeApiKey || claudeOAuthToken)"
-            class="setting-group"
-          >
-            <div class="claude-status">
-              <span class="claude-status-dot" />
-              <span class="setting-description claude-status-text">
-                Claude Code credentials configured. They will be injected into the VM on next boot.
-              </span>
-            </div>
-          </div>
-
           </div>
         </div>
       </div>
@@ -1619,116 +1838,6 @@ export default defineComponent({
   margin-bottom: 1rem;
   color: var(--text-error, var(--status-error, #ef4444));
   font-size: var(--fs-body);
-}
-
-.claude-auth-buttons {
-  display: flex;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
-
-.claude-input-row {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.claude-input-field {
-  flex: 1;
-}
-
-.claude-oauth-instructions {
-  margin-bottom: 0.5rem;
-}
-
-.claude-oauth-textarea {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  resize: vertical;
-  width: 100%;
-}
-
-.claude-deprecated-badge {
-  display: inline-block;
-  margin-left: 0.5rem;
-  padding: 0.1rem 0.5rem;
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--status-warning, #d29922);
-  background: rgba(210, 153, 34, 0.12);
-  border: 1px solid rgba(210, 153, 34, 0.3);
-  border-radius: 0.25rem;
-  vertical-align: middle;
-}
-
-.claude-deprecation-banner {
-  padding: 0.75rem 1rem;
-  margin: 0.5rem 0 1rem;
-  color: var(--text-primary, inherit);
-  background: rgba(210, 153, 34, 0.08);
-  border: 1px solid rgba(210, 153, 34, 0.25);
-  border-radius: 0.4rem;
-}
-
-.claude-deprecation-banner p {
-  margin: 0 0 0.5rem;
-}
-.claude-deprecation-banner p:last-child {
-  margin-bottom: 0;
-}
-
-.claude-legacy-warning {
-  font-size: 0.85rem;
-  opacity: 0.75;
-  margin-bottom: 1rem;
-}
-
-.claude-legacy .btn {
-  font-size: 0.85rem;
-}
-
-.claude-status {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.claude-status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--status-success, #3fb950);
-}
-
-.claude-status-text {
-  margin: 0;
-}
-
-.claude-oauth-progress-container {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
-}
-
-.claude-oauth-paste-row {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.claude-oauth-signed-in {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
-
-.claude-oauth-error {
-  color: var(--status-error, #f85149);
-  margin-top: 0.5rem;
 }
 
 .tab-content {
@@ -2836,4 +2945,389 @@ export default defineComponent({
   color: var(--text-muted, var(--muted));
 }
 
+</style>
+
+<!-- ─────────────────────────────────────────────────────────────
+     Unified "noir / steel-blue" restyle. This block is intentionally
+     LAST so its rules win at equal specificity, retuning the shared
+     chrome (header, sidebar, inputs, buttons) across EVERY tab, plus
+     the System Prompt master → detail styles.
+     ───────────────────────────────────────────────────────────── -->
+<style lang="scss" scoped>
+.lm-settings {
+  // Theme-driven aliases. Every value resolves from the ACTIVE theme's tokens
+  // (Protocol gives the steel-blue/noir/mono look; Ocean/Nord/Default give
+  // their own). Fallbacks are generic (never a pinned brand colour) so nothing
+  // is hardcoded and every theme renders correctly.
+  --sp-accent:        var(--accent-primary);
+  --sp-accent-dim:    var(--bg-active, var(--bg-surface-hover));
+  --sp-accent-border: var(--border-accent, var(--border-default));
+  --sp-bg:            var(--bg-page, var(--bg));
+  --sp-surface-1:     var(--bg-surface, var(--surface-1));
+  --sp-surface-2:     var(--bg-surface-alt, var(--surface-2));
+  --sp-surface-3:     var(--bg-surface-hover, var(--surface-3));
+  --sp-border:        var(--border-default, var(--border-muted));
+  --sp-text:          var(--text-primary, var(--text));
+  --sp-text-muted:    var(--text-muted);
+  --sp-text-dim:      var(--text-dim, var(--text-muted));
+
+  // Body font follows the theme's monospace token; headings follow an optional
+  // per-theme display token, falling back to inherit (never a pinned face).
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  background: var(--sp-bg);
+  color: var(--sp-text);
+}
+
+.lm-header {
+  background: var(--sp-surface-1);
+
+  h1 {
+    font-family: var(--font-display, inherit);
+    font-size: 1.1rem;
+    letter-spacing: 0.01em;
+  }
+}
+
+.lm-nav {
+  background: var(--sp-surface-1);
+
+  .nav-item {
+    font-size: 0.82rem;
+
+    &.active {
+      background: var(--sp-accent-dim);
+      color: var(--sp-text);
+      border-left: 2px solid var(--sp-accent);
+    }
+
+    &:hover:not(.active) {
+      background: var(--sp-surface-2);
+    }
+  }
+}
+
+.tab-content {
+  h2 {
+    font-family: var(--font-display, inherit);
+    font-size: 1.35rem;
+    font-weight: 600;
+  }
+}
+
+// Shared form controls — retuned for the whole window.
+.text-input,
+.model-select {
+  background-color: var(--sp-surface-2);
+  border: 1px solid var(--sp-border);
+  border-radius: 6px;
+  color: var(--sp-text);
+  font-family: inherit;
+  font-size: 0.82rem;
+
+  &:focus {
+    outline: none;
+    border-color: var(--sp-accent);
+  }
+}
+
+.btn.role-primary {
+  background: var(--sp-accent);
+  border-color: var(--sp-accent);
+  color: var(--text-on-accent, #fff);
+  font-weight: 600;
+}
+
+.switch input:checked + .slider {
+  background-color: var(--sp-accent);
+}
+
+// ── System Prompt tab ───────────────────────────────────────────
+.sp-identity {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  max-width: 640px;
+
+  .form-group { flex: 1; }
+
+  .form-label {
+    display: block;
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+    color: var(--sp-text-dim);
+    margin-bottom: 0.35rem;
+    text-transform: uppercase;
+  }
+
+  .text-input { width: 100%; }
+}
+
+.sp-list-header {
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  color: var(--sp-text-dim);
+  margin-bottom: 0.6rem;
+}
+
+.sp-list {
+  border: 1px solid var(--sp-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.sp-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 0.85rem;
+  border-bottom: 1px solid var(--sp-border);
+  cursor: pointer;
+  transition: background 0.12s;
+
+  &:last-child { border-bottom: none; }
+  &:hover { background: var(--sp-surface-1); }
+  &--disabled { opacity: 0.5; }
+
+  .sp-grip {
+    color: var(--sp-text-dim);
+    cursor: grab;
+    font-size: 0.8rem;
+  }
+
+  .sp-row-main { flex: 1; min-width: 0; }
+
+  .sp-row-title {
+    font-size: 0.85rem;
+    color: var(--sp-text);
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .sp-row-snippet {
+    font-size: 0.72rem;
+    color: var(--sp-text-dim);
+    margin-top: 0.2rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .sp-chevron {
+    color: var(--sp-text-dim);
+    font-size: 1.1rem;
+  }
+}
+
+.sp-badge {
+  font-size: 0.62rem;
+  padding: 0.12rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid var(--sp-border);
+  color: var(--sp-text-muted);
+  white-space: nowrap;
+
+  &--accent { color: var(--sp-accent); border-color: var(--sp-accent-border); }
+  &--custom { color: var(--status-info, var(--info)); border-color: var(--border-info, var(--sp-border)); }
+  &--warn   { color: var(--status-warning, var(--warning)); border-color: var(--border-warning, var(--sp-border)); }
+  &--dim    { color: var(--sp-text-dim); }
+}
+
+.sp-list-actions { margin-top: 0.85rem; }
+
+// Detail view
+.sp-tab {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.sp-detail-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.75rem;
+
+  .sp-detail-bar-spacer { flex: 1; }
+}
+
+.sp-back {
+  color: var(--sp-accent);
+  font-size: 0.82rem;
+  cursor: pointer;
+
+  &:hover { text-decoration: underline; }
+}
+
+.sp-mini-btn {
+  font-size: 0.72rem;
+  padding: 0.25rem 0.6rem;
+}
+
+.sp-detail-head {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin-bottom: 0.85rem;
+
+  h2 { margin: 0; }
+
+  .sp-detail-meta {
+    font-size: 0.72rem;
+    color: var(--sp-text-dim);
+  }
+}
+
+.sp-editor {
+  flex: 1;
+  min-height: 320px;
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--sp-surface-2);
+  border: 1px solid var(--sp-border);
+  border-radius: 8px;
+  color: var(--sp-text);
+  font-family: var(--font-mono, ui-monospace, Menlo, monospace);
+  font-size: 0.82rem;
+  line-height: 1.6;
+  padding: 0.9rem;
+  resize: none;
+
+  &:focus { outline: none; border-color: var(--sp-accent); }
+}
+
+.sp-generated {
+  margin-top: 0.75rem;
+  border: 1px dashed var(--sp-border);
+  border-radius: 8px;
+  background: var(--sp-surface-1);
+  padding: 0.65rem 0.8rem;
+
+  .sp-generated-label {
+    font-size: 0.65rem;
+    letter-spacing: 0.05em;
+    color: var(--sp-text-dim);
+    margin-bottom: 0.4rem;
+  }
+
+  .sp-generated-body {
+    margin: 0;
+    font-family: var(--font-mono, ui-monospace, Menlo, monospace);
+    font-size: 0.72rem;
+    color: var(--sp-text-dim);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}
+
+.sp-detail-actions {
+  margin-top: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+// ── Staged AI edits: review banner, pending badge, rationale, diff ──
+.sp-review-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 14px;
+  margin-bottom: 16px;
+  border-radius: 8px;
+  background: var(--bg-warning, rgba(254, 188, 46, .08));
+  border: 1px solid var(--border-warning, var(--sp-border));
+
+  .sp-review-banner-icon { font-size: 15px; }
+  .sp-review-banner-text { flex: 1; }
+  .sp-review-banner-title { font-size: 13px; color: var(--sp-text); }
+  .sp-review-banner-sub { font-size: 11px; color: var(--sp-text-dim); margin-top: 2px; }
+
+  .sp-review-banner-btn {
+    background: var(--status-warning, var(--warning));
+    border: none;
+    color: var(--text-on-accent, #1a1300);
+    font-weight: 600;
+    font-size: 12px;
+    padding: 7px 13px;
+  }
+}
+
+.sp-badge--pending {
+  color: var(--status-warning, var(--warning));
+  border-color: var(--border-warning, var(--sp-border));
+  background: var(--bg-warning, rgba(254, 188, 46, .08));
+  cursor: pointer;
+}
+
+.sp-review-by {
+  font-size: 11px;
+  color: var(--sp-text-muted);
+  margin-bottom: 14px;
+
+  strong { color: var(--sp-text); }
+}
+
+.sp-rationale {
+  border-left: 2px solid var(--sp-accent);
+  background: var(--sp-surface-1);
+  padding: 10px 14px;
+  border-radius: 0 6px 6px 0;
+  margin-bottom: 16px;
+
+  .sp-rationale-label {
+    font-size: 10px;
+    letter-spacing: .05em;
+    color: var(--sp-text-dim);
+    margin-bottom: 4px;
+  }
+  .sp-rationale-body {
+    font-size: 12px;
+    color: var(--sp-text-muted);
+    line-height: 1.5;
+  }
+}
+
+.sp-diff {
+  border: 1px solid var(--sp-border);
+  border-radius: 8px;
+  overflow: auto;
+  max-height: 46vh;
+  font-family: var(--font-mono, ui-monospace, Menlo, monospace);
+  font-size: 12px;
+  line-height: 1.7;
+}
+
+.sp-diff-line {
+  display: flex;
+  gap: 8px;
+  padding: 0 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+
+  .sp-diff-gutter { width: 0.8em; flex-shrink: 0; text-align: center; opacity: .8; }
+  .sp-diff-text { flex: 1; }
+
+  &.sp-diff-ctx  { color: var(--sp-text-dim); }
+  &.sp-diff-add  { background: var(--bg-success, rgba(40, 200, 64, .12)); color: var(--status-success, var(--success)); }
+  &.sp-diff-del  { background: var(--bg-error, rgba(255, 95, 87, .12)); color: var(--status-error, var(--danger)); }
+}
+
+.sp-approve-btn {
+  background: var(--status-success, var(--success));
+  border: none;
+  color: var(--text-on-accent, #04120a);
+  font-weight: 600;
+}
+
+.sp-deny-btn {
+  background: transparent;
+  border: 1px solid var(--border-error, var(--sp-border));
+  color: var(--status-error, var(--danger));
+}
+
+.sp-review-note {
+  font-size: 11px;
+  color: var(--sp-text-dim);
+}
 </style>


### PR DESCRIPTION
## DB-backed editable system prompt + staged AI-edit approval

Moves the agent system prompt into an editable Postgres-backed set of sections (surfaced under **Language Model Settings → System Prompt**) and adds a human-in-the-loop approval flow for AI-proposed edits.

### Whats here
- **Schema:** migrations `0048` (`sulla_system_prompt_sections`) + `0049` (`sulla_system_prompt_section_edits`). Schema-only; rows seeded at runtime from the baked native fallbacks.
- **Models:** `SystemPromptSectionModel` (CRUD + `seedDefaults`, `is_customized` drift policy) and `SystemPromptSectionEditModel` (propose / approve / deny).
- **Prompt engine:** `SystemPromptBuilder.build()` layers DB rows **beneath** agent `.md` overrides and **above** the baked factories; custom rows injected as new sections; `environment` stays factory-composed (DB static preamble + live runtime tail). `BaseNode` loads enabled rows into `ctx.dbSections`; disabled rows exclude their section.
- **IPC:** `system-prompt:*` and `system-prompt-edits:*` handlers.
- **UI:** System Prompt tab (list → full-height editor; add / reset / delete / toggle), theme-driven restyle (follows the active theme — Protocol = steel-blue/noir/mono), removal of the deprecated Claude Code tab, and the staged-edit review flow (banner + per-row proposed badge + red/green diff with Approve & apply / Edit & approve / Deny).

### Resolution order
`agent .md override` → `DB row (editable core)` → `baked factory (shipped default)`. The DB layer is optional and fallback-safe: an empty/unreachable DB falls back to the baked factories.

### Status: 🚧 implementation — NOT yet built or run
- [ ] Rebuild + typecheck; eyeball the live composed prompt
- [ ] Wire the agent-facing `propose_system_prompt_edit` tool (so agents can actually stage edits)
- [ ] `environment` generated-preview currently reads a placeholder setting key — wire to real `installed_extensions`

_Note: files were uploaded via the `sulla github/*` API tools (one commit per file) since this install has no local-push tool; squash on merge._