### PR TITLE
feat(routines): locked core "dreaming" routines (baked-in, un-editable)

### DIFF
--- a/pkg/rancher-desktop/agent/database/DatabaseManager.ts
+++ b/pkg/rancher-desktop/agent/database/DatabaseManager.ts
@@ -65,6 +65,16 @@ export class DatabaseManager {
       console.warn('[DB] SystemPromptSectionModel.seedDefaults() failed:', error);
     }
 
+    // Re-assert the locked core routines (nightly "dreaming" consolidation, etc.)
+    // from their bundled definitions. Idempotent + self-healing; non-fatal — a
+    // failure here just means the routine re-seeds on the next boot.
+    try {
+      const { seedCoreRoutines } = await import('@pkg/agent/routines/core/seedCoreRoutines');
+      await seedCoreRoutines();
+    } catch (error) {
+      console.warn('[DB] seedCoreRoutines() failed:', error);
+    }
+
     // Warm skills registry cache
     try {
       await skillsRegistry.initialize();

--- a/pkg/rancher-desktop/agent/database/migrations/0055_add_system_and_content_hash_to_workflows.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0055_add_system_and_content_hash_to_workflows.ts
@@ -1,0 +1,35 @@
+/**
+ * Migration 0055 — Mark workflows as locked "core" routines.
+ *
+ * Core routines (e.g. the per-domain nightly "dreaming" consolidation routines)
+ * ship baked into Sulla Desktop and are re-asserted from a bundled definition on
+ * every boot. They are visible and runnable, and may be DISABLED by the human,
+ * but they cannot be edited or deleted through any user-facing surface.
+ *
+ *   - `system`        marks a row as a locked core routine. The edit/delete
+ *                     guards in WorkflowModel + the import/status tools refuse
+ *                     to mutate a row where system = true (the boot seeder is
+ *                     the only writer, via an internal actor flag). The `enabled`
+ *                     flag stays user-writable so a core routine can be paused.
+ *   - `content_hash`  sha-256 of the seeded routine definition + its notes only
+ *                     (not sibling files). The seeder recomputes it each boot; a
+ *                     mismatch means the live definition drifted from the bundle,
+ *                     and the seeder silently re-seeds from the bundle.
+ *
+ * Both default to the non-core case so every existing row is untouched.
+ */
+
+export const up = `
+  ALTER TABLE workflows
+    ADD COLUMN IF NOT EXISTS system       BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS content_hash TEXT    NULL;
+
+  CREATE INDEX IF NOT EXISTS idx_workflows_system ON workflows(system);
+`;
+
+export const down = `
+  DROP INDEX IF EXISTS idx_workflows_system;
+  ALTER TABLE workflows
+    DROP COLUMN IF EXISTS content_hash,
+    DROP COLUMN IF EXISTS system;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -42,6 +42,7 @@ import { up as up_0051, down as down_0051 } from './0051_constrain_identity_obse
 import { up as up_0052, down as down_0052 } from './0052_add_self_observation_fields';
 import { up as up_0053, down as down_0053 } from './0053_allow_environment_identity_domain';
 import { up as up_0054, down as down_0054 } from './0054_allow_projects_identity_domain';
+import { up as up_0055, down as down_0055 } from './0055_add_system_and_content_hash_to_workflows';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -85,4 +86,5 @@ export const migrationsRegistry = [
   { name: '0052_add_self_observation_fields',                    up: up_0052, down: down_0052 },
   { name: '0053_allow_environment_identity_domain',              up: up_0053, down: down_0053 },
   { name: '0054_allow_projects_identity_domain',                 up: up_0054, down: down_0054 },
+  { name: '0055_add_system_and_content_hash_to_workflows',       up: up_0055, down: down_0055 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkflowModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkflowModel.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { BaseModel } from '../BaseModel';
 import { postgresClient } from '../PostgresClient';
 
@@ -14,8 +16,47 @@ interface WorkflowAttributes {
   definition:           Record<string, unknown>;
   enabled:              boolean;
   source_template_slug: string | null;
+  /**
+   * Locked "core" routine baked into Sulla Desktop. Re-asserted from a bundled
+   * definition on every boot by the CoreRoutineSeeder. Visible + runnable +
+   * disable-able, but cannot be edited or deleted through any user surface.
+   */
+  system:               boolean;
+  /** sha-256 of the seeded definition + notes — drift detection for `system` rows. */
+  content_hash:         string | null;
   created_at:           Date;
   updated_at:           Date;
+}
+
+/**
+ * Thrown when a user-facing surface tries to edit or delete a locked core
+ * routine. The mutation choke points (upsertFromDefinition / updateStatus /
+ * deleteById) raise this unless the caller is the boot seeder (actor: 'seeder').
+ */
+export class LockedRoutineError extends Error {
+  constructor(id: string, action: string) {
+    super(`Workflow "${ id }" is a locked core routine and cannot be ${ action }. It ships with Sulla Desktop — you can disable it, but not edit or delete it.`);
+    this.name = 'LockedRoutineError';
+  }
+}
+
+/**
+ * Canonical sha-256 over the routine definition + its notes only (never sibling
+ * files). Keys are sorted recursively so cosmetic re-serialization (object key
+ * order) never churns the hash — only real content changes flip it.
+ */
+export function hashRoutineDefinition(definition: Record<string, any>): string {
+  const stable = (value: any): any => {
+    if (Array.isArray(value)) return value.map(stable);
+    if (value && typeof value === 'object') {
+      return Object.keys(value).sort().reduce((acc: Record<string, any>, k) => {
+        acc[k] = stable(value[k]);
+        return acc;
+      }, {});
+    }
+    return value;
+  };
+  return createHash('sha256').update(JSON.stringify(stable(definition))).digest('hex');
 }
 
 export interface WorkflowListRow {
@@ -44,14 +85,26 @@ export class WorkflowModel extends BaseModel<WorkflowAttributes> {
     'definition',
     'enabled',
     'source_template_slug',
+    'system',
+    'content_hash',
   ];
 
   protected readonly casts: Record<string, string> = {
     definition: 'json',
     enabled:    'boolean',
+    system:     'boolean',
     created_at: 'timestamp',
     updated_at: 'timestamp',
   };
+
+  /** True if `id` is a locked core routine (system = true). */
+  static async isSystem(id: string): Promise<boolean> {
+    const row = await postgresClient.queryOne(
+      `SELECT system FROM workflows WHERE id = $1 LIMIT 1`,
+      [id],
+    );
+    return row?.system === true;
+  }
 
   static async findById(id: string): Promise<WorkflowModel | null> {
     const row = await postgresClient.queryOne(
@@ -141,10 +194,29 @@ export class WorkflowModel extends BaseModel<WorkflowAttributes> {
        * genuinely need to change it after creation.
        */
       sourceTemplateSlug?: string | null;
+      /**
+       * Who is writing. The boot CoreRoutineSeeder passes 'seeder' — the ONLY
+       * actor permitted to create or overwrite a locked core (system) routine.
+       * Any other caller editing an existing system row throws LockedRoutineError.
+       */
+      actor?: 'seeder' | 'user';
+      /** Seeder only: mark the row as a locked core routine (system = true). */
+      system?: boolean;
+      /** Seeder only: sha-256 of the seeded definition, stored in content_hash. */
+      contentHash?: string | null;
     } = {},
   ): Promise<WorkflowModel> {
     const id = String(definition.id ?? '').trim();
     if (!id) throw new Error('WorkflowModel.upsertFromDefinition: definition.id is required');
+
+    const isSeeder = options.actor === 'seeder';
+
+    const existing = await WorkflowModel.findById(id);
+
+    // Lock guard: a locked core routine can only be written by the seeder.
+    if (existing?.attributes.system && !isSeeder) {
+      throw new LockedRoutineError(id, 'edited');
+    }
 
     const name = String(definition.name ?? id);
     const description = definition.description ? String(definition.description) : null;
@@ -152,27 +224,36 @@ export class WorkflowModel extends BaseModel<WorkflowAttributes> {
     const status = (options.status
       ?? (definition._status as WorkflowStatus | undefined)
       ?? 'draft') as WorkflowStatus;
-    const enabled = definition.enabled !== false;
+    // On a seeder RE-SEED of an existing core routine, preserve the human's
+    // enabled/disabled choice — re-asserting the definition must never silently
+    // re-enable a routine the human deliberately paused. On first insert, honor
+    // the definition.
+    const enabled = (isSeeder && existing)
+      ? existing.attributes.enabled
+      : definition.enabled !== false;
     const sourceTemplateSlug = options.sourceTemplateSlug ?? null;
+    const system = isSeeder ? (options.system ?? true) : (existing?.attributes.system ?? false);
+    const contentHash = isSeeder ? (options.contentHash ?? null) : (existing?.attributes.content_hash ?? null);
 
-    const existing = await WorkflowModel.findById(id);
     const isInsert = !existing;
     const definitionBefore = existing ? existing.attributes.definition ?? null : null;
 
     try {
       const row = await postgresClient.queryOne(
-        `INSERT INTO workflows (id, name, description, version, status, definition, enabled, source_template_slug)
-         VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)
+        `INSERT INTO workflows (id, name, description, version, status, definition, enabled, source_template_slug, system, content_hash)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10)
          ON CONFLICT (id) DO UPDATE SET
-           name        = EXCLUDED.name,
-           description = EXCLUDED.description,
-           version     = EXCLUDED.version,
-           status      = EXCLUDED.status,
-           definition  = EXCLUDED.definition,
-           enabled     = EXCLUDED.enabled,
-           updated_at  = CURRENT_TIMESTAMP
+           name         = EXCLUDED.name,
+           description  = EXCLUDED.description,
+           version      = EXCLUDED.version,
+           status       = EXCLUDED.status,
+           definition   = EXCLUDED.definition,
+           enabled      = EXCLUDED.enabled,
+           system       = EXCLUDED.system,
+           content_hash = EXCLUDED.content_hash,
+           updated_at   = CURRENT_TIMESTAMP
          RETURNING *`,
