### PR TITLE
perf(chat-latency): default-on Claude Code prewarm/warm-pool + Codex speculative boot

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -180,11 +180,18 @@ export class ClaudeCodeService extends BaseLanguageModel {
     return { oauthToken, apiKey };
   }
 
-  /** Whether speculative boot (prewarm) is enabled. Default OFF. */
+  /**
+   * Whether speculative boot (prewarm) is enabled. Default ON — cuts the
+   * cold-spawn tax on every turn by overlapping the ~1.5-2s CLI boot with
+   * the subconscious/recall phase that already runs before it. No UI
+   * toggle; override by setting the row to 'false' via SullaSettingsModel
+   * (e.g. `sulla settings/set` or the settings_set tool) if it ever needs
+   * to be disabled for a specific install.
+   */
   private async speculativeBootEnabled(): Promise<boolean> {
     try {
       const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');
-      return (await SullaSettingsModel.get('claudeCodeSpeculativeBoot', 'false')) === 'true';
+      return (await SullaSettingsModel.get('claudeCodeSpeculativeBoot', 'true')) === 'true';
     } catch {
       return false;
     }
@@ -192,13 +199,15 @@ export class ClaudeCodeService extends BaseLanguageModel {
 
   /**
    * Whether the warm pool (keep the process alive across turns) is enabled.
-   * Default OFF. Implies speculative boot — a warm process is just a
-   * pre-warmed one that is re-parked instead of closed after each turn.
+   * Default ON. Implies speculative boot — a warm process is just a
+   * pre-warmed one that is re-parked instead of closed after each turn. No
+   * UI toggle; override by setting the row to 'false' via SullaSettingsModel
+   * if a specific install needs to fall back to cold spawns.
    */
   private async warmPoolEnabled(): Promise<boolean> {
     try {
       const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');
-      return (await SullaSettingsModel.get('claudeCodeWarmPool', 'false')) === 'true';
+      return (await SullaSettingsModel.get('claudeCodeWarmPool', 'true')) === 'true';
     } catch {
       return false;
     }

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -13,6 +13,24 @@ import type { BaseThreadState } from '@pkg/agent/nodes/Graph';
 
 const log = Logging.background;
 
+/** Idle timeout for a speculatively-booted process that is never claimed. */
+const PREWARM_IDLE_REAP_MS = 60_000;
+
+/**
+ * A `codex exec` process speculatively booted during the pre-turn
+ * (accumulator) phase, waiting to be adopted by the next runCodex for its
+ * conversation. See CodexService.prewarm().
+ */
+interface CodexPrewarmRecord {
+  proc:            childProcess.ChildProcessWithoutNullStreams;
+  model:           string;
+  existingSession: string | undefined;
+  createdAt:       number;
+  closed:          boolean;
+  busy:            boolean;
+  reapTimer:       ReturnType<typeof setTimeout> | null;
+}
+
 /**
  * CodexService — runs `codex exec` inside the Lima VM and streams the
  * --json JSONL output back into Sulla's agent loop.
@@ -39,10 +57,36 @@ const log = Logging.background;
  *     user message; codex's own session state keeps prior context warm.
  *   - Resume failures (expired/missing thread): drop the cached id and
  *     retry once with a fresh session (full history).
+ *
+ * Speculative boot (prewarm): mirrors ClaudeCodeService's Phase 1. `codex
+ * exec` reads its prompt from stdin when invoked with no positional PROMPT
+ * arg (or `-`), so the process can be spawned — and pay its Node/CLI boot +
+ * auth-file read cost — before the turn's prompt exists, overlapping that
+ * cost with the subconscious/recall phase. AgentNode.maybePrewarmPrimary
+ * picks this up automatically via the same `typeof llm.prewarm ===
+ * 'function'` duck-type check used for Claude Code.
+ *
+ * NOT implemented: a Claude-style "warm pool" that keeps one process alive
+ * across multiple turns. Claude's Phase 2 works because `claude -p
+ * --input-format stream-json` is explicitly designed to accept a *stream* of
+ * JSON user messages on one long-lived process. `codex exec` has no
+ * equivalent — per `codex exec --help` it reads exactly one prompt, runs to
+ * `task_complete`, and exits; the codebase's existing `runCodex` already
+ * relies on this (it resolves its promise on the process `close` event, and
+ * turn N+1 is `codex exec resume <threadId>`, a brand-new process). Codex
+ * does ship an experimental persistent multi-turn protocol (`codex
+ * app-server`, JSON-RPC 2.0 over stdio) that could support a real warm pool,
+ * but that's a different wire protocol from the JSONL event stream this
+ * file parses today — a separate, larger integration, not a mirror of this
+ * one. See the latency-opportunities notes in PR description for follow-up.
  */
 export class CodexService extends BaseLanguageModel {
   // conversationId → codex thread_id — in-memory cache backed by Redis.
   private sessions = new Map<string, string>();
+
+  // conversationId → a speculatively-booted process warming up during the
+  // pre-turn phase, claimed by the next runCodex. See prewarm().
+  private prewarmed = new Map<string, CodexPrewarmRecord>();
 
   /**
    * Tracks the hash of the stable <sulla_context> payload last sent per
@@ -79,6 +123,158 @@ export class CodexService extends BaseLanguageModel {
     try {
       await redisClient.del(`${ this.SESSION_KEY_PREFIX }${ convId }`);
     } catch { /* Redis unavailable — non-fatal */ }
+  }
+
+  /**
+   * Whether speculative boot (prewarm) is enabled. Default ON — see the
+   * class doc for why there is no Codex "warm pool" counterpart. No UI
+   * toggle; override by setting the row to 'false' via SullaSettingsModel
+   * if a specific install needs to fall back to cold spawns.
+   */
+  private async speculativeBootEnabled(): Promise<boolean> {
+    try {
+      const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');
+      return (await SullaSettingsModel.get('codexSpeculativeBoot', 'true')) === 'true';
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Build the `limactl shell` argv that launches `codex exec` in the VM.
+   * Shared by runCodex (fresh spawn) and prewarm (speculative boot) so both
+   * stay identical. The prompt is never baked into this argv — `codex
+   * exec`'s positional PROMPT arg is always omitted (trailing `-`) so the
+   * CLI reads its prompt from stdin once the caller writes it (see `codex
+   * exec --help`: "If not provided as an argument (or if `-` is used),
+   * instructions are read from stdin"). That's what lets prewarm spawn the
+   * process before the turn's prompt exists — runCodex and prewarm both
+   * write the prompt to stdin themselves, at different times.
+   */
+  private buildSpawnArgs(p: { existingSession?: string }): string[] {
+    const shq = (s: string) => `'${ s.replace(/'/g, "'\\''") }'`;
+
+    const codexArgs = ['codex', 'exec'];
+    if (p.existingSession) {
+      codexArgs.push('resume', shq(p.existingSession));
+    }
+    codexArgs.push(
+      '--json',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--skip-git-repo-check',
+    );
+    if (this.model && this.model !== 'codex') {
+      codexArgs.push('--model', shq(this.model));
+    }
+    codexArgs.push('-'); // read the prompt from stdin
+
+    // limactl shell sets HOME to the guest path (/home/<user>.linux), so
+    // codex would look for auth under the guest home and miss the host
+    // ~/.codex/auth.json written by CodexOAuth. Force CODEX_HOME (and HOME
+    // for any secondary path resolution) to the host home mount.
+    const hostCodexHome = shq(codexHomeDir());
+    const hostHome = shq(path.dirname(codexHomeDir()));
+
+    // `exec` replaces the inner sh with codex so there's no shell layer
+    // between the SSH session and the CLI — best chance of signal
+    // propagation when we kill limactl on the host side.
+    const innerCmd = `export CODEX_HOME=${ hostCodexHome } HOME=${ hostHome }; exec ${ codexArgs.join(' ') }`;
+    return ['shell', '0', '--', 'sh', '-c', innerCmd];
+  }
+
+  /**
+   * Speculatively boot a `codex exec` process for this conversation while
+   * the caller does pre-turn work (recall / observations). The process pays
+   * its Node/CLI boot + auth-file read cost and then idles reading stdin;
+   * the next runCodex adopts it and just writes the prompt — hiding that
+   * cost the same way ClaudeCodeService.prewarm hides claude's cold start.
+   * Fire-and-forget: every failure mode falls back to a normal cold spawn.
+   * No-op unless the codexSpeculativeBoot setting is on.
+   */
+  async prewarm(state: BaseThreadState): Promise<void> {
+    try {
+      if (process.platform === 'win32') return;         // no Lima on Windows
+      if (!await this.speculativeBootEnabled()) return;
+
+      const convId = typeof (state.metadata as any)?.threadId === 'string'
+        ? (state.metadata as any).threadId
+        : '__default__';
+
+      const existing = this.prewarmed.get(convId);
+      if (existing && !existing.closed) return;          // already warming
+      if (existing) this.disposePrewarm(convId);          // stale/dead — replace
+
+      const hasAuth = await ensureCodexAuthFile();
+      if (!hasAuth) return;                               // no creds → nothing to warm
+
+      const existingSession = await this.getSession(convId);
+
+      const limactlPath = paths.limactl;
+      const limaHome = paths.lima;
+      const args = this.buildSpawnArgs({ existingSession });
+      const proc = childProcess.spawn(limactlPath, args, {
+        env: { ...process.env, LIMA_HOME: limaHome, TERM: 'dumb' },
+      });
+
+      const record: CodexPrewarmRecord = {
+        proc,
+        model:     this.model || 'codex',
+        existingSession,
+        createdAt: Date.now(),
+        closed:    false,
+        busy:      false,
+        reapTimer: null,
+      };
+      // Deliberately attach NO stdout 'data' listener: leaving stdout paused
+      // lets Node buffer any early output so the adopting runCodex receives
+      // it intact when it switches the stream to flowing mode.
+      proc.stdin.on('error', () => { /* EPIPE before adoption — non-fatal */ });
+      proc.once('exit', () => { record.closed = true; });
+      proc.once('error', () => { record.closed = true; });
+      record.reapTimer = setTimeout(() => {
+        if (this.prewarmed.get(convId) === record) this.disposePrewarm(convId);
+      }, PREWARM_IDLE_REAP_MS);
+      record.reapTimer.unref?.();
+
+      this.prewarmed.set(convId, record);
+      log.log(`[CodexService] prewarm: speculative boot for convId=${ convId } session=${ existingSession ?? '(new)' }`);
+    } catch (err) {
+      log.log(`[CodexService] prewarm skipped: ${ (err as Error)?.message ?? err }`);
+    }
+  }
+
+  /**
+   * Claim a live pre-warmed process for this conversation, or null. Unlike
+   * ClaudeCodeService (whose --resume argument can be swapped on adoption
+   * since the prompt strategy only depends on it at message-build time),
+   * Codex bakes `resume <threadId>` into the spawned argv at prewarm time —
+   * so a session mismatch between prewarm and claim time (e.g. a session
+   * was minted concurrently) must also evict the record, not just a model
+   * mismatch.
+   */
+  private claimPrewarm(convId: string, model: string, existingSession: string | undefined): CodexPrewarmRecord | null {
+    const rec = this.prewarmed.get(convId);
+    if (!rec) return null;
+    this.prewarmed.delete(convId);
+    if (rec.reapTimer) { clearTimeout(rec.reapTimer); rec.reapTimer = null; }
+    if (rec.closed || rec.model !== model || rec.existingSession !== existingSession) {
+      this.killPrewarmRecord(rec);                       // dead, model, or session mismatch
+      return null;
+    }
+    return rec;
+  }
+
+  /** Tear down and forget the pre-warmed process for a conversation. */
+  private disposePrewarm(convId: string): void {
+    const rec = this.prewarmed.get(convId);
+    if (!rec) return;
+    this.prewarmed.delete(convId);
+    this.killPrewarmRecord(rec);
+  }
+
+  private killPrewarmRecord(rec: CodexPrewarmRecord): void {
+    if (rec.reapTimer) { clearTimeout(rec.reapTimer); rec.reapTimer = null; }
+    try { rec.proc.kill('SIGTERM'); } catch { /* already dead */ }
   }
 
   override getContextWindow(): number {
@@ -463,10 +659,6 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
     const limactlPath = paths.limactl;
     const limaHome = paths.lima;
 
-    // POSIX single-quote escape. Single-quoted strings are literal in sh, so
-    // no backtick/$VAR/! expansion can fire against untrusted text.
-    const shq = (s: string) => `'${ s.replace(/'/g, "'\\''") }'`;
-
     // Refresh ~/.codex/AGENTS.md with the full system prompt before spawning.
     // AGENTS.md is the sole source of system context for codex. On a NEW
     // session the write must land before the spawn — codex reads the file at
@@ -480,46 +672,34 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
       await memoryFileWrite;
     }
 
-    // The prompt is fed via stdin (`-` positional), NOT as an argv element —
-    // a large transcript on the command line overflows limactl's SSH
+    // Speculative boot: adopt a process pre-warmed for this conversation
+    // during the accumulator phase; otherwise spawn fresh below. Flag off →
+    // adopted is always null and the legacy path runs byte-for-byte as
+    // before. --dangerously-bypass-approvals-and-sandbox: codex runs inside
+    // the Lima VM, which IS the sandbox — its own landlock layer is
+    // redundant here and approval prompts have no TTY to land on. The
+    // prompt is fed via stdin (`-` positional), NOT as an argv element — a
+    // large transcript on the command line overflows limactl's SSH
     // multiplexing channel (same failure mode ClaudeCodeService hit).
-    //
-    // --dangerously-bypass-approvals-and-sandbox: codex runs inside the Lima
-    // VM, which IS the sandbox — its own landlock layer is redundant here and
-    // approval prompts have no TTY to land on.
-    const codexArgs = ['codex', 'exec'];
-    if (existingSession) {
-      codexArgs.push('resume', shq(existingSession));
-    }
-    codexArgs.push(
-      '--json',
-      '--dangerously-bypass-approvals-and-sandbox',
-      '--skip-git-repo-check',
-    );
-    // Pass --model only when explicitly overridden. The 'codex' sentinel means
-    // "auto" — omit the flag and let the CLI use its configured default.
-    if (this.model && this.model !== 'codex') {
-      codexArgs.push('--model', shq(this.model));
-    }
-    codexArgs.push('-'); // read the prompt from stdin
-
-    // limactl shell sets HOME to the guest path (/home/<user>.linux), so
-    // codex would look for auth under the guest home and miss the host
-    // ~/.codex/auth.json written by CodexOAuth. Force CODEX_HOME (and HOME
-    // for any secondary path resolution) to the host home mount.
-    const hostCodexHome = shq(codexHomeDir());
-    const hostHome = shq(path.dirname(codexHomeDir()));
-
-    // `exec` replaces the inner sh with codex so there's no shell layer
-    // between the SSH session and the CLI — best chance of signal
-    // propagation when we kill limactl on the host side.
-    const innerCmd = `export CODEX_HOME=${ hostCodexHome } HOME=${ hostHome }; exec ${ codexArgs.join(' ') }`;
-    const args = ['shell', '0', '--', 'sh', '-c', innerCmd];
+    const speculative = await this.speculativeBootEnabled();
+    const adopted = speculative ? this.claimPrewarm(convId, this.model || 'codex', existingSession) : null;
+    const args = this.buildSpawnArgs({ existingSession });
 
     return await new Promise((resolve, reject) => {
-      const proc = childProcess.spawn(limactlPath, args, {
-        env: { ...process.env, LIMA_HOME: limaHome, TERM: 'dumb' },
-      });
+      let proc: childProcess.ChildProcessWithoutNullStreams;
+      let adoptedSpawned = false;
+      if (adopted) {
+        proc = adopted.proc;
+        adoptedSpawned = true;
+        // Drop the prewarm holding listeners; this run attaches its own below.
+        proc.removeAllListeners('exit');
+        proc.removeAllListeners('error');
+        proc.stdin.removeAllListeners('error');
+      } else {
+        proc = childProcess.spawn(limactlPath, args, {
+          env: { ...process.env, LIMA_HOME: limaHome, TERM: 'dumb' },
+        });
+      }
 
       // Feed the prompt through stdin instead of the command line. Guard
       // against EPIPE in case codex exits before we finish.
@@ -534,9 +714,13 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
         try { callbacks.onActivity?.(msg) } catch { /* ignore */ }
       };
 
-      proc.once('spawn', () => {
-        emitActivity('Booting isolated environment…');
-      });
+      if (adoptedSpawned) {
+        emitActivity('Isolated environment ready…');
+      } else {
+        proc.once('spawn', () => {
+          emitActivity('Booting isolated environment…');
+        });
+      }
 
       let stdoutBuffer = '';
       let stderrBuffer = '';


### PR DESCRIPTION
Follow-up to #542 (merged 2026-07-30, `feat/claude-code-speculative-boot`). That PR built speculative boot (Phase 1) and a warm process pool (Phase 2) for Claude Code, but shipped both gated behind `claudeCodeSpeculativeBoot`/`claudeCodeWarmPool` settings **defaulting to the literal string `'false'`**, with no settings UI anywhere to turn them on. Net effect: every install has been cold-spawning `claude -p` unconditionally on every turn since #542 merged — the optimization has been fully dormant in production for three weeks.

**Note on scope vs #542:** #542 itself is closed/merged, not open/draft, so this is a new PR rather than an update to it (confirmed via `sulla github/github_get_pr`, not from memory).

## What this does

**1. Flip Claude Code defaults to on** (`pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts`)
- `claudeCodeSpeculativeBoot` and `claudeCodeWarmPool` both now default `'true'`.
- No UI toggle, by design — override a specific install by setting the row to `'false'` via `SullaSettingsModel`/`settings_set` if ever needed.
- Re-verified the Phase 1/2 adopt-park-rebind logic against current main (3 weeks of history since #542): dead-process detection, idle reap timers (60s prewarm / 5min warm), and the `MCPServerHost.rebindSession` token rebind on adoption are all untouched and correct. `AgentNode.maybePrewarmPrimary`'s fire-and-forget `typeof llm.prewarm === 'function'` call site is also untouched.

**2. Codex speculative boot** (`pkg/rancher-desktop/agent/languagemodels/CodexService.ts`)
- New `prewarm(state)` method, picked up automatically by `AgentNode.maybePrewarmPrimary` via the same duck-type check — zero `AgentNode.ts` changes needed.
- Gated by a new `codexSpeculativeBoot` setting (default `'true'`), **independent from the Claude keys** — the two CLIs have different process lifecycles, so sharing one flag would be misleading.
- Mirrors `ClaudeCodeService`'s prewarm/claim/dispose/idle-reap shape via a shared `buildSpawnArgs`, adapted for how `codex exec` reads its prompt from stdin when no positional `PROMPT` arg is given (confirmed via `codex exec --help`, CLI 0.148.0 in this VM).

**Deliberately NOT implemented: a Codex "warm pool."** `codex exec` is architecturally one-shot per its own `--help` text — it reads one prompt, runs to `task_complete`, and exits; turn N+1 is a brand-new `codex exec resume <threadId>` process (the existing `runCodex` already relies on this, resolving on process `close`). Claude's warm pool only works because `claude -p --input-format stream-json` is explicitly designed to accept a *stream* of JSON messages on one long-lived process — codex has no equivalent in the `exec` subcommand. Codex does ship an experimental persistent multi-turn protocol (`codex app-server`, JSON-RPC 2.0 over stdio, confirmed present in `codex --help`) that could support a real warm pool, but it's a different wire protocol from the JSONL event stream `CodexService.ts` parses today — a separate, larger integration, not something to fake here. Flagged as a follow-up opportunity below.

## Verification

- **Scoped `tsc --noEmit`** (`tsconfig.agent-check.json`, `pkg/rancher-desktop/agent/**/*.ts`) — clean on both touched files and `AgentNode.ts`. Needed `NODE_OPTIONS=--max-old-space-size=8192` to avoid an OOM in this sandbox (full-project tsc is known to OOM here per prior PRs; even the pre-scoped agent-check config OOM'd at the default heap). The 6 remaining errors are pre-existing baseline noise in **untouched** files (`JsonParseService.ts`, `MCPServerHost.ts`, `AudioNoiseProcessor.ts`) — reproduced identically against unmodified `main`, confirming they predate this change.
- **Jest**: ran the closest existing coverage under `pkg/rancher-desktop/agent/languagemodels/__tests__/` (`ModelDiscovery`, `RemoteService`, `providerRecovery`). 2 pre-existing failures (a `ModelDiscovery` TS mock-typing issue, one `RemoteService` fallback test) — both reproduced identically against unmodified `main`, unrelated to `ClaudeCodeService`/`CodexService`. **No dedicated unit tests exist for either service's prewarm/warm-pool logic in this repo** — that's a real gap, not something this PR fabricates coverage for.
- **NOT run**: `just build-mac` / full `yarn install`. Still blocked by the known `log-symbols`/`ora` → `chalk.blue is not a function` mismatch from macOS host and the Lima VM sharing one `node_modules`. Did not attempt to fix the shared-node_modules issue — out of scope here and would risk disrupting other agents' VM dev environments mid-session. **This blocker is still open.**
- Worked in an isolated git worktree (`perf/chat-latency-defaults-codex-prewarm` off `origin/main` @ `a58c3a22a`) so as not to touch the primary checkout, which another session had mid-way through unrelated work.

## Other chat-latency opportunities found (not implemented here — surfacing for review)

1. **Codex warm pool via `codex app-server`** (`pkg/rancher-desktop/agent/languagemodels/CodexService.ts`) — see above. Bigger project: new JSON-RPC 2.0 client, new turn/session semantics, distinct from the JSONL parsing this file does today. Real payoff (cuts Codex's cold-spawn cost on turn 2+, not just turn 1) but not a quick win.
2. **No settings UI for any of these flags** — `claudeCodeSpeculativeBoot`, `claudeCodeWarmPool`, and now `codexSpeculativeBoot` are only reachable via `SullaSettingsModel`/`settings_set`. Fine per Jonathon's explicit "no UI needed" direction, but worth a settings page eventually so these aren't invisible to future debugging.
3. **Subconscious/recall fan-out timing** — `AgentNode.execute()` awaits `runSubconsciousMiddleware` before the primary turn proceeds; per user memory (observations `Cg7g`/`BX0G`) this has been measured at a 40-50s median. That's the dominant latency cost on most turns — prewarm/warm-pool only hide the *primary* CLI's cold-spawn tax, which is a smaller (if still real) slice of total turn time. Not investigated in depth here (out of scope — chat-latency investigation for the *primary* provider spawn was the ask), but it's the largest remaining lever and a bigger project (Redis citation index + fast/slow path per the referenced target architecture).
4. **`generateClaudeCodeMemoryFile()` / `generateCodexMemoryFile()` fire on every turn** (`ClaudeCodeService.runClaude` line ~865, `CodexService.runCodex` line ~476) — Claude's write is fire-and-forget (non-blocking), but Codex's is `await`ed on every **new session** turn (not resumed turns) because codex reads `AGENTS.md` at process startup. Both regenerate the full system prompt file from scratch on every call. Not measured here, but if that generation is nontrivial (observation context assembly, DB reads), it's a candidate for the same kind of overlap-with-prewarm treatment already used for the CLI boot itself. Quick win to *investigate* (add perf timing), not necessarily to fix blind.
5. **MCP tool discovery cost on process boot** — mentioned in the original investigation background as a possible contributor to the Claude cold-start tax. Not independently measured in this pass; the existing `perf.log` `[RunTiming]` line in `ClaudeCodeService.ts` (added pre-#542) already captures `ttftMs`/tool-timing breakdowns per turn, which would be the right instrument to quantify this without new code — worth pulling actual numbers before treating it as confirmed.

Ready for review — draft only, no merge/deploy per standing policy on this repo.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
