### PR TITLE
fix(prompt): make Sulla-CLI-catalog + sulla-docs directive prominent (not glossed over)

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -603,6 +603,25 @@ Rules that apply on every turn:
 - You are part of a live multi-agent network — Heartbeat, Workbench, and other agents are active
 </platform_context>`);
 
+    stableParts.push(`<environment>
+STOP before you build anything from scratch. Sulla Desktop already ships a large
+catalog of real, working tools, and reinventing one — a custom script, a raw
+curl call, an ad-hoc integration, a hand-rolled workflow — is the single most
+common and most costly mistake you can make here.
+
+Every time, in this order:
+1. ASSUME THE TOOL ALREADY EXISTS. Find it with
+   \`sulla meta/browse_tools '{"query":"<what you need>"}'\`, then run it as
+   \`sulla <category>/<tool> '<json>'\`. Build something custom ONLY after you have
+   confirmed by searching that no cataloged tool covers the job.
+2. NEED TO KNOW HOW SOMETHING WORKS — running sub-agents, scheduling, git, the
+   browser, functions, workflows, any internal procedure — read the bundled
+   sulla-docs FIRST. The \`search\` tool includes sulla-docs by default; search it
+   and read the answer instead of guessing.
+
+This is a hard rule, not a suggestion: catalog and docs first, improvise last.
+</environment>`);
+
     // High-priority observational memory
     try {
       const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -312,6 +312,25 @@ Rules that apply on every turn:
 - You are part of a live multi-agent network — Heartbeat, Workbench, and other agents are active
 </platform_context>`);
 
+    stableParts.push(`<environment>
+STOP before you build anything from scratch. Sulla Desktop already ships a large
+catalog of real, working tools, and reinventing one — a custom script, a raw
+curl call, an ad-hoc integration, a hand-rolled workflow — is the single most
+common and most costly mistake you can make here.
+
+Every time, in this order:
+1. ASSUME THE TOOL ALREADY EXISTS. Find it with
+   \`sulla meta/browse_tools '{"query":"<what you need>"}'\`, then run it as
+   \`sulla <category>/<tool> '<json>'\`. Build something custom ONLY after you have
+   confirmed by searching that no cataloged tool covers the job.
+2. NEED TO KNOW HOW SOMETHING WORKS — running sub-agents, scheduling, git, the
+   browser, functions, workflows, any internal procedure — read the bundled
+   sulla-docs FIRST. The \`search\` tool includes sulla-docs by default; search it
+   and read the answer instead of guessing.
+
+This is a hard rule, not a suggestion: catalog and docs first, improvise last.
+</environment>`);
+
     // High-priority observational memory
     try {
       const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');


### PR DESCRIPTION
## Make the "use existing tools / read the docs" directive impossible to gloss over

**Problem:** the guidance to reach for the Sulla CLI catalog (and to read sulla-docs) instead of reinventing tools was a **single bullet buried in `<platform_context>`** — and it kept getting skimmed past. The agent repeatedly wrote custom scripts / raw curl / ad-hoc integrations for things the platform already does, and had to be manually reminded.

**Fix:** elevate it to a **dedicated, imperative `<environment>` block** placed right after `<platform_context>` in the stable prompt — its own delimited section, an ALL-CAPS lead, a stated consequence ("single most common and most costly mistake"), the exact mechanism (`sulla meta/browse_tools` → `sulla <category>/<tool>`; `search` includes sulla-docs), and a closing "hard rule, not a suggestion." Applied to **both** provider prefixes (Claude + Codex) for parity.

- Deliberately references sulla-docs via the **`search` tool** (verified: `search` includes bundled sulla-docs by default) rather than a `{{sulla_docs}}` template placeholder — template vars are **not** substituted in these `platform_context`/`stableParts` strings, so a raw placeholder would render literally.
- **Branch off `main`** (per your request for a separate, independently-testable branch), so you can evaluate just this prompt change in isolation.

### Relationship to PR #604
#604 (per-domain subconscious observers) separately added catalog/docs *bullets* to `platform_context` and a `SUBCONSCIOUS_ENVIRONMENT_ANCHOR`. This PR is the **stronger, prominent primary-agent treatment**. On merge the two touch the same block — intended resolution: **keep this `<environment>` block, drop #604's inline catalog bullets** (the subconscious anchor from #604 stays). Flagging so the merge is a deliberate choice, not a surprise.

### Gate
⚠️ Unbuilt/untested — needs `yarn typecheck` + rebuild on the macOS host to verify live. Prompt-string change only; no logic touched.

**Draft — human-gated. Do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
