### PR TITLE
feat(models): make model discovery live-first, drop hardcoded catalogs

### DIFF
--- a/pkg/rancher-desktop/agent/integrations/select_box/KimiModels.ts
+++ b/pkg/rancher-desktop/agent/integrations/select_box/KimiModels.ts
@@ -1,13 +1,47 @@
 import { SelectBoxProvider, type SelectBoxContext, type SelectOption } from './SelectBoxProvider';
 
+// Offline fallback only — used when the live Moonshot /models call fails or the
+// user hasn't supplied an api_key yet. The authoritative list is fetched live.
+const KIMI_FALLBACK: SelectOption[] = [
+  { value: 'moonshot-v1-128k', label: 'Moonshot v1 128K', description: '128K context window' },
+  { value: 'moonshot-v1-32k', label: 'Moonshot v1 32K', description: '32K context window' },
+  { value: 'moonshot-v1-8k', label: 'Moonshot v1 8K', description: '8K context window' },
+];
+
 export class KimiModels extends SelectBoxProvider {
   readonly id = 'kimi_models';
 
-  async getOptions(_context: SelectBoxContext): Promise<SelectOption[]> {
-    return [
-      { value: 'moonshot-v1-128k', label: 'Moonshot v1 128K', description: '128K context window' },
-      { value: 'moonshot-v1-32k', label: 'Moonshot v1 32K', description: '32K context window' },
-      { value: 'moonshot-v1-8k', label: 'Moonshot v1 8K', description: '8K context window' },
-    ];
+  async getOptions(context: SelectBoxContext): Promise<SelectOption[]> {
+    const apiKey = context.formValues.api_key;
+
+    if (!apiKey) {
+      return KIMI_FALLBACK;
+    }
+
+    try {
+      const response = await fetch('https://api.moonshot.cn/v1/models', {
+        headers: { Authorization: `Bearer ${ apiKey }` },
+      });
+
+      if (!response.ok) {
+        console.warn(`[KimiModels] API call failed: ${ response.status } ${ response.statusText }`);
+        return KIMI_FALLBACK;
+      }
+
+      const body = await response.json() as { data?: { id: string }[] };
+
+      if (body.data && body.data.length > 0) {
+        console.log(`[KimiModels] Got ${ body.data.length } models from Moonshot API`);
+        return body.data
+          .sort((a, b) => a.id.localeCompare(b.id))
+          .map(m => ({ value: m.id, label: m.id }));
+      }
+
+      console.warn('[KimiModels] API returned no data');
+    } catch (err) {
+      console.error('[KimiModels] API call failed:', err);
+    }
+
+    return KIMI_FALLBACK;
   }
 }

--- a/pkg/rancher-desktop/agent/languagemodels/ModelDiscoveryService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ModelDiscoveryService.ts
@@ -351,13 +351,11 @@ export class ModelDiscoveryService {
       throw new Error(`Unsupported provider: ${ providerId }`);
     }
 
-    // If provider has a static model list (e.g. endpoint doesn't support /models), use it —
-    // unless it opts into live discovery, in which case the static list is only a fallback.
-    if (provider.staticModels?.length && !provider.preferLive) {
-      this.cache.set(cacheKey, { models: provider.staticModels, timestamp: Date.now() });
-      return provider.staticModels;
-    }
-
+    // Always attempt live discovery first for every provider so newly released
+    // models appear automatically. Any `staticModels` array is treated purely as
+    // an offline fallback (used only when the live fetch fails or returns nothing),
+    // never as the authoritative catalog. See the catch block and empty-result
+    // handling below.
     try {
       const url = `${ provider.baseUrl }${ provider.modelsEndpoint }`;
       const headers: Record<string, string> = {
@@ -396,10 +394,14 @@ export class ModelDiscoveryService {
       const data = await response.json();
       const models = provider.parseResponse(data);
 
-      // Cache the results
-      this.cache.set(cacheKey, { models, timestamp: Date.now() });
+      // If the endpoint responded but yielded no usable models, fall back to the
+      // offline static list (if any) rather than caching an empty catalog.
+      const resolved = models.length > 0 ? models : (provider.staticModels ?? []);
 
-      return models;
+      // Cache the results
+      this.cache.set(cacheKey, { models: resolved, timestamp: Date.now() });
+
+      return resolved;
     } catch (error) {
       console.warn(`[ModelDiscovery] Failed to fetch models for ${ providerId }:`, error);
 


### PR DESCRIPTION
## Make model lists live-first — no hardcoded catalog as source of truth

**Goal (Jonathon):** model lists in Sulla should be dynamic, not hardcoded. Codex must be reached *through* Sulla so vault OAuth creds are injected — never called directly.

### What changed (2 files)

**1. `ModelDiscoveryService.ts` — live-first for every provider.**
Previously a short-circuit returned a provider's hardcoded `staticModels` array *without ever calling the API* unless `preferLive` was set — and only `alibaba` set it. So `mistral / cerebras / together / ollama / cohere / deepseek / arcee` **never fetched live**; they served a stale baked-in list. Now every provider attempts live `/models` discovery first; `staticModels` is used **only** as an offline fallback (fetch error, or endpoint returned nothing).

**2. `KimiModels.ts` select box — was hardcoded-only.**
It returned 3 fixed Moonshot entries with no network call at all. Now it fetches live from `https://api.moonshot.cn/v1/models` using the vault-injected `api_key` (mirrors `OpenAIModels`), with the 3 entries kept only as offline fallback.

### Codex / vault constraint — already correct, left untouched
Codex model discovery already runs the `codex` CLI **inside the Lima VM through Sulla** (`codexModelCatalog.ts` → `ensureCodexAuthFile()`), so the ChatGPT OAuth creds Sulla stores in the vault (`~/.codex/auth.json`) are injected. A bare `codex` call would have no creds. I verified this path and did **not** change it.

### Verification
- Both changed files transpile clean (esbuild).
- `KimiModels` is a line-for-line mirror of the working `OpenAIModels` dynamic pattern; the discovery change preserves `ModelInfo[]` typing throughout.
- Note: `pkg/.../__tests__/ModelDiscovery.test.ts` currently **fails to compile on `main`** (pre-existing TS2352 at line 178, and stale assertions expecting hardcoded Anthropic models that no longer exist in the code) — this is not introduced by this branch. Full `tsc`/`jest` remains memory/rebuild-gated in the VM.

### Deliberately NOT changed — your call whether to go further
These are hardcoded but are **not** authoritative "lists" (they're offline fallbacks, default *selections*, or routing config). Ripping them risks empty pickers offline or changed boot defaults:
- Offline **fallback** lists in the other select boxes (Grok/Alibaba/Anthropic/Nvidia/Arcee/Cohere/DeepSeek) — already fetch-live-first; fallback only on API failure.
- `shared/remoteProviders.ts` `REMOTE_PROVIDERS` — only a fallback in `models/list` when live returns empty.
- `pages/chat/services/ModelRegistry.ts` `defaultModels` — cosmetic display enrichment; the backend `modelSelector` is authoritative and unknown ids are synthesized.
- Per-service default *model* constants (e.g. `AlibabaService` → `qwen3.5-plus`) — default selection, not a list.
- `ModelDetectionService.ts` OpenAI id→endpoint map — routing config.

**Want me to also strip the offline fallbacks entirely (pickers show empty when the API is unreachable) and/or dynamize the selection-defaults?** Say the word and I'll extend this PR.

Draft only — do not merge without your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
