### PR TITLE
fix(agent): stop logging blank assistant content, add tool_use/tool_result entries

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/BaseLanguageModel.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/BaseLanguageModel.ts
@@ -67,6 +67,23 @@ export interface StreamCallbacks {
    * Providers with no built-in file tools simply never call it.
    */
   onFilePatch?: (info: import('../util/linePatch').FilePatchInfo) => void;
+  /**
+   * Emitted once a tool_use block's matching tool_result has arrived —
+   * i.e. after the tool actually ran, not at call time. Carries enough to
+   * write one conversation-log entry (tool name, key input, result size/
+   * error) without the caller needing to correlate call/result itself.
+   *
+   * Currently only ClaudeCodeService fires this — CLI tool execution
+   * happens inside the spawned `claude -p` process, invisible to Sulla's
+   * own ToolExecutor, so this is the only place that sees it.
+   */
+  onToolEvent?: (event: {
+    toolUseId:  string;
+    toolName:   string;
+    input?:     unknown;
+    resultChars: number;
+    isError?:   boolean;
+  }) => void;
 }
 
 /**

--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -1003,15 +1003,15 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
       // to time the gap between a tool_use block's input completing and its
       // matching tool_result arriving. Keyed by the tool_use id so parallel
       // tool calls are timed independently.
-      const toolStarts = new Map<string, { name: string; startedAt: number }>();
+      const toolStarts = new Map<string, { name: string; input?: unknown; startedAt: number }>();
       const toolTotals = new Map<string, { count: number; ms: number }>();
       let firstTokenAt = 0;
       const runStartedAt = Date.now();
-      const noteToolStart = (id?: string, name?: string) => {
+      const noteToolStart = (id?: string, name?: string, input?: unknown) => {
         if (!id || toolStarts.has(id)) return;
-        toolStarts.set(id, { name: name ?? 'tool', startedAt: Date.now() });
+        toolStarts.set(id, { name: name ?? 'tool', input, startedAt: Date.now() });
       };
-      const noteToolResult = (id?: string, resultChars = 0) => {
+      const noteToolResult = (id?: string, resultChars = 0, isError = false) => {
         if (!id) return;
         const started = toolStarts.get(id);
         if (!started) return;
@@ -1022,6 +1022,11 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
         agg.ms += ms;
         toolTotals.set(started.name, agg);
         perf.log(`[ToolTiming] tool=${ started.name } ms=${ ms } resultChars=${ resultChars } convId=${ convId }`);
+        try {
+          callbacks.onToolEvent?.({
+            toolUseId: id, toolName: started.name, input: started.input, resultChars, isError,
+          });
+        } catch { /* ignore */ }
       };
 
       // Kill any lingering claude process inside the VM. Without a TTY, SSH
@@ -1306,7 +1311,7 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
             const name = ev.content_block.name ?? 'tool';
             // Input is fully streamed → the CLI is about to RUN the tool. Start
             // the clock here so input-generation time isn't counted as tool time.
-            noteToolStart(ev.content_block.id, name);
+            noteToolStart(ev.content_block.id, name, ev.content_block.input);
             emitActivity(activityForToolUse(name, ev.content_block.input));
             emitFilePatch(name, ev.content_block.input);
             return;
@@ -1337,7 +1342,7 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
               // Fallback start for CLI versions that batch the whole assistant
               // message instead of emitting streamed content_block_stop events.
               // Idempotent — won't override an earlier stream-path start.
-              noteToolStart(b.id, b.name);
+              noteToolStart(b.id, b.name, b.input);
               emitActivity(activityForToolUse(b.name, b.input));
               emitFilePatch(b.name, b.input);
             }
@@ -1357,7 +1362,7 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
               } else if (Array.isArray(b.content)) {
                 chars = b.content.reduce((n: number, c: any) => n + (typeof c?.text === 'string' ? c.text.length : 0), 0);
               }
-              noteToolResult(b.tool_use_id, chars);
+              noteToolResult(b.tool_use_id, chars, b.is_error === true);
             }
           }
         }