-        [id, name, description, version, status, JSON.stringify(definition), enabled, sourceTemplateSlug],
+        [id, name, description, version, status, JSON.stringify(definition), enabled, sourceTemplateSlug, system, contentHash],
       );
 
       const model = new WorkflowModel();
@@ -211,6 +292,12 @@ export class WorkflowModel extends BaseModel<WorkflowAttributes> {
       console.warn(`[WorkflowModel.updateStatus] ✗ id=${ id } — not found`);
 
       return null;
+    }
+    // Locked core routines are pinned to their seeded status; pause them with
+    // the `enabled` flag instead. (Not applicable to the seeder, which sets
+    // status through upsertFromDefinition, never here.)
+    if (existing.attributes.system) {
+      throw new LockedRoutineError(id, 'promoted or archived');
     }
     const oldStatus = existing.attributes.status;
     if (oldStatus === newStatus) {
@@ -253,7 +340,11 @@ export class WorkflowModel extends BaseModel<WorkflowAttributes> {
     }
   }
 
-  static async deleteById(id: string): Promise<boolean> {
+  static async deleteById(id: string, options: { actor?: 'seeder' | 'user' } = {}): Promise<boolean> {
+    // Lock guard: locked core routines cannot be deleted by any user surface.
+    if (options.actor !== 'seeder' && await WorkflowModel.isSystem(id)) {
+      throw new LockedRoutineError(id, 'deleted');
+    }
     try {
       const result = await postgresClient.query(
         `DELETE FROM workflows WHERE id = $1`,
@@ -267,5 +358,43 @@ export class WorkflowModel extends BaseModel<WorkflowAttributes> {
       console.error(`[WorkflowModel.deleteById] ✗ id=${ id }`, err);
       throw err;
     }
+  }
+
+  /**
+   * Seed (or re-assert) a locked core routine from its bundled definition.
+   * Idempotent and self-healing — safe to run on every boot:
+   *
+   *   - Absent           → inserted as a system routine, status 'production'.
+   *   - Present, in sync → no write (content_hash matches the bundle).
+   *   - Present, drifted → silently re-seeded from the bundle (definition
+   *                        replaced, hash refreshed). The human's enabled/
+   *                        disabled choice is always preserved.
+   *
+   * This is the ONLY writer permitted to touch a system row (actor: 'seeder').
+   * Returns 'inserted' | 'resynced' | 'unchanged'.
+   */
+  static async seedCoreRoutine(
+    definition: Record<string, any>,
+  ): Promise<'inserted' | 'resynced' | 'unchanged'> {
+    const id = String(definition.id ?? '').trim();
+    if (!id) throw new Error('WorkflowModel.seedCoreRoutine: definition.id is required');
+
+    const contentHash = hashRoutineDefinition(definition);
+    const existing = await WorkflowModel.findById(id);
+
+    if (existing && existing.attributes.system && existing.attributes.content_hash === contentHash) {
+      return 'unchanged';
+    }
+
+    await WorkflowModel.upsertFromDefinition(definition, {
+      actor:        'seeder',
+      system:       true,
+      contentHash,
+      status:       'production',
+      changedBy:    'core-routine-seeder',
+      changeReason: existing ? 'core routine re-seeded from bundle' : 'core routine seeded from bundle',
+    });
+
+    return existing ? 'resynced' : 'inserted';
   }
 }

--- a/pkg/rancher-desktop/agent/database/models/WorkflowModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkflowModel.ts
@@ -69,6 +69,9 @@ export interface WorkflowListRow {
   // consumers don't need to re-parse the full definition just to show
   // "N agents" in a summary row.
   nodeCount:   number;
+  // True for locked core routines — the UI shows a lock badge and hides the
+  // edit/delete/archive/publish actions (enforcement is also server-side).
+  system:      boolean;
 }
 
 export class WorkflowModel extends BaseModel<WorkflowAttributes> {
@@ -130,6 +133,7 @@ export class WorkflowModel extends BaseModel<WorkflowAttributes> {
               name,
               description,
               status,
+              system,
               updated_at,
               CASE
                 WHEN jsonb_typeof(definition->'nodes') = 'array'
@@ -147,6 +151,7 @@ export class WorkflowModel extends BaseModel<WorkflowAttributes> {
       status:      r.status as WorkflowStatus,
       updatedAt:   r.updated_at instanceof Date ? r.updated_at.toISOString() : String(r.updated_at ?? ''),
       nodeCount:   Number(r.node_count ?? 0),
+      system:      r.system === true,
     }));
   }
 

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkflowModel.coreRoutines.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkflowModel.coreRoutines.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { postgresClient } from '../../PostgresClient';
+import { WorkflowHistoryModel } from '../WorkflowHistoryModel';
+import { hashRoutineDefinition, LockedRoutineError, WorkflowModel } from '../WorkflowModel';
+
+/**
+ * Locked core-routine behavior:
+ *   - hashRoutineDefinition is order-stable
+ *   - system rows refuse edit/delete/status from any non-seeder caller
+ *   - seedCoreRoutine is idempotent + self-healing and preserves `enabled`
+ */
+describe('WorkflowModel — locked core routines', () => {
+  const DEF = { id: 'core-routine-x', name: 'X', nodes: [], edges: [], enabled: true };
+
+  let originalQuery: any;
+  let originalQueryOne: any;
+  let lastInsertParams: any[] | null;
+
+  beforeEach(() => {
+    originalQuery = (postgresClient as any).query;
+    originalQueryOne = (postgresClient as any).queryOne;
+    lastInsertParams = null;
+    jest.spyOn(WorkflowHistoryModel, 'recordChange').mockResolvedValue(undefined as any);
+  });
+
+  afterEach(() => {
+    (postgresClient as any).query = originalQuery;
+    (postgresClient as any).queryOne = originalQueryOne;
+    jest.restoreAllMocks();
+  });
+
+  // Build a queryOne router around a simulated existing row (or null).
+  function stubDb(existing: Record<string, any> | null) {
+    (postgresClient as any).queryOne = jest.fn((sql: string, params: any[]) => {
+      if (sql.includes('SELECT system FROM workflows')) {
+        return Promise.resolve(existing ? { system: existing.system === true } : null);
+      }
+      if (sql.includes('SELECT * FROM workflows')) {
+        return Promise.resolve(existing);
+      }
+      if (sql.includes('INSERT INTO workflows')) {
+        lastInsertParams = params;
+        // Echo a row shaped from the insert params (col order matches the model).
+        return Promise.resolve({
+          id: params[0], name: params[1], description: params[2], version: params[3],
+          status: params[4], definition: JSON.parse(params[5]), enabled: params[6],
+          source_template_slug: params[7], system: params[8], content_hash: params[9],
+        });
+      }
+      if (sql.includes('UPDATE workflows')) {
+        return Promise.resolve({ ...existing, status: params[1] });
+      }
+      return Promise.resolve(null);
+    });
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([{ id: existing?.id }]));
+  }
+
+  it('hashRoutineDefinition ignores key order', () => {
+    const a = hashRoutineDefinition({ id: 'x', name: 'n', nodes: [{ a: 1, b: 2 }] });
+    const b = hashRoutineDefinition({ nodes: [{ b: 2, a: 1 }], name: 'n', id: 'x' });
+    expect(a).toBe(b);
+    const c = hashRoutineDefinition({ id: 'x', name: 'CHANGED', nodes: [] });
+    expect(c).not.toBe(a);
+  });
+
+  it('refuses to delete a system row unless the seeder asks', async() => {
+    stubDb({ id: DEF.id, system: true, enabled: true });
+    await expect(WorkflowModel.deleteById(DEF.id)).rejects.toBeInstanceOf(LockedRoutineError);
+    // seeder bypass is allowed
+    await expect(WorkflowModel.deleteById(DEF.id, { actor: 'seeder' })).resolves.toBe(true);
+  });
+
+  it('refuses to edit or re-status a system row from a user caller', async() => {
+    stubDb({ id: DEF.id, system: true, enabled: true, status: 'production', definition: DEF });
+    await expect(WorkflowModel.upsertFromDefinition(DEF)).rejects.toBeInstanceOf(LockedRoutineError);
+    await expect(WorkflowModel.updateStatus(DEF.id, 'archive')).rejects.toBeInstanceOf(LockedRoutineError);
+  });
+
+  it('seedCoreRoutine inserts when absent and marks the row system', async() => {
+    stubDb(null);
+    const result = await WorkflowModel.seedCoreRoutine(DEF);
+    expect(result).toBe('inserted');
+    expect(lastInsertParams?.[8]).toBe(true);                       // system column
+    expect(lastInsertParams?.[9]).toBe(hashRoutineDefinition(DEF)); // content_hash column
+  });
+
+  it('seedCoreRoutine is a no-op when the hash already matches', async() => {
+    stubDb({ id: DEF.id, system: true, content_hash: hashRoutineDefinition(DEF), enabled: true, definition: DEF });
+    const result = await WorkflowModel.seedCoreRoutine(DEF);
+    expect(result).toBe('unchanged');
+    expect(lastInsertParams).toBeNull(); // never wrote
+  });
+
+  it('seedCoreRoutine re-syncs on drift and preserves the human disable choice', async() => {
+    stubDb({ id: DEF.id, system: true, content_hash: 'stale-hash', enabled: false, definition: { old: true } });
+    const result = await WorkflowModel.seedCoreRoutine(DEF);
+    expect(result).toBe('resynced');
+    expect(lastInsertParams?.[6]).toBe(false); // enabled preserved from the existing (paused) row
+    expect(lastInsertParams?.[9]).toBe(hashRoutineDefinition(DEF));
+  });
+});

