### PR TITLE
fix(vm): install real bash — Claude Code Bash tool died with constant exit 2

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -701,11 +701,29 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     const dockerComposeScript = '#!/bin/sh\nset -o errexit\napk info -e docker-cli-compose >/dev/null 2>&1 || { apk update && apk add --no-cache docker-cli-compose; }';
     const pythonNodeScript = '#!/bin/sh\nset -o errexit\napk info -e python3 nodejs npm >/dev/null 2>&1 || apk add --no-cache python3 py3-pip nodejs npm git jq yq tree rsync curl nano vim';
 
+    // Real GNU bash. The base image only ships busybox (/bin/sh -> /bin/ash).
+    // Claude Code's Bash tool launches its persistent shell with bash-only
+    // options (e.g. `-O expand_aliases`) and sources a snapshot that uses bash
+    // arrays. busybox ash rejects the unknown option and exits 2 *before*
+    // running anything, so every Bash call returns a constant exit 2 with no
+    // stdout/stderr. A hand-rolled `/bin/bash -> ash` shim makes it worse: the
+    // CLI finds a "bash" that silently fails instead of a missing-binary error.
+    // Kept as its own guarded step so existing VMs (where python3/nodejs/npm
+    // are already present and that install short-circuits) still get bash.
+    const bashScript = [
+      '#!/bin/sh',
+      'set -o errexit',
+      'apk info -e bash >/dev/null 2>&1 && exit 0',
+      '# Drop a non-apk shim squatting on the path so apk can own /bin/bash.',
+      'if [ -e /bin/bash ] && ! apk info -W /bin/bash >/dev/null 2>&1; then rm -f /bin/bash; fi',
+      'apk add --no-cache bash',
+    ].join('\n');
+
     // Remove any previously appended copies (including old unguarded format) to prevent duplication
     config.provision = config.provision.filter((p: { script?: string }) => {
       const s = p.script ?? '';
 
-      return !s.includes('docker-cli-compose') && !s.includes('py3-pip nodejs npm');
+      return !s.includes('docker-cli-compose') && !s.includes('py3-pip nodejs npm') && !s.includes('apk info -W /bin/bash');
     });
 
     if (this.cfg?.containerEngine?.name === ContainerEngine.MOBY) {
@@ -719,6 +737,12 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
     config.provision.push({
       mode:   'system',
       script: pythonNodeScript,
+    });
+
+    // Install real bash before the AI CLIs — their Bash tool depends on it.
+    config.provision.push({
+      mode:   'system',
+      script: bashScript,
     });
 
     // Install Claude Code CLI.


### PR DESCRIPTION
## Root cause

The in-app agent's **Bash tool was completely dead**: every command returned a
constant **exit 2 with zero stdout/stderr**. `true`, `false`, `exit 7` and
`echo hello` all failed identically, which proved the command string never
reached a shell.

It was **not** the host bridge, the sandbox, or the VM being down. Verified
on the live VM (`~/.rd/lima`, instance `0`, status Running):

```
$ limactl shell 0 -- sh -lc 'export HOME=...; export PATH=...; echo hello'
hello        # exit 0 — the host bridge works fine
```

The break is **inside the guest**. Claude Code runs in the VM
(`ClaudeCodeService.buildClaudeArgs` -> `limactl shell 0 -- sh -c 'exec claude -p …'`),
so its Bash tool uses the guest's `/bin/bash`. But the Alpine base image ships
only busybox, and nothing ever provisioned bash — `lima.ts:702` installs
`python3 py3-pip nodejs npm git jq yq tree rsync curl nano vim`, no `bash`.

Something had papered over that with a hand-rolled 29-byte shim:

```
$ ls -la /bin/bash
-rwxr-xr-x 1 root root 29 Aug 19 22:28 /bin/bash
$ cat /bin/bash
#!/bin/sh
exec /bin/ash "$@"
```

Claude Code's Bash tool starts its persistent shell with **bash-only options**
and sources a snapshot using **bash arrays**. busybox ash rejects those:

```
$ /bin/bash -O expand_aliases -c "echo hello"; echo $?
2            # <-- no output, exit 2, command never ran
$ /bin/bash --version; echo $?
2
$ /bin/bash -c 'echo ${arr[0]}'; echo $?
2            # parse error
```

That is the exact reported signature. The shim made it worse than a missing
binary: the CLI found a "bash" that silently fails instead of erroring out.

## Fix

Provision real GNU bash as its **own guarded step**. It can't be appended to
the existing python/node line because that install short-circuits on
`apk info -e python3 nodejs npm`, so existing VMs would never get bash. The
script also evicts a non-apk shim squatting on `/bin/bash` so apk can own the
path.

Idempotent, and deduped on repeated config writes via the existing provision filter.

## Test plan

- [ ] `sh -n` on the generated provision script — **passes** (validated locally)
- [ ] Restart the VM so provisioning reruns; confirm `apk info -e bash` succeeds and `/bin/bash --version` reports GNU bash
- [ ] Through the app's Bash tool: `echo hello` -> `hello`, exit 0; `true` -> 0; `false` -> 1; `exit 7` -> 7
- [ ] Confirm `tsc --noEmit` is clean (blocked locally by the sandbox classifier — needs a run in CI)

## Notes

- Not a regression from #620 / `buildAiCliProvisionScript`. That reworked the AI-CLI symlink path and is unrelated; bash was never installed at any point.
- Do **not** merge — Jonathon reviews/merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)