### PR TITLE
fix(build): finalSubState inferred as unknown, breaking the build

### DIFF
--- a/pkg/rancher-desktop/agent/controllers/PlaybookController.ts
+++ b/pkg/rancher-desktop/agent/controllers/PlaybookController.ts
@@ -1690,7 +1690,7 @@ export class PlaybookController<TState = any> {
               // (e.g. the sub-workflow's own first node never starting)
               // froze the parent workflow_executions row forever with no
               // failure signal. Same watchdog treatment as executeSubAgent.
-              const finalSubState = await this.raceWithSubAgentWatchdog(
+              const finalSubState: any = await this.raceWithSubAgentWatchdog(
                 subState,
                 `Sub-workflow "${ subWfLabel }" (agent "${ step.agentId }")`,
                 () => subGraph.execute(subState),


### PR DESCRIPTION
## Problem

After merging #624-#629, `just build` failed:

```
ERROR in pkg/rancher-desktop/agent/controllers/PlaybookController.ts(1699,48)
TS18046: 'finalSubState' is of type 'unknown'.
```

## Root cause

`finalSubState` (added in #626, the sub-workflow watchdog fix) was declared via bare `const` inference from `raceWithSubAgentWatchdog<T>()`. `subGraph` is typed `any`, and in this const-inference position TypeScript resolved `T` to `unknown` instead of `any`, breaking every downstream `.metadata` access.

The sibling call site (`executeSubAgent`, same file, ~line 2300) already avoids exactly this by declaring `let finalState: any` before assignment instead of relying on inference.

## Fix

One line: `const finalSubState: any = await this.raceWithSubAgentWatchdog(...)`, matching the sibling pattern.

## Verification

Ran the actual `just build` (host-side yarn/webpack, not just a syntax check) before and after:
- Before: failed with the TS18046 error above.
- After: both webpack passes compiled successfully, "Done in 78.00s."

Draft per standing rule.