### PR TITLE
feat(subconscious): give projects recall read-only Projects work-state tools

### DIFF
--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -63,6 +63,22 @@ const IDENTITY_OBSERVATION_RECALL_TOOLS: string[] = [
   'list_identity_observations',
 ];
 
+/** Projects recall also needs read-only access to live Projects work-state:
+ *  keyword search to find relevant items, plus drill-down to pull a hit's full
+ *  detail (children/status) and its comment thread when the turn needs it. */
+function identityObservationRecallToolsForDomain(domain: string): string[] {
+  if (domain === 'projects') {
+    return [
+      ...IDENTITY_OBSERVATION_RECALL_TOOLS,
+      'search_project_items',  // keyword search across projects/epics/tasks
+      'get_project_item',      // fetch one hit's full detail + children/comments
+      'list_task_comments',    // read a task's progress/blocker/decision thread
+    ];
+  }
+
+  return IDENTITY_OBSERVATION_RECALL_TOOLS;
+}
+
 /**
  * Per-domain focus config for the identity observer template. Mirrors
  * ~/sulla/identity/ (human / business / world / agent). Adding a new domain
@@ -492,8 +508,9 @@ ${ cfg.focus }
 Rules:
 - Call search_identity_observations with key topic/phrase variants from the conversation.
 - Optionally call list_identity_observations when broad identity context is needed.
-- Return ONLY observations that are relevant or possibly relevant to this turn.
+${ cfg.domain === 'projects' ? '- Also call search_project_items when the current turn names, implies, or depends on live Projects work-state. Use it only to find relevant project/epic/task context; do not create, update, archive, or comment on project items from recall.\n- When a search hit is clearly central to this turn and its title/status is not enough, drill down: call get_project_item to pull that item\'s full detail (children, status) or list_task_comments to read a task\'s progress/blocker/decision thread. These are READ-ONLY. Drill down only for the one or two items that actually matter — you block the primary agent, so do not fetch detail for every hit.\n' : '' }- Return ONLY observations that are relevant or possibly relevant to this turn.
 - Format each result as: \`[id] L<level>·<category> date — content (basis: ...)\`
+- When including live Projects work-state from search_project_items, format it as: \`[project:<id>] <kind> <status> — <title> (source: Projects work-state)\`
 - If many observations are relevant, return many. If only a few matter, return a few.
 - If nothing is relevant, return an empty string — do NOT pad with filler.
 - Do NOT narrate your process. Output only the filtered observation lines.
@@ -979,7 +996,7 @@ export const GraphRegistry = {
     const graph = createSubconsciousGraph();
     const state = await buildSubconsciousState({
       systemPrompt:           buildIdentityObservationRecallPrompt(cfg),
-      tools:                  IDENTITY_OBSERVATION_RECALL_TOOLS,
+      tools:                  identityObservationRecallToolsForDomain(cfg.domain),
       userMessage:            `Read the recent conversation context and return only ${ cfg.domain } identity observations that are relevant or possibly relevant to what is happening now. Return compact lines only — nothing if nothing is relevant.`,
       messages:               [...parentState.messages],
       contextWindow:          20,

--- a/resources/sulla-docs/environment/subconscious.md
+++ b/resources/sulla-docs/environment/subconscious.md
@@ -99,7 +99,8 @@ Subconscious writers are **observers, not actors**. They are granted only observ
 | Tool-Result Digester | none |
 | Observation Recall | `search_observations`, `list_observations` (read-only) |
 | Observation Writer | `add_/remove_/search_/list_observational_memory` |
-| Identity Recall (per domain) | `search_/list_identity_observations` (read-only) |
+| Identity Recall (human / agent / business / world / environment) | `search_/list_identity_observations` (read-only) |
+| Identity Recall (projects) | `search_/list_identity_observations` + `search_project_items` (read-only) |
 | Identity Observer (per domain) | `add_/remove_/search_/list_identity_observation` |
 
 Subconscious agents also never get host access even when the primary Sulla agent does.
@@ -135,6 +136,6 @@ Every user-facing conversation is written to `~/sulla/logs/conv_*.jsonl` (traini
 ---
 
 ## Adding a new identity domain
-It's deliberately cheap: add one `IdentityObserverDomainConfig` entry in `GraphRegistry.ts`, one dispatch line in `SubconsciousMiddleware.ts`, and (if it's a new `domain` value) widen the check constraint with a migration. No new table, model, or tool — every domain shares `identity_observations` and the same four identity tools.
+It's deliberately cheap: add one `IdentityObserverDomainConfig` entry in `GraphRegistry.ts`, one dispatch line in `SubconsciousMiddleware.ts`, and (if it's a new `domain` value) widen the check constraint with a migration. No new table or model — every domain shares `identity_observations`; only add domain-specific read tools when recall needs another existing source of truth, as projects recall does with `search_project_items`.
 
 See also: [`tools/meta.md`](../tools/meta.md) (memory + identity tool reference), [`identity/structure.md`](../identity/structure.md) (the `~/sulla/identity/` files), [`environment/heartbeat.md`](heartbeat.md).


### PR DESCRIPTION
## What

Gives the **projects identity-recall** subconscious agent read-only access to the live Projects work-state, so pre-turn recall can ground context in real project/epic/task state instead of only static identity observations.

Tools added to the projects recall allowlist (`identityObservationRecallToolsForDomain('projects')`):

| tool | purpose |
|------|---------|
| `search_project_items` | keyword search across projects/epics/tasks (base) |
| `get_project_item` | drill down into one hit's full detail + children/status |
| `list_task_comments` | read a task's progress/blocker/decision thread |

All three are **read-only** — recall never creates, updates, archives, or comments on project items. Only the `projects` domain gets these; other identity domains are unchanged.

## Why / latency guardrail

Recall **blocks the primary agent**, so the prompt teaches selective drill-down: only fetch full detail for the one or two items that actually matter, never for every search hit. This keeps recall from ballooning turn latency (consistent with the "recall must not block instructed execution" guidance).

## Files
- `pkg/rancher-desktop/agent/services/GraphRegistry.ts` — allowlist + prompt guidance + wiring resolves via `identityObservationRecallToolsForDomain(cfg.domain)`
- `resources/sulla-docs/environment/subconscious.md` — docs updated for the projects-specific tool set

## Notes for review
- The base `search_project_items` recall capability was uncommitted local working-tree work; this PR commits it together with the new drill-down tools as one coherent change. Unrelated in-flight provider-settings edits in the working tree were deliberately left out.
- Full agent `tsc`/build is memory/rebuild-gated in the Lima VM; change is additive strings + a template literal (no type surface change). No invariant test asserts this allowlist.

**Draft — do not merge/deploy without Jonathon.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