--- a/pkg/rancher-desktop/agent/nodes/AgentNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/AgentNode.ts
@@ -402,6 +402,11 @@ export class AgentNode extends BaseNode {
         const alreadyStreamed = !!reply.metadata.streamingEmitted;
         if (!isDuplicate && !alreadyStreamed) {
           await this.wsChatMessage(state, userVisibleText, 'assistant');
+        } else if (!isDuplicate) {
+          // UI already has this text from streaming chunks (which are
+          // excluded from conversation logging as noise) — still persist
+          // the assembled text so the conversation log isn't blank.
+          this.logConversationMessage(state, 'assistant', userVisibleText);
         }
       }
 

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -1657,7 +1657,17 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
       this.wsChatMessage(state, '', 'assistant', 'file_patch', { filePatch: info });
     };
 
-    const reply = await this.llm!.chatStream(messages, { onToken, onActivity, onFilePatch }, { ...options, state });
+    // Tool_use/tool_result pairs run inside the provider's own CLI (Claude
+    // Code, Codex) and never touch Sulla's ToolExecutor — this is the only
+    // place that sees them, so log each one directly once its result lands.
+    const onToolEvent = (event: { toolUseId: string; toolName: string; input?: unknown; resultChars: number; isError?: boolean }): void => {
+      this.logConversationToolCall(state, event.toolName, event.input, {
+        chars: event.resultChars,
+        error: event.isError || undefined,
+      });
+    };
+
+    const reply = await this.llm!.chatStream(messages, { onToken, onActivity, onFilePatch, onToolEvent }, { ...options, state });
 
     // End-of-turn flush. `onActivity` only fires segment boundaries while
     // the model is still producing activity; a stream that ends naturally
@@ -1837,12 +1847,12 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     const muted = !!(state.metadata as any)._muteWsChat;
 
     // Log to conversation logger so the Live Monitor can see all messages.
