### PR TITLE
feat(subconscious): add skills identity-observation domain

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0057_allow_skills_identity_domain.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0057_allow_skills_identity_domain.ts
@@ -1,0 +1,45 @@
+/**
+ * Migration 0057 — Allow the `skills` identity-observation domain.
+ *
+ * The `skills` domain records durable facts about actual skill ARTIFACTS
+ * (SKILL.md files) — where a named skill was found (marketplace, locally
+ * installed under ~/sulla/skills/, or discovered elsewhere), and whether a
+ * run of a named skill succeeded or failed. Widen the domain CHECK to
+ * include it. NOT VALID so startup never blocks on historical rows.
+ */
+
+export const up = `
+  DO $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'identity_observations_domain_check'
+        AND conrelid = 'identity_observations'::regclass
+    ) THEN
+      ALTER TABLE identity_observations DROP CONSTRAINT identity_observations_domain_check;
+    END IF;
+
+    ALTER TABLE identity_observations
+      ADD CONSTRAINT identity_observations_domain_check
+      CHECK (domain IN ('human', 'business', 'world', 'agent', 'environment', 'projects', 'skills'))
+      NOT VALID;
+  END $$;
+`;
+
+export const down = `
+  DO $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'identity_observations_domain_check'
+        AND conrelid = 'identity_observations'::regclass
+    ) THEN
+      ALTER TABLE identity_observations DROP CONSTRAINT identity_observations_domain_check;
+    END IF;
+
+    ALTER TABLE identity_observations
+      ADD CONSTRAINT identity_observations_domain_check
+      CHECK (domain IN ('human', 'business', 'world', 'agent', 'environment', 'projects'))
+      NOT VALID;
+  END $$;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/0058_add_skill_slug_to_identity_observations.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0058_add_skill_slug_to_identity_observations.ts
@@ -1,0 +1,25 @@
+/**
+ * Migration 0058 — Add `skill_slug` to identity_observations.
+ *
+ * The skills domain (0057) originally enforced "must name the skill" via a
+ * content regex only (content must contain "Skill '<slug>' ..."). That is
+ * enforceable but not queryable — you cannot ask "every row about skill
+ * 'pdf-fill'" without parsing prose. Adds a real column so skills-domain
+ * writes carry a structured slug alongside the prose requirement (defense in
+ * depth: the column proves a row is about a specific skill, the content
+ * regex proves the row's own text actually names it).
+ */
+
+export const up = `
+  ALTER TABLE identity_observations
+    ADD COLUMN IF NOT EXISTS skill_slug TEXT;
+
+  CREATE INDEX IF NOT EXISTS idx_identity_obs_skill_slug
+    ON identity_observations (skill_slug)
+    WHERE skill_slug IS NOT NULL;
+`;
+
+export const down = `
+  DROP INDEX IF EXISTS idx_identity_obs_skill_slug;
+  ALTER TABLE identity_observations DROP COLUMN IF EXISTS skill_slug;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -45,6 +45,7 @@ import { up as up_0054, down as down_0054 } from './0054_allow_projects_identity
 import { up as up_0055, down as down_0055 } from './0055_add_system_and_content_hash_to_workflows';
 import { up as up_0056, down as down_0056 } from './0056_fix_routine_scorecard_null_slug';
 import { up as up_0057, down as down_0057 } from './0057_allow_skills_identity_domain';
