### PR TITLE
docs: sulla-docs accuracy refresh (part 2 — tool docs + identity/environment)

### DIFF
--- a/resources/sulla-docs/identity/structure.md
+++ b/resources/sulla-docs/identity/structure.md
@@ -102,19 +102,43 @@ The business identity and goals files are the authoritative source for:
 
 ---
 
-## Observational Memory
+## Two memory layers
 
-Short-term facts injected into every agent context:
+Identity lives in **two** places now — the editable `~/sulla/identity/` files above, and a **domain-keyed Postgres store** that the subconscious writes and recalls automatically. Prefer the DB store for anything the agent should learn on its own; the files remain a human-editable baseline.
 
-```bash
-# Add a memory
-exec({ command: "sulla meta/add_observational_memory '{\"priority\":\"high\",\"content\":\"ICP is security-conscious small businesses, not solopreneurs\"}'" })
+### 1. `identity_observations` — domain-keyed identity (the live store)
+Migrations `0050`–`0054`. One row = one focused fact about a domain. The `domain` column is constrained to exactly six values, mirroring `~/sulla/identity/`:
 
-# Remove stale memory
-exec({ command: "sulla meta/remove_observational_memory '{\"id\":\"abc123\"}'" })
+```
+human · business · world · agent · environment · projects
 ```
 
-Observations appear in every agent's context automatically. Use for facts that affect ongoing behavior — not for temporary task state.
+Each row carries a **certainty level**:
+- **L3 — stated fact:** the subject told us directly, or it's a direct instruction.
+- **L2 — derived fact:** established from conversation/tool evidence.
+- **L1 — conclusion:** reasoned from L2/L3 (personality, style, habits).
+
+Plus `category`, provenance/basis, and confidence. Writes **dedupe** — pass an existing `id`, or a substantially-similar active row in the same domain is updated in place instead of duplicated. Soft-archive only.
+
+```bash
+sulla observation/search_identity_observations '{"domain":"human","query":"communication preferences"}'
+sulla observation/add_identity_observation '{"domain":"human","level":3,"category":"preference","content":"Prefers concise status updates.","basis":"Stated directly."}'
+sulla observation/list_identity_observations '{"domain":"business"}'
+sulla observation/remove_identity_observation '{"id":"abcd"}'
+```
+
+A subconscious **observer** per domain writes these after each turn, and a per-domain **recall** agent surfaces the relevant rows before each turn — injected as `<user_observations>` (human), `<self_observations>` (agent), `<business_observations>`, `<world_observations>`, `<environment_observations>`, `<projects_observations>`. Don't hardcode a specific person/business into observer logic — the domain describes *what* to study. Full mechanics: [`environment/subconscious.md`](../environment/subconscious.md).
+
+### 2. `observations` — operational memory
+Migration `0028`. Short, priority-ranked operational facts (surprising or non-obvious), recalled by keyword each turn into `<observation_context>`.
+
+```bash
+sulla observation/add_observational_memory '{"priority":"high","content":"ICP is security-conscious small businesses, not solopreneurs"}'
+sulla observation/search_observations '{"query":"ICP"}'
+sulla observation/remove_observational_memory '{"id":"abc123"}'
+```
+
+Both stores soft-archive (never hard-delete), so history is recoverable. Use them for facts that affect ongoing behavior — not temporary task state (that's Projects, below).
 
 ---
 

--- a/resources/sulla-docs/tools/browser.md
+++ b/resources/sulla-docs/tools/browser.md
@@ -1,6 +1,6 @@
 # Browser Tools
 
-The richest tool surface in Sulla. ~28 tools for tabs, page reading, interaction, JS evaluation, cookies, history, network monitoring, and persistent agent storage. **All tools target Sulla's built-in WebContentsViews — not the user's external browser.**
+The richest tool surface in Sulla. **23 tools** for tabs, page reading, interaction, JS evaluation, cookies, history, network monitoring, and persistent agent storage. **All tools target Sulla's built-in WebContentsViews — not the user's external browser.**
 
 ## Two paradigms — pick the right one
 

--- a/resources/sulla-docs/tools/capture.md
+++ b/resources/sulla-docs/tools/capture.md
@@ -1,10 +1,22 @@
 # Capture Studio Tools
 
-Headless control of Capture Studio components — teleprompter, microphone, desktop-audio loopback, screen enumeration, and screenshots. **All tools run in the main process (no Capture Studio tab needed)** so you can drive these from chat without the user opening the recorder window.
+**20 tools** for headless control of Capture Studio — teleprompter, microphone, desktop-audio loopback, screen/window enumeration, screenshots, and now a full recording pipeline (recorder + camera + screen stream + quality). **You can drive all of it from chat** without the user opening the recorder window.
 
-## What's NOT here (yet)
+## Recording, camera & screen
 
-The renderer-side recorder (multi-track WebM via `MediaRecorder`, camera/screen stream acquisition via `getUserMedia` / `desktopCapturer` in the renderer) is intentionally out of scope for this tool surface. To start a full multi-source recording session today, the user still opens the Capture Studio window manually. The tools here cover everything that doesn't require renderer plumbing — which turns out to be most of what you need for: prompted reads, voice memos, system-audio transcription, screen captures, and AI-driven teleprompter sessions.
+The recorder pipeline is now agent-drivable (it used to require opening the Capture Studio window). Acquire the streams you want, set quality, then start/stop the session.
+
+| Tool | Purpose |
+|------|---------|
+| `sulla capture/list_screens '{"kind":"all"}'` | Enumerate capturable displays and/or windows (`kind`: `screen`/`window`/`all`). |
+| `sulla capture/screen_set '{"sourceId":"..."}'` | Acquire a screen/window capture stream by `sourceId` (from `list_screens`). |
+| `sulla capture/camera_list` | Enumerate video input devices (webcams, capture cards). |
+| `sulla capture/camera_set` | Acquire a camera stream. |
+| `sulla capture/camera_release` | Stop and release the current camera stream. |
+| `sulla capture/quality_set '{"target":"screen","preset":"1080p"}'` | Set the quality preset (`480p`/`720p`/`1080p`/`4k`/`auto`) for the `screen` or `camera` stream. |
+| `sulla capture/recorder_start` | Start a recording session. |
+| `sulla capture/recorder_stop` | Stop the active recording session. |
+| `sulla capture/recorder_status` | Active? + elapsed seconds, bytes written, session directory, last error. |
 
 ## Tool families
 

--- a/resources/sulla-docs/tools/github.md
+++ b/resources/sulla-docs/tools/github.md
@@ -1,83 +1,66 @@
 # Sulla Tools — GitHub / Git
 
+**52 tools** — local git on the shared Mac filesystem, plus the GitHub REST/GraphQL API. All authenticated by the vault PAT.
+
 ## Authentication
 
-Git push/pull authenticates via a Personal Access Token (PAT) stored in the vault. SSH remotes are auto-converted to HTTPS with the PAT injected as `x-access-token`.
+Git and API calls authenticate via a Personal Access Token (PAT) stored in the vault, injected automatically at call time. SSH remotes are auto-converted to HTTPS with the PAT as `x-access-token`. **No SSH key setup, no raw `gh`, never extract the PAT yourself** — it's autofill-protected and a raw `git push` fails with no credential helper. Always go through these tools.
 
-**No SSH key setup needed.** The vault PAT handles all authentication.
-
----
-
-## git_push / git_pull
-
-```bash
-exec({ command: "sulla github/git_push '{\"absolutePath\":\"/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop\"}'" })
-exec({ command: "sulla github/git_pull '{\"absolutePath\":\"/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop\"}'" })
-```
-
-Parameters:
-- `absolutePath` (required): Full path to the git repo on the Mac
-- `remote` (optional): Remote name, defaults to `"origin"`
-- `branch` (optional): Branch name, defaults to current branch
+Local git tools take `absolutePath` — the repo path (or **any path inside it**) on the Mac. Home is shared into Lima, so `/Users/<you>/Sites/...` paths work from the agent.
 
 ---
 
-## git_commit
-
-Stage and commit in one call.
+## Local git (13)
+| Tool | Purpose |
+|------|---------|
+| `git_status` | Working-tree status: branch, staged/unstaged/untracked. |
+| `git_add` | Stage files. |
+| `git_commit` | Stage + commit (`message`; optional `files[]`, else stages all). |
+| `git_push` | Push to remote (PAT injected). `remote` default `origin`, `branch` default current. |
+| `git_pull` | Pull from remote. |
+| `git_branch` | Create / switch / delete / list branches. |
+| `git_checkout` | Restore files from a commit/branch, or discard changes. |
+| `git_log` | Commit history (`limit`). |
+| `git_diff` | Diff working tree / staged / commits. |
+| `git_blame` | Per-line last-modifier attribution. |
+| `git_conflicts` | List conflicted files + their conflict diffs. |
+| `git_stash` | Save / list / apply / pop / drop. |
+| `git_worktree` | Add / list / remove / prune worktrees — check out several branches at once (great for reviewing/building parallel PRs). |
 
 ```bash
