### PR TITLE
Harden identity observations and add model inventory tools

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0050_create_identity_observations_table.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0050_create_identity_observations_table.ts
@@ -18,7 +18,7 @@
 export const up = `
   CREATE TABLE IF NOT EXISTS identity_observations (
     id          TEXT        PRIMARY KEY,
-    domain      TEXT        NOT NULL DEFAULT 'human',
+    domain      TEXT        NOT NULL DEFAULT 'human' CHECK (domain IN ('human', 'business', 'world', 'agent')),
     level       SMALLINT    NOT NULL DEFAULT 2 CHECK (level IN (1, 2, 3)),
     category    TEXT,
     content     TEXT        NOT NULL,

--- a/pkg/rancher-desktop/agent/database/migrations/0051_constrain_identity_observation_domains.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0051_constrain_identity_observation_domains.ts
@@ -1,0 +1,31 @@
+/**
+ * Migration 0051 — Constrain identity observation domains.
+ *
+ * 0050 introduced a domain-keyed table intended to mirror ~/sulla/identity/
+ * (human / business / world / agent). Add the database guard for installs that
+ * already ran 0050 before the CHECK constraint was present. NOT VALID avoids
+ * blocking startup if historical bad-domain rows exist, while still enforcing
+ * the constraint for new and updated rows.
+ */
+
+export const up = `
+  DO $$
+  BEGIN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_constraint
+      WHERE conname = 'identity_observations_domain_check'
+        AND conrelid = 'identity_observations'::regclass
+    ) THEN
+      ALTER TABLE identity_observations
+        ADD CONSTRAINT identity_observations_domain_check
+        CHECK (domain IN ('human', 'business', 'world', 'agent'))
+        NOT VALID;
+    END IF;
+  END $$;
+`;
+
+export const down = `
+  ALTER TABLE identity_observations
+    DROP CONSTRAINT IF EXISTS identity_observations_domain_check;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -39,6 +39,7 @@ import { up as up_0047, down as down_0047 } from './0047_add_work_task_actor';
 import { up as up_0048, down as down_0048 } from './0048_create_system_prompt_sections_table';
 import { up as up_0049, down as down_0049 } from './0049_create_system_prompt_section_edits_table';
 import { up as up_0050, down as down_0050 } from './0050_create_identity_observations_table';
+import { up as up_0051, down as down_0051 } from './0051_constrain_identity_observation_domains';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -78,4 +79,5 @@ export const migrationsRegistry = [
   { name: '0048_create_system_prompt_sections_table',          up: up_0048, down: down_0048 },
   { name: '0049_create_system_prompt_section_edits_table',      up: up_0049, down: down_0049 },
   { name: '0050_create_identity_observations_table',            up: up_0050, down: down_0050 },
+  { name: '0051_constrain_identity_observation_domains',         up: up_0051, down: down_0051 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
@@ -22,6 +22,12 @@ import { postgresClient } from '../PostgresClient';
 export type IdentityDomain = 'human' | 'business' | 'world' | 'agent';
 
 export const IDENTITY_DOMAINS: IdentityDomain[] = ['human', 'business', 'world', 'agent'];
+const MAX_CONTENT_CHARS = 1200;
+const MAX_BASIS_CHARS = 600;
+const MAX_LABEL_CHARS = 80;
+const MAX_SOURCE_CHARS = 120;
+const DEFAULT_LIST_LIMIT = 100;
+const MAX_LIST_LIMIT = 100;
 
 export interface IdentityObservationRecord {
   id:         string;
@@ -30,8 +36,8 @@ export interface IdentityObservationRecord {
   category:   string | null;
   content:    string;
   basis:      string | null;
-  created_at: string;
-  updated_at: string | null;
+  created_at: string | Date;
+  updated_at: string | Date | null;
   archived:   boolean;
   source:     string | null;
 }
@@ -65,9 +71,69 @@ function generateTinyId(): string {
   return id;
 }
 
-function clampLevel(level: any): number {
+export function normalizeIdentityLevel(level: unknown): number {
   const n = Number(level);
-  return n === 1 || n === 2 || n === 3 ? n : 2;
+  if (n === 1 || n === 2 || n === 3) return n;
+  throw new Error(`Invalid identity certainty level "${ String(level) }"; expected 1, 2, or 3.`);
+}
+
+export function normalizeIdentityDomain(domain: unknown): IdentityDomain {
+  const normalized = typeof domain === 'string' && domain.trim()
+    ? domain.trim().toLowerCase()
+    : 'human';
+
+  if (IDENTITY_DOMAINS.includes(normalized as IdentityDomain)) {
+    return normalized as IdentityDomain;
+  }
+
+  throw new Error(`Invalid identity domain "${ String(domain) }"; expected one of: ${ IDENTITY_DOMAINS.join(', ') }`);
+}
+
+export function normalizeIdentityLimit(limit: unknown, fallback = DEFAULT_LIST_LIMIT): number {
+  const n = Math.floor(Number(limit));
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.min(n, MAX_LIST_LIMIT);
+}
+
+function normalizeRequiredText(value: unknown, field: string, maxChars: number): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${ field } must be a string.`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${ field } is required.`);
+  }
+  if (trimmed.length > maxChars) {
+    throw new Error(`${ field } must be ${ maxChars } characters or fewer.`);
+  }
+  return trimmed;
+}
+
+function normalizeOptionalText(value: unknown, field: string, maxChars: number): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== 'string') {
+    throw new Error(`${ field } must be a string.`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > maxChars) {
+    throw new Error(`${ field } must be ${ maxChars } characters or fewer.`);
+  }
+  return trimmed;
+}
+
+export function formatIdentityObservationDate(value: unknown): string {
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? value.slice(0, 10) : parsed.toISOString().slice(0, 10);
+  }
+
+  return '';
 }
 
 // ── Model ──────────────────────────────────────────────────────────────