+import { up as up_0058, down as down_0058 } from './0058_add_skill_slug_to_identity_observations';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -91,4 +92,5 @@ export const migrationsRegistry = [
   { name: '0055_add_system_and_content_hash_to_workflows',       up: up_0055, down: down_0055 },
   { name: '0056_fix_routine_scorecard_null_slug',                 up: up_0056, down: down_0056 },
   { name: '0057_allow_skills_identity_domain',                    up: up_0057, down: down_0057 },
+  { name: '0058_add_skill_slug_to_identity_observations',         up: up_0058, down: down_0058 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -44,6 +44,7 @@ import { up as up_0053, down as down_0053 } from './0053_allow_environment_ident
 import { up as up_0054, down as down_0054 } from './0054_allow_projects_identity_domain';
 import { up as up_0055, down as down_0055 } from './0055_add_system_and_content_hash_to_workflows';
 import { up as up_0056, down as down_0056 } from './0056_fix_routine_scorecard_null_slug';
+import { up as up_0057, down as down_0057 } from './0057_allow_skills_identity_domain';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -89,4 +90,5 @@ export const migrationsRegistry = [
   { name: '0054_allow_projects_identity_domain',                 up: up_0054, down: down_0054 },
   { name: '0055_add_system_and_content_hash_to_workflows',       up: up_0055, down: down_0055 },
   { name: '0056_fix_routine_scorecard_null_slug',                 up: up_0056, down: down_0056 },
+  { name: '0057_allow_skills_identity_domain',                    up: up_0057, down: down_0057 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
@@ -234,6 +234,20 @@ function validateSubjectForDomain(domain: IdentityDomain, subject: string | null
   }
 }
 
+/**
+ * Same gap as validateSubjectForDomain, same fix: `kind` (correction |
+ * constraint | method | commitment | preference) is agent-domain field
+ * contract per the agent writerNote in GraphRegistry.ts, but was never
+ * actually gated to that domain — any domain could set it and pass. Caught
+ * during the same review pass that found the subject gap.
+ */
+function validateKindForDomain(domain: IdentityDomain, kind: string | null | undefined): void {
+  if (kind == null) return;
+  if (domain !== 'agent') {
+    throw new Error(`kind is only valid in the agent domain (got domain "${ domain }") — it is the agent-domain field contract (correction | constraint | method | commitment | preference), not a general-purpose tag.`);
+  }
+}
+
 function validateContentForDomain(domain: IdentityDomain, content: string): void {
   if (WORK_STATE_CONTENT_RE.test(content)) {
     throw new Error('content reads as task/engineering status (a PR/commit/branch/tsc/worktree reference) — that is work-state and belongs in the Projects system, never an identity domain. If this is genuinely a durable fact, rephrase it without the ticket/branch/commit/SHA.');
@@ -315,6 +329,7 @@ export class IdentityObservationsModel {
 
     validateCategoryForDomain(domain, category);
     validateSubjectForDomain(domain, subject);
+    validateKindForDomain(domain, kind);
     validateContentForDomain(domain, content);
 
     const rows = await postgresClient.query<IdentityObservationRecord>(
@@ -386,8 +401,10 @@ export class IdentityObservationsModel {
       values.push(normalizeConfidence(changes.confidence));
     }
     if (changes.kind !== undefined) {
+      const kind = normalizeIdentityKind(changes.kind);
+      validateKindForDomain(domain, kind);
       setClauses.push(`kind = $${ idx++ }`);
-      values.push(normalizeIdentityKind(changes.kind));
+      values.push(kind);
     }
     if (changes.source !== undefined) {
       setClauses.push(`source = $${ idx++ }`);

--- a/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
@@ -19,9 +19,9 @@ import { postgresClient } from '../PostgresClient';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
-export type IdentityDomain = 'human' | 'business' | 'world' | 'agent' | 'environment' | 'projects';
+export type IdentityDomain = 'human' | 'business' | 'world' | 'agent' | 'environment' | 'projects' | 'skills';
 
-export const IDENTITY_DOMAINS: IdentityDomain[] = ['human', 'business', 'world', 'agent', 'environment', 'projects'];
+export const IDENTITY_DOMAINS: IdentityDomain[] = ['human', 'business', 'world', 'agent', 'environment', 'projects', 'skills'];
 const MAX_CONTENT_CHARS = 1200;
 const MAX_BASIS_CHARS = 600;
 const MAX_LABEL_CHARS = 80;
@@ -188,7 +188,7 @@ export class IdentityObservationsModel {
       await postgresClient.query(`
         CREATE TABLE IF NOT EXISTS ${ IdentityObservationsModel.TABLE } (
           id          TEXT        PRIMARY KEY,
-          domain      TEXT        NOT NULL DEFAULT 'human' CHECK (domain IN ('human', 'business', 'world', 'agent', 'environment', 'projects')),
+          domain      TEXT        NOT NULL DEFAULT 'human' CHECK (domain IN ('human', 'business', 'world', 'agent', 'environment', 'projects', 'skills')),
           level       SMALLINT    NOT NULL DEFAULT 2 CHECK (level IN (1, 2, 3)),
           category    TEXT,
           content     TEXT        NOT NULL,

--- a/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
@@ -29,6 +29,51 @@ const MAX_SOURCE_CHARS = 120;
 const MAX_EVIDENCE_CHARS = 600;
 const DEFAULT_LIST_LIMIT = 100;
 const MAX_LIST_LIMIT = 100;
+/**
+ * Dedup scanning deliberately reads MORE rows than any public list/recall
+ * path ever returns (MAX_LIST_LIMIT=100) — duplicate-checking must cover the
+ * whole domain, not just the page a human/tool would want back. A domain
+ * regrowing past 100 active rows is exactly the regime where silent
+ * duplication matters most (human hit 70, agent hit 52 in the 2026-08-19
+ * pollution audit, before either was capped by this scan).
+ */
+const MAX_DEDUP_SCAN = 500;
+
+/**
+ * Per-domain closed category sets, transcribed from each domain's own focus
+ * text in GraphRegistry.ts (every domain presents its "Record: - x: ... - y:
+ * ..." list as an exhaustive scheme, not examples). Enforced at the DB
+ * boundary so a miscategorized write fails with a reason INSTEAD of silently
+ * landing — a tool error at the decision moment is what a prompt reject-list
+ * could never be: unignorable. `agent` is intentionally omitted — its
+ * "category" field semantics overlap with the separately-enforced `kind`
+ * enum and are not cleanly closed; left as free text pending a follow-up.
+ */
+const DOMAIN_CATEGORIES: Partial<Record<IdentityDomain, string[]>> = {
+  human:       ['identity', 'relationship', 'association', 'personality', 'habit', 'preference', 'goal'],
+  business:    ['identity', 'model', 'operations', 'market', 'priorities', 'constraints', 'assets'],
+  world:       ['event', 'condition', 'trend', 'actor'],
+  environment: ['fact', 'tool', 'path', 'build', 'limit', 'method', 'anti-pattern', 'process'],
+  projects:    ['project', 'structure', 'priority', 'decision', 'process', 'relationship', 'blocker'],
+  skills:      ['provenance', 'success', 'failure', 'gap', 'inventory'],
+};
+
+/**
+ * Blunt content lint for the single most common pollution class found in the
+ * 2026-08-19 domain audit: this-session task/engineering status recorded as
+ * if it were durable identity. Every domain's writer prompt already says
+ * "reject this" in prose; prose alone kept eroding (business hit 44 rows,
+ * ~40 tagged subject:agent.user; world was 10/10 off-topic). This is the
+ * first MECHANICAL backstop — a validation error the writer model sees
+ * in-context at the exact decision point, not a rule 2000 tokens upstream.
+ * Deliberately narrow (specific technical signatures only) to avoid
+ * false-positiving on legitimate content like "the business merged with X".
+ */
+const WORK_STATE_CONTENT_RE = /\bPR ?#\d+\b|\bcommit\s+[0-9a-f]{7,40}\b|\b(?:feat|fix|chore|refactor|hb)\/[a-z0-9][a-z0-9-]*\b|\bdraft PR\b|\btsc --noEmit\b|\bworktree\b/i;
+
+/** Field contract for skills-domain rows (GraphRegistry.ts writerNote): every
+ *  row must name the exact skill it is about, e.g. "Skill 'pdf-fill' …". */
+const SKILLS_SLUG_CONTENT_RE = /\bskill\s+'[a-z0-9][a-z0-9-]*'/i;
 
 export type IdentityObservationSubject = 'agent' | 'agent.user';
 export type IdentityObservationKind = 'correction' | 'constraint' | 'method' | 'commitment' | 'preference';
@@ -165,6 +210,39 @@ function normalizeOptionalText(value: unknown, field: string, maxChars: number):
   return trimmed;
 }
 
+/**
+ * Mechanical write guards — the tool-layer backstop behind the writer
+ * prompts' prose reject-lists. Prose alone eroded on every domain in the
+ * 2026-08-19 audit; these throw at insert/update time so the writer model
+ * sees a validation error in-context at the exact decision point instead of
+ * a rule far upstream it can silently ignore. Called for BOTH insert (full
+ * field set) and update (only the fields actually being changed).
+ */
+function validateCategoryForDomain(domain: IdentityDomain, category: string | null | undefined): void {
+  if (category == null) return;
+  const allowed = DOMAIN_CATEGORIES[domain];
+  if (!allowed) return; // domain has no closed set (currently only `agent`) — free text
+  if (!allowed.includes(category)) {
+    throw new Error(`category "${ category }" is not valid for domain "${ domain }"; expected one of: ${ allowed.join(', ') }.`);
+  }
+}
+
+function validateSubjectForDomain(domain: IdentityDomain, subject: string | null | undefined): void {
+  if (subject == null) return;
+  if (domain !== 'agent') {
+    throw new Error(`subject is only valid in the agent domain (got domain "${ domain }"). A row about the agent or the agent+human pair (subject agent.user) belongs in the agent domain, not here — this is the exact misfiling pattern the 2026-08-19 business-domain audit found (40 of 44 rows).`);
+  }
+}
+
+function validateContentForDomain(domain: IdentityDomain, content: string): void {
+  if (WORK_STATE_CONTENT_RE.test(content)) {
+    throw new Error('content reads as task/engineering status (a PR/commit/branch/tsc/worktree reference) — that is work-state and belongs in the Projects system, never an identity domain. If this is genuinely a durable fact, rephrase it without the ticket/branch/commit/SHA.');
+  }
+  if (domain === 'skills' && !SKILLS_SLUG_CONTENT_RE.test(content)) {
+    throw new Error('skills-domain content must name the exact skill in the shape "Skill \'<slug>\' …" — a row with no quoted skill slug is not about a specific skill artifact and does not belong in this domain.');
+  }
+}
+
 export function formatIdentityObservationDate(value: unknown): string {
   if (value instanceof Date) {
     return value.toISOString().slice(0, 10);
@@ -225,6 +303,7 @@ export class IdentityObservationsModel {
 
   static async insert(input: InsertIdentityObservationInput): Promise<IdentityObservationRecord> {
     const id = input.id || generateTinyId();
+    const domain = normalizeIdentityDomain(input.domain);
     const category = normalizeOptionalText(input.category, 'category', MAX_LABEL_CHARS);
     const basis = normalizeOptionalText(input.basis, 'basis', MAX_BASIS_CHARS);
     const subject = normalizeIdentitySubject(input.subject);
@@ -232,16 +311,22 @@ export class IdentityObservationsModel {
     const confidence = normalizeConfidence(input.confidence);
     const kind = normalizeIdentityKind(input.kind);
     const source = normalizeOptionalText(input.source, 'source', MAX_SOURCE_CHARS);
+    const content = normalizeRequiredText(input.content, 'content', MAX_CONTENT_CHARS);
+
+    validateCategoryForDomain(domain, category);
+    validateSubjectForDomain(domain, subject);
+    validateContentForDomain(domain, content);
+
     const rows = await postgresClient.query<IdentityObservationRecord>(
       `INSERT INTO ${ IdentityObservationsModel.TABLE } (id, domain, level, category, content, basis, subject, evidence, confidence, kind, source)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         id,
-        normalizeIdentityDomain(input.domain),
+        domain,
         normalizeIdentityLevel(input.level),
         category ?? null,
-        normalizeRequiredText(input.content, 'content', MAX_CONTENT_CHARS),
+        content,
         basis ?? null,
         subject ?? null,
         evidence ?? null,
@@ -254,6 +339,14 @@ export class IdentityObservationsModel {
   }
 
   static async update(id: string, changes: UpdateIdentityObservationInput): Promise<IdentityObservationRecord | null> {
+    // The write guards are domain-scoped, but UpdateIdentityObservationInput
+    // has no domain field (a row's domain never changes) — fetch it once so
+    // category/subject/content changes are validated against the row's own
+    // domain, not skipped.
+    const existing = await IdentityObservationsModel.getById(id);
+    if (!existing) return null;
+    const domain = normalizeIdentityDomain(existing.domain);
+
     const setClauses: string[] = ['updated_at = now()'];
     const values: any[] = [];
     let idx = 1;
@@ -263,20 +356,26 @@ export class IdentityObservationsModel {
       values.push(normalizeIdentityLevel(changes.level));
     }
     if (changes.category !== undefined) {
+      const category = normalizeOptionalText(changes.category, 'category', MAX_LABEL_CHARS);
+      validateCategoryForDomain(domain, category);
       setClauses.push(`category = $${ idx++ }`);
-      values.push(normalizeOptionalText(changes.category, 'category', MAX_LABEL_CHARS));
+      values.push(category);
     }
     if (changes.content !== undefined) {
+      const content = normalizeRequiredText(changes.content, 'content', MAX_CONTENT_CHARS);
+      validateContentForDomain(domain, content);
       setClauses.push(`content = $${ idx++ }`);
-      values.push(normalizeRequiredText(changes.content, 'content', MAX_CONTENT_CHARS));
+      values.push(content);
     }
     if (changes.basis !== undefined) {
       setClauses.push(`basis = $${ idx++ }`);
       values.push(normalizeOptionalText(changes.basis, 'basis', MAX_BASIS_CHARS));
     }
     if (changes.subject !== undefined) {
+      const subject = normalizeIdentitySubject(changes.subject);
+      validateSubjectForDomain(domain, subject);
       setClauses.push(`subject = $${ idx++ }`);
-      values.push(normalizeIdentitySubject(changes.subject));
+      values.push(subject);
     }
     if (changes.evidence !== undefined) {
       setClauses.push(`evidence = $${ idx++ }`);
@@ -398,14 +497,28 @@ export class IdentityObservationsModel {
 
   /**
    * Check whether a substantially similar active row already exists in the
-   * domain (exact normalised match or substring containment). Same logic as
-   * ObservationsModel.findDuplicate, scoped by domain.
+   * domain (exact normalised match or substring containment). Deliberately
+   * bypasses listActive's public MAX_LIST_LIMIT (100) via MAX_DEDUP_SCAN
+   * (500) — dedup must cover the whole domain, not just the page a human/
+   * tool would want back. Previously called listActive(domain, {limit: 500}),
+   * but listActive clamps to MAX_LIST_LIMIT=100, so any domain past 100
+   * active rows was silently dedup-checked against only its newest/highest-
+   * certainty 100 — exactly the polluted regime (human hit 70, agent hit 52)
+   * where duplication matters most.
    */
   static async findDuplicate(domain: string, content: string): Promise<IdentityObservationRecord | null> {
-    const rows = await IdentityObservationsModel.listActive(normalizeIdentityDomain(domain), { limit: 500 });
+    const normalizedDomain = normalizeIdentityDomain(domain);
     const normalise = (s: string) =>
       s.toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/\s+/g, ' ').trim();
     const norm = normalise(normalizeRequiredText(content, 'content', MAX_CONTENT_CHARS));
+
+    const rows = await postgresClient.query<IdentityObservationRecord>(
+      `SELECT * FROM ${ IdentityObservationsModel.TABLE }
+       WHERE archived = false AND domain = $1
+       ORDER BY level DESC, created_at DESC
+       LIMIT $2`,
+      [normalizedDomain, MAX_DEDUP_SCAN],
+    );
 
     for (const row of rows) {
       const existing = normalise(row.content);
@@ -413,5 +526,21 @@ export class IdentityObservationsModel {
       if (existing.includes(norm) || norm.includes(existing)) return row;
     }
     return null;
+  }
+
+  /**
+   * Cheap row count for the recall-dispatch row-count gate (see
+   * SubconsciousMiddleware's SQL fast-path): 0 active rows means skip the
+   * search entirely; a small count means inject listActive() directly
+   * without spinning up a blocking LLM subagent to search almost nothing.
+   */
+  static async countActive(domain: string): Promise<number> {
+    const normalizedDomain = normalizeIdentityDomain(domain);
+    const rows = await postgresClient.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM ${ IdentityObservationsModel.TABLE }
+       WHERE archived = false AND domain = $1`,
+      [normalizedDomain],
+    );
+    return Number(rows[0]?.count ?? 0);
   }
 }

--- a/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/IdentityObservationsModel.ts
@@ -45,14 +45,19 @@ const MAX_DEDUP_SCAN = 500;
  * ..." list as an exhaustive scheme, not examples). Enforced at the DB
  * boundary so a miscategorized write fails with a reason INSTEAD of silently
  * landing — a tool error at the decision moment is what a prompt reject-list
- * could never be: unignorable. `agent` is intentionally omitted — its
- * "category" field semantics overlap with the separately-enforced `kind`
- * enum and are not cleanly closed; left as free text pending a follow-up.
+ * could never be: unignorable. `agent` gets an EMPTY set, not an omission —
+ * the agent domain's certainty/kind field is `kind` (correction | constraint
+ * | method | commitment | preference), not `category`; the writerNote used
+ * to say "category — the kind: ..." which pointed the writer at the wrong
+ * column entirely (silently landing in `category`, leaving `kind` — the
+ * field validateKindForDomain actually enforces — always null). Rejecting
+ * `category` outright on this domain forces the correct field.
  */
 const DOMAIN_CATEGORIES: Partial<Record<IdentityDomain, string[]>> = {
   human:       ['identity', 'relationship', 'association', 'personality', 'habit', 'preference', 'goal'],
   business:    ['identity', 'model', 'operations', 'market', 'priorities', 'constraints', 'assets'],
   world:       ['event', 'condition', 'trend', 'actor'],
+  agent:       [],
   environment: ['fact', 'tool', 'path', 'build', 'limit', 'method', 'anti-pattern', 'process'],
   projects:    ['project', 'structure', 'priority', 'decision', 'process', 'relationship', 'blocker'],
   skills:      ['provenance', 'success', 'failure', 'gap', 'inventory'],
@@ -89,6 +94,7 @@ export interface IdentityObservationRecord {
   evidence:   string | null;
   confidence: number | null;
   kind:       string | null;
+  skill_slug: string | null;
   created_at: string | Date;
   updated_at: string | Date | null;
   archived:   boolean;
@@ -106,6 +112,7 @@ export interface InsertIdentityObservationInput {
   evidence?: string;
   confidence?: number;
   kind?:     string;
+  skillSlug?: string;
   source?:   string;
 }
 
@@ -118,6 +125,7 @@ export interface UpdateIdentityObservationInput {
   evidence?: string;
   confidence?: number;
   kind?:     string;
+  skillSlug?: string;
   source?:   string;
 }
 
@@ -172,6 +180,19 @@ function normalizeIdentityKind(value: unknown): IdentityObservationKind | null |
   throw new Error('kind must be one of: correction, constraint, method, commitment, preference.');
 }
 
+/** Kebab-case artifact slug — same shape marketplace/scaffold requires. */
+const SKILL_SLUG_SHAPE_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+function normalizeSkillSlug(value: unknown): string | null | undefined {
+  const normalized = normalizeOptionalText(value, 'skillSlug', MAX_LABEL_CHARS);
+  if (normalized === undefined || normalized === null) return normalized;
+  const lower = normalized.toLowerCase();
+  if (!SKILL_SLUG_SHAPE_RE.test(lower)) {
+    throw new Error('skillSlug must be a kebab-case artifact slug (lowercase letters, digits, hyphens — e.g. "pdf-fill").');
+  }
+  return lower;
+}
+
 function normalizeConfidence(value: unknown): number | null | undefined {
   if (value === undefined) return undefined;
   if (value === null || value === '') return null;
@@ -221,7 +242,10 @@ function normalizeOptionalText(value: unknown, field: string, maxChars: number):
 function validateCategoryForDomain(domain: IdentityDomain, category: string | null | undefined): void {
   if (category == null) return;
   const allowed = DOMAIN_CATEGORIES[domain];
-  if (!allowed) return; // domain has no closed set (currently only `agent`) — free text
+  if (allowed === undefined) return; // no closed set registered for this domain — free text
+  if (allowed.length === 0) {
+    throw new Error(`category is not used in the "${ domain }" domain — did you mean to set kind instead? (agent-domain rows use kind: correction | constraint | method | commitment | preference.)`);
+  }
   if (!allowed.includes(category)) {
     throw new Error(`category "${ category }" is not valid for domain "${ domain }"; expected one of: ${ allowed.join(', ') }.`);
   }
@@ -254,6 +278,26 @@ function validateContentForDomain(domain: IdentityDomain, content: string): void
   }
   if (domain === 'skills' && !SKILLS_SLUG_CONTENT_RE.test(content)) {
     throw new Error('skills-domain content must name the exact skill in the shape "Skill \'<slug>\' …" — a row with no quoted skill slug is not about a specific skill artifact and does not belong in this domain.');
+  }
+}
+
+/**
+ * skill_slug is the structural counterpart to the content-regex check above:
+ * the column makes "every row about skill X" queryable without parsing
+ * prose; the content regex proves the row's own text actually names the
+ * skill (defense in depth — a writer could set the column without ever
+ * saying the skill's name out loud in content). Required on every
+ * skills-domain row, illegal everywhere else — same shape as subject/kind.
+ */
+function validateSkillSlugForDomain(domain: IdentityDomain, skillSlug: string | null | undefined): void {
+  if (domain === 'skills') {
+    if (skillSlug == null) {
+      throw new Error('skillSlug is required for skills-domain rows — set it to the exact artifact slug (e.g. "pdf-fill") this row is about.');
+    }
+    return;
+  }
+  if (skillSlug != null) {
+    throw new Error(`skillSlug is only valid in the skills domain (got domain "${ domain }").`);
   }
 }
 
@@ -304,7 +348,8 @@ export class IdentityObservationsModel {
           ADD COLUMN IF NOT EXISTS subject TEXT,
           ADD COLUMN IF NOT EXISTS evidence TEXT,
           ADD COLUMN IF NOT EXISTS confidence REAL,
-          ADD COLUMN IF NOT EXISTS kind TEXT
+          ADD COLUMN IF NOT EXISTS kind TEXT,
+          ADD COLUMN IF NOT EXISTS skill_slug TEXT
       `);
     } catch (err) {
       console.error('[IdentityObservationsModel] Failed to ensure table:', err);
@@ -324,17 +369,19 @@ export class IdentityObservationsModel {
     const evidence = normalizeOptionalText(input.evidence, 'evidence', MAX_EVIDENCE_CHARS);
     const confidence = normalizeConfidence(input.confidence);
     const kind = normalizeIdentityKind(input.kind);
+    const skillSlug = normalizeSkillSlug(input.skillSlug);
     const source = normalizeOptionalText(input.source, 'source', MAX_SOURCE_CHARS);
     const content = normalizeRequiredText(input.content, 'content', MAX_CONTENT_CHARS);
 
     validateCategoryForDomain(domain, category);
     validateSubjectForDomain(domain, subject);
     validateKindForDomain(domain, kind);
+    validateSkillSlugForDomain(domain, skillSlug);
     validateContentForDomain(domain, content);
 
     const rows = await postgresClient.query<IdentityObservationRecord>(
-      `INSERT INTO ${ IdentityObservationsModel.TABLE } (id, domain, level, category, content, basis, subject, evidence, confidence, kind, source)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      `INSERT INTO ${ IdentityObservationsModel.TABLE } (id, domain, level, category, content, basis, subject, evidence, confidence, kind, skill_slug, source)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
       [
         id,
@@ -347,6 +394,7 @@ export class IdentityObservationsModel {
         evidence ?? null,
         confidence ?? null,
         kind ?? null,
+        skillSlug ?? null,
         source ?? null,
       ],
     );
@@ -405,6 +453,12 @@ export class IdentityObservationsModel {
       validateKindForDomain(domain, kind);
       setClauses.push(`kind = $${ idx++ }`);
       values.push(kind);
+    }
+    if (changes.skillSlug !== undefined) {
+      const skillSlug = normalizeSkillSlug(changes.skillSlug);
+      validateSkillSlugForDomain(domain, skillSlug);
+      setClauses.push(`skill_slug = $${ idx++ }`);
+      values.push(skillSlug);
     }
     if (changes.source !== undefined) {
       setClauses.push(`source = $${ idx++ }`);

--- a/pkg/rancher-desktop/agent/database/models/__tests__/IdentityObservationsModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/IdentityObservationsModel.test.ts
@@ -159,6 +159,36 @@ describe('IdentityObservationsModel', () => {
     expect(postgresClient.query).not.toHaveBeenCalled();
   });
 
+  it('rejects kind outside the agent domain (same gap as subject, same fix)', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:      'bad9',
+      domain:  'environment',
+      level:   2,
+      kind:    'method',
+      content: 'The build cannot run in the Lima VM.',
+    })).rejects.toThrow('kind is only valid in the agent domain');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('accepts kind within the agent domain', async() => {
+    const inserted = { id: 'ag01', domain: 'agent', level: 3, kind: 'method', content: 'Agent drafts PRs; the human merges.' };
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([inserted]));
+
+    const row = await IdentityObservationsModel.insert({
+      id:      'ag01',
+      domain:  'agent',
+      level:   3,
+      kind:    'method',
+      subject: 'agent.user',
+      content: 'Agent drafts PRs; the human merges.',
+    });
+
+    expect(row).toBe(inserted);
+  });
+
   it('rejects content that reads as task/PR/commit status', async() => {
     (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
 

--- a/pkg/rancher-desktop/agent/database/models/__tests__/IdentityObservationsModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/IdentityObservationsModel.test.ts
@@ -104,7 +104,11 @@ describe('IdentityObservationsModel', () => {
   });
 
   it('updates only provided mutable fields and stamps updated_at', async() => {
-    (postgresClient as any).query = jest.fn(() => Promise.resolve([{ id: 'hum1', level: 3 }]));
+    // update() fetches the existing row first (getById) to know the row's
+    // domain for write-guard validation, then issues the UPDATE — two calls.
+    (postgresClient as any).query = (jest.fn() as any)
+      .mockResolvedValueOnce([{ id: 'hum1', domain: 'human', level: 2 }])
+      .mockResolvedValueOnce([{ id: 'hum1', level: 3 }]);
 
     await IdentityObservationsModel.update('hum1', {
       level:   3,
@@ -115,7 +119,85 @@ describe('IdentityObservationsModel', () => {
       expect.stringContaining('updated_at = now(), level = $1, content = $2'),
       [3, 'Jonathon stated this directly.', 'hum1'],
     );
-    expect((postgresClient.query as any).mock.calls[0][0]).toContain('WHERE id = $3 RETURNING *');
+    expect((postgresClient.query as any).mock.calls[1][0]).toContain('WHERE id = $3 RETURNING *');
+  });
+
+  it('returns null when updating an observation that no longer exists', async() => {
+    (postgresClient as any).query = (jest.fn() as any).mockResolvedValueOnce([]);
+
+    const result = await IdentityObservationsModel.update('gone', { level: 3 });
+
+    expect(result).toBeNull();
+    expect(postgresClient.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a category outside the domain\'s closed set', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:       'bad5',
+      domain:   'human',
+      level:    2,
+      category: 'not-a-real-category',
+      content:  'Some fact about the human.',
+    })).rejects.toThrow('is not valid for domain "human"');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects subject outside the agent domain (the business-domain misfile pattern)', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:      'bad6',
+      domain:  'business',
+      level:   2,
+      subject: 'agent.user',
+      content: 'The business ships receptionist software.',
+    })).rejects.toThrow('subject is only valid in the agent domain');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects content that reads as task/PR/commit status', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:      'bad7',
+      domain:  'human',
+      level:   2,
+      content: 'Opened draft PR #633 for the skills domain.',
+    })).rejects.toThrow('task/engineering status');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects skills-domain content with no quoted skill slug', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:      'bad8',
+      domain:  'skills',
+      level:   2,
+      content: 'A skill ran successfully today.',
+    })).rejects.toThrow('must name the exact skill');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('accepts well-formed skills-domain content naming a slug', async() => {
+    const inserted = { id: 'sk01', domain: 'skills', level: 3, category: 'success', content: "Skill 'pdf-fill' succeeded filling a 12-field form." };
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([inserted]));
+
+    const row = await IdentityObservationsModel.insert({
+      id:       'sk01',
+      domain:   'skills',
+      level:    3,
+      category: 'success',
+      content:  "Skill 'pdf-fill' succeeded filling a 12-field form.",
+    });
+
+    expect(row).toBe(inserted);
   });
 
   it('lists active rows by domain, certainty, and recency', async() => {
@@ -176,8 +258,8 @@ describe('IdentityObservationsModel', () => {
     );
   });
 
-  it('finds duplicates only within the requested domain', async() => {
-    jest.spyOn(IdentityObservationsModel, 'listActive').mockResolvedValue([
+  it('finds duplicates by scanning up to 500 rows directly, bypassing the public 100-row list cap', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([
       {
         id:         'hum1',
         domain:     'human',
@@ -194,11 +276,25 @@ describe('IdentityObservationsModel', () => {
         archived:   false,
         source:     null,
       },
-    ]);
+    ]));
 
     const duplicate = await IdentityObservationsModel.findDuplicate('human', 'Jonathon prefers direct status reports');
 
-    expect(IdentityObservationsModel.listActive).toHaveBeenCalledWith('human', { limit: 500 });
+    const [sql, params] = (postgresClient.query as any).mock.calls[0];
+    expect(sql).toContain('WHERE archived = false AND domain = $1');
+    expect(params).toEqual(['human', 500]);
     expect(duplicate?.id).toBe('hum1');
+  });
+
+  it('counts active rows for the recall row-count gate', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([{ count: '7' }]));
+
+    const count = await IdentityObservationsModel.countActive('agent');
+
+    expect(postgresClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE archived = false AND domain = $1'),
+      ['agent'],
+    );
+    expect(count).toBe(7);
   });
 });

--- a/pkg/rancher-desktop/agent/database/models/__tests__/IdentityObservationsModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/IdentityObservationsModel.test.ts
@@ -45,7 +45,7 @@ describe('IdentityObservationsModel', () => {
 
     expect(postgresClient.query).toHaveBeenCalledWith(
       expect.stringContaining('INSERT INTO identity_observations'),
-      ['hum1', 'human', 2, 'preference', 'Jonathon prefers direct status reports.', 'Repeated instruction in chat.', null, null, null, null, 'test'],
+      ['hum1', 'human', 2, 'preference', 'Jonathon prefers direct status reports.', 'Repeated instruction in chat.', null, null, null, null, null, 'test'],
     );
     expect(row).toBe(inserted);
   });
@@ -189,6 +189,20 @@ describe('IdentityObservationsModel', () => {
     expect(row).toBe(inserted);
   });
 
+  it('rejects category on the agent domain (points the writer at kind instead)', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:       'bad12',
+      domain:   'agent',
+      level:    2,
+      category: 'method',
+      content:  'Agent drafts PRs; the human merges.',
+    })).rejects.toThrow('did you mean to set kind instead');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
   it('rejects content that reads as task/PR/commit status', async() => {
     (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
 
@@ -202,31 +216,78 @@ describe('IdentityObservationsModel', () => {
     expect(postgresClient.query).not.toHaveBeenCalled();
   });
 
-  it('rejects skills-domain content with no quoted skill slug', async() => {
+  it('rejects skills-domain inserts missing skillSlug', async() => {
     (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
 
     await expect(IdentityObservationsModel.insert({
       id:      'bad8',
       domain:  'skills',
       level:   2,
-      content: 'A skill ran successfully today.',
+      content: "Skill 'pdf-fill' ran successfully today.",
+    })).rejects.toThrow('skillSlug is required');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects skillSlug outside the skills domain', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:        'bad10',
+      domain:    'human',
+      level:     2,
+      skillSlug: 'pdf-fill',
+      content:   'Jonathon prefers direct status reports.',
+    })).rejects.toThrow('skillSlug is only valid in the skills domain');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed skillSlug', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:        'bad11',
+      domain:    'skills',
+      level:     2,
+      skillSlug: 'PDF Fill!',
+      content:   "Skill 'pdf-fill' ran successfully today.",
+    })).rejects.toThrow('kebab-case artifact slug');
+
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects skills-domain content with no quoted skill slug even when skillSlug is set', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await expect(IdentityObservationsModel.insert({
+      id:        'bad9',
+      domain:    'skills',
+      level:     2,
+      skillSlug: 'pdf-fill',
+      content:   'A skill ran successfully today.',
     })).rejects.toThrow('must name the exact skill');
 
     expect(postgresClient.query).not.toHaveBeenCalled();
   });
 
-  it('accepts well-formed skills-domain content naming a slug', async() => {
-    const inserted = { id: 'sk01', domain: 'skills', level: 3, category: 'success', content: "Skill 'pdf-fill' succeeded filling a 12-field form." };
+  it('accepts well-formed skills-domain content naming a slug, with skillSlug set', async() => {
+    const inserted = { id: 'sk01', domain: 'skills', level: 3, category: 'success', skill_slug: 'pdf-fill', content: "Skill 'pdf-fill' succeeded filling a 12-field form." };
     (postgresClient as any).query = jest.fn(() => Promise.resolve([inserted]));
 
     const row = await IdentityObservationsModel.insert({
-      id:       'sk01',
-      domain:   'skills',
-      level:    3,
-      category: 'success',
-      content:  "Skill 'pdf-fill' succeeded filling a 12-field form.",
+      id:        'sk01',
+      domain:    'skills',
+      level:     3,
+      category:  'success',
+      skillSlug: 'PDF-Fill',
+      content:   "Skill 'pdf-fill' succeeded filling a 12-field form.",
     });
 
+    expect(postgresClient.query).toHaveBeenCalledWith(
+      expect.stringContaining('skill_slug'),
+      expect.arrayContaining(['pdf-fill']),
+    );
     expect(row).toBe(inserted);
   });
 

--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -764,6 +764,11 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
       parts.push(`<projects_observations>\n${ projectsObservationContext.trim() }\n</projects_observations>`);
     }
 
+    const skillsObservationContext = (state?.metadata as any)?.skillsObservationContext;
+    if (skillsObservationContext && typeof skillsObservationContext === 'string' && skillsObservationContext.trim()) {
+      parts.push(`<skills_observations>\n${ skillsObservationContext.trim() }\n</skills_observations>`);
+    }
+
     if (parts.length === 0) return '';
     return `<sulla_context>\n${ parts.join('\n\n') }\n</sulla_context>`;
   }

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -406,6 +406,11 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
       parts.push(`<projects_observations>\n${ projectsObservationContext.trim() }\n</projects_observations>`);
     }
 
+    const skillsObservationContext = (state?.metadata as any)?.skillsObservationContext;
+    if (skillsObservationContext && typeof skillsObservationContext === 'string' && skillsObservationContext.trim()) {
+      parts.push(`<skills_observations>\n${ skillsObservationContext.trim() }\n</skills_observations>`);
+    }
+
     if (parts.length === 0) return { prefix: '', stableHash };
     return { prefix: `<sulla_context>\n${ parts.join('\n\n') }\n</sulla_context>`, stableHash };
   }

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -270,6 +270,18 @@ export async function runSubconsciousMiddleware(
     awaitedTasks.push(timed('world-observation-recall', 'Recalling the world', worldRecallPromise.then(ctx => { (state.metadata as any).worldObservationContext = ctx })));
   }
 
+  // R8. Skills Observation Recall (skills) — awaited: relevant `skills`-domain
+  //     rows (provenance/success/failure/gap/inventory for named skill
+  //     artifacts), injected as <skills_observations>. Also searches the
+  //     marketplace + local ~/sulla/skills/ install (read-only) so recall can
+  //     surface a skill that fits the current turn even if it was never run
+  //     before, not just skills already logged.
+  if (options.includeObservations && analyzable) {
+    launched.push('skills-observation-recall');
+    const skillsRecallPromise = runIdentityObservationRecall(state, 'skills');
+    awaitedTasks.push(timed('skills-observation-recall', 'Recalling what skills exist', skillsRecallPromise.then(ctx => { (state.metadata as any).skillsObservationContext = ctx })));
+  }
+
   console.log(`[SubconsciousMiddleware] Launched (pre-turn recalls): ${ launched.join(', ') } | messages: ${ state.messages.length }`);
 
   // Every task in awaitedTasks writes into the live turn state. The primary
@@ -311,6 +323,7 @@ export async function runSubconsciousMiddleware(
  *   - Business Observer  business   → the human's business/employment
  *   - World Observer      world     → external events relevant to us (gated)
  *   - Environment Observer environment → this install/host + repeatable processes
+ *   - Skills Observer     skills    → provenance + run outcomes of named skill artifacts
  */
 export function runSubconsciousObservationWriters(
   state: BaseThreadState,
@@ -335,8 +348,9 @@ export function runSubconsciousObservationWriters(
   launch('world-observer', () => runIdentityObserver(state, 'world'));
   launch('environment-observer', () => runIdentityObserver(state, 'environment'));
   launch('projects-observer', () => runIdentityObserver(state, 'projects'));
+  launch('skills-observer', () => runIdentityObserver(state, 'skills'));
 
-  console.log(`[SubconsciousMiddleware] Post-turn writers launched (observation + human/agent/business/world/environment/projects) | messages: ${ state.messages.length }`);
+  console.log(`[SubconsciousMiddleware] Post-turn writers launched (observation + human/agent/business/world/environment/projects/skills) | messages: ${ state.messages.length }`);
 }
 
 // ============================================================================

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -16,7 +16,7 @@
  * Logs are written to ~/sulla/logs/ and can be inspected for debugging.
  */
 
-import { formatIdentityObservationDate, IdentityObservationsModel, type IdentityObservationRecord } from '../database/models/IdentityObservationsModel';
+import { IdentityObservationsModel } from '../database/models/IdentityObservationsModel';
 import { ObservationsModel } from '../database/models/ObservationsModel';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { GraphRegistry, type DigestibleToolResult } from '../services/GraphRegistry';
@@ -704,118 +704,42 @@ async function runIdentityObserver(state: BaseThreadState, domain: string): Prom
 }
 
 /**
- * Domains whose recall never needs anything beyond the identity_observations
- * table — safe to route through the same deterministic SQL fast-path
- * ObservationsModel recall already uses (see runObservationRecall above),
- * for the identical reason: these used to spin up a full LLM agent loop (up
- * to 10 iterations) to keyword-search a domain that, post the 2026-08-19
- * pollution cleanup, holds a handful of rows (or, for business/world, zero).
- * `projects` and `skills` are excluded — their recall also augments with
- * live tools (Projects work-state / marketplace discovery) that only an LLM
- * can decide whether and how to call; they keep the agent-loop path below.
- */
-const IDENTITY_SQL_FAST_PATH_DOMAINS = new Set(['human', 'business', 'world', 'agent', 'environment']);
-
-/** Max identity rows surfaced per domain per turn via the SQL fast-path. */
-const IDENTITY_RECALL_MAX_ROWS = 8;
-
-function formatIdentityRecallRow(row: IdentityObservationRecord): string {
-  const date = formatIdentityObservationDate(row.created_at);
-  const cat = row.category ? `·${ row.category }` : '';
-  const basis = row.basis ? ` (basis: ${ row.basis })` : '';
-  return `[${ row.id }] L${ row.level }${ cat } ${ date } — ${ row.content }${ basis }`;
-}
-
-/**
- * Cheap relevance prefilter for skills recall's marketplace-augmented LLM
- * path. Skills is the only recall domain whose agent-loop can make a LIVE
- * NETWORK CALL (marketplace search) — dispatching that on every turn
- * regardless of relevance was flagged as a real cost. When the turn doesn't
- * even look skill/task-shaped, skills recall falls back to the same SQL
- * fast-path the other five domains use (still surfaces already-logged skill
- * facts by keyword, just without live marketplace discovery or the LLM
- * round-trip) instead of either skipping outright or paying the full cost
- * on every turn.
- */
-const SKILL_SHAPED_TURN_RE = /\bskill(s)?\b|\bautomat(e|es|ed|ion|ic|ing)\b|\brepeatable\b|\btemplate\b|\bhow do i\b|\bworkflow\b|\bscript\b|\brecipe\b|\bmarketplace\b/i;
-
-/**
  * Read-only recall for one identity domain. The primary agent blocks on this
  * because the selected rows are injected as <xxx_observations> before the
- * main response starts — recall is never time-limited by design, so the
- * SQL fast-path below isn't just an optimization, it removes the entire
- * class of 17-120s-blocking-prelude-to-search-almost-nothing failure the
- * general ObservationsModel recall was already converted to fix.
+ * main response starts — recall is never time-limited by design (Jonathon,
+ * jJ76: "I expect to wait forever for the memory recall agents… help them do
+ * their job more efficiently").
+ *
+ * A prior version of this function routed 5 of the 7 domains through a
+ * deterministic SQL search with NO model in the loop, and gated skills'
+ * marketplace-augmented recall behind a keyword prefilter that could skip
+ * the LLM entirely. Jonathon reverted both (2026-08-20): "I want the model
+ * to choose what to search and then choose what to provide to the primary
+ * context. I explicitly want a model in the loop doing the searching. Sure
+ * give them efficient tools, but I want a model deciding." Every domain
+ * therefore always dispatches the LLM agent — it decides what to search
+ * (via search_identity_observations / list_identity_observations, and for
+ * projects/skills the extra live-tool grants), and decides what's relevant
+ * enough to surface. "Efficient tools" means the SQL underneath those tools
+ * stays fast (IdentityObservationsModel.search/listActive, both ms-scale) —
+ * not that the model gets bypassed.
+ *
+ * The one thing still short-circuited below is dispatch on a domain with 0
+ * logged rows — there is nothing for a model to find or decide over, so
+ * this isn't the model being cut out of a judgment call, it's not asking a
+ * question with a definitionally empty answer. Flag if you want that gone
+ * too.
  */
 async function runIdentityObservationRecall(state: BaseThreadState, domain: string): Promise<string | null> {
   const startTime = Date.now();
-  const parentThreadId = (state.metadata as any).threadId;
 
-  if (IDENTITY_SQL_FAST_PATH_DOMAINS.has(domain)) {
-    try {
-      const query = extractLatestUserText(state);
-      if (!query) {
-        console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] No user text to search — skipped`);
-        return null;
-      }
-
-      const rows = await IdentityObservationsModel.search(domain, query, IDENTITY_RECALL_MAX_ROWS, false);
-      const elapsed = Date.now() - startTime;
-
-      if (!rows || rows.length === 0) {
-        perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } matched=0 ms=${ elapsed } path=sql-fast-path`);
-        console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] No matching rows in ${ elapsed }ms (sql-fast-path)`);
-        return null;
-      }
-
-      const response = rows.map(formatIdentityRecallRow).join('\n');
-      perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } matched=${ rows.length } chars=${ response.length } ms=${ elapsed } path=sql-fast-path`);
-      console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Returning ${ rows.length } rows (${ response.length } chars) in ${ elapsed }ms (sql-fast-path)`);
-      return response;
-    } catch (error) {
-      console.error(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Failed in ${ Date.now() - startTime }ms (sql-fast-path):`, error instanceof Error ? error.message : error);
-      return null;
-    }
-  }
-
-  // Remaining domains (projects, skills) augment DB search with live tools
-  // (search_project_items / marketplace discovery) an LLM must decide
-  // whether and how to call — keep the agent-loop path. But skip dispatching
-  // it entirely when the domain has logged nothing yet: an empty table plus
-  // an unused live-tool grant isn't worth up to 10 LLM iterations — and for
-  // skills specifically, a live marketplace network call — on every turn
-  // regardless of whether the turn is remotely skill/project-shaped.
   try {
     const loggedCount = await IdentityObservationsModel.countActive(domain);
     if (loggedCount === 0) {
       const elapsed = Date.now() - startTime;
-      perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } chars=0 ms=${ elapsed } path=agent-skipped-empty`);
+      perf.log(`[IdentityRecall] threadId=${ (state.metadata as any).threadId } domain=${ domain } chars=0 ms=${ elapsed } path=agent-skipped-empty`);
       console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Skipped — 0 logged rows (agent-skipped-empty)`);
       return null;
