### PR TITLE
fix(cli): sulla CLI `models/` (and `project/`) category routing

### DIFF
--- a/resources/darwin/bin/sulla
+++ b/resources/darwin/bin/sulla
@@ -25,7 +25,7 @@ BODY="$2"
 # Known internal tool categories. Must stay in sync with agent/tools/registry.ts
 # `categoriesList` so `sulla <category>/<tool>` routes to /v1/tools/internal
 # instead of falling through as a proxy call.
-TOOL_CATEGORIES="agents|applescript|bridge|browser|calendar|capture|docker|extensions|fs|function|github|integrations|kubectl|ledger|lima|marketplace|memory|meta|mobile|notify|observation|pg|projects|rdctl|redis|rules|secretary|settings|skills|slack|ui|vault|work|workflow|workspace"
+TOOL_CATEGORIES="agents|applescript|bridge|browser|calendar|capture|docker|extensions|fs|function|github|integrations|kubectl|ledger|lima|marketplace|memory|meta|mobile|models|notify|observation|pg|project|projects|rdctl|redis|rules|secretary|settings|skills|slack|ui|vault|work|workflow|workspace"
 
 # ── Help & discovery ─────────────────────────────────────────────
 # sulla --help | sulla -h | sulla help | sulla (no args) — query the backend


### PR DESCRIPTION
## Problem
`sulla models/models_list '{"provider":"codex"}'` — the documented `category/tool` invocation — failed with:
```
{"success":false,"error":"Missing required field \"path\" (e.g. \"/rest/companies\", \"/graphql\")"}
```
Only the bare form (`sulla models_list '{...}'`) worked. Same for `models_providers` and `models_usage`.

## Root cause
The `sulla` wrapper script (`resources/darwin/bin/sulla`) hard-codes a `TOOL_CATEGORIES` allowlist (line 28) that it uses to decide whether `PART1/PART2` is an internal tool call (→ `/v1/tools/internal/...`) or a proxy call (→ `/v1/proxy/...`). Its own comment says it *"Must stay in sync with agent/tools/registry.ts categoriesList"*.

It had drifted. `registry.ts` `categoriesList` includes `models` (and `project`), but the wrapper's list did **not** — so `models` failed the category test and fell through to the proxy handler, which requires a REST `path` and errored.

## Fix
Additive one-line change: add `models` and `project` to `TOOL_CATEGORIES`. Left `work` in place (present in wrapper, not in registry list — may be runtime-registered; not removed to avoid regression).

## Verification (live, installed binary patched identically)
- ✅ `sulla models/models_list '{"provider":"codex"}'` → returns Codex provider + 3 models (`codex`, `gpt-5.3-codex`, `gpt-5-codex`)
- ✅ `sulla models/models_providers '{...}'` → provider inventory
- ✅ `sulla models/models_usage '{...}'` → rolling usage
- ✅ `project/` now routes internal (no longer proxy); bare + proxy forms unchanged

## Follow-up (not in this PR)
The allowlist is manually mirrored and will drift again. Worth having the wrapper pull the live category list (the help path already does this via `/v1/tools/help`) or generating the script from `categoriesList` at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)