--- a/pkg/rancher-desktop/agent/routines/core/dreamAboutHuman.ts
+++ b/pkg/rancher-desktop/agent/routines/core/dreamAboutHuman.ts
@@ -1,0 +1,228 @@
+/**
+ * Core routine — "Dreaming About My Human"
+ *
+ * A locked, baked-in nightly consolidation routine (the human-domain "Dreamer").
+ * It reads the raw human-domain identity observations, synthesizes them through
+ * parallel lenses, prunes what's stale, and writes a consolidated profile into
+ * the `user` system-prompt section — the slot injected into every system prompt.
+ *
+ * DB-PURE by contract: every sub-agent uses ONLY the identity/observation DB
+ * tools + update_identity_section. It never touches the filesystem, shell, or
+ * source control — honoring the observe-only subconscious-writer gate.
+ *
+ * Distributed with Sulla Desktop and re-asserted on every boot by the
+ * CoreRoutineSeeder; visible + disable-able, but not editable or deletable.
+ *
+ * Runs nightly at 00:00 local (staggered ahead of the other per-domain dreamers).
+ */
+
+export const DREAM_ABOUT_HUMAN_ID = 'core-routine-dream-about-human';
+
+/**
+ * Shared guardrail prepended to every sub-agent so the DB-pure / observe-only
+ * contract is explicit at the prompt layer as well as (eventually) the persona
+ * tool-allowlist layer.
+ */
+const OBSERVE_ONLY = [
+  'You are a subconscious consolidation agent. You may use ONLY these tools:',
+  'list_identity_observations, search_identity_observations, remove_identity_observation,',
+  'add_identity_observation, and update_identity_section.',
+  'You MUST NOT read or write any files, run shell commands, use git, or open a browser.',
+  'Operate entirely against the identity/observation database.',
+].join(' ');
+
+export const DREAM_ABOUT_HUMAN_DEFINITION: Record<string, any> = {
+  id:          DREAM_ABOUT_HUMAN_ID,
+  name:        'Dreaming About My Human',
+  description:
+    'Nightly consolidation of the human-domain identity. Reads all human identity ' +
+    'observations, synthesizes goals-over-time and personality/communication style, ' +
+    'prunes what is stale or contradicted, and writes the consolidated profile into ' +
+    'the `user` system-prompt section. Locked core routine — DB-only, no filesystem.',
+  version:   2,
+  enabled:   true,
+  createdAt: '2026-08-19T00:00:00.000Z',
+  updatedAt: '2026-08-19T00:00:00.000Z',
+
+  edges: [
+    { id: 'e-dah-trigger-load',      source: 'node-dah-trigger',     target: 'node-dah-load',        animated: true },
+    { id: 'e-dah-load-lenses',       source: 'node-dah-load',        target: 'node-dah-lenses',      animated: true },
+    { id: 'e-dah-lenses-goals',      source: 'node-dah-lenses',      target: 'node-dah-goals',       animated: true },
+    { id: 'e-dah-lenses-persona',    source: 'node-dah-lenses',      target: 'node-dah-personality', animated: true },
+    { id: 'e-dah-goals-merge',       source: 'node-dah-goals',       target: 'node-dah-merge',       animated: true },
+    { id: 'e-dah-persona-merge',     source: 'node-dah-personality', target: 'node-dah-merge',       animated: true },
+    { id: 'e-dah-merge-prune',       source: 'node-dah-merge',       target: 'node-dah-prune',       animated: true },
+    { id: 'e-dah-prune-synth',       source: 'node-dah-prune',       target: 'node-dah-synthesize',  animated: true },
+    { id: 'e-dah-synth-done',        source: 'node-dah-synthesize',  target: 'node-dah-done',        animated: true },
+  ],
+
+  nodes: [
+    {
+      id:       'node-dah-trigger',
+      type:     'workflow',
+      position: { x: 400, y: 0 },
+      data: {
+        label:    'Nightly Trigger',
+        category: 'trigger',
+        subtype:  'schedule',
+        config: {
+          triggerType:        'schedule',
+          triggerDescription: 'Runs nightly at 00:00 local to consolidate the human identity.',
+          frequency:          'daily',
+          intervalMinutes:    0,
+          hour:               0,
+          minute:             0,
+          dayOfWeek:          0,
+          dayOfMonth:         1,
+          timezone:           '',
+        },
+      },
+    },
+    {
+      id:       'node-dah-load',
+      type:     'workflow',
+      position: { x: 400, y: 130 },
+      data: {
+        label:    'Load Human Observations',
+        category: 'agent',
+        subtype:  'tool-call',
+        config: {
+          toolName: 'list_identity_observations',
+          defaults: { domain: 'human' },
+        },
+      },
+    },
+    {
+      id:       'node-dah-lenses',
+      type:     'workflow',
+      position: { x: 400, y: 260 },
+      data: {
+        label:    'Consolidation Lenses',
+        category: 'flow-control',
+        subtype:  'parallel',
+        config:   {},
+      },
+    },
+    {
+      id:       'node-dah-goals',
+      type:     'workflow',
+      position: { x: 200, y: 390 },
+      data: {
+        label:    'Goals Over Time',
+        category: 'agent',
+        subtype:  'agent',
+        config: {
+          agentId:                  'thinker-worker',
+          agentName:                'Human Goals Horizon',
+          additionalPrompt:         OBSERVE_ONLY,
+          successCriteria:          'A concise goals-over-time snapshot for the human.',
+          completionContract:       'Exit when the 1-month / 6-month / 2-year snapshot is written.',
+          orchestratorInstructions:
+            'You have the full set of human-domain identity observations (passed from the load step). ' +
+            'Search for more with search_identity_observations {domain:"human"} if needed. ' +
+            'Infer what the human is trying to accomplish over three horizons — the next 1 month, ' +
+            '6 months, and 2 years — grounded ONLY in the observations. Mark anything speculative as ' +
+            'inferred (L1). Output a tight snapshot (<300 words) of goals per horizon. Do not write ' +
+            'files. Return the snapshot as your result.',
+        },
+      },
+    },
+    {
+      id:       'node-dah-personality',
+      type:     'workflow',
+      position: { x: 600, y: 390 },
+      data: {
+        label:    'Personality & Communication Style',
+        category: 'agent',
+        subtype:  'agent',
+        config: {
+          agentId:                  'thinker-worker',
+          agentName:                'Human Personality Reader',
+          additionalPrompt:         OBSERVE_ONLY,
+          successCriteria:          'A personality + how-to-work-with-them snapshot for the human.',
+          completionContract:       'Exit when the personality & communication snapshot is written.',
+          orchestratorInstructions:
+            'Using ONLY the human-domain identity observations, characterize the human: personality, ' +
+            'working style, communication preferences, what earns their trust, what frustrates them, ' +
+            'and how Sulla should best communicate and work alongside them. Ground every claim in the ' +
+            'observations; label reasoned conclusions as inferred (L1). Output a tight snapshot ' +
+            '(<300 words). Do not write files. Return the snapshot as your result.',
+        },
+      },
+    },
+    {
+      id:       'node-dah-merge',
+      type:     'workflow',
+      position: { x: 400, y: 520 },
+      data: {
+        label:    'Lenses Complete',
+        category: 'flow-control',
+        subtype:  'merge',
+        config:   { strategy: 'wait-all' },
+      },
+    },
+    {
+      id:       'node-dah-prune',
+      type:     'workflow',
+      position: { x: 400, y: 650 },
+      data: {
+        label:    'Prune Stale Observations',
+        category: 'agent',
+        subtype:  'agent',
+        config: {
+          agentId:                  'thinker-worker',
+          agentName:                'Human Observation Pruner',
+          additionalPrompt:         OBSERVE_ONLY,
+          successCriteria:          'Stale, duplicate, or contradicted human observations archived.',
+          completionContract:       'Exit when pruning is complete and a short summary is returned.',
+          orchestratorInstructions:
+            'Review the human-domain identity observations for redundancy and staleness. ' +
+            'For clear duplicates (same fact stated multiple times), keep the highest-certainty row ' +
+            'and archive the rest with remove_identity_observation. Archive observations that a newer ' +
+            'observation directly contradicts (keep the newer). Be conservative — when in doubt, keep. ' +
+            'Never delete via any means other than remove_identity_observation. Return a one-line ' +
+            'summary of how many rows you archived and why. Do not write files.',
+        },
+      },
+    },
+    {
+      id:       'node-dah-synthesize',
+      type:     'workflow',
+      position: { x: 400, y: 780 },
+      data: {
+        label:    'Write Consolidated Profile',
+        category: 'agent',
+        subtype:  'agent',
+        config: {
+          agentId:                  'thinker-worker',
+          agentName:                'Human Profile Synthesizer',
+          additionalPrompt:         OBSERVE_ONLY,
+          successCriteria:          'The `user` system-prompt section holds a fresh consolidated human profile.',
+          completionContract:       'Exit when update_identity_section has written the `user` section.',
+          orchestratorInstructions:
+            'You have two lens snapshots (goals-over-time and personality/communication) plus the pruned ' +
+            'observation set. Synthesize a single consolidated human profile written in the second person ' +
+            '("You are working with ...") that Sulla can carry in every system prompt. Keep it under 500 ' +
+            'words, factual, and free of speculation presented as fact. Then persist it by calling ' +
+            'update_identity_section with { "id": "user", "content": <the profile> }. Do NOT write any ' +
+            'files. Confirm the section was written and return the profile you saved.',
+        },
+      },
+    },
+    {
+      id:       'node-dah-done',
+      type:     'workflow',
+      position: { x: 400, y: 910 },
+      data: {
+        label:    'Done',
+        category: 'io',
+        subtype:  'response',
+        config: {
+          responseTemplate: 'Dreamed about the human — consolidated profile written to the `user` section.',
+        },
+      },
+    },
+  ],
+
+  viewport: { x: 0, y: 0, zoom: 1 },
+};