-    }
-
-    // Skills-only relevance gate — see SKILL_SHAPED_TURN_RE. Falls back to
-    // the SQL fast-path instead of the marketplace-augmented agent when the
-    // turn gives no signal it's skill/task-shaped.
-    if (domain === 'skills') {
-      const query = extractLatestUserText(state);
-      if (!query) {
-        console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] No user text to search — skipped`);
-        return null;
-      }
-      if (!SKILL_SHAPED_TURN_RE.test(query)) {
-        const rows = await IdentityObservationsModel.search(domain, query, IDENTITY_RECALL_MAX_ROWS, false);
-        const elapsed = Date.now() - startTime;
-        if (!rows || rows.length === 0) {
-          perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } matched=0 ms=${ elapsed } path=sql-fast-path-ungated`);
-          console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Turn not skill-shaped, no matches in ${ elapsed }ms (sql-fast-path-ungated)`);
-          return null;
-        }
-        const response = rows.map(formatIdentityRecallRow).join('\n');
-        perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } matched=${ rows.length } chars=${ response.length } ms=${ elapsed } path=sql-fast-path-ungated`);
-        console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Turn not skill-shaped — SQL fast-path returned ${ rows.length } rows in ${ elapsed }ms instead of dispatching the marketplace-augmented agent`);
-        return response;
-      }
     }
 
     const { graph, state: subState, threadId } = await GraphRegistry.createIdentityObservationRecall(state, domain);

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -727,6 +727,19 @@ function formatIdentityRecallRow(row: IdentityObservationRecord): string {
 }
 
 /**
+ * Cheap relevance prefilter for skills recall's marketplace-augmented LLM
+ * path. Skills is the only recall domain whose agent-loop can make a LIVE
+ * NETWORK CALL (marketplace search) — dispatching that on every turn
+ * regardless of relevance was flagged as a real cost. When the turn doesn't
+ * even look skill/task-shaped, skills recall falls back to the same SQL
+ * fast-path the other five domains use (still surfaces already-logged skill
+ * facts by keyword, just without live marketplace discovery or the LLM
+ * round-trip) instead of either skipping outright or paying the full cost
+ * on every turn.
+ */
+const SKILL_SHAPED_TURN_RE = /\bskill(s)?\b|\bautomat(e|es|ed|ion|ic|ing)\b|\brepeatable\b|\btemplate\b|\bhow do i\b|\bworkflow\b|\bscript\b|\brecipe\b|\bmarketplace\b/i;
+
+/**
  * Read-only recall for one identity domain. The primary agent blocks on this
  * because the selected rows are injected as <xxx_observations> before the
  * main response starts — recall is never time-limited by design, so the
@@ -779,6 +792,30 @@ async function runIdentityObservationRecall(state: BaseThreadState, domain: stri
       perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } chars=0 ms=${ elapsed } path=agent-skipped-empty`);
       console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Skipped — 0 logged rows (agent-skipped-empty)`);
       return null;
+    }
+
+    // Skills-only relevance gate — see SKILL_SHAPED_TURN_RE. Falls back to
+    // the SQL fast-path instead of the marketplace-augmented agent when the
+    // turn gives no signal it's skill/task-shaped.
+    if (domain === 'skills') {
+      const query = extractLatestUserText(state);
+      if (!query) {
+        console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] No user text to search — skipped`);
+        return null;
+      }
+      if (!SKILL_SHAPED_TURN_RE.test(query)) {
+        const rows = await IdentityObservationsModel.search(domain, query, IDENTITY_RECALL_MAX_ROWS, false);
+        const elapsed = Date.now() - startTime;
+        if (!rows || rows.length === 0) {
+          perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } matched=0 ms=${ elapsed } path=sql-fast-path-ungated`);
+          console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Turn not skill-shaped, no matches in ${ elapsed }ms (sql-fast-path-ungated)`);
+          return null;
+        }
+        const response = rows.map(formatIdentityRecallRow).join('\n');
+        perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } matched=${ rows.length } chars=${ response.length } ms=${ elapsed } path=sql-fast-path-ungated`);
+        console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Turn not skill-shaped — SQL fast-path returned ${ rows.length } rows in ${ elapsed }ms instead of dispatching the marketplace-augmented agent`);
+        return response;
+      }
     }
 
     const { graph, state: subState, threadId } = await GraphRegistry.createIdentityObservationRecall(state, domain);

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -16,6 +16,7 @@
  * Logs are written to ~/sulla/logs/ and can be inspected for debugging.
  */
 