-exec({ command: "sulla github/git_commit '{\"absolutePath\":\"/path/to/repo\",\"message\":\"feat: add docs\",\"files\":[\"docs/README.md\"]}'" })
+sulla github/git_push '{"absolutePath":"/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop","branch":"my-branch"}'
+sulla github/git_commit '{"absolutePath":"/path/to/repo","message":"feat: X","files":["docs/README.md"]}'
 ```
 
-Parameters:
-- `absolutePath` (required)
-- `message` (required): Commit message
-- `files` (optional): Array of specific files to stage; omit to stage all changes
+## Repositories & refs (10)
+`github_init`, `github_add_remote`, `github_create_repo`, `github_get_repo`, `github_list_repos`, `github_delete_repo` (destructive), `github_fork_repo`, `github_list_branches`, `github_create_ref` (create a remote branch/tag at a SHA or another branch's tip), `github_delete_ref` (delete a remote branch/tag).
+
+## Files via API (3)
+`github_read_file`, `github_create_file`, `github_update_file` — read/write a file directly in a remote repo without cloning. This is the **API-replication fallback** when local push is unavailable: `create_ref` a branch → `create_file`/`update_file` per changed file → `create_pr`.
+
+## Issues (7)
+`github_create_issue`, `github_get_issue`, `github_get_issues`, `github_get_issue_comments` (PRs are issues — pass the PR number), `github_update_issue`, `github_close_issue` (reason `completed`/`not_planned`), `github_comment_on_issue`.
+
+## Pull requests (11)
+`github_create_pr` (`draft:true` for draft), `github_get_pr`, `github_list_prs`, `github_update_pr`, `github_ready_pr` (draft → ready; drafts can't be merged), `github_close_pr`, `github_merge_pr` (`merge`/`squash`/`rebase`, requires `confirm:true`), `github_add_pr_review` (APPROVE / REQUEST_CHANGES / COMMENT), `github_list_pr_reviews`, `github_request_pr_reviewers`, `github_get_pr_files`.
+
+```bash
+sulla github/github_create_pr '{"owner":"merchantprotocol","repo":"sulla-desktop","title":"feat: X","head":"feature/x","base":"main","draft":true}'
+```
+
+## Releases & CI (3)
+`github_create_release` (cuts the release + git tag), `github_check_runs` (CI status for a ref — is it green?), `github_trigger_workflow_run` (manual `workflow_dispatch`).
+
+## Projects V2 boards (3, GraphQL)
+`github_list_projects` (board node ids + fields + single-select options), `github_add_issue_to_project`, `github_set_project_field` (most often the Status single-select).
+
+## Heartbeat issue-discovery (2)
+`heartbeat_new_issues` (open issues Heartbeat hasn't handled — anti-joined against the seen-set), `heartbeat_claim_issue` (atomic claim + collision guard). Internal to the Heartbeat operator loop.
 
 ---
 
-## git_status / git_diff / git_log
-
-```bash
-exec({ command: "sulla github/git_status '{\"absolutePath\":\"/path/to/repo\"}'" })
-exec({ command: "sulla github/git_diff '{\"absolutePath\":\"/path/to/repo\"}'" })
-exec({ command: "sulla github/git_log '{\"absolutePath\":\"/path/to/repo\",\"limit\":10}'" })
-```
-
----
-
-## git_branch / git_checkout
-
-```bash
-exec({ command: "sulla github/git_branch '{\"absolutePath\":\"/path/to/repo\"}'" })
-exec({ command: "sulla github/git_checkout '{\"absolutePath\":\"/path/to/repo\",\"branch\":\"feature/new-thing\",\"create\":true}'" })
-```
-
----
-
-## GitHub API Tools
-
-### Create Issue
-```bash
-exec({ command: "sulla github/github_create_issue '{\"owner\":\"merchantprotocol\",\"repo\":\"sulla-desktop\",\"title\":\"Bug: X fails\",\"body\":\"Details...\",\"labels\":[\"bug\"]}'" })
-```
-
-### Create Pull Request
-```bash
-exec({ command: "sulla github/github_create_pr '{\"owner\":\"merchantprotocol\",\"repo\":\"sulla-desktop\",\"title\":\"feat: X\",\"body\":\"Summary...\",\"head\":\"feature/x\",\"base\":\"main\"}'" })
-```
-
-### Read/Write Files via GitHub API
-```bash
-exec({ command: "sulla github/github_read_file '{\"owner\":\"merchantprotocol\",\"repo\":\"sulla-resources\",\"path\":\"skills/README.md\"}'" })
-exec({ command: "sulla github/github_create_file '{\"owner\":\"merchantprotocol\",\"repo\":\"sulla-resources\",\"path\":\"skills/new-skill.md\",\"content\":\"...\",\"message\":\"add skill\"}'" })
-```
-
----
-
-## Important Notes
-
-- All git operations work on the **Mac filesystem** (paths like `/Users/jonathonbyrdziak/...`) even though the agent runs in Lima — the home dir is shared.
-- Commits show author as configured in the repo's git config.
-- PAT is fetched from vault at call time — never expires mid-session unexpectedly.
+## Notes
+- All local git operates on the **Mac filesystem** — the home dir is shared into Lima.
+- Commit author is the repo's configured git identity.
+- Merges and destructive ops (`github_merge_pr`, `github_delete_repo`) require `confirm:true`.
+- Pushed changes to a running app still need a **rebuild/restart** to take effect in the binary.


### PR DESCRIPTION
Continuation of the sulla-docs accuracy refresh (part 1 was #609, merged). Ground-truthed against source manifests + code.

**In this PR (growing):**
- `github.md` — rewritten for all **52** tools (was 25): local git incl worktree, repos/refs, API files + replication fallback, issues, 11 PR tools, releases/CI, Projects V2, heartbeat issue-discovery.

**Planned on this branch:** `identity/structure.md` (add identity_observations DB + 6 domains + L3/L2/L1), `browser.md` (23), `capture.md` (20), `meta.md` (spawn_agent/identity/recall sections), `overview.md` table, `pg.md` tables, remaining `environment/` + `agent-patterns/` + `workflows/` + `functions/` verification.

Docs-only; takes effect for running agents on next rebuild/package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)