@@ -80,7 +146,7 @@ export class IdentityObservationsModel {
       await postgresClient.query(`
         CREATE TABLE IF NOT EXISTS ${ IdentityObservationsModel.TABLE } (
           id          TEXT        PRIMARY KEY,
-          domain      TEXT        NOT NULL DEFAULT 'human',
+          domain      TEXT        NOT NULL DEFAULT 'human' CHECK (domain IN ('human', 'business', 'world', 'agent')),
           level       SMALLINT    NOT NULL DEFAULT 2 CHECK (level IN (1, 2, 3)),
           category    TEXT,
           content     TEXT        NOT NULL,
@@ -106,18 +172,21 @@ export class IdentityObservationsModel {
 
   static async insert(input: InsertIdentityObservationInput): Promise<IdentityObservationRecord> {
     const id = input.id || generateTinyId();
+    const category = normalizeOptionalText(input.category, 'category', MAX_LABEL_CHARS);
+    const basis = normalizeOptionalText(input.basis, 'basis', MAX_BASIS_CHARS);
+    const source = normalizeOptionalText(input.source, 'source', MAX_SOURCE_CHARS);
     const rows = await postgresClient.query<IdentityObservationRecord>(
       `INSERT INTO ${ IdentityObservationsModel.TABLE } (id, domain, level, category, content, basis, source)
        VALUES ($1, $2, $3, $4, $5, $6, $7)
        RETURNING *`,
       [
         id,
-        input.domain || 'human',
-        clampLevel(input.level),
-        input.category ?? null,
-        input.content,
-        input.basis ?? null,
-        input.source ?? null,
+        normalizeIdentityDomain(input.domain),
+        normalizeIdentityLevel(input.level),
+        category ?? null,
+        normalizeRequiredText(input.content, 'content', MAX_CONTENT_CHARS),
+        basis ?? null,
+        source ?? null,
       ],
     );
     return rows[0];
@@ -130,23 +199,23 @@ export class IdentityObservationsModel {
 
     if (changes.level !== undefined) {
       setClauses.push(`level = $${ idx++ }`);
-      values.push(clampLevel(changes.level));
+      values.push(normalizeIdentityLevel(changes.level));
     }
     if (changes.category !== undefined) {
       setClauses.push(`category = $${ idx++ }`);
-      values.push(changes.category);
+      values.push(normalizeOptionalText(changes.category, 'category', MAX_LABEL_CHARS));
     }
     if (changes.content !== undefined) {
       setClauses.push(`content = $${ idx++ }`);
-      values.push(changes.content);
+      values.push(normalizeRequiredText(changes.content, 'content', MAX_CONTENT_CHARS));
     }
     if (changes.basis !== undefined) {
       setClauses.push(`basis = $${ idx++ }`);
-      values.push(changes.basis);
+      values.push(normalizeOptionalText(changes.basis, 'basis', MAX_BASIS_CHARS));
     }
     if (changes.source !== undefined) {
       setClauses.push(`source = $${ idx++ }`);
-      values.push(changes.source);
+      values.push(normalizeOptionalText(changes.source, 'source', MAX_SOURCE_CHARS));
     }
 
     if (setClauses.length === 1) return null; // nothing to update
@@ -186,19 +255,20 @@ export class IdentityObservationsModel {
     domain: string,
     opts: { level?: number; category?: string; limit?: number } = {},
   ): Promise<IdentityObservationRecord[]> {
+    const normalizedDomain = normalizeIdentityDomain(domain);
     const conds = ['archived = false', 'domain = $1'];
-    const values: any[] = [domain];
+    const values: any[] = [normalizedDomain];
     let idx = 2;
 
     if (opts.level !== undefined) {
       conds.push(`level = $${ idx++ }`);
-      values.push(clampLevel(opts.level));
+      values.push(normalizeIdentityLevel(opts.level));
     }
     if (opts.category) {
       conds.push(`category = $${ idx++ }`);
-      values.push(opts.category);
+      values.push(normalizeOptionalText(opts.category, 'category', MAX_LABEL_CHARS));
     }
-    values.push(opts.limit ?? 100);
+    values.push(normalizeIdentityLimit(opts.limit, DEFAULT_LIST_LIMIT));
 
     return postgresClient.query<IdentityObservationRecord>(
       `SELECT * FROM ${ IdentityObservationsModel.TABLE }
@@ -220,6 +290,8 @@ export class IdentityObservationsModel {
     limit = 20,
     includeArchived = false,
   ): Promise<IdentityObservationRecord[]> {
+    const normalizedDomain = normalizeIdentityDomain(domain);
+    const normalizedLimit = normalizeIdentityLimit(limit, 20);
     const activeCond = includeArchived ? 'true' : 'archived = false';
     const words = ObservationsModel.tokenizeQuery(query);
 
@@ -230,7 +302,7 @@ export class IdentityObservationsModel {
            AND content ILIKE $2
          ORDER BY level DESC, created_at DESC
          LIMIT $3`,
-        [domain, `%${ query }%`, limit],
+        [normalizedDomain, `%${ query }%`, normalizedLimit],
       );
     }
 
@@ -243,7 +315,7 @@ export class IdentityObservationsModel {
          AND (content ILIKE $2 OR ${ wordConds.join(' OR ') })
        ORDER BY (content ILIKE $2)::int DESC, (${ matchScore }) DESC, level DESC, created_at DESC
        LIMIT $3`,
-      [domain, `%${ query }%`, limit, ...words.map(w => `%${ w }%`)],
+      [normalizedDomain, `%${ query }%`, normalizedLimit, ...words.map(w => `%${ w }%`)],
     );
   }
 
@@ -253,10 +325,10 @@ export class IdentityObservationsModel {
    * ObservationsModel.findDuplicate, scoped by domain.
    */
   static async findDuplicate(domain: string, content: string): Promise<IdentityObservationRecord | null> {
-    const rows = await IdentityObservationsModel.listActive(domain, { limit: 500 });
+    const rows = await IdentityObservationsModel.listActive(normalizeIdentityDomain(domain), { limit: 500 });
     const normalise = (s: string) =>
       s.toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/\s+/g, ' ').trim();
-    const norm = normalise(content);
+    const norm = normalise(normalizeRequiredText(content, 'content', MAX_CONTENT_CHARS));
 
     for (const row of rows) {
       const existing = normalise(row.content);

--- a/pkg/rancher-desktop/agent/database/models/ObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/ObservationsModel.ts
@@ -20,8 +20,8 @@ export interface ObservationRecord {
   id:         string;
   priority:   string;
   content:    string;
-  created_at: string;
-  updated_at: string | null;
+  created_at: string | Date;
+  updated_at: string | Date | null;
   archived:   boolean;
   source:     string | null;
 }
@@ -50,6 +50,19 @@ function generateTinyId(): string {
     id += chars.charAt(Math.floor(Math.random() * chars.length));
   }
   return id;
+}
+
+export function formatObservationDate(value: unknown): string {
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+
+  if (typeof value === 'string') {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? value.slice(0, 10) : parsed.toISOString().slice(0, 10);
+  }
+
+  return '';
 }
 
 // ── Model ──────────────────────────────────────────────────────────────

--- a/pkg/rancher-desktop/agent/database/models/__tests__/IdentityObservationsModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/IdentityObservationsModel.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { postgresClient } from '../../PostgresClient';
-import { IdentityObservationsModel } from '../IdentityObservationsModel';
+import { formatIdentityObservationDate, IdentityObservationsModel, normalizeIdentityDomain } from '../IdentityObservationsModel';
 
 describe('IdentityObservationsModel', () => {
   let originalQuery: any;
@@ -18,7 +18,7 @@ describe('IdentityObservationsModel', () => {
     jest.restoreAllMocks();
   });
 
-  it('inserts domain-scoped observations with clamped certainty levels', async() => {
+  it('inserts domain-scoped observations with normalized fields', async() => {
     const inserted = {
       id:         'hum1',
       domain:     'human',
@@ -35,12 +35,12 @@ describe('IdentityObservationsModel', () => {
 
     const row = await IdentityObservationsModel.insert({
       id:       'hum1',
-      domain:   'human',
-      level:    9,
-      category: 'preference',
-      content:  'Jonathon prefers direct status reports.',
-      basis:    'Repeated instruction in chat.',
-      source:   'test',
+      domain:   ' Human ',
+      level:    2,
+      category: ' preference ',
+      content:  ' Jonathon prefers direct status reports. ',
+      basis:    ' Repeated instruction in chat. ',
+      source:   ' test ',
     });
 
     expect(postgresClient.query).toHaveBeenCalledWith(
@@ -48,6 +48,58 @@ describe('IdentityObservationsModel', () => {
       ['hum1', 'human', 2, 'preference', 'Jonathon prefers direct status reports.', 'Repeated instruction in chat.', 'test'],
     );
     expect(row).toBe(inserted);
+  });
+
+  it('rejects invalid domains and certainty levels instead of coercing them', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:      'bad1',
+      domain:  'bogus',
+      level:   3,
+      content: 'Should fail.',
+    })).rejects.toThrow('Invalid identity domain');
+
+    await expect(IdentityObservationsModel.insert({
+      id:      'bad2',
+      domain:  'human',
+      level:   9,
+      content: 'Should fail.',
+    })).rejects.toThrow('Invalid identity certainty level');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty or overlong content before writing', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:      'bad3',
+      domain:  'human',
+      level:   3,
+      content: '   ',
+    })).rejects.toThrow('content is required');
+
+    await expect(IdentityObservationsModel.insert({
+      id:      'bad4',
+      domain:  'human',
+      level:   3,
+      content: 'x'.repeat(1201),
+    })).rejects.toThrow('content must be 1200 characters or fewer');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('normalizes supported identity domains and rejects unsupported domains', () => {
+    expect(normalizeIdentityDomain(undefined)).toBe('human');
+    expect(normalizeIdentityDomain(' Business ')).toBe('business');
+    expect(() => normalizeIdentityDomain('not-a-domain')).toThrow('Invalid identity domain');
+  });
+
+  it('formats Date and string timestamps consistently for tool output', () => {
+    expect(formatIdentityObservationDate(new Date('2026-08-19T18:00:00.000Z'))).toBe('2026-08-19');
+    expect(formatIdentityObservationDate('2026-08-19T18:00:00.000Z')).toBe('2026-08-19');
+    expect(formatIdentityObservationDate(null)).toBe('');
   });
 
   it('updates only provided mutable fields and stamps updated_at', async() => {
@@ -83,10 +135,19 @@ describe('IdentityObservationsModel', () => {
     expect(params).toEqual(['human', 3, 'identity', 12]);
   });
 
+  it('bounds list limits to protect prompt context size', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await IdentityObservationsModel.listActive('human', { limit: 10000 });
+
+    const [, params] = (postgresClient.query as any).mock.calls[0];
+    expect(params).toEqual(['human', 100]);
+  });
+
   it('searches by phrase and meaningful words within one domain', async() => {
     (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
 
-    await IdentityObservationsModel.search('human', 'direct status reports', 5, false);
+    await IdentityObservationsModel.search('human', 'direct status reports', 5000, false);
 
     const [sql, params] = (postgresClient.query as any).mock.calls[0];
     expect(sql).toContain('archived = false');
@@ -96,7 +157,7 @@ describe('IdentityObservationsModel', () => {
     expect(params).toEqual([
       'human',
       '%direct status reports%',
-      5,
+      100,
       '%direct%',
       '%status%',
       '%reports%',

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -16,8 +16,8 @@
  * Logs are written to ~/sulla/logs/ and can be inspected for debugging.
  */
 
-import { IdentityObservationsModel } from '../database/models/IdentityObservationsModel';
-import { ObservationsModel } from '../database/models/ObservationsModel';
+import { formatIdentityObservationDate, IdentityObservationsModel } from '../database/models/IdentityObservationsModel';
+import { formatObservationDate, ObservationsModel } from '../database/models/ObservationsModel';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { GraphRegistry, type DigestibleToolResult } from '../services/GraphRegistry';
 import { parseJson } from '../services/JsonParseService';
@@ -507,7 +507,7 @@ const OBSERVATION_RECALL_MAX_ROWS = 8;
  * that carries any (string or text-block) content.
  */
 function extractLatestUserText(state: BaseThreadState): string {
-  const messages = state.messages as any[];
+  const messages = state.messages;
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i];
     if (m?.role !== 'user') continue;
@@ -572,7 +572,7 @@ async function runObservationRecall(state: BaseThreadState): Promise<string | nu
     }
 
     const response = rows
-      .map((r) => `[${ r.id }] ${ r.priority } ${ (r.created_at || '').slice(0, 10) } — ${ r.content }`)
+      .map((r) => `[${ r.id }] ${ r.priority } ${ formatObservationDate(r.created_at) } — ${ r.content }`)
       .join('\n');
 
     perf.log(`[ObservationRecall] threadId=${ threadId } matched=${ rows.length } chars=${ response.length } ms=${ elapsed } path=sql-fast-path`);
@@ -640,7 +640,7 @@ async function runIdentityObservationRecall(state: BaseThreadState, domain: stri
     }
 
     const response = rows
-      .map((r) => `[${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ (r.created_at || '').slice(0, 10) } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }`)
+      .map((r) => `[${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ formatIdentityObservationDate(r.created_at) } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }`)
       .join('\n');
 
     perf.log(`[IdentityRecall] threadId=${ threadId } domain=${ domain } matched=${ rows.length } chars=${ response.length } ms=${ elapsed } path=sql-fast-path`);

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -16,7 +16,6 @@
  * Logs are written to ~/sulla/logs/ and can be inspected for debugging.
  */
 
-import { formatIdentityObservationDate, IdentityObservationsModel } from '../database/models/IdentityObservationsModel';
 import { formatObservationDate, ObservationsModel } from '../database/models/ObservationsModel';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { GraphRegistry, type DigestibleToolResult } from '../services/GraphRegistry';
@@ -228,10 +227,10 @@ export async function runSubconsciousMiddleware(
     });
   }
 
-  // 3d. Identity Observation Recall — awaited: deterministic SQL fast-path
-  //     (no LLM, same design as 3b). Compiles the most important human
-  //     observations — most certain first (L3 stated → L2 derived → L1
-  //     concluded), then most recent — into state.metadata.userObservationContext.
+  // 3d. Identity Observation Recall — awaited: read-only recall agent that
+  //     searches/lists identity_observations and returns whatever is relevant
+  //     to the current conversation. This deliberately avoids a fixed "last N"
+  //     profile dump; relevance is turn-dependent.
   if (options.includeObservations && analyzable) {
     launched.push('identity-observation-recall');
     const idRecallPromise = runIdentityObservationRecall(state, 'human');
@@ -612,39 +611,32 @@ async function runIdentityObserver(state: BaseThreadState, domain: string): Prom
 }
 
 /**
- * Max identity rows surfaced into <user_observations> per turn. The domain
- * picture is a compact profile, not a search result — certainty-ranked so
- * the primary agent always sees the stated facts before the conclusions.
- */
-const IDENTITY_RECALL_MAX_ROWS = 12;
-
-/**
- * Deterministic SQL fast-path reader for one identity domain — no LLM, same
- * design (and rationale) as runObservationRecall. Unlike the general recall,
- * this is NOT query-matched: the domain picture is ranked purely by
- * certainty level (L3 stated → L2 derived → L1 concluded) then recency,
- * because who the user IS matters on every turn, not just topical ones.
- * Returns null when the domain has no rows yet so no block is injected.
+ * Read-only recall agent for one identity domain. It searches/listens through
+ * identity observations and returns only rows relevant to the current turn.
+ * The primary agent blocks on this because the selected rows are injected as
+ * <user_observations> before the main response starts.
  */
 async function runIdentityObservationRecall(state: BaseThreadState, domain: string): Promise<string | null> {
   const startTime = Date.now();
-  const threadId = (state.metadata as any).threadId;
 
   try {
-    const rows = await IdentityObservationsModel.listActive(domain, { limit: IDENTITY_RECALL_MAX_ROWS });
-    const elapsed = Date.now() - startTime;
+    const { graph, state: subState, threadId } = await GraphRegistry.createIdentityObservationRecall(state, domain);
+    console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Started | threadId: ${ threadId }`);
 
-    if (!rows || rows.length === 0) {
-      perf.log(`[IdentityRecall] threadId=${ threadId } domain=${ domain } matched=0 ms=${ elapsed } path=sql-fast-path`);
+    await graph.execute(subState, 'subconscious', { maxIterations: 10 });
+
+    const elapsed = Date.now() - startTime;
+    const agentMeta = (subState.metadata as any).agent || {};
+    const response = typeof agentMeta.response === 'string' ? agentMeta.response.trim() : '';
+
+    if (!response) {
+      perf.log(`[IdentityRecall] threadId=${ threadId } domain=${ domain } chars=0 ms=${ elapsed } path=agent`);
+      console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] No relevant rows in ${ elapsed }ms (agent)`);
       return null;
     }
 
-    const response = rows
-      .map((r) => `[${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ formatIdentityObservationDate(r.created_at) } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }`)
-      .join('\n');
-
-    perf.log(`[IdentityRecall] threadId=${ threadId } domain=${ domain } matched=${ rows.length } chars=${ response.length } ms=${ elapsed } path=sql-fast-path`);
-    console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Returning ${ rows.length } rows (${ response.length } chars) in ${ elapsed }ms (sql-fast-path)`);
+    perf.log(`[IdentityRecall] threadId=${ threadId } domain=${ domain } chars=${ response.length } ms=${ elapsed } path=agent`);
+    console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Returning ${ response.length } chars in ${ elapsed }ms (agent)`);
     return response;
   } catch (error) {
     console.error(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Failed in ${ Date.now() - startTime }ms:`, error instanceof Error ? error.message : error);

--- a/pkg/rancher-desktop/agent/middleware/__tests__/SubconsciousMiddleware.test.ts
+++ b/pkg/rancher-desktop/agent/middleware/__tests__/SubconsciousMiddleware.test.ts
@@ -2,19 +2,23 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const createSummarizerMock: any = jest.fn();
 const createObservationAgentMock: any = jest.fn();
+const createIdentityObserverMock: any = jest.fn();
+const createIdentityObservationRecallMock: any = jest.fn();
 const createToolResultDigesterMock: any = jest.fn();
 
 jest.mock('../../services/GraphRegistry', () => ({
   GraphRegistry: {
-    createSummarizer:         createSummarizerMock,
-    createObservationAgent:   createObservationAgentMock,
-    createToolResultDigester: createToolResultDigesterMock,
+    createSummarizer:                createSummarizerMock,
+    createObservationAgent:          createObservationAgentMock,
+    createIdentityObserver:          createIdentityObserverMock,
+    createIdentityObservationRecall: createIdentityObservationRecallMock,
+    createToolResultDigester:        createToolResultDigesterMock,
   },
 }));
 
 jest.mock('@pkg/utils/logging', () => ({
   __esModule: true,
-  default: {
+  default:    {
     perf: {
       log: jest.fn(),
     },
@@ -35,6 +39,8 @@ describe('runSubconsciousMiddleware', () => {
   beforeEach(() => {
     createSummarizerMock.mockReset();
     createObservationAgentMock.mockReset();
+    createIdentityObserverMock.mockReset();
+    createIdentityObservationRecallMock.mockReset();
     createToolResultDigesterMock.mockReset();
 
     createSummarizerMock.mockResolvedValue({
@@ -54,6 +60,22 @@ describe('runSubconsciousMiddleware', () => {
         metadata: { agent: { status: 'done' } },
       },
       threadId: 'observation-agent-test-thread',
+    });
+    createIdentityObserverMock.mockResolvedValue({
+      graph: { execute: jest.fn(() => Promise.resolve()) },
+      state: {
+        messages:  [],
+        metadata: { agent: { status: 'done' } },
+      },
+      threadId: 'identity-observer-test-thread',
+    });
+    createIdentityObservationRecallMock.mockResolvedValue({
+      graph: { execute: jest.fn(() => Promise.resolve()) },
+      state: {
+        messages:  [],
+        metadata: { agent: { status: 'done', response: '' } },
+      },
+      threadId: 'identity-recall-test-thread',
     });
   });
 
@@ -93,5 +115,7 @@ describe('runSubconsciousMiddleware', () => {
     await runSubconsciousMiddleware(state, { includeObservations: true });
 
     expect(createObservationAgentMock).not.toHaveBeenCalled();
+    expect(createIdentityObserverMock).not.toHaveBeenCalled();
+    expect(createIdentityObservationRecallMock).not.toHaveBeenCalled();
   });
 });

--- a/pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts
+++ b/pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts
@@ -19,7 +19,7 @@
  * on every turn.
  */
 
-import { ObservationsModel } from '../../database/models/ObservationsModel';
+import { formatObservationDate, ObservationsModel } from '../../database/models/ObservationsModel';
 import { SullaSettingsModel } from '../../database/models/SullaSettingsModel';
 import { parseJson } from '../../services/JsonParseService';
 
@@ -44,7 +44,7 @@ export async function buildObservationalMemorySection(
 
     if (rows.length > 0) {
       const lines = rows.map((r) =>
-        `- [id:${ r.id }] ${ r.priority } ${ r.created_at.slice(0, 10) } — ${ r.content }`.trim(),
+        `- [id:${ r.id }] ${ r.priority } ${ formatObservationDate(r.created_at) } — ${ r.content }`.trim(),
       );
 
       const content = `## Memory (top-${ TOP_N } observations)

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -53,6 +53,12 @@ const IDENTITY_OBSERVER_TOOLS: string[] = [
   'list_identity_observations',    // Browse the domain's current picture
 ];
 
+/** Identity Observation Recall: read-only — search/list domain rows for context injection */
+const IDENTITY_OBSERVATION_RECALL_TOOLS: string[] = [
+  'search_identity_observations',
+  'list_identity_observations',
+];
+
 /**
  * Per-domain focus config for the identity observer template. Mirrors
  * ~/sulla/identity/ (human / business / world / agent). Adding a new domain
@@ -237,6 +243,37 @@ plus list_observations) as ONE batch in your first response, then answer.
 Do not search one term at a time across multiple rounds.
 
 Be selective: a 5-entry relevant subset is better than 30 entries dumped verbatim.`;
+
+function buildIdentityObservationRecallPrompt(cfg: IdentityObserverDomainConfig): string {
+  return `You are the focused identity observation RECALL process for ${ cfg.subjectLabel } (domain: ${ cfg.domain }).
+
+CRITICAL: You are READ-ONLY. You NEVER write, insert, update, or delete identity observations.
+You only search and list — then return the observations relevant to the current conversation.
+
+## Your job
+
+Read the recent conversation context. Based on what the human is asking about,
+what task is in progress, and what identity facts could help the primary
+agent respond well, search the ${ cfg.domain } identity_observations table.
+
+${ cfg.focus }
+
+Rules:
+- Call search_identity_observations with key topic/phrase variants from the conversation.
+- Optionally call list_identity_observations when broad identity context is needed.
+- Return ONLY observations that are relevant or possibly relevant to this turn.
+- Format each result as: \`[id] L<level>·<category> date — content (basis: ...)\`
+- If many observations are relevant, return many. If only a few matter, return a few.
+- If nothing is relevant, return an empty string — do NOT pad with filler.
+- Do NOT narrate your process. Output only the filtered observation lines.
+
+Speed: the primary agent BLOCKS until you finish. Tool calls in the SAME
+response run in PARALLEL — issue every search you need (different phrasings,
+plus list_identity_observations if useful) as ONE batch in your first response,
+then answer. Do not search one term at a time across multiple rounds.
+
+Be selective by relevance, not by recency or a fixed count.`;
+}
 // ── Observation Recall: cache constants ──────────────────────────────────
 
 const SUMMARIZER_PROMPT = `You are the memory compression process for an AI agent. Talk through
@@ -689,6 +726,36 @@ export const GraphRegistry = {
   },
 
   /**
+   * Create an Identity Observation Recall graph — read-only search/list of
+   * domain-keyed identity observations. The recall agent selects observations
+   * relevant to the current conversation; it is not a top-N recency dump.
+   */
+  createIdentityObservationRecall: async function(parentState: BaseThreadState, domain = 'human'): Promise<{
+    graph:    Graph<BaseThreadState>;
+    state:    BaseThreadState;
+    threadId: string;
+  }> {
+    const cfg = IDENTITY_OBSERVER_DOMAINS[domain];
+    if (!cfg) throw new Error(`Unknown identity observer domain: ${ domain }`);
+
+    const graph = createSubconsciousGraph();
+    const state = await buildSubconsciousState({
+      systemPrompt:           buildIdentityObservationRecallPrompt(cfg),
+      tools:                  IDENTITY_OBSERVATION_RECALL_TOOLS,
+      userMessage:            `Read the recent conversation context and return only ${ cfg.domain } identity observations that are relevant or possibly relevant to what is happening now. Return compact lines only — nothing if nothing is relevant.`,
+      messages:               [...parentState.messages],
+      contextWindow:          20,
+      parentAbortSignal:      (parentState.metadata as any).options?.abort,
+      agentLabel:             `identity-observation-recall-${ cfg.domain }`,
+      parentWsChannel:        String(parentState.metadata.wsChannel || ''),
+      parentConversationId:   (parentState.metadata as any).threadId || (parentState.metadata as any).conversationId,
+      workflowNodeId:         (parentState.metadata as any).workflowNodeId,
+      workflowParentChannel:  (parentState.metadata as any).workflowParentChannel,
+    });
+    return { graph, state, threadId: state.metadata.threadId };
+  },
+
+  /**
    * Create an Observation Recall graph — read-only search of the observations
    * table to surface entries relevant to the current conversation context.
    * Returns compact `[id] priority date — content` lines, or null when nothing
@@ -716,7 +783,6 @@ export const GraphRegistry = {
     });
     return { graph, state, threadId: state.metadata.threadId };
   },
-
 
   delete(threadId: string): void {
     registry.delete(threadId);

--- a/pkg/rancher-desktop/agent/tools/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/manifests.ts
@@ -14,23 +14,24 @@ import { functionToolManifests } from './function/manifests';
 import { githubToolManifests } from './github/manifests';
 import { integrationsToolManifests } from './integrations/manifests';
 import { kubectlToolManifests } from './kubectl/manifests';
+import { ledgerToolManifests } from './ledger/manifests';
 import { limaToolManifests } from './lima/manifests';
 import { marketplaceToolManifests } from './marketplace/manifests';
 import { metaToolManifests } from './meta/manifests';
 import { mobileToolManifests } from './mobile/manifests';
+import { modelsToolManifests } from './models/manifests';
 import { notifyToolManifests } from './notify/manifests';
 import { pgToolManifests } from './pg/manifests';
+import { projectToolManifests } from './project/manifests';
 import { rdctlToolManifests } from './rdctl/manifests';
 import { redisToolManifests } from './redis/manifests';
 import { toolRegistry } from './registry';
 import { rulesToolManifests } from './rules/manifests';
-import { ledgerToolManifests } from './ledger/manifests';
 import { secretaryToolManifests } from './secretary/manifests';
 import { settingsToolManifests } from './settings/manifests';
 import { slackToolManifests } from './slack/manifests';
 import { uiToolManifests } from './ui/manifests';
 import { workflowToolManifests } from './workflow/manifests';
-import { projectToolManifests } from './project/manifests';
 
 toolRegistry.registerManifests([
   ...agentToolManifests,
@@ -49,6 +50,7 @@ toolRegistry.registerManifests([
   ...marketplaceToolManifests,
   ...metaToolManifests,
   ...mobileToolManifests,
+  ...modelsToolManifests,
   ...notifyToolManifests,
   ...pgToolManifests,
   ...rdctlToolManifests,

--- a/pkg/rancher-desktop/agent/tools/meta/__tests__/identity_observations.test.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/__tests__/identity_observations.test.ts
@@ -98,6 +98,33 @@ describe('identity observation tools', () => {
     });
   });
 
+  it('fails closed for invalid identity domains', async() => {
+    jest.spyOn(IdentityObservationsModel, 'findDuplicate').mockRejectedValue(new Error('Invalid identity domain "bogus"; expected one of: human, business, world, agent'));
+
+    const result = await addWorker().invoke({
+      domain:  'bogus',
+      level:   3,
+      content: 'This should not be saved.',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error ?? result.result).toContain('Invalid identity domain');
+  });
+
+  it('fails closed for invalid certainty levels instead of silently downgrading', async() => {
+    jest.spyOn(IdentityObservationsModel, 'findDuplicate').mockResolvedValue(null);
+    jest.spyOn(IdentityObservationsModel, 'insert').mockRejectedValue(new Error('Invalid identity certainty level "9"; expected 1, 2, or 3.'));
+
+    const result = await addWorker().invoke({
+      domain:  'human',
+      level:   9,
+      content: 'This should not be saved.',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.result).toContain('Invalid identity certainty level');
+  });
+
   it('updates an existing duplicate instead of inserting another row', async() => {
     jest.spyOn(IdentityObservationsModel, 'findDuplicate').mockResolvedValue(row({ id: 'dupe' }));
     jest.spyOn(IdentityObservationsModel, 'update').mockResolvedValue(row({ id: 'dupe' }));
@@ -136,6 +163,65 @@ describe('identity observation tools', () => {
     });
   });
 
+  it('passes list limits through the model for bounding', async() => {
+    jest.spyOn(IdentityObservationsModel, 'listActive').mockResolvedValue([]);
+
+    const result = await listWorker().invoke({
+      domain: 'human',
+      limit:  10000,
+    });
+
+    expect(result.success).toBe(true);
+    expect(IdentityObservationsModel.listActive).toHaveBeenCalledWith('human', {
+      level:    undefined,
+      category: undefined,
+      limit:    10000,
+    });
+  });
+
+  it('lists active rows when postgres returns Date instances', async() => {
+    jest.spyOn(IdentityObservationsModel, 'listActive').mockResolvedValue([
+      row({ created_at: new Date('2026-08-19T18:00:00.000Z') }),
+    ]);
+
+    const result = await listWorker().invoke({
+      domain: 'human',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('[id:hum1] L3·preference 2026-08-19');
+  });
+
+  it('lists rows when Postgres returns Date timestamps', async() => {
+    jest.spyOn(IdentityObservationsModel, 'listActive').mockResolvedValue([
+      row({ created_at: new Date('2026-08-19T18:00:00.000Z') }),
+    ] as any);
+
+    const result = await listWorker().invoke({
+      domain: 'human',
+      limit:  12,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('[id:hum1] L3·preference 2026-08-19');
+  });
+
+  it('rejects invalid identity domains before writing', async() => {
+    const findDuplicate = jest.spyOn(IdentityObservationsModel, 'findDuplicate').mockResolvedValue(null);
+    const insert = jest.spyOn(IdentityObservationsModel, 'insert').mockResolvedValue(row());
+
+    const result = await addWorker().invoke({
+      domain:  'not-a-domain',
+      level:   3,
+      content: 'Invalid domain probe.',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error ?? result.result).toContain('Invalid identity domain');
+    expect(findDuplicate).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   it('searches one identity domain and reports matched rows', async() => {
     jest.spyOn(IdentityObservationsModel, 'search').mockResolvedValue([row()]);
 
@@ -149,6 +235,20 @@ describe('identity observation tools', () => {
     expect(result.result).toContain('Found 1 human identity observation');
     expect(result.result).toContain('[id:hum1] L3·preference');
     expect(IdentityObservationsModel.search).toHaveBeenCalledWith('human', 'status reports', 5, false);
+  });
+
+  it('searches rows when Postgres returns Date timestamps', async() => {
+    jest.spyOn(IdentityObservationsModel, 'search').mockResolvedValue([
+      row({ created_at: new Date('2026-08-19T18:00:00.000Z') }),
+    ] as any);
+
+    const result = await searchWorker().invoke({
+      domain: 'human',
+      query:  'status reports',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('[id:hum1] L3·preference 2026-08-19');
   });
 
   it('soft-archives an identity observation by id', async() => {

--- a/pkg/rancher-desktop/agent/tools/meta/add_identity_observation.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/add_identity_observation.ts
@@ -1,4 +1,4 @@
-import { IdentityObservationsModel } from '../../database/models/IdentityObservationsModel';
+import { IdentityObservationsModel, normalizeIdentityDomain } from '../../database/models/IdentityObservationsModel';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -21,10 +21,11 @@ export class AddIdentityObservationWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { id, level, category, content, basis, source } = input;
-    const domain = (typeof input.domain === 'string' && input.domain.trim()) || 'human';
     const existingId = typeof id === 'string' ? id.trim() : '';
 
     try {
+      const domain = normalizeIdentityDomain(input.domain);
+
       if (existingId) {
         const updated = await IdentityObservationsModel.update(existingId, { level, category, content, basis, source });
         if (!updated) {

--- a/pkg/rancher-desktop/agent/tools/meta/list_identity_observations.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/list_identity_observations.ts
@@ -1,4 +1,4 @@
-import { IdentityObservationsModel } from '../../database/models/IdentityObservationsModel';
+import { formatIdentityObservationDate, IdentityObservationsModel, normalizeIdentityDomain } from '../../database/models/IdentityObservationsModel';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -13,12 +13,12 @@ export class ListIdentityObservationsWorker extends BaseTool {
   description = '';
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
-    const domain = (typeof input.domain === 'string' && input.domain.trim()) || 'human';
     const level = input.level !== undefined ? Number(input.level) : undefined;
     const category = typeof input.category === 'string' && input.category.trim() ? input.category.trim() : undefined;
     const limit = Number(input.limit) || 50;
 
     try {
+      const domain = normalizeIdentityDomain(input.domain);
       const rows = await IdentityObservationsModel.listActive(domain, { level, category, limit });
 
       if (rows.length === 0) {
@@ -29,7 +29,7 @@ export class ListIdentityObservationsWorker extends BaseTool {
       }
 
       const lines = rows.map(r =>
-        `[id:${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ (r.created_at || '').slice(0, 10) } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }`,
+        `[id:${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ formatIdentityObservationDate(r.created_at) } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }`,
       );
 
       return {

--- a/pkg/rancher-desktop/agent/tools/meta/search_identity_observations.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/search_identity_observations.ts
@@ -1,4 +1,4 @@
-import { IdentityObservationsModel } from '../../database/models/IdentityObservationsModel';
+import { formatIdentityObservationDate, IdentityObservationsModel, normalizeIdentityDomain } from '../../database/models/IdentityObservationsModel';
 import { ObservationsModel } from '../../database/models/ObservationsModel';
 import { BaseTool, ToolResponse } from '../base';
 
@@ -15,7 +15,6 @@ export class SearchIdentityObservationsWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const { query, limit = 20 } = input;
-    const domain = (typeof input.domain === 'string' && input.domain.trim()) || 'human';
     const includeArchived = Boolean(input.include_archived ?? input.includeArchived ?? false);
 
     if (!query || typeof query !== 'string' || !query.trim()) {
@@ -26,6 +25,7 @@ export class SearchIdentityObservationsWorker extends BaseTool {
     }
 
     try {
+      const domain = normalizeIdentityDomain(input.domain);
       const rows = await IdentityObservationsModel.search(domain, query.trim(), Number(limit) || 20, includeArchived);
       const words = ObservationsModel.tokenizeQuery(query.trim());
       const matchDesc = words.length > 1 ? `"${ query }" (any of: ${ words.join(', ') })` : `"${ query }"`;
@@ -38,7 +38,7 @@ export class SearchIdentityObservationsWorker extends BaseTool {
       }
 
       const lines = rows.map(r =>
-        `[id:${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ r.created_at } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }${ r.archived ? ' (archived)' : '' }`,
+        `[id:${ r.id }] L${ r.level }${ r.category ? `·${ r.category }` : '' } ${ formatIdentityObservationDate(r.created_at) } — ${ r.content }${ r.basis ? ` (basis: ${ r.basis })` : '' }${ r.archived ? ' (archived)' : '' }`,
       );
 
       return {

--- a/pkg/rancher-desktop/agent/tools/models/index.ts
+++ b/pkg/rancher-desktop/agent/tools/models/index.ts
@@ -1,0 +1,1 @@
+export { modelsToolManifests } from './manifests';

--- a/pkg/rancher-desktop/agent/tools/models/list.ts
+++ b/pkg/rancher-desktop/agent/tools/models/list.ts
@@ -1,0 +1,42 @@
+import { getModelProviderService } from '../../services/ModelProviderService';
+import { BaseTool, ToolResponse } from '../base';
+import { getProviderRuntimeStatus, getStaticModels } from './shared';
+
+export class ModelsListWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const providerId = String(input.provider ?? '').trim();
+    if (!providerId) {
+      return { successBoolean: false, responseString: 'provider is required.' };
+    }
+
+    const status = await getProviderRuntimeStatus(providerId);
+    if (!status) {
+      return { successBoolean: false, responseString: `Unknown AI provider: ${ providerId }` };
+    }
+
+    const liveModels = await getModelProviderService().getModelsForProvider(providerId);
+    const staticModels = getStaticModels(providerId);
+    const models = liveModels.length > 0
+      ? liveModels.map(model => ({ ...model, source: 'provider-or-cli' }))
+      : staticModels.map(model => ({ ...model, source: 'static-catalog' }));
+
+    return {
+      successBoolean: true,
+      responseString: JSON.stringify({
+        provider: {
+          id:               status.providerId,
+          name:             status.name,
+          connected:        status.connected,
+          commandLine:      status.commandLine,
+          sullaCompatible:  status.sullaCompatible,
+          ready:            status.ready,
+        },
+        modelCount: models.length,
+        models,
+      }, null, 2),
+    };
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/models/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/models/manifests.ts
@@ -1,0 +1,36 @@
+import type { ToolManifest } from '../registry';
+
+export const modelsToolManifests: ToolManifest[] = [
+  {
+    name:        'models_providers',
+    description: 'List AI model providers, whether each is connected/on or disconnected/off, whether any required CLI is installed in the Sulla VM, and whether Sulla can use it.',
+    category:    'models',
+    schemaDef:   {
+      include_disconnected: { type: 'boolean', optional: true, description: 'Include disconnected/off providers. Defaults to true.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./providers'),
+  },
+  {
+    name:        'models_list',
+    description: 'List models available for one provider using Sulla provider discovery, with static catalog fallback when live discovery is unavailable.',
+    category:    'models',
+    schemaDef:   {
+      provider: { type: 'string', description: 'Provider id, e.g. codex, claude-code, grok, openai, anthropic, google, cohere.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./list'),
+  },
+  {
+    name:        'models_usage',
+    description: 'Read locally tracked model usage captured by Sulla. Supports Codex and Claude Code rolling usage today; other provider billing APIs are not queried.',
+    category:    'models',
+    schemaDef:   {
+      provider: { type: 'string', optional: true, description: 'Optional provider filter, e.g. codex or claude-code.' },
+      model:    { type: 'string', optional: true, description: 'Optional exact model id filter.' },
+      hours:    { type: 'number', optional: true, description: 'Lookback window in hours. Defaults to 24.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./usage'),
+  },
+];

--- a/pkg/rancher-desktop/agent/tools/models/providers.ts
+++ b/pkg/rancher-desktop/agent/tools/models/providers.ts
@@ -1,0 +1,39 @@
+import { getModelProviderService } from '../../services/ModelProviderService';
+import { BaseTool, ToolResponse } from '../base';
+import { getAiProviderIntegrations, getProviderRuntimeStatus } from './shared';
+
+export class ModelsProvidersWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const includeDisconnected = input.include_disconnected !== false;
+    const providers = getAiProviderIntegrations();
+    const modelState = getModelProviderService().getState();
+
+    const statuses = (await Promise.all(
+      providers.map(provider => getProviderRuntimeStatus(provider.id)),
+    )).filter((status): status is NonNullable<typeof status> => !!status);
+
+    const visible = includeDisconnected
+      ? statuses
+      : statuses.filter(status => status.connected);
+
+    return {
+      successBoolean: true,
+      responseString: JSON.stringify({
+        active: {
+          primaryProvider:      modelState.primaryProvider,
+          primaryModelId:       modelState.activeModelId,
+          secondaryProvider:    modelState.secondaryProvider,
+          secondaryModelId:     modelState.secondaryModelId,
+          heartbeatProvider:    modelState.heartbeatProvider,
+          heartbeatModelId:     modelState.heartbeatModelId,
+          subconsciousProvider: modelState.subconsciousProvider,
+          subconsciousModelId:  modelState.subconsciousModelId,
+        },
+        providers: visible,
+      }, null, 2),
+    };
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/models/shared.ts
+++ b/pkg/rancher-desktop/agent/tools/models/shared.ts
@@ -1,0 +1,121 @@
+import { REMOTE_PROVIDERS } from '../../../shared/remoteProviders';
+import { integrations } from '../../integrations/catalog';
+import { modelDiscoveryService } from '../../languagemodels/ModelDiscoveryService';
+import { getIntegrationService } from '../../services/IntegrationService';
+import { runCommand } from '../util/CommandRunner';
+
+const EXCLUDED_PROVIDER_IDS = new Set(['activepieces', 'composio', 'mcp', 'enterprise-gateway']);
+
+export const CLI_PROVIDERS: Record<string, { command: string; versionCommand: string }> = {
+  'claude-code': { command: 'claude', versionCommand: 'claude --version' },
+  codex:         { command: 'codex', versionCommand: 'codex --version' },
+};
+
+const EXTRA_SUPPORTED_PROVIDER_IDS = new Set(['claude-code', 'codex', 'custom']);
+
+export interface ProviderRuntimeStatus {
+  providerId:       string;
+  name:             string;
+  description:      string;
+  connected:        boolean;
+  connectionState:  'on' | 'off';
+  activeAccountId?: string;
+  accounts: {
+    accountId:    string;
+    label:        string;
+    active:       boolean;
+    connected:    boolean;
+    connectedAt?: string;
+  }[];
+  commandLine: {
+    required:  boolean;
+    command?:  string;
+    installed: boolean;
+    version?:  string;
+    error?:    string;
+  };
+  sullaCompatible: boolean;
+  ready:           boolean;
+}
+
+export function getAiProviderIntegrations() {
+  return Object.values(integrations)
+    .filter(integration => integration.category === 'AI Infrastructure')
+    .filter(integration => !EXCLUDED_PROVIDER_IDS.has(integration.id))
+    .sort((a, b) => (a.sort ?? 999) - (b.sort ?? 999) || a.name.localeCompare(b.name));
+}
+
+export function isSullaCompatibleProvider(providerId: string): boolean {
+  return modelDiscoveryService.getSupportedProviders().includes(providerId) ||
+    EXTRA_SUPPORTED_PROVIDER_IDS.has(providerId);
+}
+
+export async function getCliStatus(providerId: string): Promise<ProviderRuntimeStatus['commandLine']> {
+  const cli = CLI_PROVIDERS[providerId];
+  if (!cli) return { required: false, installed: true };
+
+  const res = await runCommand(
+    `command -v ${ cli.command } >/dev/null 2>&1 && ${ cli.versionCommand }`,
+    [],
+    { runInLimaShell: true, timeoutMs: 10_000, maxOutputChars: 4_000 },
+  );
+
+  if (res.exitCode === 0) {
+    return {
+      required:  true,
+      command:   cli.command,
+      installed: true,
+      version:   (res.stdout || res.stderr).trim(),
+    };
+  }
+
+  return {
+    required:  true,
+    command:   cli.command,
+    installed: false,
+    error:     (res.stderr || res.stdout || `exit ${ res.exitCode }`).trim(),
+  };
+}
+
+export async function getProviderRuntimeStatus(providerId: string): Promise<ProviderRuntimeStatus | null> {
+  const integration = integrations[providerId];
+  if (integration?.category !== 'AI Infrastructure' || EXCLUDED_PROVIDER_IDS.has(providerId)) {
+    return null;
+  }
+
+  const service = getIntegrationService();
+  await service.initialize();
+
+  const [connected, accounts, activeAccountId, commandLine] = await Promise.all([
+    service.isAnyAccountConnected(providerId).catch(() => false),
+    service.getAccounts(providerId).catch(() => []),
+    service.getActiveAccountId(providerId).catch(() => undefined),
+    getCliStatus(providerId),
+  ]);
+
+  const sullaCompatible = isSullaCompatibleProvider(providerId);
+  const ready = connected && sullaCompatible && (!commandLine.required || commandLine.installed);
+
+  return {
+    providerId,
+    name:            integration.name,
+    description:     integration.description,
+    connected,
+    connectionState: connected ? 'on' : 'off',
+    activeAccountId,
+    accounts:        accounts.map(account => ({
+      accountId:    account.account_id,
+      label:        account.label,
+      active:       account.active,
+      connected:    account.connected,
+      connectedAt:  account.connected_at?.toISOString(),
+    })),
+    commandLine,
+    sullaCompatible,
+    ready,
+  };
+}
+
+export function getStaticModels(providerId: string) {
+  return REMOTE_PROVIDERS.find(provider => provider.id === providerId)?.models ?? [];
+}

--- a/pkg/rancher-desktop/agent/tools/models/usage.ts
+++ b/pkg/rancher-desktop/agent/tools/models/usage.ts
@@ -1,0 +1,137 @@
+import { SullaSettingsModel } from '../../database/models/SullaSettingsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+type UsageRecord = Record<string, unknown> & {
+  ts?:                          string;
+  model?:                       string;
+  input_tokens?:                number;
+  output_tokens?:               number;
+  cached_input_tokens?:         number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?:     number;
+  cost_usd?:                    number;
+  duration_ms?:                 number;
+};
+
+const USAGE_SETTINGS: Record<string, string> = {
+  'claude-code': 'claudeCodeUsage',
+  codex:         'codexUsage',
+};
+
+export class ModelsUsageWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const providerFilter = typeof input.provider === 'string' && input.provider.trim()
+      ? input.provider.trim()
+      : undefined;
+    const modelFilter = typeof input.model === 'string' && input.model.trim()
+      ? input.model.trim()
+      : undefined;
+    const hours = typeof input.hours === 'number' && Number.isFinite(input.hours) && input.hours > 0
+      ? input.hours
+      : 24;
+    const sinceMs = Date.now() - hours * 60 * 60 * 1000;
+
+    const providerIds = providerFilter ? [providerFilter] : Object.keys(USAGE_SETTINGS);
+    const unsupported = providerIds.filter(providerId => !USAGE_SETTINGS[providerId]);
+    const supported = providerIds.filter(providerId => USAGE_SETTINGS[providerId]);
+
+    const records = (await Promise.all(supported.map(async(providerId) => {
+      const raw = await SullaSettingsModel.get(USAGE_SETTINGS[providerId], '[]');
+      return parseUsage(raw)
+        .filter(record => isInWindow(record, sinceMs))
+        .filter(record => !modelFilter || record.model === modelFilter)
+        .map(record => ({ provider: providerId, ...record }));
+    }))).flat();
+
+    const totals = records.reduce((acc, record) => {
+      acc.input_tokens += asNumber(record.input_tokens);
+      acc.output_tokens += asNumber(record.output_tokens);
+      acc.cached_input_tokens += asNumber(record.cached_input_tokens);
+      acc.cache_creation_input_tokens += asNumber(record.cache_creation_input_tokens);
+      acc.cache_read_input_tokens += asNumber(record.cache_read_input_tokens);
+      acc.cost_usd += asNumber(record.cost_usd);
+      acc.duration_ms += asNumber(record.duration_ms);
+      return acc;
+    }, {
+      input_tokens:                0,
+      output_tokens:               0,
+      cached_input_tokens:         0,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens:     0,
+      cost_usd:                    0,
+      duration_ms:                 0,
+    });
+
+    const byProviderModel: Record<string, typeof totals & { provider: string; model: string; records: number }> = {};
+    for (const record of records) {
+      const provider = String(record.provider);
+      const model = typeof record.model === 'string' && record.model ? record.model : '(unknown)';
+      const key = `${ provider }:${ model }`;
+      byProviderModel[key] ??= {
+        provider,
+        model,
+        records:                     0,
+        input_tokens:                0,
+        output_tokens:               0,
+        cached_input_tokens:         0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens:     0,
+        cost_usd:                    0,
+        duration_ms:                 0,
+      };
+      byProviderModel[key].records += 1;
+      byProviderModel[key].input_tokens += asNumber(record.input_tokens);
+      byProviderModel[key].output_tokens += asNumber(record.output_tokens);
+      byProviderModel[key].cached_input_tokens += asNumber(record.cached_input_tokens);
+      byProviderModel[key].cache_creation_input_tokens += asNumber(record.cache_creation_input_tokens);
+      byProviderModel[key].cache_read_input_tokens += asNumber(record.cache_read_input_tokens);
+      byProviderModel[key].cost_usd += asNumber(record.cost_usd);
+      byProviderModel[key].duration_ms += asNumber(record.duration_ms);
+    }
+
+    return {
+      successBoolean: true,
+      responseString: JSON.stringify({
+        source: 'SullaSettingsModel local rolling usage telemetry',
+        note:   unsupported.length > 0
+          ? `Provider usage is locally tracked for ${ Object.keys(USAGE_SETTINGS).join(', ') }. Unsupported filters: ${ unsupported.join(', ') }.`
+          : 'Provider billing dashboards are not queried; this reports usage Sulla captured from model runs.',
+        windowHours: hours,
+        filters:     {
+          provider: providerFilter ?? null,
+          model:    modelFilter ?? null,
+        },
+        records:         records.length,
+        totals,
+        byProviderModel: Object.values(byProviderModel),
+      }, null, 2),
+    };
+  }
+}
+
+function parseUsage(raw: unknown): UsageRecord[] {
+  if (Array.isArray(raw)) return raw.filter(isObject) as UsageRecord[];
+  if (typeof raw !== 'string') return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(isObject) as UsageRecord[] : [];
+  } catch {
+    return [];
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isInWindow(record: UsageRecord, sinceMs: number): boolean {
+  const timestamp = typeof record.ts === 'string' ? Date.parse(record.ts) : NaN;
+  return Number.isFinite(timestamp) && timestamp >= sinceMs;
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}

--- a/pkg/rancher-desktop/agent/tools/registry.ts
+++ b/pkg/rancher-desktop/agent/tools/registry.ts
@@ -49,7 +49,7 @@ export class ToolRegistry {
   /** Native tool definitions that bypass convertToolToLLM (e.g. Anthropic computer use). */
   private nativeToolDefs = new Map<string, Record<string, any>>();
   private categoriesList = [
-    'agents', 'applescript', 'bridge', 'browser', 'calendar', 'capture', 'docker', 'extensions', 'fs', 'function', 'github', 'integrations', 'kubectl', 'ledger', 'lima', 'marketplace', 'memory', 'meta', 'mobile', 'notify', 'observation', 'pg', 'project', 'projects', 'rdctl', 'redis', 'rules', 'secretary', 'settings', 'skills', 'slack', 'ui', 'vault', 'workspace', 'workflow',
+    'agents', 'applescript', 'bridge', 'browser', 'calendar', 'capture', 'docker', 'extensions', 'fs', 'function', 'github', 'integrations', 'kubectl', 'ledger', 'lima', 'marketplace', 'memory', 'meta', 'mobile', 'models', 'notify', 'observation', 'pg', 'project', 'projects', 'rdctl', 'redis', 'rules', 'secretary', 'settings', 'skills', 'slack', 'ui', 'vault', 'workspace', 'workflow',
     // Integration catalog categories (AP backed)
     'communication', 'developer_tools', 'productivity', 'project_management', 'crm_sales', 'marketing', 'customer_support', 'social_media', 'finance', 'file_storage', 'ecommerce', 'analytics', 'automation', 'database', 'design', 'hr_recruiting', 'ai_ml',
   ];
@@ -76,6 +76,7 @@ export class ToolRegistry {
     integrations:       'Tools for checking integration status and retrieving integration credentials.',
     lima:               'Lima VM instance management.',
     mobile:             'Sulla Mobile companion — read calls, leads, and messages captured by the AI receptionist without picking up the phone.',
+    models:             'AI provider/model inventory — provider connection status, Sulla compatibility, CLI installation checks, model discovery, and locally tracked usage.',
     notify:             'Send desktop notifications to alert the user when async work completes or needs attention.',
     vault:              'Credential vault — list saved credentials, check integration connection status, read secrets, and autofill login forms.',
     function:           'Custom function runner — list installed functions and invoke them by slug across python, shell, and node runtimes. Returns full execution trace in one call.',

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -290,6 +290,20 @@ export interface IpcMainInvokeEvents {
   'sulla-settings:get':    (key: string) => any;
   'sulla-settings:set':    (key: string, value: any, cast?: string) => any;
 
+  // DB-backed System Prompt editor (Language Model Settings)
+  'system-prompt:list':              () => import('@pkg/agent/database/models/SystemPromptSectionModel').SystemPromptSectionRecord[];
+  'system-prompt:update':            (id: string, changes: import('@pkg/agent/database/models/SystemPromptSectionModel').UpdateSectionInput) => import('@pkg/agent/database/models/SystemPromptSectionModel').SystemPromptSectionRecord | null;
+  'system-prompt:reset':             (id: string) => import('@pkg/agent/database/models/SystemPromptSectionModel').SystemPromptSectionRecord | null;
+  'system-prompt:add':               (input: import('@pkg/agent/database/models/SystemPromptSectionModel').AddSectionInput) => import('@pkg/agent/database/models/SystemPromptSectionModel').SystemPromptSectionRecord;
+  'system-prompt:remove':            (id: string) => boolean;
+  'system-prompt:preview-generated': (id: string) => string;
+
+  // Staged, human-approved System Prompt edit proposals
+  'system-prompt-edits:list-pending': () => import('@pkg/agent/database/models/SystemPromptSectionEditModel').SectionEditRecord[];
+  'system-prompt-edits:propose':      (input: import('@pkg/agent/database/models/SystemPromptSectionEditModel').ProposeEditInput) => import('@pkg/agent/database/models/SystemPromptSectionEditModel').SectionEditRecord | null;
+  'system-prompt-edits:approve':      (id: string, finalContent?: string) => { section: import('@pkg/agent/database/models/SystemPromptSectionModel').SystemPromptSectionRecord | null; edit: import('@pkg/agent/database/models/SystemPromptSectionEditModel').SectionEditRecord } | null;
+  'system-prompt-edits:deny':         (id: string) => import('@pkg/agent/database/models/SystemPromptSectionEditModel').SectionEditRecord | null;
+
   /** Claude Code OAuth flow */
   'claude-oauth:start':  () => { token?: string; error?: string };
   'claude-oauth:cancel': () => void;


### PR DESCRIPTION
## Summary
- Harden identity_observations with fail-closed domain/level validation, bounded text fields, bounded search/list limits, Date-safe formatting, and a follow-up DB constraint migration for installs that already ran 0050.
- Change identity observation recall to use a read-only recall agent that searches/lists domain observations and selects whatever is relevant to the current conversation, instead of injecting a fixed top-12 profile dump.
- Add focused identity observation tests for invalid domains, invalid levels, content bounds, Date timestamps, and bounded limits.
- Add the models tool category for provider status, model listing, and local usage telemetry, plus the needed registry/manifests wiring and IPC typings already present in the working tree.

## Validation
- PASS: BROWSERSLIST_IGNORE_OLD_DATA=1 node --experimental-vm-modules node_modules/jest/bin/jest.js pkg/rancher-desktop/agent/database/models/__tests__/IdentityObservationsModel.test.ts pkg/rancher-desktop/agent/tools/meta/__tests__/identity_observations.test.ts --runInBand
- PASS: node_modules/.bin/eslint pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts pkg/rancher-desktop/agent/middleware/__tests__/SubconsciousMiddleware.test.ts
- PASS: targeted ESLint on changed leaf files excluding migrations/index.ts and registry.ts, which already have repo-wide lint violations unrelated to this PR.
- PASS: git diff --check
- INFO: broad tsc agent check is still blocked by existing unrelated issues: missing discord.js typings, stale Slack/PG test exports, relaxed-json Jest import mismatch, MCPServerHost deep type instantiation, and missing declaration files for dirty-json/rnnoise.

## Notes
- Local untracked temp file intentionally not included: tsconfig.agent-check.json.