### PR TITLE
fix(shutdown): restart survives a forced exit, not just a clean one

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -1045,11 +1045,39 @@ function isK8sError(object: any): object is K8sError {
 
 // When true, the app is restarting (not fully quitting) — skip container/VM teardown
 let isRestarting = false;
+let relaunchSpawned = false;
 
 mainEvents.on('restarting', () => {
   console.log('[Shutdown] background.ts received "restarting" event — setting isRestarting=true');
   isRestarting = true;
 });
+
+// Electron.app.relaunch() (called once, early, in mainmenu.ts's
+// restartApplication()) only actually spawns the new instance as part of
+// Electron's own native quit path completing. Both force-exit backstops
+// below call raw process.exit(), which terminates the process immediately
+// and bypasses that native path entirely — so a restart that hits either
+// backstop (the exact "some item hanging that wouldn't ever let go" case)
+// silently drops the relaunch: the app shuts down and never comes back.
+// Guard against that by spawning the new instance ourselves, independent
+// of how cleanly the current process manages to exit. Idempotent (only
+// ever spawns once) so it's safe to call from more than one backstop.
+function ensureRelaunchIfRestarting(): void {
+  if (!isRestarting || relaunchSpawned) return;
+  relaunchSpawned = true;
+  try {
+    const child = spawn(process.execPath, process.argv.slice(1), {
+      detached: true,
+      stdio:    'ignore',
+      cwd:      process.cwd(),
+    });
+
+    child.unref();
+    sullaLog({ topic: 'shutdown', level: 'info', message: 'ensureRelaunchIfRestarting: spawned detached relaunch process' });
+  } catch (err: any) {
+    sullaLog({ topic: 'shutdown', level: 'error', message: `ensureRelaunchIfRestarting failed: ${ err?.message }`, error: err });
+  }
+}
 
 Electron.app.on('before-quit', async(event) => {
   const triggerStack = new Error('before-quit trigger trace').stack;
@@ -1079,6 +1107,7 @@ Electron.app.on('before-quit', async(event) => {
   const forceExitTimer = setTimeout(() => {
     sullaLog({ topic: 'shutdown', level: 'error', message: `Graceful shutdown exceeded ${ SHUTDOWN_DEADLINE_MS / 1000 }s — force-exiting` });
     console.error(`[Shutdown] Graceful shutdown exceeded ${ SHUTDOWN_DEADLINE_MS / 1000 }s — force-exiting`);
+    ensureRelaunchIfRestarting();
     process.exit(1);
   }, SHUTDOWN_DEADLINE_MS);
 
@@ -1219,6 +1248,7 @@ Electron.app.on('before-quit', async(event) => {
     const postQuitTimer = setTimeout(() => {
       sullaLog({ topic: 'shutdown', level: 'warn', message: 'Post-quit backstop: process still alive after 15s — force-exiting' });
       console.warn('[Shutdown] Post-quit backstop: process still alive after 15s — force-exiting');
+      ensureRelaunchIfRestarting();
       process.exit(0);
     }, 15_000);
 


### PR DESCRIPTION
## Problem (Jonathon, live)

Telling the app to restart just shuts it down — it never boots back up. Traced to root cause, not guessed: this used to work, then something hung during shutdown, a timeout forced the process closed, and restart has been broken ever since.

## Root cause

`restartApplication()` (`mainmenu.ts`) calls `Electron.app.relaunch()` once, early, then `Electron.app.quit()`. `relaunch()`'s actual spawn of the new instance rides on Electron's own native quit path completing.

But the `before-quit` handler in `background.ts` has **two independent hard-exit backstops** that both call raw `process.exit()` when the graceful async shutdown sequence hangs or overruns its deadline:

- `SHUTDOWN_DEADLINE_MS` (90s) — the whole `before-quit` sequence stalled
- the post-quit backstop (15s after `app.quit()`) — a lingering handle (postgres/redis/k8s per the existing comment) kept the process alive

Both are a raw `process.exit()`, which bypasses whatever native hook Electron uses to fire the queued relaunch. So the exact failure mode Jonathon described is the **intended behavior of the existing safety nets** — they're just missing the one piece that makes a restart actually restart when they fire.

## Fix

`ensureRelaunchIfRestarting()`, called from both backstops right before their `process.exit()`. Spawns a detached copy of the app directly via `child_process.spawn(process.execPath, ...)`, independent of Electron's own relaunch mechanism. Idempotent (spawns at most once) and only acts when `isRestarting` is true, so it's a no-op on a normal full quit and a no-op on the happy path where `app.quit()` completes cleanly and Electron's own relaunch already did its job — it only fires as the safety net for the exact case that's currently broken.

## Verification

- Full `just build` (real host yarn/webpack, not a syntax check) passes clean — 0 new errors, same pre-existing Sass deprecation warnings as before this change.
- **Not yet live-tested** — this fix can't verify its own restart path from within the same running process that would need to restart. Needs a rebuild + restart to test.

## To test after merge + rebuild

Trigger a restart (menu item) and confirm the app actually comes back up. Ideally also force the slow path once (e.g. temporarily hold a lock so the graceful sequence overruns) to confirm the backstop path relaunches too, not just the happy path.

Draft per standing rule — do not merge/deploy without Jonathon.