### PR TITLE
fix(chat): start a new thinking bubble after each assistant reply

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/MessageDispatcher.ts
+++ b/pkg/rancher-desktop/agent/database/models/MessageDispatcher.ts
@@ -50,12 +50,27 @@ function isUserTurnBoundary(m: ChatMessage, msgThreadId: string): boolean {
   return m.id.startsWith('user_');
 }
 
+function isAssistantOutputBoundary(m: ChatMessage, msgThreadId: string): boolean {
+  if (m.role !== 'assistant') return false;
+  if (m.threadId && msgThreadId && m.threadId !== msgThreadId) return false;
+
+  // Visible assistant output ends one thinking lifecycle. The final full reply
+  // dump is often dropped when streaming segments already showed it, so the
+  // completed streaming segment itself has to serve as the boundary.
+  if (!m.kind || m.kind === 'text' || m.kind === 'streaming' || m.kind === 'html') {
+    return true;
+  }
+
+  return false;
+}
+
 function appendThinkingMessage(ctx: DispatchContext, agentId: string, msgThreadId: string, content: string): void {
   let existingIdx = -1;
 
   for (let i = ctx.messages.length - 1; i >= 0; i--) {
     const m = ctx.messages[i];
     if (isUserTurnBoundary(m, msgThreadId)) break;
+    if (isAssistantOutputBoundary(m, msgThreadId)) break;
     if (m.kind === 'thinking' && m.role === 'assistant') {
       existingIdx = i;
       break;

--- a/pkg/rancher-desktop/agent/database/models/__tests__/MessageDispatcher.thinking.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/MessageDispatcher.thinking.test.ts
@@ -107,4 +107,42 @@ describe('MessageDispatcher thinking coalescing', () => {
     expect(thinkingMessages).toHaveLength(2);
     expect(thinkingMessages[1].content).toBe('Thinking about the second request');
   });
+
+  it('starts a new thinking bubble after visible assistant output', () => {
+    const messages: ChatMessage[] = [
+      {
+        id:        'user_1',
+        channelId: 'sulla-desktop',
+        threadId:  'thread-1',
+        role:      'user',
+        content:   'request',
+      },
+      {
+        id:        'thinking_1',
+        channelId: 'sulla-desktop',
+        threadId:  'thread-1',
+        role:      'assistant',
+        kind:      'thinking',
+        content:   'Thinking before the answer',
+        _completed: true,
+      } as ChatMessage,
+      {
+        id:         'streaming_1',
+        channelId:  'sulla-desktop',
+        threadId:   'thread-1',
+        role:       'assistant',
+        kind:       'streaming',
+        content:    'The answer already streamed here.',
+        _completed: true,
+      } as ChatMessage,
+    ];
+    const ctx = makeContext(messages);
+
+    createMessageDispatcher().dispatch(ctx, 'sulla-desktop', 'thread-1', thinking('Thinking after the answer'));
+
+    const thinkingMessages = ctx.messages.filter(m => m.kind === 'thinking');
+    expect(thinkingMessages).toHaveLength(2);
+    expect(thinkingMessages[0].content).toBe('Thinking before the answer');
+    expect(thinkingMessages[1].content).toBe('Thinking after the answer');
+  });
 });


### PR DESCRIPTION
## Problem
The recent thinking-bubble *merge* work regressed the transcript: after an assistant reply dropped, no new thinking bubble was created. All reasoning collapsed into a single bubble pinned at the very top, and assistant replies stacked together with no thinking between them.

## Root cause
`appendThinkingMessage()` in `MessageDispatcher.ts` walked backward through the turn and appended new thinking into *any* prior thinking message, stopping only at a user-turn boundary. Once a reply had streamed, that walk still reached the already-sealed thinking bubble sitting **above** the reply and re-opened it — merging every later reasoning burst back up into the top bubble.

## Fix
Add `isAssistantOutputBoundary()` and use it as a stop condition in the backward scan:
- Visible assistant output (`text` / `streaming` / `html`, or an untyped reply bubble) now **terminates** the scan.
- An active (unsealed) thinking bubble still receives new thinking.
- Once a reply drops, the next thinking starts a **fresh active bubble at the correct timeline position**, below the reply.
- Tool cards (`kind: 'tool'`) are intentionally **not** boundaries, so reasoning still coalesces across tool calls.

This matches the intended model: active bubble takes thinking → assistant reply marks it inactive → new thinking opens a new bubble in place.

## Tests
Adds a regression test (`starts a new thinking bubble after visible assistant output`). All 3 thinking-coalescing tests pass; existing restored-context merge behavior is preserved.

## Not live yet
Requires a host rebuild (`yarn build` — can't run in the Lima VM) before the running desktop app reflects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)