### PR TITLE
feat(subconscious): projects memory domain + Projects-system prompt awareness

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0054_allow_projects_identity_domain.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0054_allow_projects_identity_domain.ts
@@ -1,0 +1,45 @@
+/**
+ * Migration 0054 — Allow the `projects` identity-observation domain.
+ *
+ * The `projects` domain records durable, observed facts about the internal
+ * projects and the project-management system (goals, structure, priorities,
+ * decisions, processes, relationships, blockers) — distinct from the structured
+ * Projects work-state store that holds live task/epic status. Widen the domain
+ * CHECK to include it. NOT VALID so startup never blocks on historical rows.
+ */
+
+export const up = `
+  DO $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'identity_observations_domain_check'
+        AND conrelid = 'identity_observations'::regclass
+    ) THEN
+      ALTER TABLE identity_observations DROP CONSTRAINT identity_observations_domain_check;
+    END IF;
+
+    ALTER TABLE identity_observations
+      ADD CONSTRAINT identity_observations_domain_check
+      CHECK (domain IN ('human', 'business', 'world', 'agent', 'environment', 'projects'))
+      NOT VALID;
+  END $$;
+`;
+
+export const down = `
+  DO $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'identity_observations_domain_check'
+        AND conrelid = 'identity_observations'::regclass
+    ) THEN
+      ALTER TABLE identity_observations DROP CONSTRAINT identity_observations_domain_check;
+    END IF;
+
+    ALTER TABLE identity_observations
+      ADD CONSTRAINT identity_observations_domain_check
+      CHECK (domain IN ('human', 'business', 'world', 'agent', 'environment'))
+      NOT VALID;
+  END $$;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -41,6 +41,7 @@ import { up as up_0050, down as down_0050 } from './0050_create_identity_observa
 import { up as up_0051, down as down_0051 } from './0051_constrain_identity_observation_domains';
 import { up as up_0052, down as down_0052 } from './0052_add_self_observation_fields';
 import { up as up_0053, down as down_0053 } from './0053_allow_environment_identity_domain';
+import { up as up_0054, down as down_0054 } from './0054_allow_projects_identity_domain';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -83,4 +84,5 @@ export const migrationsRegistry = [
   { name: '0051_constrain_identity_observation_domains',         up: up_0051, down: down_0051 },
   { name: '0052_add_self_observation_fields',                    up: up_0052, down: down_0052 },
   { name: '0053_allow_environment_identity_domain',              up: up_0053, down: down_0053 },
+  { name: '0054_allow_projects_identity_domain',                 up: up_0054, down: down_0054 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
@@ -19,9 +19,9 @@ import { postgresClient } from '../PostgresClient';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
-export type IdentityDomain = 'human' | 'business' | 'world' | 'agent' | 'environment';
+export type IdentityDomain = 'human' | 'business' | 'world' | 'agent' | 'environment' | 'projects';
 
-export const IDENTITY_DOMAINS: IdentityDomain[] = ['human', 'business', 'world', 'agent', 'environment'];
+export const IDENTITY_DOMAINS: IdentityDomain[] = ['human', 'business', 'world', 'agent', 'environment', 'projects'];
 const MAX_CONTENT_CHARS = 1200;
 const MAX_BASIS_CHARS = 600;
 const MAX_LABEL_CHARS = 80;
@@ -188,7 +188,7 @@ export class IdentityObservationsModel {
       await postgresClient.query(`
         CREATE TABLE IF NOT EXISTS ${ IdentityObservationsModel.TABLE } (
           id          TEXT        PRIMARY KEY,
-          domain      TEXT        NOT NULL DEFAULT 'human' CHECK (domain IN ('human', 'business', 'world', 'agent', 'environment')),
+          domain      TEXT        NOT NULL DEFAULT 'human' CHECK (domain IN ('human', 'business', 'world', 'agent', 'environment', 'projects')),
           level       SMALLINT    NOT NULL DEFAULT 2 CHECK (level IN (1, 2, 3)),
           category    TEXT,
           content     TEXT        NOT NULL,

--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -606,6 +606,7 @@ Rules that apply on every turn:
 - Git/GitHub → \`sulla github/git_push\` / \`sulla github/git_pull\`, never SSH or raw curl
 - Browser → \`sulla browser/tab\` with action \`upsert\` or \`remove\` only
 - Recurring tasks become workflows, not one-off commands
+- Work state lives in the internal Projects system — read and update it with the \`sulla project/*\` tools (\`list_project_items\` / \`get_project_item\` / \`create_task\` / \`update_task\` / \`add_task_comment\`); never keep a separate ad-hoc task list
 - You are part of a live multi-agent network — Heartbeat, Workbench, and other agents are active
 </platform_context>`);
 