-    const convId = (state.metadata as any).conversationId;
-    if (convId && kind !== 'thinking' && kind !== 'streaming') {
-      try {
-        const { getConversationLogger } = require('../services/ConversationLogger');
-        getConversationLogger().logMessage(convId, role, content.trim());
-      } catch { /* best-effort */ }
+    // Individual streaming/thinking chunks are excluded (too noisy — the
+    // caller is responsible for logging the assembled final text once the
+    // turn completes, even when it skips re-sending it over the WebSocket
+    // because streaming already displayed it — see logConversationMessage).
+    if (kind !== 'thinking' && kind !== 'streaming' && content.trim()) {
+      this.logConversationMessage(state, role, content);
     }
 
     if (muted) {
@@ -1930,6 +1940,39 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
    * content. All speak content must flow through here — never through
    * `wsChatMessage()`.
    */
+
+  /**
+   * Log one message (user/assistant/system) to the conversation logger.
+   * Extracted out of wsChatMessage so callers can log the fully-assembled
+   * text of a turn even when they deliberately skip re-sending it over the
+   * WebSocket (e.g. AgentNode's `alreadyStreamed` dedup — the UI already
+   * has the text from streaming chunks, but the log still needs it since
+   * individual streaming chunks are excluded from logging as noise).
+   */
+  protected logConversationMessage(state: BaseThreadState, role: 'user' | 'assistant' | 'system', content: string): void {
+    if (!content.trim()) return;
+    const convId = (state.metadata as any).conversationId;
+    if (!convId) return;
+    try {
+      const { getConversationLogger } = require('../services/ConversationLogger');
+      getConversationLogger().logMessage(convId, role, content.trim());
+    } catch { /* best-effort */ }
+  }
+
+  /**
+   * Log a completed tool_use/tool_result pair to the conversation logger.
+   * Used for CLI-backed providers (ClaudeCodeService, CodexService) whose
+   * tool execution happens inside their own subprocess and never touches
+   * Sulla's ToolExecutor — see StreamCallbacks.onToolEvent.
+   */
+  protected logConversationToolCall(state: BaseThreadState, toolName: string, args: unknown, result?: unknown): void {
+    const convId = (state.metadata as any).conversationId;
+    if (!convId) return;
+    try {
+      const { getConversationLogger } = require('../services/ConversationLogger');
+      getConversationLogger().logToolCall(convId, toolName, args, result);
+    } catch { /* best-effort */ }
+  }
 
   /**
    * Log a voice pipeline event to ConversationLogger with a grep-friendly tag.

--- a/pkg/rancher-desktop/agent/nodes/__tests__/BaseNode.conversationLogging.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/BaseNode.conversationLogging.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+// Regression coverage for the conversation-log blank-content bug (Projects
+// task 7BAO): streaming/thinking chunks carry the real assistant text but
+// are deliberately excluded from the conversation log as noise, while the
+// empty 'streaming_complete'/'thinking_complete' boundary sentinels used to
+// slip through the old logging condition and get logged as blank rows.
+// wsChatMessage must log real content once (non-streaming/thinking kinds)
+// and must never log empty sentinel content.
+
+const logMessageMock: any = jest.fn();
+const logToolCallMock: any = jest.fn();
+
+// BaseNode reaches the conversation logger through a lazy `require(...)`
+// inside a try/catch (deliberate — avoids a hard import cycle). Under
+// ts-jest's ESM mode `require` doesn't exist as a global at all (throws
+// "require is not defined"), so the try/catch silently no-ops and
+// jest.unstable_mockModule alone never intercepts it. Polyfill a minimal
+// `require` so the existing lazy-load pattern resolves to these mocks —
+// this mirrors how it actually resolves in the real Electron/Node runtime.
+(globalThis as any).require = (id: string) => {
+  if (id.includes('ConversationLogger')) {
+    return {
+      getConversationLogger: () => ({
+        logMessage:  logMessageMock,
+        logToolCall: logToolCallMock,
+      }),
+    };
+  }
+  throw new Error(`unmocked require() in test: ${ id }`);
+};
+
+jest.unstable_mockModule('../../languagemodels', () => ({
+  getAgentOverrideService: jest.fn(async() => null),
+  getPrimaryService:       jest.fn(async() => null),
+  getSecondaryService:     jest.fn(async() => null),
+  getSubconsciousService:  jest.fn(async() => null),
+}));
+
+jest.unstable_mockModule('../../controllers/ChatController', () => ({
+  ChatController: class MockChatController {
+    private mode = 'text';
+
+    setMode(mode: string) { this.mode = mode }
+    getMode() { return this.mode }
+    buildContext() { return {} }
+    reset() {}
+    processChunk(token: string) { return token }
+    processComplete(content: string, metadata: any) {
+      return { content, metadata };
+    }
+    processNonVoiceSpeak() {}
+  },
+}));
+
+jest.unstable_mockModule('../../controllers/ToolExecutor', () => ({
+  ToolExecutor: class MockToolExecutor {
+    ctx: any;
+
+    constructor(ctx: any) {
+      this.ctx = ctx;
+    }
+
+    buildToolAccessPolicyForCall() {
+      return {};
+    }
+
+    async filterLLMToolsByAccessPolicy(tools: any[]) {
+      return { tools };
+    }
+  },
+}));
+
+jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
+  SullaSettingsModel: {
+    get: jest.fn(async(_key: string, fallback: any) => fallback),
+    set: jest.fn(async() => undefined),
+  },
+}));
+
+jest.unstable_mockModule('../../services/JsonParseService', () => ({
+  parseJson: jest.fn((value: string) => JSON.parse(value)),
+}));
+
+jest.unstable_mockModule('../../services/WebSocketClientService', () => ({
+  getWebSocketClientService: jest.fn(() => ({
+    send:        jest.fn(async() => true),
+    onMessage:   jest.fn(),
+    connect:     jest.fn(() => true),
+    isConnected: jest.fn(() => true),
+  })),
+}));
+
+jest.unstable_mockModule('../../tools/registry', () => ({
+  toolRegistry: {
+    convertToolToLLM:          jest.fn(async() => null),
+    getSlimPrimaryLLMTools:    jest.fn(async() => []),
+    getLLMToolsFor:            jest.fn(async() => []),
+    getToolsByCategory:        jest.fn(async() => []),
+    getToolNamesForCategory:   jest.fn(() => []),
+    getToolNames:              jest.fn(() => []),
+    getNativeToolDefinitions:  jest.fn(() => new Map()),
+  },
+}));
+
+jest.unstable_mockModule('../../utils/stripProtocolTags', () => ({
+  stripProtocolTags:         (s: string) => s,
+  stripProtocolTagsStreaming: (s: string) => s,
+}));
+
+describe('BaseNode conversation logging', () => {
+  beforeEach(() => {
+    logMessageMock.mockReset();
+    logToolCallMock.mockReset();
+  });
+
+  const buildState = () => ({
+    messages: [],
+    metadata: {
+      threadId:       'test-thread',
+      wsChannel:      'test-channel',
+      conversationId: 'conv-123',
+    },
+  }) as any;
+
+  it('logs real assistant content once for a normal (non-streaming) message', async() => {
+    const { BaseNode } = await import('../BaseNode');
+
+    class TestNode extends BaseNode<any> {
+      async execute(state: any) {
+        return { state, decision: { type: 'end' as const }, response: '' };
+      }
+
+      async send(state: any, content: string, kind = 'progress') {
+        return this.wsChatMessage(state, content, 'assistant', kind);
+      }
+    }
+
+    const node = new TestNode('test-node', 'TestNode');
+    const state = buildState();
+
+    await node.send(state, 'Here is the daily briefing you asked for.');
+
+    expect(logMessageMock).toHaveBeenCalledTimes(1);
+    expect(logMessageMock).toHaveBeenCalledWith('conv-123', 'assistant', 'Here is the daily briefing you asked for.');
+  });
+
+  it('does not log individual streaming/thinking chunks', async() => {
+    const { BaseNode } = await import('../BaseNode');
+
+    class TestNode extends BaseNode<any> {
+      async execute(state: any) {
+        return { state, decision: { type: 'end' as const }, response: '' };
+      }
+
+      async send(state: any, content: string, kind: string) {
+        return this.wsChatMessage(state, content, 'assistant', kind);
+      }
+    }
+
+    const node = new TestNode('test-node', 'TestNode');
+    const state = buildState();
+
+    await node.send(state, 'partial toke', 'streaming');
+    await node.send(state, 'reasoning about the plan', 'thinking');
+
+    expect(logMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('does not log empty streaming_complete/thinking_complete boundary sentinels', async() => {
+    const { BaseNode } = await import('../BaseNode');
+
+    class TestNode extends BaseNode<any> {
+      async execute(state: any) {
+        return { state, decision: { type: 'end' as const }, response: '' };
+      }
+
+      async send(state: any, kind: string) {
+        return this.wsChatMessage(state, '', 'assistant', kind);
+      }
+    }
+
+    const node = new TestNode('test-node', 'TestNode');
+    const state = buildState();
+
+    await node.send(state, 'streaming_complete');
+    await node.send(state, 'thinking_complete');
+
+    expect(logMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('logConversationMessage lets a caller persist the assembled text after skipping the WS resend', async() => {
+    const { BaseNode } = await import('../BaseNode');
+
+    class TestNode extends BaseNode<any> {
+      async execute(state: any) {
+        return { state, decision: { type: 'end' as const }, response: '' };
+      }
+
+      logFullText(state: any, content: string) {
+        this.logConversationMessage(state, 'assistant', content);
+      }
+    }
+
+    const node = new TestNode('test-node', 'TestNode');
+    const state = buildState();
+
+    // Mirrors AgentNode's alreadyStreamed branch: streaming already showed
+    // this text in the UI, so no wsChatMessage WS resend — but the log
+    // still needs the full text since 'streaming' chunks weren't logged.
+    node.logFullText(state, 'The full assembled reply text.');
+
+    expect(logMessageMock).toHaveBeenCalledTimes(1);
+    expect(logMessageMock).toHaveBeenCalledWith('conv-123', 'assistant', 'The full assembled reply text.');
+  });
+
+  it('logConversationToolCall writes a tool_use/tool_result entry for CLI-backed providers', async() => {
+    const { BaseNode } = await import('../BaseNode');
+
+    class TestNode extends BaseNode<any> {
+      async execute(state: any) {
+        return { state, decision: { type: 'end' as const }, response: '' };
+      }
+
+      logTool(state: any) {
+        this.logConversationToolCall(state, 'Read', { file_path: '/etc/hosts' }, { chars: 240, error: undefined });
+      }
+    }
+
+    const node = new TestNode('test-node', 'TestNode');
+    const state = buildState();
+
+    node.logTool(state);
+
+    expect(logToolCallMock).toHaveBeenCalledTimes(1);
+    expect(logToolCallMock).toHaveBeenCalledWith(
+      'conv-123', 'Read', { file_path: '/etc/hosts' }, { chars: 240, error: undefined },
+    );
+  });
+
+  it('skips logging entirely when the state has no conversationId', async() => {
+    const { BaseNode } = await import('../BaseNode');
+
+    class TestNode extends BaseNode<any> {
+      async execute(state: any) {
+        return { state, decision: { type: 'end' as const }, response: '' };
+      }
+
+      logFullText(state: any, content: string) {
+        this.logConversationMessage(state, 'assistant', content);
+      }
+    }
+
+    const node = new TestNode('test-node', 'TestNode');
+    const state = buildState();
+    delete state.metadata.conversationId;
+
+    node.logFullText(state, 'orphaned text with no conversation to attach to');
+
+    expect(logMessageMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary — Projects task 7BAO

Two bugs in conversation logging, both traced to the same shape: real content is deliberately excluded from the log as "noisy per-chunk streaming", but nothing ever logs the assembled final version.

### Bug 1 — every streamed assistant turn logs content:""

wsChatMessage (BaseNode.ts) excludes kind==='streaming'/'thinking' from conversation logging (correct — those are noisy per-token chunks). But the only non-excluded call for a streamed turn was the empty streaming_complete/thinking_complete boundary sentinel, so that's what got logged: blank content. AgentNode also deliberately skips re-sending the assembled text over WebSocket once streaming already showed it (reply.metadata.streamingEmitted) — which silently dropped the only place that would have logged the real text at all.

Fix: wsChatMessage now skips logging when content is blank (so the empty sentinels are never persisted), and AgentNode logs the assembled text via a new logConversationMessage() helper when it skips the WS resend.

### Bug 2 — zero tool_use/tool_result entries anywhere

ToolExecutor.logToolCall is wired up correctly but unreachable for the primary Claude-Code-backed agent loop: tool execution happens inside the spawned claude -p subprocess, never through Sulla's own ToolExecutor. ClaudeCodeService already parses tool_use/tool_result blocks out of the CLI's stream-json output (it uses them for per-tool perf timing), but only ever surfaced them as opaque "thinking" activity strings — which are excluded from logging entirely, same as bug 1.

Fix: added StreamCallbacks.onToolEvent, fired once a tool_use block's matching tool_result arrives (name, input, result size, error flag). BaseNode wires it to a new logConversationToolCall() helper, writing one tool_call log entry per tool run.

### Verification

- Confirmed the bug against live logs before fixing: 3/3 recent conv_*.jsonl files (7/7, 23/23, 12/12 assistant turns) had every assistant row content:"" and zero tool_call entries.
- node_modules/.bin/tsc --noEmit (with NODE_OPTIONS=--max-old-space-size=6144 — full project typecheck OOMs on this box regardless of this change): clean, 0 errors.
- Jest: BaseNode.providerRecovery.test.ts + new BaseNode.conversationLogging.test.ts (6 new regression tests) + agentNodeError.test.ts — 3 suites, 12/12 passed.
- Not yet re-verified against a live rebuilt app (would need a rebuild + restart) — the fix is proven at the unit level and by tracing the exact code path that produced the blank logs, not by a fresh production log sample.

Human review, merge, and deploy remain separate gates.

Generated during a heartbeat autonomous cycle.