### PR TITLE
fix(subconscious): make memory observers observe, not act

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -44,6 +44,34 @@ const perf = Logging.perf;
  * (or ANTHROPIC_API_KEY) and stay out of its auth lifecycle.
  */
 
+/**
+ * Base `--disallowedTools` set applied to EVERY claude spawn (primary and
+ * subconscious): the built-in AskUserQuestion (routed through the sulla-native
+ * MCP tool instead) and Claude Code's built-in task/todo list, which competes
+ * with Sulla Projects. See buildSpawnArgs for the full rationale.
+ */
+const BASE_DISALLOWED_TOOLS = 'AskUserQuestion TaskCreate TaskUpdate TaskList TaskGet TodoWrite TodoRead';
+
+/**
+ * Additional native tools disabled for SUBCONSCIOUS (observer) spawns only.
+ *
+ * Subconscious agents (observation/identity writers + recalls, summarizer,
+ * digester) are OBSERVERS — their entire job is to read the conversation and
+ * record memory through their Sulla DB tools. They must never take real action
+ * on the host. Their Sulla-registry toolset is already locked down to DB tools
+ * via `allowedToolNames`, but that gate does NOT govern Claude Code's OWN
+ * built-in tools. Spawned with --dangerously-skip-permissions, the CLI would
+ * otherwise hand an observer full Read/Write/Edit/Bash/Grep/WebFetch access —
+ * so a subconscious pass could (and did) start editing files instead of just
+ * observing. Denylisting the native actor tools here makes acting structurally
+ * impossible, matching the observer invariant (observers get DB tools only,
+ * never filesystem/shell/source-control/browser/code-editing tools).
+ *
+ * Names include current + legacy aliases (e.g. KillShell/KillBash) so a rename
+ * on either side is harmless — an unknown disallowed name is simply ignored.
+ */
+const SUBCONSCIOUS_NATIVE_TOOL_DENYLIST = 'Read Write Edit MultiEdit NotebookEdit Bash BashOutput KillShell KillBash Glob Grep WebFetch WebSearch Task SlashCommand';
+
 /** Idle timeout for a speculatively-booted process that is never claimed. */
 const PREWARM_IDLE_REAP_MS = 60_000;
 
@@ -194,6 +222,12 @@ export class ClaudeCodeService extends BaseLanguageModel {
     existingSession?: string;
     mcpConfigPath:   string | null;
     streamJsonInput: boolean;
+    /**
+     * Observer spawn: extend --disallowedTools with the native actor toolset
+     * (Read/Write/Edit/Bash/…) so a subconscious pass can only observe and
+     * write memory, never touch the host. See SUBCONSCIOUS_NATIVE_TOOL_DENYLIST.
+     */
+    subconscious?:   boolean;
   }): string[] {
     // POSIX single-quote escape. Single-quoted strings are literal in sh, so
     // no backtick/$VAR/! expansion can fire against untrusted text.
@@ -220,7 +254,12 @@ export class ClaudeCodeService extends BaseLanguageModel {
       // (Postgres) — there must be exactly one task system, not a second
       // in-memory to-do list. NOTE: TaskOutput / TaskStop are background-process
       // controls (not the to-do list) and stay enabled.
-      '--disallowedTools', 'AskUserQuestion TaskCreate TaskUpdate TaskList TaskGet TodoWrite TodoRead',
+      //
+      // Subconscious observers additionally lose the native actor tools
+      // (Read/Write/Edit/Bash/…) — see SUBCONSCIOUS_NATIVE_TOOL_DENYLIST.
+      '--disallowedTools', p.subconscious
+        ? `${ BASE_DISALLOWED_TOOLS } ${ SUBCONSCIOUS_NATIVE_TOOL_DENYLIST }`
+        : BASE_DISALLOWED_TOOLS,
     ];
     // stream-json input lets the process boot before the prompt exists (the
     // prompt is fed as a JSON user message on stdin by the caller).
@@ -272,7 +311,8 @@ export class ClaudeCodeService extends BaseLanguageModel {
         }
       } catch { /* continue without sulla-native tools */ }
 
