### PR TITLE
fix(db): repair broken task ORDER BY and stuck routine_scorecard migration

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0056_fix_routine_scorecard_null_slug.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0056_fix_routine_scorecard_null_slug.ts
@@ -15,11 +15,18 @@
 // available without re-aggregating over workflow_executions).
 //
 // View-only, additive, fully reversible (`down` restores the exact 0037 view).
+//
+// The ::varchar(255) cast on routine_slug is required, not cosmetic: Postgres
+// rejects CREATE OR REPLACE VIEW if a column's data type changes, and
+// COALESCE(varchar(255), regexp_replace(...)) resolves to an unconstrained
+// varchar — without the cast this migration fails with "cannot change data
+// type of view column" and (since runMigrations fails fast) silently blocks
+// every migration after it from ever running.
 
 export const up = `
   CREATE OR REPLACE VIEW routine_scorecard AS
   SELECT
-    COALESCE(w.source_template_slug, regexp_replace(w.id, '^workflow-', '')) AS routine_slug,
+    COALESCE(w.source_template_slug, regexp_replace(w.id, '^workflow-', ''))::varchar(255) AS routine_slug,
     w.name                                                                    AS routine_name,
     w.description                                                             AS problem,
     CASE

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -290,7 +290,10 @@ function slugify(value: string): string {
 
 const CLOSED_STATUSES = `status IN ('done', 'cancelled', 'parked')`;
 
-const PRIORITY_RANK = `
+// Bare CASE expression, no trailing ASC — reused standalone (with ASC appended
+// for ORDER BY) and nested inside EPIC_PRIORITY_RANK_FOR_TASK's COALESCE, where
+// an embedded ASC would land inside the parens and break the SQL.
+const PRIORITY_CASE = `
   CASE priority
     WHEN '🔴' THEN 0 WHEN 'critical' THEN 0 WHEN 'p0' THEN 0 WHEN 'P0' THEN 0
     WHEN 'p1' THEN 1 WHEN 'P1' THEN 1 WHEN 'high' THEN 1
@@ -298,7 +301,9 @@ const PRIORITY_RANK = `
     WHEN 'p3' THEN 3 WHEN 'P3' THEN 3
     WHEN '⚪' THEN 4 WHEN 'low' THEN 4 WHEN 'p4' THEN 4 WHEN 'P4' THEN 4
     ELSE 5
-  END ASC`;
+  END`;
+
+const PRIORITY_RANK = `${ PRIORITY_CASE } ASC`;
 
 // Same rank scale as PRIORITY_RANK, but resolved for the parent epic via a
 // correlated subquery so a task's *epic* priority is available to ORDER BY
@@ -318,7 +323,7 @@ const EPIC_PRIORITY_RANK_FOR_TASK = `
       ELSE 5
     END
     FROM work_epics we WHERE we.id = work_tasks.epic_id),
-    ${ PRIORITY_RANK.replace('priority', 'work_tasks.priority') }
+    ${ PRIORITY_CASE.replace('priority', 'work_tasks.priority') }
   ) ASC`;
 
 const STOPWORDS = new Set([


### PR DESCRIPTION
## Summary
Two live bugs found while smoke-testing tonight's rebuild (v1.4.1, HEAD #631):

1. **`list_project_items(kind=task)` and `project/report` throw `syntax error at or near "ASC"`.**
   `EPIC_PRIORITY_RANK_FOR_TASK` (added in #629) interpolated `PRIORITY_RANK`'s
   trailing `END ASC` inside a `COALESCE(...)` call, landing `ASC` *inside* the
   parens. Split out a bare `PRIORITY_CASE` expression reused by both constants,
   with `ASC` only appended where it's actually valid SQL.

2. **Migration `0056_fix_routine_scorecard_null_slug` has never applied**, even
   though it's registered — `sulla_migrations` tops out at `0055`. Root cause:
   Postgres rejects `CREATE OR REPLACE VIEW` when a column's data type changes,
   and `COALESCE(varchar(255), regexp_replace(...))` resolves to an unconstrained
   `varchar`, not `varchar(255)`. Cast the result back to `varchar(255)` so the
   view's column type matches exactly. Since `runMigrations()` fails fast on any
   error, this bug has also been silently blocking every migration registered
   after 0056 from ever running.

## Verification
- Both fixes proven directly against the live DB: the corrected `ORDER BY`
  runs clean (returns rows), and the corrected view now resolves
  `core-routine-dream-about-human` instead of `null`.
- Focused `WorkItemsModel.test.ts` jest suite: 3/3 passed.
- Full `tsc --noEmit` OOMs in this VM as usual (known limit, not from this change).

## Test plan
- [ ] Rebuild + restart Sulla Desktop
- [ ] Confirm `sulla project/list_project_items '{"kind":"task"}'` returns rows instead of erroring
- [ ] Confirm `sulla project/report` succeeds
- [ ] Confirm `routine_scorecard.routine_slug` is non-null for `core-routine-dream-about-human`