@@ -687,6 +688,11 @@ Rules that apply on every turn:
     const environmentObservationContext = (state?.metadata as any)?.environmentObservationContext;
     if (environmentObservationContext && typeof environmentObservationContext === 'string' && environmentObservationContext.trim()) {
       parts.push(`<environment_observations>\n${ environmentObservationContext.trim() }\n</environment_observations>`);
+    }
+
+    const projectsObservationContext = (state?.metadata as any)?.projectsObservationContext;
+    if (projectsObservationContext && typeof projectsObservationContext === 'string' && projectsObservationContext.trim()) {
+      parts.push(`<projects_observations>\n${ projectsObservationContext.trim() }\n</projects_observations>`);
     }
 
     if (parts.length === 0) return '';

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -315,6 +315,7 @@ Rules that apply on every turn:
 - Git/GitHub → \`sulla github/git_push\` / \`sulla github/git_pull\`, never SSH or raw curl
 - Browser → \`sulla browser/tab\` with action \`upsert\` or \`remove\` only
 - Recurring tasks become workflows, not one-off commands
+- Work state lives in the internal Projects system — read and update it with the \`sulla project/*\` tools (\`list_project_items\` / \`get_project_item\` / \`create_task\` / \`update_task\` / \`add_task_comment\`); never keep a separate ad-hoc task list
 - You are part of a live multi-agent network — Heartbeat, Workbench, and other agents are active
 </platform_context>`);
 
@@ -369,6 +370,11 @@ Rules that apply on every turn:
     const environmentObservationContext = (state?.metadata as any)?.environmentObservationContext;
     if (environmentObservationContext && typeof environmentObservationContext === 'string' && environmentObservationContext.trim()) {
       parts.push(`<environment_observations>\n${ environmentObservationContext.trim() }\n</environment_observations>`);
+    }
+
+    const projectsObservationContext = (state?.metadata as any)?.projectsObservationContext;
+    if (projectsObservationContext && typeof projectsObservationContext === 'string' && projectsObservationContext.trim()) {
+      parts.push(`<projects_observations>\n${ projectsObservationContext.trim() }\n</projects_observations>`);
     }
 
     if (parts.length === 0) return { prefix: '', stableHash };

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -251,6 +251,14 @@ export async function runSubconsciousMiddleware(
     awaitedTasks.push(timed('environment-observation-recall', 'Recalling this environment', envRecallPromise.then(ctx => { (state.metadata as any).environmentObservationContext = ctx })));
   }
 
+  // R6. Projects Observation Recall (projects) — awaited: relevant
+  //     `projects`-domain rows, injected as <projects_observations>.
+  if (options.includeObservations && analyzable) {
+    launched.push('projects-observation-recall');
+    const projRecallPromise = runIdentityObservationRecall(state, 'projects');
+    awaitedTasks.push(timed('projects-observation-recall', 'Recalling the projects', projRecallPromise.then(ctx => { (state.metadata as any).projectsObservationContext = ctx })));
+  }
+
   console.log(`[SubconsciousMiddleware] Launched (pre-turn recalls): ${ launched.join(', ') } | messages: ${ state.messages.length }`);
 
   // Every task in awaitedTasks writes into the live turn state. The primary
@@ -315,8 +323,9 @@ export function runSubconsciousObservationWriters(
   launch('business-observer', () => runIdentityObserver(state, 'business'));
   launch('world-observer', () => runIdentityObserver(state, 'world'));
   launch('environment-observer', () => runIdentityObserver(state, 'environment'));
+  launch('projects-observer', () => runIdentityObserver(state, 'projects'));
 
-  console.log(`[SubconsciousMiddleware] Post-turn writers launched (observation + human/agent/business/world/environment) | messages: ${ state.messages.length }`);
+  console.log(`[SubconsciousMiddleware] Post-turn writers launched (observation + human/agent/business/world/environment/projects) | messages: ${ state.messages.length }`);
 }
 
 // ============================================================================