--- a/pkg/rancher-desktop/agent/routines/core/index.ts
+++ b/pkg/rancher-desktop/agent/routines/core/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Core routines — locked, baked-in routines distributed with Sulla Desktop.
+ *
+ * Every definition listed here is re-asserted into the `workflows` table on
+ * boot by seedCoreRoutines(), marked system = true. They are visible and
+ * runnable and may be disabled by the human, but cannot be edited or deleted
+ * through any user-facing surface (enforced in WorkflowModel + the workflow
+ * tools). Deleting a row from the DB self-heals on the next launch.
+ *
+ * To add a new core routine: author its WorkflowDefinition as a TS module in
+ * this directory and add it to CORE_ROUTINES below.
+ */
+
+import { DREAM_ABOUT_HUMAN_DEFINITION } from './dreamAboutHuman';
+
+export const CORE_ROUTINES: ReadonlyArray<Record<string, any>> = [
+  DREAM_ABOUT_HUMAN_DEFINITION,
+];

--- a/pkg/rancher-desktop/agent/routines/core/seedCoreRoutines.ts
+++ b/pkg/rancher-desktop/agent/routines/core/seedCoreRoutines.ts
@@ -1,0 +1,47 @@
+/**
+ * seedCoreRoutines — boot-time installer for locked core routines.
+ *
+ * Idempotent and self-healing: for each bundled core routine it calls
+ * WorkflowModel.seedCoreRoutine, which inserts an absent routine, silently
+ * re-syncs a drifted one from the bundle, and leaves an unchanged one alone —
+ * always preserving the human's enabled/disabled choice. After seeding it
+ * re-arms the workflow scheduler so any newly-seeded schedule fires without an
+ * app restart.
+ *
+ * Non-fatal by contract: a failure here must never block DB init, so callers
+ * wrap it and swallow errors (the routine simply re-seeds next boot).
+ */
+
+import { WorkflowModel } from '@pkg/agent/database/models/WorkflowModel';
+
+import { CORE_ROUTINES } from './index';
+
+export async function seedCoreRoutines(): Promise<void> {
+  let inserted = 0;
+  let resynced = 0;
+  let unchanged = 0;
+
+  for (const definition of CORE_ROUTINES) {
+    try {
+      const result = await WorkflowModel.seedCoreRoutine(definition);
+      if (result === 'inserted') inserted++;
+      else if (result === 'resynced') resynced++;
+      else unchanged++;
+    } catch (err) {
+      console.error(`[seedCoreRoutines] failed for '${ definition.id }':`, err);
+    }
+  }
+
+  console.log(`[seedCoreRoutines] core routines: ${ inserted } inserted, ${ resynced } re-synced, ${ unchanged } unchanged`);
+
+  // Re-arm the scheduler so a freshly-seeded schedule trigger is live now,
+  // not only after the next restart. Non-fatal.
+  if (inserted > 0 || resynced > 0) {
+    try {
+      const { getWorkflowSchedulerService } = await import('@pkg/agent/services/WorkflowSchedulerService');
+      await getWorkflowSchedulerService().refresh();
+    } catch (err) {
+      console.warn('[seedCoreRoutines] scheduler refresh failed:', err);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/meta/__tests__/update_identity_section.test.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/__tests__/update_identity_section.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { SystemPromptSectionModel } from '../../../database/models/SystemPromptSectionModel';
+import { UpdateIdentitySectionWorker } from '../update_identity_section';
+
+describe('update_identity_section tool', () => {
+  const call = (input: any) => (new UpdateIdentitySectionWorker() as any)._validatedCall(input);
+
+  afterEach(() => { jest.restoreAllMocks(); });
+
+  it('rejects a missing id or empty content', async() => {
+    expect((await call({ content: 'x' })).successBoolean).toBe(false);
+    expect((await call({ id: 'user', content: '   ' })).successBoolean).toBe(false);
+  });
+
+  it('refuses to write a section that does not exist', async() => {
+    jest.spyOn(SystemPromptSectionModel, 'getById').mockResolvedValue(null as any);
+    const res = await call({ id: 'nope', content: 'profile' });
+    expect(res.successBoolean).toBe(false);
+    expect(res.responseString).toContain('No system-prompt section');
+  });
+
+  it('updates an existing section and reports success', async() => {
+    jest.spyOn(SystemPromptSectionModel, 'getById').mockResolvedValue({ id: 'user' } as any);
+    const update = jest.spyOn(SystemPromptSectionModel, 'update').mockResolvedValue({ id: 'user' } as any);
+    const res = await call({ id: 'user', content: 'You are working with a direct, first-principles builder.' });
+    expect(res.successBoolean).toBe(true);
+    expect(update).toHaveBeenCalledWith('user', { content: 'You are working with a direct, first-principles builder.' });
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/meta/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/manifests.ts
@@ -133,6 +133,17 @@ export const metaToolManifests: ToolManifest[] = [
     loader:         () => import('./list_identity_observations'),
   },
   {
+    name:        'update_identity_section',
+    description: 'Write the consolidated identity profile for a domain into its system-prompt section (e.g. the "user" section injected into every system prompt). Overwrites the section content and marks it customized so the boot seeder never clobbers it. Used by the nightly "dreaming" consolidation routines; DB-only, no filesystem.',
+    category:    'observation',
+    schemaDef:   {
+      id:      { type: 'string', description: 'System-prompt section id to write — the consolidated identity slot for a domain (e.g. "user").' },
+      content: { type: 'string', description: 'The consolidated profile text to store as the section content.' },
+    },
+    operationTypes: ['update'],
+    loader:         () => import('./update_identity_section'),
+  },
+  {
     name:        'ask_user_question',
     description: 'Pause and ask the user one or more multiple-choice questions, then BLOCK until they answer in the chat (or the timeout elapses — default 5 min). Renders an interactive card with selectable options; the user may also type a free-form answer. Returns the selected option(s) per question. Use whenever the next step depends on a decision only the user can make — picking between approaches, confirming an assumption, supplying a missing detail, or getting a yes/no go-ahead (offer Approve / Deny options).',
     category:    'meta',

--- a/pkg/rancher-desktop/agent/tools/meta/update_identity_section.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/update_identity_section.ts
@@ -1,0 +1,53 @@
+import { SystemPromptSectionModel } from '../../database/models/SystemPromptSectionModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Update Identity Section Tool
+ *
+ * Writes the consolidated identity profile for a domain into its system-prompt
+ * section (e.g. the `user` section, injected into every system prompt). This is
+ * the DB-only writer the nightly "dreaming" consolidation routines use to
+ * persist their synthesized profile — no filesystem access.
+ *
+ * SystemPromptSectionModel.update flips is_customized = true on any content
+ * write, so the boot seeder never clobbers the consolidated profile with the
+ * (empty) baked default.
+ */
+export class UpdateIdentitySectionWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const id = typeof input.id === 'string' ? input.id.trim() : '';
+    const content = typeof input.content === 'string' ? input.content : '';
+
+    if (!id) {
+      return { successBoolean: false, responseString: 'update_identity_section: "id" is required (e.g. "user").' };
+    }
+    if (!content.trim()) {
+      return { successBoolean: false, responseString: 'update_identity_section: "content" must be a non-empty string.' };
+    }
+
+    try {
+      const existing = await SystemPromptSectionModel.getById(id);
+      if (!existing) {
+        return {
+          successBoolean: false,
+          responseString: `No system-prompt section "${ id }". Consolidated identity writes must target an existing section (e.g. "user").`,
+        };
+      }
+
+      const updated = await SystemPromptSectionModel.update(id, { content });
+      if (!updated) {
+        return { successBoolean: false, responseString: `Failed to update the "${ id }" section.` };
+      }
+
+      return {
+        successBoolean: true,
+        responseString: `Updated the "${ id }" identity section (${ content.length } chars). It will be injected into the system prompt on the next build.`,
+      };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to update identity section: ${ err?.message }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/workflow/import_workflow.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/import_workflow.ts
@@ -55,6 +55,23 @@ export class ImportWorkflowWorker extends BaseTool {
 
     const { postgresClient } = await import('@pkg/agent/database/PostgresClient');
 
+    // Lock guard: never let an import overwrite a locked core routine. Core
+    // routines are seeded from the bundled definition on boot — not importable.
+    try {
+      const locked = await postgresClient.queryOne(
+        `SELECT system FROM workflows WHERE id = $1 LIMIT 1`,
+        [definition.id],
+      );
+      if (locked?.system === true) {
+        return {
+          successBoolean: false,
+          responseString: `"${ definition.id }" is a locked core routine baked into Sulla Desktop and cannot be imported over. You can disable it, but not replace it.`,
+        };
+      }
+    } catch {
+      // If the lookup fails, fall through — the DB upsert below surfaces real errors.
+    }
+
     try {
       await postgresClient.query(
         `INSERT INTO workflows (id, name, description, version, status, definition, enabled, source_template_slug, created_at, updated_at)

--- a/pkg/rancher-desktop/agent/tools/workflow/set_workflow_status.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/set_workflow_status.ts
@@ -49,8 +49,8 @@ export class SetWorkflowStatusWorker extends BaseTool {
     let rows: any[];
     try {
       rows = id
-        ? await postgresClient.queryAll(`SELECT id, name, status, enabled FROM workflows WHERE id = $1`, [id])
-        : await postgresClient.queryAll(`SELECT id, name, status, enabled FROM workflows WHERE LOWER(name) = LOWER($1)`, [name]);
+        ? await postgresClient.queryAll(`SELECT id, name, status, enabled, system FROM workflows WHERE id = $1`, [id])
+        : await postgresClient.queryAll(`SELECT id, name, status, enabled, system FROM workflows WHERE LOWER(name) = LOWER($1)`, [name]);
     } catch (err) {
       return { successBoolean: false, responseString: `Workflow lookup failed: ${ (err as Error).message }` };
     }
@@ -65,6 +65,17 @@ export class SetWorkflowStatusWorker extends BaseTool {
     }
 
     const target = rows[0];
+
+    // Lock guard: a locked core routine is pinned to its seeded status. The
+    // `enabled` toggle stays open (that's the sanctioned pause), but status
+    // changes (draft/production/archive) are refused.
+    if (target.system === true && status !== undefined && status !== target.status) {
+      return {
+        successBoolean: false,
+        responseString: `"${ target.name }" is a locked core routine — its status is fixed at "${ target.status }". You can disable it with { "enabled": false }, but not change its status.`,
+      };
+    }
+
     const sets: string[] = [];
     const params: unknown[] = [];
 

--- a/pkg/rancher-desktop/components/routines/RoutineStrip.vue
+++ b/pkg/rancher-desktop/components/routines/RoutineStrip.vue
@@ -29,6 +29,11 @@
           v-if="routine.featured"
           class="chip violet"
         >Featured</span>
+        <span
+          v-if="routine.system"
+          class="chip lock"
+          title="Core routine — ships with Sulla Desktop. You can disable it, but not edit or delete it."
+        >🔒 Core</span>
       </div>
       <div class="title">
         {{ routine.name }}
@@ -111,6 +116,7 @@
               Duplicate
             </button>
             <button
+              v-if="!routine.system"
               type="button"
               class="menu-item"
               role="menuitem"
@@ -127,6 +133,7 @@
               Export…
             </button>
             <button
+              v-if="!routine.system"
               type="button"
               class="menu-item"
               role="menuitem"
@@ -134,15 +141,23 @@
             >
               Publish to Marketplace…
             </button>
-            <div class="menu-sep" />
-            <button
-              type="button"
-              class="menu-item danger"
-              role="menuitem"
-              @click="emitAction('delete')"
+            <template v-if="!routine.system">
+              <div class="menu-sep" />
+              <button
+                type="button"
+                class="menu-item danger"
+                role="menuitem"
+                @click="emitAction('delete')"
+              >
+                Delete…
+              </button>
+            </template>
+            <div
+              v-else
+              class="menu-locked"
             >
-              Delete…
-            </button>
+              🔒 Core routine — you can disable it, but not edit or delete it.
+            </div>
           </div>
         </div>
       </div>
@@ -384,6 +399,11 @@ const timingLabel = computed(() => {
   background: #fb7185;
   animation: pulse-v 1.2s infinite;
 }
+.chip.lock {
+  border-color: rgba(148, 163, 184, 0.5);
+  color: #cbd5e1;
+  background: rgba(71, 85, 105, 0.28);
+}
 @keyframes pulse-v { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
 .metrics {
@@ -494,6 +514,14 @@ const timingLabel = computed(() => {
   height: 1px;
   background: rgba(168, 192, 220, 0.14);
   margin: 4px 2px;
+}
+.menu-locked {
+  padding: 7px 10px;
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 1.4;
+  letter-spacing: 0.04em;
+  color: var(--steel-400);
 }
 
 .btn {

--- a/pkg/rancher-desktop/composables/useRoutines.ts
+++ b/pkg/rancher-desktop/composables/useRoutines.ts
@@ -39,6 +39,7 @@ interface DbListRow {
   status:      'draft' | 'production' | 'archive';
   updatedAt:   string;
   nodeCount:   number;
+  system?:     boolean;
 }
 
 /** Map the DB's coarse status to the richer view status. */
@@ -140,6 +141,7 @@ function rowToSummary(row: DbListRow): RoutineSummary {
     agents:        row.nodeCount,
     integrations:  [],      // TODO: surface from definition when we enrich the query
     lastRunAgo:    timeAgo(row.updatedAt),
+    system:        row.system === true,
     // Runtime metrics (runsPerWeek, avgCycle, costPerRun, schedule,
     // featured) come from run history + trigger analysis in later phases.
   };

--- a/pkg/rancher-desktop/types/routines.ts
+++ b/pkg/rancher-desktop/types/routines.ts
@@ -35,6 +35,8 @@ export interface RoutineSummary {
   nextIn?:       string;
   schedule?:     string;
   featured?:     boolean;
+  /** Locked core routine baked into Sulla Desktop — read-only in the UI. */
+  system?:       boolean;
 }
 
 export type RoutineCategory =


### PR DESCRIPTION
## Goal

Add **locked "core" routines** — routines baked into and distributed with Sulla Desktop that are **visible and runnable, can be disabled, but cannot be edited or deleted** by any user surface. First use case: the nightly per-domain **"dreaming"** consolidation routines (starting with `dream-about-human`).

This is a draft opened early per standing rule — it will grow with more commits. Merges/deploys remain human-gated.

## Design (grounded in live code)

- **Storage:** `workflows` table gains `system BOOLEAN` + `content_hash TEXT` (migration 0055). No new table.
- **Distribution / un-deletable:** a boot-time `CoreRoutineSeeder` re-asserts each bundled core routine from its baked definition on every launch → deleting a row just self-heals next boot.
- **Lock enforcement at every write surface:** `WorkflowModel` (upsert/updateStatus/delete) + the two raw-SQL bypass tools (`import_workflow`, `set_workflow_status`). Only the seeder (`actor:'seeder'`) may write a `system` row.
- **Disable allowed:** the `enabled` flag stays user-writable and is **preserved across re-seed**; status/definition are locked.
- **Tamper handling:** silent re-seed when the live definition's hash drifts from the bundle. Hash covers the routine **definition + notes only**.
- **Dreaming routine is DB-pure:** reads `identity_observations` (domain=human) → sub-agent lenses (goals-horizon, personality/comms, prune) → writes the consolidated profile into the **`user` row of `sulla_system_prompt_sections`** (the empty consolidated-human slot injected into every system prompt). No filesystem — honors the observe-only subconscious gate.

## Status

**Landed in this PR:**
- migration 0055 (`workflows.system` + `content_hash`), registered
- `WorkflowModel`: `LockedRoutineError`, stable-sha256 `hashRoutineDefinition`, `isSystem`, `seedCoreRoutine` (idempotent / self-healing / preserves enabled), edit+delete guards
- `import_workflow` + `set_workflow_status`: bypass paths closed

**To come (same branch):**
- [ ] `CoreRoutineSeeder` registry + boot wiring in `DatabaseManager`
- [ ] `dream-about-human` baked routine definition (nightly 00:00, staggered)
- [ ] DB-only `update_identity_section` writer tool
- [ ] UI lock badge + hidden edit/delete for `system` rows
- [ ] Jest tests (guard + seeder behavior); validate routine via `validate_sulla_workflow`

## Gates

Full `tsc` OOMs in Lima → verified with focused Jest + routine validator. Build/package is a host step. Draft only — do not merge.