### PR TITLE
fix(routines): stop routine_scorecard.routine_slug going NULL for system core routines

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0056_fix_routine_scorecard_null_slug.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0056_fix_routine_scorecard_null_slug.ts
@@ -1,0 +1,91 @@
+// Migration 0056 — Fix routine_scorecard.routine_slug going NULL for core routines.
+//
+// `routine_scorecard` (0037) selected `w.source_template_slug` directly with no
+// fallback. `source_template_slug` is only populated for routines imported from
+// a `~/sulla/routines/<slug>/routine.yaml` file via `import_workflow`. The new
+// "system" core routines (0055, e.g. `core-routine-dream-about-human`) are
+// seeded directly by `CoreRoutineSeeder`, so `source_template_slug` is NULL —
+// `routine_scorecard.routine_slug` (and everything downstream: `routine_exceptions`,
+// `routines_digest`) rendered the literal string "null" instead of a real name.
+//
+// `routine_run_history` (0037) already solved this correctly for run rows:
+//   COALESCE(w.source_template_slug, regexp_replace(e.workflow_slug, '^workflow-', ''))
+// This applies the same fallback to the per-routine scorecard, using `w.id`
+// (equivalent to `e.workflow_slug` for every row of a given workflow, and
+// available without re-aggregating over workflow_executions).
+//
+// View-only, additive, fully reversible (`down` restores the exact 0037 view).
+
+export const up = `
+  CREATE OR REPLACE VIEW routine_scorecard AS
+  SELECT
+    COALESCE(w.source_template_slug, regexp_replace(w.id, '^workflow-', '')) AS routine_slug,
+    w.name                                                                    AS routine_name,
+    w.description                                                             AS problem,
+    CASE
+      WHEN w.description ILIKE '%heartbeat%' OR w.description ILIKE '%derived by%'
+        THEN 'heartbeat'
+      ELSE 'unattributed'
+    END                                                                       AS authored_by,
+    w.version,
+    w.status,
+    w.enabled,
+    w.created_at,
+    COUNT(e.execution_id)                                                     AS fire_count,
+    COUNT(e.execution_id) FILTER (WHERE e.status = 'completed')               AS completed_count,
+    COUNT(e.execution_id) FILTER (WHERE e.status = 'failed')                  AS failed_count,
+    COUNT(e.execution_id) FILTER (WHERE e.status = 'running')                 AS running_count,
+    COUNT(e.execution_id) FILTER (WHERE e.status = 'suspended')               AS suspended_count,
+    COUNT(e.execution_id) FILTER (
+      WHERE e.status = 'running'
+        AND e.updated_at = e.started_at
+        AND e.started_at < NOW() - INTERVAL '1 day')                          AS zombie_count,
+    ROUND(
+      100.0 * COUNT(e.execution_id) FILTER (WHERE e.status = 'completed')
+      / NULLIF(COUNT(e.execution_id) FILTER (WHERE e.status IN ('completed', 'failed')), 0)
+    )::int                                                                    AS success_rate_pct,
+    MAX(e.started_at)                                                         AS last_run_at,
+    (ARRAY_AGG(e.status ORDER BY e.started_at DESC))[1]                       AS last_run_status
+  FROM workflows w
+  LEFT JOIN workflow_executions e ON e.workflow_id = w.id
+  GROUP BY
+    w.id, w.source_template_slug, w.name, w.description,
+    w.version, w.status, w.enabled, w.created_at;
+`;
+
+export const down = `
+  CREATE OR REPLACE VIEW routine_scorecard AS
+  SELECT
+    w.source_template_slug                                                    AS routine_slug,
+    w.name                                                                    AS routine_name,
+    w.description                                                             AS problem,
+    CASE
+      WHEN w.description ILIKE '%heartbeat%' OR w.description ILIKE '%derived by%'
+        THEN 'heartbeat'
+      ELSE 'unattributed'
+    END                                                                       AS authored_by,
+    w.version,
+    w.status,
+    w.enabled,
+    w.created_at,
+    COUNT(e.execution_id)                                                     AS fire_count,
+    COUNT(e.execution_id) FILTER (WHERE e.status = 'completed')               AS completed_count,
+    COUNT(e.execution_id) FILTER (WHERE e.status = 'failed')                  AS failed_count,
+    COUNT(e.execution_id) FILTER (WHERE e.status = 'running')                 AS running_count,
+    COUNT(e.execution_id) FILTER (WHERE e.status = 'suspended')               AS suspended_count,
+    COUNT(e.execution_id) FILTER (
+      WHERE e.status = 'running'
+        AND e.updated_at = e.started_at
+        AND e.started_at < NOW() - INTERVAL '1 day')                          AS zombie_count,
+    ROUND(
+      100.0 * COUNT(e.execution_id) FILTER (WHERE e.status = 'completed')
+      / NULLIF(COUNT(e.execution_id) FILTER (WHERE e.status IN ('completed', 'failed')), 0)
+    )::int                                                                    AS success_rate_pct,
+    MAX(e.started_at)                                                         AS last_run_at,
+    (ARRAY_AGG(e.status ORDER BY e.started_at DESC))[1]                       AS last_run_status
+  FROM workflows w
+  LEFT JOIN workflow_executions e ON e.workflow_id = w.id
+  GROUP BY
+    w.source_template_slug, w.name, w.description,
+    w.version, w.status, w.enabled, w.created_at;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -43,6 +43,7 @@ import { up as up_0052, down as down_0052 } from './0052_add_self_observation_fi
 import { up as up_0053, down as down_0053 } from './0053_allow_environment_identity_domain';
 import { up as up_0054, down as down_0054 } from './0054_allow_projects_identity_domain';
 import { up as up_0055, down as down_0055 } from './0055_add_system_and_content_hash_to_workflows';
+import { up as up_0056, down as down_0056 } from './0056_fix_routine_scorecard_null_slug';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -87,4 +88,5 @@ export const migrationsRegistry = [
   { name: '0053_allow_environment_identity_domain',              up: up_0053, down: down_0053 },
   { name: '0054_allow_projects_identity_domain',                 up: up_0054, down: down_0054 },
   { name: '0055_add_system_and_content_hash_to_workflows',       up: up_0055, down: down_0055 },
+  { name: '0056_fix_routine_scorecard_null_slug',                 up: up_0056, down: down_0056 },
 ] as const;


### PR DESCRIPTION
## Problem

Discovered while reviewing the routine-stewardship digest during a heartbeat cycle: `routines_digest` was showing a routine literally named `null`.

Root cause: `routine_scorecard.routine_slug` (migration 0037) selects `w.source_template_slug` directly with no fallback. That column is only populated for routines imported from a `~/sulla/routines/<slug>/routine.yaml` file via `import_workflow`. The new **system core routines** (migration 0055, e.g. `core-routine-dream-about-human` from #608) are seeded directly by `CoreRoutineSeeder` and never get a `source_template_slug` — so `routine_scorecard.routine_slug` (and everything downstream: `routine_exceptions`, `routines_digest`) is `NULL`, which the JS template string renders as the literal text `null`.

`routine_run_history` (also migration 0037) already solved this correctly for run rows:
```sql
COALESCE(w.source_template_slug, regexp_replace(e.workflow_slug, ^workflow-, ))
```
This PR applies the identical fallback to `routine_scorecard`, using `w.id` in place of `e.workflow_slug` (equivalent per-workflow value, no re-aggregation needed).

## Verified

Ran the corrected expression directly against the live `workflows` table for `core-routine-dream-about-human`:
```
routine_slug: "core-routine-dream-about-human"  (was: NULL / displayed as "null")
```

`routine_exceptions` / `routine_digest_summary` (migration 0038/0045) read `routine_slug` straight through from `routine_scorecard` with no redefinition needed, so this one view fix propagates automatically.

## Scope

View-only, additive `CREATE OR REPLACE VIEW`, fully reversible via `down`. Does not touch `routine_run_history` or `routine_report` (already correct — confirmed `routine_report` works today when queried with the real slug).

Draft per standing rule — merges/rebuilds remain Jonathon-gated.