-      const args = this.buildSpawnArgs({ oauthToken, apiKey, existingSession, mcpConfigPath, streamJsonInput: true });
+      const subconscious = !!(state.metadata as any)?.isSubAgent;
+      const args = this.buildSpawnArgs({ oauthToken, apiKey, existingSession, mcpConfigPath, streamJsonInput: true, subconscious });
       const proc = childProcess.spawn(paths.limactl, args, {
         env: { ...process.env, LIMA_HOME: paths.lima, TERM: 'dumb' },
       });
@@ -834,7 +874,12 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
     // no shell layer between the SSH session and the CLI. When speculative,
     // buildSpawnArgs adds --input-format stream-json and the prompt is delivered
     // as a JSON line on stdin (see below) instead of raw text.
-    const args = this.buildSpawnArgs({ oauthToken, apiKey, existingSession, mcpConfigPath, streamJsonInput: speculative });
+    // Observer runs (subconscious writers/recalls/summarizer/digester) lose the
+    // native actor tools so they can only observe + write memory, never act on
+    // the host. Keyed off the graph state's isSubAgent flag (set for every
+    // subconscious build in buildSubconsciousState).
+    const subconscious = !!(options.state?.metadata as any)?.isSubAgent;
+    const args = this.buildSpawnArgs({ oauthToken, apiKey, existingSession, mcpConfigPath, streamJsonInput: speculative, subconscious });
 
     const cleanupMcp = () => {
       if (mcpSession) {

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -916,6 +916,10 @@ export const GraphRegistry = {
       // Wider than recall — the writer mines the conversation for facts —
       // but still bounded; the summarizer compacts anything older anyway.
       contextWindow:          30,
+      // Observe a flat transcript, not a live agentic thread — see
+      // buildObserverTranscriptMessage. Keeps the writer recording memory
+      // instead of continuing the assistant's work.
+      observeAsTranscript:    true,
       parentAbortSignal:      (parentState.metadata as any).options?.abort,
       agentLabel:             'observation',
       // Post-turn writer — runs after the loop closed; narrate nothing.
@@ -951,6 +955,7 @@ export const GraphRegistry = {
       messages:               [...parentState.messages],
       // Same window as the general writer — it mines conversation for facts.
       contextWindow:          30,
+      observeAsTranscript:    true,   // flat transcript — observe, don't act
       parentAbortSignal:      (parentState.metadata as any).options?.abort,
       agentLabel:             `identity-observer-${ cfg.domain }`,
       // Post-turn writer — runs after the loop closed; narrate nothing.
@@ -983,6 +988,7 @@ export const GraphRegistry = {
       userMessage:            `Read the recent conversation context and return only ${ cfg.domain } identity observations that are relevant or possibly relevant to what is happening now. Return compact lines only — nothing if nothing is relevant.`,
       messages:               [...parentState.messages],
       contextWindow:          20,
+      observeAsTranscript:    true,   // flat transcript — observe, don't act
       parentAbortSignal:      (parentState.metadata as any).options?.abort,
       agentLabel:             `identity-observation-recall-${ cfg.domain }`,
       parentWsChannel:        String(parentState.metadata.wsChannel || ''),
@@ -1013,6 +1019,7 @@ export const GraphRegistry = {
       messages:               [...parentState.messages],
       // Recent tail only: obs-recall reads the latest exchange, then searches the table.
       contextWindow:          20,
+      observeAsTranscript:    true,   // flat transcript — observe, don't act
       parentAbortSignal:      (parentState.metadata as any).options?.abort,
       agentLabel:             'observation-recall',
       parentWsChannel:        String(parentState.metadata.wsChannel || ''),
@@ -1431,6 +1438,73 @@ function windowedContext(messages: any[], windowSize: number, maxBlockChars: num
   });
 }
 
+/**
+ * Render one message's content as a compact plain-text line for an observer
+ * transcript. tool_use / tool_result blocks are described in prose ("[called
+ * tool X …]", "[tool result …]") rather than replayed as structural blocks —
+ * the observer only needs to know what happened, not to sit inside a live
+ * tool-calling turn it might feel compelled to continue.
+ */
+function observerBlocksToText(content: any): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return content == null ? '' : JSON.stringify(content);
+
+  const parts: string[] = [];
+  for (const b of content) {
+    if (!b || typeof b !== 'object') { if (b != null) parts.push(String(b)); continue }
+    if (b.type === 'text' && typeof b.text === 'string') {
+      parts.push(b.text);
+    } else if (b.type === 'tool_use') {
+      const input = b.input ? ` ${ JSON.stringify(b.input).slice(0, 300) }` : '';
+      parts.push(`[called tool ${ b.name || 'unknown' }${ input }]`);
+    } else if (b.type === 'tool_result') {
+      const inner = typeof b.content === 'string'
+        ? b.content
+        : Array.isArray(b.content)
+          ? b.content.map((c: any) => (c?.type === 'text' && typeof c.text === 'string' ? c.text : c?.type === 'image' ? '[image omitted]' : '')).filter(Boolean).join('\n')
+          : JSON.stringify(b.content ?? '');
+      parts.push(`[tool result] ${ inner }`);
+    } else if (b.type === 'image') {
+      parts.push('[image omitted]');
+    } else {
+      parts.push(JSON.stringify(b));
+    }
+  }
+  return parts.join('\n');
+}
+
+/**
+ * Flatten a windowed conversation context into a single observer message: a
+ * plain-text transcript bracketed by explicit markers, preceded by a hard
+ * observe-don't-act instruction and followed by the caller's task prompt. The
+ * absence of any real assistant/tool_use/tool_result message structure — plus
+ * the explicit framing — is what stops the observer from continuing the
+ * assistant's work instead of recording memory about it.
+ */
+function buildObserverTranscriptMessage(context: any[], userMessage: string): string {
+  const lines: string[] = [];
+  for (const m of context) {
+    if (!m || m.role === 'system') continue;                 // observer has its own system prompt
+    if (m?.metadata?.source === 'subconscious') continue;    // skip prior subconscious injections
+    const who = m.role === 'assistant' ? 'Assistant' : m.role === 'user' ? 'User' : (m.role || 'unknown');
+    const text = observerBlocksToText(m.content).trim();
+    if (!text) continue;
+    lines.push(`${ who }: ${ text }`);
+  }
+  const transcript = lines.join('\n\n') || '(no prior conversation)';
+
+  return [
+    'You are a silent OBSERVER of the conversation below. Your ONLY job is to analyze it and record memory through your provided database tools.',
+    'You are NOT a participant. Do NOT continue the assistant\'s work, do NOT take any action the conversation describes, and do NOT read, write, or edit files, run commands, browse, or use source control. Only observe and record.',
+    '',
+    '=== BEGIN CONVERSATION TRANSCRIPT ===',
+    transcript,
+    '=== END CONVERSATION TRANSCRIPT ===',
+    '',
+    userMessage,
+  ].join('\n');
+}
+
 async function buildSubconsciousState(opts: {
   systemPrompt:          string;
   tools:                 string[];
@@ -1440,6 +1514,18 @@ async function buildSubconsciousState(opts: {
   contextWindow?:        number;
   /** Per-block truncation size used with contextWindow; default 4000 chars */
   maxContextBlockChars?: number;
+  /**
+   * OBSERVER FRAMING. When true, the conversation is NOT inherited as a live
+   * multi-turn message array (assistant turns + tool_use / tool_result blocks).
+   * Instead it is flattened into a single plain-text transcript wrapped in one
+   * user message: "here is a conversation to observe; record memory; take no
+   * action." Handing an observer the raw agentic message array makes the model
+   * read it as a live session it's sitting inside — so it keeps working (runs
+   * tools, edits files) instead of observing. A flat transcript with no
+   * tool_use/tool_result scaffolding removes that structural cue. Pair with the
+   * subconscious native-tool lockdown in ClaudeCodeService for defense in depth.
+   */
+  observeAsTranscript?:  boolean;
   maxIterations?:        number;
   temperature?:          number;
   format?:               'json';
@@ -1490,7 +1576,19 @@ async function buildSubconsciousState(opts: {
   const context: any[] = opts.messages
     ? (opts.contextWindow ? windowedContext(opts.messages, opts.contextWindow, opts.maxContextBlockChars ?? 4_000) : [...opts.messages])
     : [];
-  const messages: any[] = [...context, { role: 'user', content: opts.userMessage, metadata: { source: 'subconscious' } }];
+
+  // OBSERVER FRAMING (observeAsTranscript): collapse the inherited conversation
+  // into ONE user message containing a flat transcript + an observe-don't-act
+  // instruction, so the model treats it as material to analyze, not a live
+  // session to continue. Otherwise keep the legacy behavior: replay the raw
+  // message array and append the instruction as the last user turn.
+  const messages: any[] = opts.observeAsTranscript
+    ? [{
+      role:     'user',
+      content:  buildObserverTranscriptMessage(context, opts.userMessage),
+      metadata: { source: 'subconscious' },
+    }]
+    : [...context, { role: 'user', content: opts.userMessage, metadata: { source: 'subconscious' } }];
 
   return {
     messages,


### PR DESCRIPTION
## Problem

When the subconscious memory agents run on the **claude-code** (or codex) provider, they were taking real filesystem/shell/code action — reading, writing, and editing files — instead of just observing the conversation and recording memory. Two independent leaks caused this.

### Leak 1 — native provider tools were wide open
The subconscious provider defaults to `claude-code` (`ModelProviderService`). The CLI is spawned with `--dangerously-skip-permissions` and only disallowed `AskUserQuestion` + the Task/Todo list — so `Read/Write/Edit/Bash/Grep/WebFetch` stayed live. Our `allowedToolNames` lockdown (DB tools only) governs **Sulla's** registry tools, **not** the CLI's own built-ins. So an observer could (and did) edit the codebase from a subconscious pass. This violates the observer invariant: observers get DB tools only, never fs/shell/scm/browser/code.

### Leak 2 — the framing invited acting
`buildSubconsciousState` handed each observer a **copy of the live agentic message array** (assistant turns + `tool_use`/`tool_result` blocks) with the "observe this" instruction tacked on as the last user turn. The model reads that as a live session it's sitting inside — so it keeps working.

## Fix (both halves)

**A. Reframe the input (`GraphRegistry.ts`).** New `observeAsTranscript` mode flattens the windowed thread into **one** plain-text transcript inside a single user message, wrapped in an explicit observe-don't-act instruction. No `tool_use`/`tool_result` scaffolding to sit inside. Enabled for the observation writer, the domain identity observers, and both recall agents.

**B. Hard-disable the native tools for observer runs (`ClaudeCodeService.ts`).** `buildSpawnArgs` takes a `subconscious` flag (keyed off `state.isSubAgent` at both call sites + prewarm) and extends `--disallowedTools` with the native actor set (`Read/Write/Edit/MultiEdit/NotebookEdit/Bash/Glob/Grep/WebFetch/WebSearch/Task/…`). Acting becomes structurally impossible. Same lockdown covers the codex path.

B is what closes the hole; A removes the model's instinct to reach for tools. Belt-and-suspenders.

Summarizer/digester are intentionally unchanged (they need structured message-ids / are already single-message) and remain covered by fix B via `isSubAgent`.

## Verification
- Both changed files pass `esbuild` transpile (parse) clean.
- Full agent `tsc` is memory/rebuild-gated on this host (OOM-kills, same wall the DOD1 work hits) — **not** yet run to completion. Needs a rebuild-host typecheck before merge.
- No behavior change on the primary agent path (flag is false for non-subagents).

Draft — do not merge without Jonathon + a clean typecheck/rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)