+import { formatIdentityObservationDate, IdentityObservationsModel, type IdentityObservationRecord } from '../database/models/IdentityObservationsModel';
 import { ObservationsModel } from '../database/models/ObservationsModel';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { GraphRegistry, type DigestibleToolResult } from '../services/GraphRegistry';
@@ -703,15 +704,83 @@ async function runIdentityObserver(state: BaseThreadState, domain: string): Prom
 }
 
 /**
- * Read-only recall agent for one identity domain. It searches/listens through
- * identity observations and returns only rows relevant to the current turn.
- * The primary agent blocks on this because the selected rows are injected as
- * <user_observations> before the main response starts.
+ * Domains whose recall never needs anything beyond the identity_observations
+ * table — safe to route through the same deterministic SQL fast-path
+ * ObservationsModel recall already uses (see runObservationRecall above),
+ * for the identical reason: these used to spin up a full LLM agent loop (up
+ * to 10 iterations) to keyword-search a domain that, post the 2026-08-19
+ * pollution cleanup, holds a handful of rows (or, for business/world, zero).
+ * `projects` and `skills` are excluded — their recall also augments with
+ * live tools (Projects work-state / marketplace discovery) that only an LLM
+ * can decide whether and how to call; they keep the agent-loop path below.
+ */
+const IDENTITY_SQL_FAST_PATH_DOMAINS = new Set(['human', 'business', 'world', 'agent', 'environment']);
+
+/** Max identity rows surfaced per domain per turn via the SQL fast-path. */
+const IDENTITY_RECALL_MAX_ROWS = 8;
+
+function formatIdentityRecallRow(row: IdentityObservationRecord): string {
+  const date = formatIdentityObservationDate(row.created_at);
+  const cat = row.category ? `·${ row.category }` : '';
+  const basis = row.basis ? ` (basis: ${ row.basis })` : '';
+  return `[${ row.id }] L${ row.level }${ cat } ${ date } — ${ row.content }${ basis }`;
+}
+
+/**
+ * Read-only recall for one identity domain. The primary agent blocks on this
+ * because the selected rows are injected as <xxx_observations> before the
+ * main response starts — recall is never time-limited by design, so the
+ * SQL fast-path below isn't just an optimization, it removes the entire
+ * class of 17-120s-blocking-prelude-to-search-almost-nothing failure the
+ * general ObservationsModel recall was already converted to fix.
  */
 async function runIdentityObservationRecall(state: BaseThreadState, domain: string): Promise<string | null> {
   const startTime = Date.now();
+  const parentThreadId = (state.metadata as any).threadId;
 
+  if (IDENTITY_SQL_FAST_PATH_DOMAINS.has(domain)) {
+    try {
+      const query = extractLatestUserText(state);
+      if (!query) {
+        console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] No user text to search — skipped`);
+        return null;
+      }
+
+      const rows = await IdentityObservationsModel.search(domain, query, IDENTITY_RECALL_MAX_ROWS, false);
+      const elapsed = Date.now() - startTime;
+
+      if (!rows || rows.length === 0) {
+        perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } matched=0 ms=${ elapsed } path=sql-fast-path`);
+        console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] No matching rows in ${ elapsed }ms (sql-fast-path)`);
+        return null;
+      }
+
+      const response = rows.map(formatIdentityRecallRow).join('\n');
+      perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } matched=${ rows.length } chars=${ response.length } ms=${ elapsed } path=sql-fast-path`);
+      console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Returning ${ rows.length } rows (${ response.length } chars) in ${ elapsed }ms (sql-fast-path)`);
+      return response;
+    } catch (error) {
+      console.error(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Failed in ${ Date.now() - startTime }ms (sql-fast-path):`, error instanceof Error ? error.message : error);
+      return null;
+    }
+  }
+
+  // Remaining domains (projects, skills) augment DB search with live tools
+  // (search_project_items / marketplace discovery) an LLM must decide
+  // whether and how to call — keep the agent-loop path. But skip dispatching
+  // it entirely when the domain has logged nothing yet: an empty table plus
+  // an unused live-tool grant isn't worth up to 10 LLM iterations — and for
+  // skills specifically, a live marketplace network call — on every turn
+  // regardless of whether the turn is remotely skill/project-shaped.
   try {
+    const loggedCount = await IdentityObservationsModel.countActive(domain);
+    if (loggedCount === 0) {
+      const elapsed = Date.now() - startTime;
+      perf.log(`[IdentityRecall] threadId=${ parentThreadId } domain=${ domain } chars=0 ms=${ elapsed } path=agent-skipped-empty`);
+      console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Skipped — 0 logged rows (agent-skipped-empty)`);
+      return null;
+    }
+
     const { graph, state: subState, threadId } = await GraphRegistry.createIdentityObservationRecall(state, domain);
     console.log(`[SubconsciousMiddleware:IdentityRecall:${ domain }] Started | threadId: ${ threadId }`);
 

--- a/pkg/rancher-desktop/agent/nodes/AgentNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/AgentNode.ts
@@ -177,6 +177,8 @@ export class AgentNode extends BaseNode {
     if (environmentObservationContext) combinedContextParts.push(`<environment_observations>\n${ environmentObservationContext }\n</environment_observations>`);
     const projectsObservationContext = (state.metadata as any).projectsObservationContext;
     if (projectsObservationContext) combinedContextParts.push(`<projects_observations>\n${ projectsObservationContext }\n</projects_observations>`);
+    const skillsObservationContext = (state.metadata as any).skillsObservationContext;
+    if (skillsObservationContext) combinedContextParts.push(`<skills_observations>\n${ skillsObservationContext }\n</skills_observations>`);
 
     if (combinedContextParts.length > 0) {
       const contextBlock = `\n\n${ combinedContextParts.join('\n\n') }`;

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -832,8 +832,8 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
    * Also drops first-turn synthetic carrier messages once emptied.
    */
   protected stripInjectedContextBlocks(state: BaseThreadState): void {
-    const BLOCK_RE = /\n*<(observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|routine_digest|lane_health)>[\s\S]*?<\/\1>/g;
-    const MARKER_RE = /<(?:observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|routine_digest|lane_health)>/;
+    const BLOCK_RE = /\n*<(observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|skills_observations|routine_digest|lane_health)>[\s\S]*?<\/\1>/g;
+    const MARKER_RE = /<(?:observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|skills_observations|routine_digest|lane_health)>/;
 
     for (const msg of state.messages) {
       if (msg.role !== 'assistant') continue;

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -543,6 +543,34 @@ this conversation, finish immediately; most turns need NO write here.`,
 };
 
 /**
+ * Shared reject rules for EVERY identity-observer domain, hoisted out of the
+ * per-domain focus text. Every domain audit (2026-08-19: human/business/
+ * world/agent/environment/projects) found the SAME three pollution classes —
+ * task/PR/commit status, agent instructions restated as fact, and system-
+ * prompt/AGENTS.md residue — independently re-derived per domain. Maintaining
+ * one canonical block instead of six near-copies is both less error-prone and
+ * gives the tool-layer validation (IdentityObservationsModel work-state lint)
+ * a single prompt-side rule it actually matches.
+ */
+const IDENTITY_OBSERVER_UNIVERSAL_REJECTS = `## Universal rejects — apply in EVERY domain, before the domain-specific rules below
+
+These three classes caused every domain audit finding to date. Reject them
+regardless of how relevant the domain-specific focus makes them sound:
+1. Task/work status: a PR/branch/commit/worktree reference, a tsc/test/CI
+   result, a routed/exempted/blocked count, "shipped X", "opened draft PR #N".
+   This is work-state — it belongs in the Projects system, never here, in ANY
+   domain, even the projects domain itself.
+2. An instruction restated as fact: something the human told the agent to DO
+   ("split the work one task per agent", "always draft a PR first") is a task
+   directive, not identity — unless it is genuinely a standing working
+   agreement, in which case it belongs in the agent domain (subject
+   agent.user), not wherever it happened to come up.
+3. System-prompt / AGENTS.md / platform-context residue: a rule, persona
+   trait, or behavior spec copied from your own instructions and presented as
+   if it were something learned this conversation. If your only basis is "the
+   instructions say…", that is not an observation — discard it.`;
+
+/**
  * Build the writer prompt for a domain observer. The discipline is the
  * SAME for every domain — record stated facts first (L3), then derived
  * facts (L2), then reasoned conclusions (L1, always with their basis) —
@@ -554,6 +582,14 @@ function buildIdentityObserverPrompt(cfg: IdentityObserverDomainConfig): string 
 CRITICAL: You are NOT the primary agent. You do NOT execute tasks, answer
 questions, browse websites, call APIs, or do anything the user asked for.
 Another agent handles that. You ONLY manage ${ cfg.domain } identity observations.
+
+DEFAULT IS ZERO WRITES. Most turns reveal nothing durable about ${ cfg.subjectLabel }
+— that is the expected, correct outcome, not a failure to find something. Write
+budget: at most 1-2 rows this turn. If more than 3 candidates pass every gate
+below, keep only the most durable and drop the rest — do not write all of them
+just because they qualify.
+
+${ IDENTITY_OBSERVER_UNIVERSAL_REJECTS }
 
 ${ cfg.focus }
 
@@ -583,7 +619,10 @@ BEFORE calling add_identity_observation for any new observation:
 - Only INSERT a fresh entry when nothing similar is found.
 
 Each observation is ONE concise sentence with its context, a level, and a
-category. Include why, not just what, when the reason matters.
+category. Include why, not just what, when the reason matters. In basis, name
+which gate/evidence justified the row (e.g. "L3: human stated this directly" /
+"L1 conclusion from repeated behavior, see evidence") — not what the system
+prompt says the domain covers.
 
 If nothing about ${ cfg.subjectLabel } was revealed this conversation, finish
 immediately — most task-focused turns need NO writes.
@@ -592,7 +631,11 @@ Do NOT:
 - Try to complete the user's task
 - Record task/project state (the general observation writer owns that)
 - Record facts about other domains
-- Search for tools, APIs, or integrations${ cfg.writerNote ? `\n\n${ cfg.writerNote }` : '' }`;
+- Search for tools, APIs, or integrations${ cfg.writerNote ? `\n\n${ cfg.writerNote }` : '' }
+
+Before you finish, re-read every row you are about to write against the
+Universal rejects above one more time — it is the single most common reason
+a domain regresses.`;
 }
 
 /**
@@ -728,6 +771,17 @@ Do not search one term at a time across multiple rounds.
 
 Be selective: a 5-entry relevant subset is better than 30 entries dumped verbatim.`;
 
+/**
+ * Recall only needs to know what a domain CONTAINS, not the writer's reject
+ * rules — those are "never write" instructions to an agent with no write
+ * tools, and they were bloating every recall prompt with the writer's full
+ * charter. Every domain's focus block follows "Observe X ... Record: ...
+ * \n\nReject (...)" — cut at that boundary and keep only the scope half.
+ */
+function identityRecallScope(cfg: IdentityObserverDomainConfig): string {
+  return cfg.focus.split(/\nReject \(/)[0].trim();
+}
+
 function buildIdentityObservationRecallPrompt(cfg: IdentityObserverDomainConfig): string {
   return `You are the focused identity observation RECALL process for ${ cfg.subjectLabel } (domain: ${ cfg.domain }).
 
@@ -740,12 +794,12 @@ Read the recent conversation context. Based on what the human is asking about,
 what task is in progress, and what identity facts could help the primary
 agent respond well, search the ${ cfg.domain } identity_observations table.
 
-${ cfg.focus }
+${ identityRecallScope(cfg) }
 
 Rules:
 - Call search_identity_observations with key topic/phrase variants from the conversation.
 - Optionally call list_identity_observations when broad identity context is needed.
-${ cfg.domain === 'projects' ? '- Also call search_project_items when the current turn names, implies, or depends on live Projects work-state. Use it only to find relevant project/epic/task context; do not create, update, archive, or comment on project items from recall.\n- When a search hit is clearly central to this turn and its title/status is not enough, drill down: call get_project_item to pull that item\'s full detail (children, status) or list_task_comments to read a task\'s progress/blocker/decision thread. These are READ-ONLY. Drill down only for the one or two items that actually matter — you block the primary agent, so do not fetch detail for every hit.\n' : '' }- Return ONLY observations that are relevant or possibly relevant to this turn.
+${ cfg.domain === 'projects' ? '- Also call search_project_items when the current turn names, implies, or depends on live Projects work-state. Use it only to find relevant project/epic/task context; do not create, update, archive, or comment on project items from recall.\n- When a search hit is clearly central to this turn and its title/status is not enough, drill down: call get_project_item to pull that item\'s full detail (children, status) or list_task_comments to read a task\'s progress/blocker/decision thread. These are READ-ONLY. Drill down only for the one or two items that actually matter — you block the primary agent, so do not fetch detail for every hit.\n' : '' }${ cfg.domain === 'skills' ? '- Also call the marketplace tools `search` and `list_local` — ALWAYS pass `kind:\'skill\'`, never omit it (they default to searching every artifact kind) — but ONLY when the current turn describes a repeatable task a skill could plausibly cover. Most turns are not skill-shaped; do not call them speculatively. Budget: at most 1-2 marketplace lookups — you block the primary agent on a live network call, so do not go searching multiple phrasings. Use `info` only to pull full detail on the one hit that actually matters.\n' : '' }- Return ONLY observations that are relevant or possibly relevant to this turn.
 - Format each result as: \`[id] L<level>·<category> date — content (basis: ...)\`
 - When including live Projects work-state from search_project_items, format it as: \`[project:<id>] <kind> <status> — <title> (source: Projects work-state)\`
 - If many observations are relevant, return many. If only a few matter, return a few.
@@ -1205,7 +1259,7 @@ export const GraphRegistry = {
     const state = await buildSubconsciousState({
       systemPrompt:           buildIdentityObserverPrompt(cfg),
       tools:                  IDENTITY_OBSERVER_TOOLS,
-      userMessage:            `Review this conversation for facts about ${ cfg.subjectLabel }. Record stated facts (L3) first, then derived facts (L2), then reasoned conclusions (L1, with their basis). Search for existing entries before adding (update instead of duplicate); promote levels when evidence upgrades a fact; soft-archive contradicted rows. If nothing about ${ cfg.subjectLabel } was revealed, finish immediately.`,
+      userMessage:            `Review this conversation for facts about ${ cfg.subjectLabel }. Record stated facts (L3) first, then derived facts (L2), then reasoned conclusions (L1, with their basis). Search for existing entries before adding (update instead of duplicate); promote levels when evidence upgrades a fact; soft-archive contradicted rows. If nothing about ${ cfg.subjectLabel } was revealed, finish immediately. Before writing anything: is it task/PR/commit status, an instruction restated as fact, or system-prompt residue? If so, do not write it — default is zero writes.`,
       messages:               [...parentState.messages],
       // Same window as the general writer — it mines conversation for facts.
       contextWindow:          30,
@@ -1728,6 +1782,18 @@ function observerBlocksToText(content: any): string {
 }
 
 /**
+ * Matches BaseNode.stripInjectedContextBlocks' tag list — kept in sync
+ * manually since it lives on the node layer and this is the service layer.
+ * Recall/writer subagents were reading THIS TURN's own injected
+ * <xxx_observations> blocks back out of the last assistant message (merged in
+ * by AgentNode before the primary reply, not stripped until the NEXT turn's
+ * injection) and could re-record a recalled row as if it were fresh
+ * conversational evidence — a self-reinforcement loop. Stripped here so no
+ * subconscious subagent ever observes its own — or a sibling's — injection.
+ */
+const INJECTED_CONTEXT_BLOCK_RE = /\n*<(observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|skills_observations|routine_digest|lane_health)>[\s\S]*?<\/\1>/g;
+
+/**
  * Flatten a windowed conversation context into a single observer message: a
  * plain-text transcript bracketed by explicit markers, preceded by a hard
  * observe-don't-act instruction and followed by the caller's task prompt. The
@@ -1741,7 +1807,7 @@ function buildObserverTranscriptMessage(context: any[], userMessage: string): st
     if (!m || m.role === 'system') continue;                 // observer has its own system prompt
     if (m?.metadata?.source === 'subconscious') continue;    // skip prior subconscious injections
     const who = m.role === 'assistant' ? 'Assistant' : m.role === 'user' ? 'User' : (m.role || 'unknown');
-    const text = observerBlocksToText(m.content).trim();
+    const text = observerBlocksToText(m.content).replace(INJECTED_CONTEXT_BLOCK_RE, '').trim();
     if (!text) continue;
     lines.push(`${ who }: ${ text }`);
   }

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -258,9 +258,12 @@ Field contract for every agent-domain row:
   more careful" and NOT "I will not push to main." First person or self-talk
   pollutes the snapshot: always start with "Agent ..." or "The pair ..." /
   "The human ...", never "I ...".
-- source — the subject: exactly \`agent\` or \`agent.user\`.
-- category — the kind: exactly one of correction | constraint | method |
-  commitment | preference.
+- subject — exactly \`agent\` or \`agent.user\` (NOT the \`source\` parameter —
+  \`source\` is an unrelated free-text label; set \`subject\` or the row is
+  rejected as agent.user work correctly categorized nowhere).
+- kind — exactly one of correction | constraint | method | commitment |
+  preference (NOT the \`category\` parameter — \`category\` has no meaning in
+  this domain; set \`kind\` or add_identity_observation rejects it).
 - basis — the evidence, and for a success/failure/personality row the SENTIMENT
   signal that labeled it: the short quote or reaction that showed delight or
   frustration ("he said 'perfect, ship it'", "he replied 'why'd you push without a
@@ -526,8 +529,13 @@ the agent's general working style, not Sulla Desktop's skills feature? If you
 cannot point to the slug, do not write the row.
 
 Field contract for every skills-domain row:
+- skillSlug — REQUIRED. The exact kebab-case artifact slug (e.g. "pdf-fill").
+  add_identity_observation rejects any skills-domain write missing this — it
+  is what makes rows about one skill queryable without parsing prose.
 - content — ONE sentence, third person, naming the skill: "Skill 'pdf-fill' …" —
-  never a first-person narration of what you just did.
+  never a first-person narration of what you just did. Must name the same
+  skill as skillSlug; add_identity_observation rejects skills-domain content
+  with no quoted skill name even when skillSlug is set.
 - category — exactly one of: provenance | success | failure | gap | inventory.
 - basis / evidence — the concrete signal: the marketplace/local lookup result
   for provenance, or what happened when the skill ran for success/failure.

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -76,6 +76,23 @@ function identityObservationRecallToolsForDomain(domain: string): string[] {
     ];
   }
 
+  // Skills recall also needs read-only discovery across every place a skill
+  // can actually live — the public/cloud marketplace, and artifacts already
+  // materialised locally under ~/sulla/skills/ (list_local reads that
+  // directory; no raw filesystem tool is granted). All three are
+  // operationTypes:['read'] — no download/publish/scaffold/update capability,
+  // so this cannot be used to install or mutate anything (Jonathon,
+  // 2026-08-20: marketplace read tools are fine for an observer; they are not
+  // the filesystem/shell access the observer lockdown forbids).
+  if (domain === 'skills') {
+    return [
+      ...IDENTITY_OBSERVATION_RECALL_TOOLS,
+      'search',      // marketplace/search — public Sulla Cloud marketplace, kind:'skill'
+      'info',        // marketplace/info — full metadata for one marketplace or local skill
+      'list_local',  // marketplace/list_local — skills already installed under ~/sulla/skills/
+    ];
+  }
+
   return IDENTITY_OBSERVATION_RECALL_TOOLS;
 }
 
@@ -460,6 +477,68 @@ domain, and LIVE task status belongs in the structured Projects store (via the
   set basis to the evidence.
 - L1 — a conclusion you reasoned about a project ("this project is release-gated
   on human review", "these two repos always move together"), always with basis.`,
+  },
+  skills: {
+    domain:       'skills',
+    subjectLabel: 'the skill files (SKILL.md artifacts) the agent uses or could use',
+    focus: `Observe the SKILL FILES — the reusable SKILL.md artifacts the agent runs
+to perform a repeatable task — never the task itself. A row belongs here ONLY if
+its real subject is a NAMED skill artifact: what it is, where it lives, and
+whether running it worked. If you cannot name the specific skill slug the row is
+about, it does NOT belong in this domain.
+
+Record, always naming the skill slug/name:
+- provenance: where a specific skill was actually found this conversation —
+  its marketplace slug + version/publisher ("marketplace/search returned
+  'pdf-fill' v1.2.0 from publisher X"), its local install path under
+  ~/sulla/skills/ ("'commit-msg' is installed locally at ~/sulla/skills/
+  commit-msg"), or another concrete source it was discovered at
+- success: a named skill was run and worked — record which skill, for what kind
+  of task, and any reason it's worth reaching for again
+- failure: a named skill was run and did NOT work — record which skill, what
+  broke, and why, so it is not reached for the same way again
+- gap: a task needed a skill and NONE existed for it (a scaffolding/publishing
+  candidate) — name the task and what kind of skill would have covered it
+- inventory: a durable catalog fact about a skill's purpose or scope ("'pdf-fill'
+  fills PDF form fields from a JSON map") — NOT its internal steps, which
+  already live in SKILL.md; do not duplicate the file's content here
+
+Reject (never write these — they are this domain's most common pollution):
+- anything that is not about a specific, named skill artifact. A general working
+  method or lesson that never invokes a named SKILL.md file belongs in the agent
+  domain, not here
+- the task itself, its outcome, or its business context ("fixed the invoice
+  parser", "shipped PR #614") — unless the row's actual subject is a named skill
+  that ran as part of it
+- a paraphrase or summary of a skill's instructions/steps — that duplicates the
+  SKILL.md file, which is already the source of truth; record only that it
+  exists and what it is for
+- a marketplace/product feature request about Sulla Desktop itself ("the
+  marketplace UI should…") — belongs to the projects domain, not here
+- a PR/branch/commit status about building the skills system or marketplace
+  itself — that is work-state, not a fact about a skill artifact
+- a generic tool call or command that isn't backed by an actual named skill file`,
+    writerNote: `## How to write a skills observation
+
+Every candidate row must name the exact skill slug it is about. Pass it through
+this gate first: is the subject a specific SKILL.md artifact — not the task, not
+the agent's general working style, not Sulla Desktop's skills feature? If you
+cannot point to the slug, do not write the row.
+
+Field contract for every skills-domain row:
+- content — ONE sentence, third person, naming the skill: "Skill 'pdf-fill' …" —
+  never a first-person narration of what you just did.
+- category — exactly one of: provenance | success | failure | gap | inventory.
+- basis / evidence — the concrete signal: the marketplace/local lookup result
+  for provenance, or what happened when the skill ran for success/failure.
+- level — L3 when the run outcome or location was directly observed this
+  conversation (it ran, or the lookup returned it); L2 when established from
+  strong evidence without directly observing it; L1 only for a genuine
+  generalization across repeated runs, always with basis.
+
+A failure is worth exactly as much as a success — it stops the skill being
+reached for the same broken way next time. If nothing named a specific skill
+this conversation, finish immediately; most turns need NO write here.`,
   },
 };
 