--- a/pkg/rancher-desktop/agent/nodes/AgentNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/AgentNode.ts
@@ -177,6 +177,8 @@ export class AgentNode extends BaseNode {
     if (selfObservationContext) combinedContextParts.push(`<self_observations>\n${ selfObservationContext }\n</self_observations>`);
     if (businessObservationContext) combinedContextParts.push(`<business_observations>\n${ businessObservationContext }\n</business_observations>`);
     if (environmentObservationContext) combinedContextParts.push(`<environment_observations>\n${ environmentObservationContext }\n</environment_observations>`);
+    const projectsObservationContext = (state.metadata as any).projectsObservationContext;
+    if (projectsObservationContext) combinedContextParts.push(`<projects_observations>\n${ projectsObservationContext }\n</projects_observations>`);
 
     if (combinedContextParts.length > 0) {
       const contextBlock = `\n\n${ combinedContextParts.join('\n\n') }`;

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -832,8 +832,8 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
    * Also drops first-turn synthetic carrier messages once emptied.
    */
   protected stripInjectedContextBlocks(state: BaseThreadState): void {
-    const BLOCK_RE = /\n*<(observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|routine_digest|lane_health)>[\s\S]*?<\/\1>/g;
-    const MARKER_RE = /<(?:observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|routine_digest|lane_health)>/;
+    const BLOCK_RE = /\n*<(observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|routine_digest|lane_health)>[\s\S]*?<\/\1>/g;
+    const MARKER_RE = /<(?:observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|routine_digest|lane_health)>/;
 
     for (const msg of state.messages) {
       if (msg.role !== 'assistant') continue;

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -258,6 +258,35 @@ A method that worked once cleanly is worth recording; a method that FAILED is
 worth just as much — it stops the next chat repeating it. Flag repeatable
 processes (seen 3+ times or clearly routine) as skill candidates.`,
   },
+  projects: {
+    domain:       'projects',
+    subjectLabel: 'the internal projects and project-management system',
+    focus: `Observe the INTERNAL PROJECTS and the project-management system that
+tracks them — durable facts about what is being built and how the work is
+organized. NOT this turn's task status: live task/epic state lives in the
+structured Projects work-state store (the \`sulla project/*\` tools), not here.
+- project: what a project/product is — its goal, scope, owner, current phase
+- structure: how it is organized — epics, workstreams, repos, environments
+- priority: what is being pushed, protected, or deprioritized right now
+- decision: durable directions/decisions taken on a project
+- process: release / build / deploy processes and conventions for a project
+- relationship: how projects, repos, teams, and people connect
+- blocker: standing constraints or dependencies between projects
+
+Record what stays true across chats about a project, not "task 123 moved to
+done" — that belongs in the structured Projects work-state store.`,
+    writerNote: `## Certainty for project facts
+
+The SUBJECT is a project or the PM system — personal facts belong to the human
+domain, and LIVE task status belongs in the structured Projects store (via the
+\`sulla project/*\` tools), never here. Name the project each row is about.
+- L3 — the human stated it about a project directly ("Ripple Core ships behind a
+  subscription gate").
+- L2 — established from the conversation / work evidence, not stated outright;
+  set basis to the evidence.
+- L1 — a conclusion you reasoned about a project ("this project is release-gated
+  on human review", "these two repos always move together"), always with basis.`,
+  },
 };
 
 /**
@@ -342,6 +371,11 @@ Primary/operator agents can discover tools with:
 Sulla's bundled docs describe the environment, tool catalog, workflows,
 functions, sub-agents, and common operating procedures. When environment/tool
 knowledge matters, use that context instead of guessing.
+
+Sulla has an internal Projects system — the single source of truth for work
+state (projects → epics → tasks → comments), reached through the \`sulla
+project/*\` tools. It is where commitments, outcomes, and gate changes are
+recorded; there is never a separate ad-hoc task list.
 
 This context does not expand your authority. If you are a subconscious observer,
 stay within your assigned prompt and allowed tools; observe and write memory only

--- a/pkg/rancher-desktop/agent/tools/meta/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/manifests.ts
@@ -78,11 +78,11 @@ export const metaToolManifests: ToolManifest[] = [
   },
   {
     name:        'add_identity_observation',
-    description: 'Store a focused identity observation into the domain-keyed identity_observations table (human / business / world / agent / environment — mirrors ~/sulla/identity/). Levels are CERTAINTY: 3 = stated fact (subject directly told us), 2 = derived fact (established from conversation evidence), 1 = conclusion (reasoned from L3/L2 facts — personality, style, habits). Pass an existing id to update in place; otherwise a substantially similar active row in the same domain is updated instead of duplicated.',
+    description: 'Store a focused identity observation into the domain-keyed identity_observations table (human / business / world / agent / environment / projects — mirrors ~/sulla/identity/). Levels are CERTAINTY: 3 = stated fact (subject directly told us), 2 = derived fact (established from conversation evidence), 1 = conclusion (reasoned from L3/L2 facts — personality, style, habits). Pass an existing id to update in place; otherwise a substantially similar active row in the same domain is updated instead of duplicated.',
     category:    'observation',
     schemaDef:   {
       id:       { type: 'string', optional: true, description: 'Existing observation ID to update in place. Omit to add a new observation or update a duplicate by content.' },
-      domain:   { type: 'string', optional: true, description: 'Identity domain: human, business, world, agent, or environment (default human).' },
+      domain:   { type: 'string', optional: true, description: 'Identity domain: human, business, world, agent, environment, or projects (default human).' },
       level:    { type: 'number', description: 'Certainty level: 3 = stated fact, 2 = derived fact, 1 = conclusion.' },
       category: { type: 'string', optional: true, description: 'Focus category — e.g. identity, relationship, association, personality, habit, preference, goal.' },
       content:  { type: 'string', description: 'One sentence only — extremely concise, always include the context.' },
@@ -108,11 +108,11 @@ export const metaToolManifests: ToolManifest[] = [
   },
   {
     name:        'search_identity_observations',
-    description: 'Search active identity observations within one domain (human / business / world / agent / environment) by keyword or phrase. Any-word ILIKE match ranked by phrase hit, word-match count, then certainty level (stated facts first) and recency. Use this before adding a new identity observation to check for existing similar ones.',
+    description: 'Search active identity observations within one domain (human / business / world / agent / environment / projects) by keyword or phrase. Any-word ILIKE match ranked by phrase hit, word-match count, then certainty level (stated facts first) and recency. Use this before adding a new identity observation to check for existing similar ones.',
     category:    'observation',
     schemaDef:   {
       query:            { type: 'string', description: 'Search keyword or phrase — split into words, any-word ILIKE match against observation content.' },
-      domain:           { type: 'string', optional: true, description: 'Identity domain to search: human, business, world, agent, or environment (default human).' },
+      domain:           { type: 'string', optional: true, description: 'Identity domain to search: human, business, world, agent, environment, or projects (default human).' },
       limit:            { type: 'number', optional: true, description: 'Max results to return (default 20).' },
       include_archived: { type: 'boolean', optional: true, description: 'When true, also searches archived (soft-deleted) rows (default false).' },
     },
@@ -124,7 +124,7 @@ export const metaToolManifests: ToolManifest[] = [
     description: 'List active identity observations for one domain, most certain first (L3 stated → L2 derived → L1 concluded) then most recent. Optionally filter by level and/or category.',
     category:    'observation',
     schemaDef:   {
-      domain:   { type: 'string', optional: true, description: 'Identity domain: human, business, world, agent, or environment (default human).' },
+      domain:   { type: 'string', optional: true, description: 'Identity domain: human, business, world, agent, environment, or projects (default human).' },
       level:    { type: 'number', optional: true, description: 'Certainty level filter: 3, 2, or 1. Omit to list all levels.' },
       category: { type: 'string', optional: true, description: 'Category filter — e.g. identity, relationship, personality, habit. Omit to list all.' },
       limit:    { type: 'number', optional: true, description: 'Max results to return (default 50).' },


### PR DESCRIPTION
## `projects` — sixth memory domain + Projects-system awareness

Adds a **`projects`** domain to the per-domain subconscious observer system, plus prompt awareness so every agent knows about and uses the internal Projects PM system. Base is `feat/subconscious-per-domain-observers` (#604) so this diff is only the `projects` delta.

### 1. Projects awareness in the system prompt (all agents)
- **Primary** (`platform_context`, Claude + Codex): a rule — *"Work state lives in the internal Projects system — read and update it with the `sulla project/*` tools (`list_project_items` / `get_project_item` / `create_task` / `update_task` / `add_task_comment`); never keep a separate ad-hoc task list."*
- **Subconscious** (`SUBCONSCIOUS_ENVIRONMENT_ANCHOR`): the same fact, so background agents know the Projects store is the single source of truth for work state.

### 2. `projects` observation domain (tracked like every other domain)
- `IdentityObservationsModel` — `IdentityDomain` + `IDENTITY_DOMAINS` + inline CHECK include `projects`
- **migration 0054** — widens `identity_observations_domain_check` (idempotent `DO $$`, `NOT VALID`, clean `down`)
- `GraphRegistry` — `projects` observer config: durable facts about projects (goal/structure/priority/decision/process/relationship/blocker), L3/L2/L1
- `SubconsciousMiddleware` — post-turn **writer** + pre-turn **recall** (R6)
- `<projects_observations>` injection (Claude/Codex/AgentNode) + BaseNode strip regex
- manifest domain text updated

**Key boundary (baked into the prompt):** the `projects` *observation* domain holds durable facts *about* projects; **live task/epic status stays in the structured Projects work-state store** via the `sulla project/*` tools — the observer explicitly must not duplicate task status.

### Follow-up noted
The prominent `<environment>` block on **PR #605** (the "don't gloss over it" primary-prompt branch) should gain a matching Projects line when #604/#605/this branch reconcile, so Projects awareness is equally un-glossable for the primary agent.

### Gate
⚠️ Unbuilt/untested — needs `yarn typecheck` + host rebuild. Verified by source read + brace/backtick balance only.

**Draft — human-gated. Do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
