### PR TITLE
feat(heartbeat): auto-dispatch Fable investigation on every blocked task

### DIFF
--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -97,6 +97,20 @@ describe('heartbeatPrompt', () => {
     expect(heartbeatPrompt).toContain('fan out up to 10 sub-agents');
   });
 
+  // aQLP: Jonathon does not want to be the default unblock mechanism. Every
+  // task that goes blocked must get a Fable investigation + concrete unblock
+  // recommendation as a task comment, not a question punted back to him.
+  it('dispatches a Fable sub-agent to investigate every blocked task before parking or notifying', () => {
+    expect(heartbeatPrompt).toContain('## Auto-Dispatch on Blocked — Fable Investigates, Never Just Asks');
+    expect(heartbeatPrompt).toContain('does not want to be the default unblock mechanism');
+    expect(heartbeatPrompt).toContain('Fable sub-agent');
+    expect(heartbeatPrompt).toContain("'sulla meta/spawn_agent'");
+    expect(heartbeatPrompt).toContain('post a concrete unblock recommendation as a task comment');
+    expect(heartbeatPrompt).toContain('never a bare punt');
+    expect(heartbeatPrompt).toContain('standing process for every blocked item, not a one-off triage');
+    expect(heartbeatPrompt).toContain('never double-dispatch');
+  });
+
   // Regression guard for #587: Jonathon rejected the "pick one task, make one
   // move, STOP" cycle ceiling (#581) and required a continuous operator that
   // works the whole portfolio per wake. PR #581 proved this framing can be

--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -142,6 +142,14 @@ Parked decisions are project tasks with 'status=parked' (or 'blocked' while a ga
 - Re-scan it every cycle (lane 3). Close or unpark answered/obsolete items.
 - Never re-ask a parked question in a notification more than once per day; the task carries it.
 
+## Auto-Dispatch on Blocked — Fable Investigates, Never Just Asks
+
+Jonathon does not want to be the default unblock mechanism. The moment any Projects task's status becomes 'blocked' — whether you just landed there yourself at the end of the Unblock Ladder, or a lane-3 scan of 'status=blocked' turns one up — dispatch a Fable sub-agent (or the highest-capability planner persona on the roster) via 'sulla meta/spawn_agent' before you park it or send a notification. Its job: investigate the actual blocker (repo, PRs, prior comments, docs, Redis/Postgres) and post a concrete unblock recommendation as a task comment via 'sulla project/add_task_comment' (author 'heartbeat') — exact next steps, not a question lobbed back at Jonathon.
+
+- If the investigation finds the blocker is reversible or answerable, that finding closes the loop right there — resume the task instead of leaving it sitting blocked.
+- If the blocker is genuinely a Jonathon-only judgment call (money, an irreversible action, a real architectural fork), the Fable sub-agent says so explicitly and lays out the options with a recommendation — never a bare punt back with just a question.
+- This is the standing process for every blocked item, not a one-off triage. Skip the dispatch only when a live investigation job already covers the same task ('sulla agents/check_agent_jobs') or a comment newer than the block already carries its findings — never double-dispatch.
+
 ## Questions Ride Alongside Work, Never In Front of It
 
 - Reversible & low-stakes: *"Doing X next cycle unless you redirect."* Then actually do X next cycle if no reply.

--- a/pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts
@@ -34,6 +34,11 @@ export const HEARTBEAT_REQUIRED_PHRASES = [
   'DRAFT PR',
   'The Prospector',
   'Artifact-per-Cycle',
+  // Auto-dispatch-on-blocked (aQLP): every blocked task gets a Fable
+  // investigation + concrete unblock recommendation, not a bare punt.
+  'Auto-Dispatch on Blocked',
+  'Fable sub-agent',
+  'never a bare punt',
   // Stability covenant: the prompt is frozen — heartbeat may not tweak itself.
   'This Prompt Is Frozen',
 ] as const;


### PR DESCRIPTION
## Summary

Task aQLP ("Standing process: Heartbeat auto-dispatches a Fable sub-agent whenever a task goes blocked"). Jonathon's directive on 2026-08-21: he does not want to be the default unblock mechanism. Whenever any Projects task's status moves to `blocked`, Heartbeat should launch a Fable sub-agent (or the roster's highest-capability planner) to investigate the actual blocker and post a concrete unblock recommendation as a task comment — exact next steps, not a question punted back to Jonathon. If a blocker is genuinely a Jonathon-only judgment call (money, an irreversible action, a real architectural fork), the sub-agent says so explicitly with options + a recommendation, never a bare punt.

A manual proof-of-pattern already ran against the 10 currently-blocked tasks via `spawn_agent` (job `agent-job-1787329168530-18`) — e.g. the `[unblock-review][fable-planner] Unblock plan` comment posted on task qB9f this morning. This PR is what makes that automatic on every future wake instead of a one-off.

Per the prompt-freeze covenant (`heartbeat.ts` is DB-backed shipped source, not just `~/sulla/agents/heartbeat/heartbeat.md`), this lands the same way PR #598 (Orchestrator Mode) did: a real source change to `heartbeatPrompt`, gated behind Jonathon's review — not self-merged, not deployed.

### What changed

- `pkg/rancher-desktop/agent/prompts/heartbeat.ts`: new `## Auto-Dispatch on Blocked — Fable Investigates, Never Just Asks` section, placed right after the Parked Decisions Queue section, since it governs the moment a task's status becomes `blocked` (whether from the Unblock Ladder or a lane-3 rescan).
- `pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts`: added `Auto-Dispatch on Blocked`, `Fable sub-agent`, `never a bare punt` to `HEARTBEAT_REQUIRED_PHRASES` so a stale/reverted deploy is caught at runtime (same defense-in-depth pattern used for the #598 Orchestrator Mode phrases).
- `pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts`: new test asserting the section and its key phrases are present.

### Verification

`node --experimental-vm-modules node_modules/.bin/jest pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts pkg/rancher-desktop/agent/prompts/__tests__/heartbeatInvariants.test.ts --runInBand`

2 suites passed, 17/17 tests passed.

### Gate

Human review, merge, and rebuild+restart remain separate gates — this does not go live until Jonathon merges and the app is rebuilt. Refs task aQLP.