--- a/pkg/rancher-desktop/agent/tools/meta/__tests__/identity_observations.test.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/__tests__/identity_observations.test.ts
@@ -65,6 +65,7 @@ function row(overrides: Record<string, any> = {}) {
     evidence:   null,
     confidence: null,
     kind:       null,
+    skill_slug: null,
     created_at: '2026-08-19T18:00:00.000Z',
     updated_at: null,
     archived:   false,

--- a/pkg/rancher-desktop/agent/tools/meta/add_identity_observation.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/add_identity_observation.ts
@@ -20,14 +20,14 @@ export class AddIdentityObservationWorker extends BaseTool {
   description = '';
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
-    const { id, level, category, content, basis, subject, evidence, confidence, kind, source } = input;
+    const { id, level, category, content, basis, subject, evidence, confidence, kind, skillSlug, source } = input;
     const existingId = typeof id === 'string' ? id.trim() : '';
 
     try {
       const domain = normalizeIdentityDomain(input.domain);
 
       if (existingId) {
-        const updated = await IdentityObservationsModel.update(existingId, { level, category, content, basis, subject, evidence, confidence, kind, source });
+        const updated = await IdentityObservationsModel.update(existingId, { level, category, content, basis, subject, evidence, confidence, kind, skillSlug, source });
         if (!updated) {
           return {
             successBoolean: false,
@@ -44,14 +44,14 @@ export class AddIdentityObservationWorker extends BaseTool {
       const duplicate = await IdentityObservationsModel.findDuplicate(domain, content);
 
       if (duplicate) {
-        await IdentityObservationsModel.update(duplicate.id, { level, category, content, basis, subject, evidence, confidence, kind, source });
+        await IdentityObservationsModel.update(duplicate.id, { level, category, content, basis, subject, evidence, confidence, kind, skillSlug, source });
         return {
           successBoolean: true,
           responseString: `Remembering (updated): "${ content }" (id: ${ duplicate.id }, domain: ${ domain }, L${ level })`,
         };
       }
 
-      const record = await IdentityObservationsModel.insert({ domain, level, category, content, basis, subject, evidence, confidence, kind, source });
+      const record = await IdentityObservationsModel.insert({ domain, level, category, content, basis, subject, evidence, confidence, kind, skillSlug, source });
       return {
         successBoolean: true,
         responseString: `Remembering: "${ content }" (id: ${ record.id }, domain: ${ record.domain }, L${ record.level }${ record.category ? `, ${ record.category }` : '' })`,

--- a/pkg/rancher-desktop/agent/tools/meta/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/manifests.ts
@@ -78,11 +78,11 @@ export const metaToolManifests: ToolManifest[] = [
   },
   {
     name:        'add_identity_observation',
-    description: 'Store a focused identity observation into the domain-keyed identity_observations table (human / business / world / agent / environment / projects — mirrors ~/sulla/identity/). Levels are CERTAINTY: 3 = stated fact (subject directly told us), 2 = derived fact (established from conversation evidence), 1 = conclusion (reasoned from L3/L2 facts — personality, style, habits). Pass an existing id to update in place; otherwise a substantially similar active row in the same domain is updated instead of duplicated.',
+    description: 'Store a focused identity observation into the domain-keyed identity_observations table (human / business / world / agent / environment / projects / skills — mirrors ~/sulla/identity/). Levels are CERTAINTY: 3 = stated fact (subject directly told us), 2 = derived fact (established from conversation evidence), 1 = conclusion (reasoned from L3/L2 facts — personality, style, habits). Pass an existing id to update in place; otherwise a substantially similar active row in the same domain is updated instead of duplicated.',
     category:    'observation',
     schemaDef:   {
       id:       { type: 'string', optional: true, description: 'Existing observation ID to update in place. Omit to add a new observation or update a duplicate by content.' },
-      domain:   { type: 'string', optional: true, description: 'Identity domain: human, business, world, agent, environment, or projects (default human).' },
+      domain:   { type: 'string', optional: true, description: 'Identity domain: human, business, world, agent, environment, projects, or skills (default human).' },
       level:    { type: 'number', description: 'Certainty level: 3 = stated fact, 2 = derived fact, 1 = conclusion.' },
       category: { type: 'string', optional: true, description: 'Focus category — e.g. identity, relationship, association, personality, habit, preference, goal.' },
       content:  { type: 'string', description: 'One sentence only — extremely concise, always include the context.' },
@@ -108,11 +108,11 @@ export const metaToolManifests: ToolManifest[] = [
   },
   {
     name:        'search_identity_observations',
-    description: 'Search active identity observations within one domain (human / business / world / agent / environment / projects) by keyword or phrase. Any-word ILIKE match ranked by phrase hit, word-match count, then certainty level (stated facts first) and recency. Use this before adding a new identity observation to check for existing similar ones.',
+    description: 'Search active identity observations within one domain (human / business / world / agent / environment / projects / skills) by keyword or phrase. Any-word ILIKE match ranked by phrase hit, word-match count, then certainty level (stated facts first) and recency. Use this before adding a new identity observation to check for existing similar ones.',
     category:    'observation',
     schemaDef:   {
       query:            { type: 'string', description: 'Search keyword or phrase — split into words, any-word ILIKE match against observation content.' },
-      domain:           { type: 'string', optional: true, description: 'Identity domain to search: human, business, world, agent, environment, or projects (default human).' },
+      domain:           { type: 'string', optional: true, description: 'Identity domain to search: human, business, world, agent, environment, projects, or skills (default human).' },
       limit:            { type: 'number', optional: true, description: 'Max results to return (default 20).' },
       include_archived: { type: 'boolean', optional: true, description: 'When true, also searches archived (soft-deleted) rows (default false).' },
     },
@@ -124,7 +124,7 @@ export const metaToolManifests: ToolManifest[] = [
     description: 'List active identity observations for one domain, most certain first (L3 stated → L2 derived → L1 concluded) then most recent. Optionally filter by level and/or category.',
     category:    'observation',
     schemaDef:   {
-      domain:   { type: 'string', optional: true, description: 'Identity domain: human, business, world, agent, environment, or projects (default human).' },
+      domain:   { type: 'string', optional: true, description: 'Identity domain: human, business, world, agent, environment, projects, or skills (default human).' },
       level:    { type: 'number', optional: true, description: 'Certainty level filter: 3, 2, or 1. Omit to list all levels.' },
       category: { type: 'string', optional: true, description: 'Category filter — e.g. identity, relationship, personality, habit. Omit to list all.' },
       limit:    { type: 'number', optional: true, description: 'Max results to return (default 50).' },

--- a/pkg/rancher-desktop/agent/tools/meta/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/manifests.ts
@@ -91,6 +91,7 @@ export const metaToolManifests: ToolManifest[] = [
       evidence: { type: 'string', optional: true, description: 'Optional quote or turn reference supporting the observation.' },
       confidence: { type: 'number', optional: true, description: 'Optional confidence score from 0 to 1.' },
       kind:     { type: 'string', optional: true, description: 'Optional self-observation kind: correction, constraint, method, commitment, or preference.' },
+      skillSlug: { type: 'string', optional: true, description: 'REQUIRED for domain:skills — the exact kebab-case artifact slug this row is about (e.g. "pdf-fill"). Illegal in every other domain.' },
       source:   { type: 'string', optional: true, description: 'Optional source label for this observation.' },
     },
     operationTypes: ['create', 'read', 'update'],


### PR DESCRIPTION
## Summary
- Adds a 7th domain-observer pair (writer + recall) scoped to named SKILL.md artifacts: `provenance` (where a skill was found — marketplace slug/version, local `~/sulla/skills/` install, or another discovered source), `success`/`failure` (a named skill run outcome and why), `gap` (a task needed a skill and none existed), and `inventory` (a durable catalog fact about a skill's purpose, not a paraphrase of its SKILL.md steps).
- Focus + explicit reject rules require every row to name a specific skill slug, so generic task status, agent-method notes, and Sulla Desktop marketplace-feature requests stay out of this domain — addresses the "no junk observations" requirement directly.
- Recall gets read-only marketplace discovery tools (`search`, `info`, `list_local` — all `operationTypes:[read]`, scoped by prompt to `kind:skill`) so it can surface a fitting skill even if it was never run before, not just skills already logged. Same observer lockdown as every other domain: DB tools + read-only marketplace tools only, no filesystem/shell/actor tools.
- Migration `0057` widens the `identity_observations.domain` CHECK constraint; `IdentityObservationsModel`'s `IdentityDomain` type/list and the four `*_identity_observation*` tool manifest descriptions follow.
- Wires `<skills_observations>` injection/stripping alongside the existing six domains in `AgentNode`, `BaseNode`, `ClaudeCodeService`, and `CodexService`.

## Test plan
- [x] `esbuild` parse check on all 10 touched files (full `tsc` OOM-kills in this VM even scoped to `tsconfig.agent-check.json`, per known environment limitation — same as prior domain-observer PRs)
- [x] `IdentityObservationsModel.test.ts` — 12/12 passed
- [x] `identity_observations.test.ts` (tool layer) — 11/11 passed
- [x] Confirmed the one pre-existing `SubconsciousMiddleware.test.ts` failure (`relaxed-json` module-linking error) reproduces identically on `main` before this change — unrelated to this PR
- [ ] Jonathon: review prompt focus/reject rules, merge, rebuild/restart

Draft — no merge/deploy without Jonathon review, per standing rule.
