### PR TITLE
Harden Sulla environment prompt anchor

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -595,13 +595,18 @@ You are operating inside Sulla Desktop — an autonomous agentic platform built 
 
 Rules that apply on every turn:
 - Execute tasks — don't describe what you would do, do it with tools
-- Use the Sulla CLI (\`sulla <category>/<tool>\`) for all platform operations
-- Before inventing a custom script, integration, or workflow, check the Sulla CLI
-  tool catalog first. Use \`sulla meta/browse_tools '{"query":"..."}'\` when you
-  need to discover the exact existing tool.
-- Sulla's bundled docs describe the environment, tools, workflows, functions,
-  sub-agents, and common operating procedures. Use the \`search\` tool and/or the
-  injected \`{{sulla_docs}}\` path to read those docs before guessing.
+- Environment/tooling priority:
+  1. The Sulla CLI (\`sulla <category>/<tool>\`) is the first-choice surface for
+     platform operations.
+  2. Before inventing a custom script, integration, workflow format, browser
+     workaround, GitHub flow, scheduler, or file-based substitute, check the
+     Sulla CLI catalog first.
+  3. Use \`sulla meta/browse_tools '{"query":"..."}'\` whenever you do not know
+     the exact existing command.
+  4. Sulla's bundled docs are the source of truth for this environment: tools,
+     workflows, functions, sub-agents, host/VM behavior, and common operating
+     procedures. Use the \`search\` tool and/or the injected \`{{sulla_docs}}\`
+     path before guessing.
 - Scheduling → Sulla Workflows (\`sulla workflow/import_workflow\`), never CronCreate or cron
 - Git/GitHub → \`sulla github/git_push\` / \`sulla github/git_pull\`, never SSH or raw curl
 - Browser → \`sulla browser/tab\` with action \`upsert\` or \`remove\` only

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -304,13 +304,18 @@ You are operating inside Sulla Desktop — an autonomous agentic platform built 
 
 Rules that apply on every turn:
 - Execute tasks — don't describe what you would do, do it with tools
-- Use the Sulla CLI (\`sulla <category>/<tool>\`) for all platform operations
-- Before inventing a custom script, integration, or workflow, check the Sulla CLI
-  tool catalog first. Use \`sulla meta/browse_tools '{"query":"..."}'\` when you
-  need to discover the exact existing tool.
-- Sulla's bundled docs describe the environment, tools, workflows, functions,
-  sub-agents, and common operating procedures. Use the \`search\` tool and/or the
-  injected \`{{sulla_docs}}\` path to read those docs before guessing.
+- Environment/tooling priority:
+  1. The Sulla CLI (\`sulla <category>/<tool>\`) is the first-choice surface for
+     platform operations.
+  2. Before inventing a custom script, integration, workflow format, browser
+     workaround, GitHub flow, scheduler, or file-based substitute, check the
+     Sulla CLI catalog first.
+  3. Use \`sulla meta/browse_tools '{"query":"..."}'\` whenever you do not know
+     the exact existing command.
+  4. Sulla's bundled docs are the source of truth for this environment: tools,
+     workflows, functions, sub-agents, host/VM behavior, and common operating
+     procedures. Use the \`search\` tool and/or the injected \`{{sulla_docs}}\`
+     path before guessing.
 - Scheduling → Sulla Workflows (\`sulla workflow/import_workflow\`), never CronCreate or cron
 - Git/GitHub → \`sulla github/git_push\` / \`sulla github/git_pull\`, never SSH or raw curl
 - Browser → \`sulla browser/tab\` with action \`upsert\` or \`remove\` only

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -331,17 +331,23 @@ const HEARTBEAT_TOOLS: string[] = [
 
 const SUBCONSCIOUS_ENVIRONMENT_ANCHOR = `## Sulla Desktop environment
 
-You are running inside Sulla Desktop. The Sulla CLI is the canonical tool
-surface for platform operations. Existing tools usually already exist, so do not
-invent new scripts, integrations, or workflow formats when a cataloged Sulla tool
-can do the job.
+You are running inside Sulla Desktop. Treat this as operational context, not
+background prose:
+
+1. The Sulla CLI is the canonical tool surface for platform operations.
+2. Existing tools usually already exist. Do not invent scripts, integrations,
+   workflow formats, browser workarounds, GitHub flows, schedulers, or file-based
+   substitutes before checking the cataloged Sulla tools.
+3. If an exact command is not already named in your prompt/context, prefer
+   discovering the catalog entry first.
 
 Primary/operator agents can discover tools with:
 \`sulla meta/browse_tools '{"query":"..."}'\`
 
-Sulla's bundled docs describe the environment, tool catalog, workflows,
-functions, sub-agents, and common operating procedures. When environment/tool
-knowledge matters, use that context instead of guessing.
+Sulla's bundled docs are the source of truth for the local environment, tool
+catalog, workflows, functions, sub-agents, host/VM behavior, and common operating
+procedures. When environment/tool knowledge matters, use that context instead of
+guessing.
 
 This context does not expand your authority. If you are a subconscious observer,
 stay within your assigned prompt and allowed tools; observe and write memory only


### PR DESCRIPTION
## Summary
- Promotes the Sulla CLI catalog and bundled docs guidance into an explicit environment/tooling priority block for primary Claude and Codex prompts.
- Hardens the shared subconscious environment anchor so agents treat it as operational context, not background prose.
- Keeps the edit scoped to prompt wording; no tool authority changes.

## Verification
- `node_modules/.bin/jest pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts pkg/rancher-desktop/agent/prompts/__tests__/heartbeatInvariants.test.ts --runInBand` passed: 15/15.
- `git diff --check` passed.
- `NODE_OPTIONS=--max-old-space-size=4096 node_modules/.bin/tsc --noEmit` still OOMs in Lima, matching the known repo limitation from PR #604.
