### PR TITLE
fix: harden identity observation date formatting

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
@@ -30,8 +30,8 @@ export interface IdentityObservationRecord {
   category:   string | null;
   content:    string;
   basis:      string | null;
-  created_at: string;
-  updated_at: string | null;
+  created_at: string | Date;
+  updated_at: string | Date | null;
   archived:   boolean;
   source:     string | null;
 }

--- a/pkg/rancher-desktop/agent/database/models/ObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/ObservationsModel.ts
@@ -20,8 +20,8 @@ export interface ObservationRecord {
   id:         string;
   priority:   string;
   content:    string;
-  created_at: string;
-  updated_at: string | null;
+  created_at: string | Date;
+  updated_at: string | Date | null;
   archived:   boolean;
   source:     string | null;
 }

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -21,6 +21,7 @@ import { ObservationsModel } from '../database/models/ObservationsModel';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { GraphRegistry, type DigestibleToolResult } from '../services/GraphRegistry';
 import { parseJson } from '../services/JsonParseService';
+import { formatDateOnly } from '../utils/formatDateOnly';
 
 import Logging from '@pkg/utils/logging';
 
@@ -511,7 +512,7 @@ function extractLatestUserText(state: BaseThreadState): string {
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i];
     if (m?.role !== 'user') continue;
-    if ((m?.metadata as any)?.source === 'subconscious') continue;
+    if (m?.metadata?.source === 'subconscious') continue;
 
     const c = m?.content;
     if (typeof c === 'string') {
@@ -572,7 +573,7 @@ async function runObservationRecall(state: BaseThreadState): Promise<string | nu
     }
 
     const response = rows
-      .map((r) => `[${ r.id }] ${ r.priority } ${ (r.created_at || '').slice(0, 10) } — ${ r.content }`)
+      .map((r) => `[${ r.id }] ${ r.priority } ${ formatDateOnly(r.created_at) } — ${ r.content }`)
       .join('\n');
 
     perf.log(`[ObservationRecall] threadId=${ threadId } matched=${ rows.length } chars=${ response.length } ms=${ elapsed } path=sql-fast-path`);
@@ -640,7 +641,7 @@ async function runIdentityObservationRecall(state: BaseThreadState, domain: stri
     }
 
     const response = rows
-      .map((r) => `[${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ (r.created_at || '').slice(0, 10) } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }`)
+      .map((r) => `[${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ formatDateOnly(r.created_at) } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }`)
       .join('\n');
 
     perf.log(`[IdentityRecall] threadId=${ threadId } domain=${ domain } matched=${ rows.length } chars=${ response.length } ms=${ elapsed } path=sql-fast-path`);

--- a/pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts
+++ b/pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts
@@ -22,6 +22,7 @@
 import { ObservationsModel } from '../../database/models/ObservationsModel';
 import { SullaSettingsModel } from '../../database/models/SullaSettingsModel';
 import { parseJson } from '../../services/JsonParseService';
+import { formatDateOnly } from '../../utils/formatDateOnly';
 
 import type { PromptBuildContext, PromptSection } from '../SystemPromptBuilder';
 
@@ -44,7 +45,7 @@ export async function buildObservationalMemorySection(
 
     if (rows.length > 0) {
       const lines = rows.map((r) =>
-        `- [id:${ r.id }] ${ r.priority } ${ r.created_at.slice(0, 10) } — ${ r.content }`.trim(),
+        `- [id:${ r.id }] ${ r.priority } ${ formatDateOnly(r.created_at) } — ${ r.content }`.trim(),
       );
 
       const content = `## Memory (top-${ TOP_N } observations)

--- a/pkg/rancher-desktop/agent/tools/meta/__tests__/identity_observations.test.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/__tests__/identity_observations.test.ts
@@ -119,7 +119,9 @@ describe('identity observation tools', () => {
   });
 
   it('lists active rows in compact certainty-first format', async() => {
-    jest.spyOn(IdentityObservationsModel, 'listActive').mockResolvedValue([row()]);
+    jest.spyOn(IdentityObservationsModel, 'listActive').mockResolvedValue([row({
+      created_at: new Date('2026-08-19T18:00:00.000Z'),
+    })]);
 
     const result = await listWorker().invoke({
       domain: 'human',

--- a/pkg/rancher-desktop/agent/tools/meta/list_identity_observations.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/list_identity_observations.ts
@@ -1,4 +1,5 @@
 import { IdentityObservationsModel } from '../../database/models/IdentityObservationsModel';
+import { formatDateOnly } from '../../utils/formatDateOnly';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -29,7 +30,7 @@ export class ListIdentityObservationsWorker extends BaseTool {
       }
 
       const lines = rows.map(r =>
-        `[id:${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ (r.created_at || '').slice(0, 10) } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }`,
+        `[id:${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ formatDateOnly(r.created_at) } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }`,
       );
 
       return {

--- a/pkg/rancher-desktop/agent/utils/__tests__/formatDateOnly.test.ts
+++ b/pkg/rancher-desktop/agent/utils/__tests__/formatDateOnly.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { formatDateOnly } from '../formatDateOnly';
+
+describe('formatDateOnly', () => {
+  it('formats Date objects without relying on string methods', () => {
+    expect(formatDateOnly(new Date('2026-08-19T18:00:00.000Z'))).toBe('2026-08-19');
+  });
+
+  it('preserves existing ISO string behavior', () => {
+    expect(formatDateOnly('2026-08-19T18:00:00.000Z')).toBe('2026-08-19');
+  });
+
+  it('returns an empty string for missing or invalid Date values', () => {
+    expect(formatDateOnly(null)).toBe('');
+    expect(formatDateOnly(new Date('not-a-date'))).toBe('');
+  });
+});

--- a/pkg/rancher-desktop/agent/utils/formatDateOnly.ts
+++ b/pkg/rancher-desktop/agent/utils/formatDateOnly.ts
@@ -1,0 +1,18 @@
+export function formatDateOnly(value: unknown): string {
+  if (!value) return '';
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? '' : value.toISOString().slice(0, 10);
+  }
+
+  if (typeof value === 'string') {
+    return value.slice(0, 10);
+  }
+
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? '' : date.toISOString().slice(0, 10);
+  }
+
+  return String(value).slice(0, 10);
+}


### PR DESCRIPTION
## Summary
- Reproduces and fixes the live `list_identity_observations` Date-object crash.
- Adds a shared `formatDateOnly` helper for Date/string/null-safe date rendering.
- Uses the helper in identity list, deterministic observation recall, identity observation recall, and prompt observational-memory formatting.
- Updates observation model timestamp types to match runtime Postgres `Date` values.

## Verification
- `sulla observation/list_identity_observations` reproduced the current live failure: `(e.created_at || "").slice is not a function`.
- `node --experimental-vm-modules node_modules/jest/bin/jest.js pkg/rancher-desktop/agent/tools/meta/__tests__/identity_observations.test.ts pkg/rancher-desktop/agent/utils/__tests__/formatDateOnly.test.ts --runInBand` passed: 2 suites, 8 tests.
- Focused ESLint JSON run passed with 0 errors / 0 warnings for touched TS files.
- `git diff --check` passed.
- `grep -RIn "created_at.*slice\|updated_at.*slice" pkg/rancher-desktop/agent` returned no matches after the patch.

## Gate
Draft until review/rebuild/restart. Live Sulla CLI will keep showing the old failure until this branch lands and Desktop is rebuilt.