### PR TITLE
feat(db): add conversation_keywords index table (LE0Z)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0057_create_conversation_keywords_table.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0057_create_conversation_keywords_table.ts
@@ -1,0 +1,57 @@
+/**
+ * Migration 0057 — Create conversation_keywords index table.
+ *
+ * Substrate for the Conversation-Recall subconscious agent (epic 01aZ): the
+ * writer indexes salient terms per turn against thread/conversation id, and
+ * the reader's DB-search tool (G7bd) queries this table instead of scanning
+ * conversation_history (which stores only title/summary, not full content).
+ *
+ * Standalone table, not a conversation_history column — a conversation
+ * produces many keywords over its lifetime, so this is a one-to-many child,
+ * same shape as observations vs identity_observations.
+ *
+ * `source` distinguishes which loop wrote the term (primary chat vs a
+ * subconscious/worker channel) since those already use separate channel_id
+ * namespaces per the standing rule that domain loops stay separate.
+ *
+ * UNIQUE(term, thread_id) makes re-seeing a term in the same thread an
+ * upsert (bump hit_count / last_seen) instead of a duplicate row.
+ *
+ * pg_trgm GIN index on term for fuzzy/substring match — consistent with the
+ * no-embeddings constraint (pgvector isn't available on install; same
+ * approach as migration 0041's observations.content trigram index).
+ */
+
+export const up = `
+  CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+  CREATE TABLE IF NOT EXISTS conversation_keywords (
+    id                       TEXT        PRIMARY KEY,
+    term                     TEXT        NOT NULL,
+    thread_id                TEXT        NOT NULL,
+    conversation_history_id  TEXT        REFERENCES conversation_history(id),
+    channel_id               TEXT,
+    agent_id                 TEXT,
+    source                   TEXT        NOT NULL DEFAULT 'primary',
+    first_seen               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    hit_count                INTEGER     NOT NULL DEFAULT 1,
+    CONSTRAINT conversation_keywords_source_check
+      CHECK (source IN ('primary', 'subconscious', 'worker'))
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_conversation_keywords_thread
+    ON conversation_keywords (thread_id);
+
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_conversation_keywords_term_thread
+    ON conversation_keywords (term, thread_id);
+
+  CREATE INDEX IF NOT EXISTS idx_conversation_keywords_term_trgm
+    ON conversation_keywords USING gin (term gin_trgm_ops);
+
+  CREATE INDEX IF NOT EXISTS idx_conversation_keywords_conversation_history
+    ON conversation_keywords (conversation_history_id)
+    WHERE conversation_history_id IS NOT NULL;
+`;
+
+export const down = `DROP TABLE IF EXISTS conversation_keywords CASCADE;`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -44,6 +44,7 @@ import { up as up_0053, down as down_0053 } from './0053_allow_environment_ident
 import { up as up_0054, down as down_0054 } from './0054_allow_projects_identity_domain';
 import { up as up_0055, down as down_0055 } from './0055_add_system_and_content_hash_to_workflows';
 import { up as up_0056, down as down_0056 } from './0056_fix_routine_scorecard_null_slug';
+import { up as up_0057, down as down_0057 } from './0057_create_conversation_keywords_table';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -89,4 +90,5 @@ export const migrationsRegistry = [
   { name: '0054_allow_projects_identity_domain',                 up: up_0054, down: down_0054 },
   { name: '0055_add_system_and_content_hash_to_workflows',       up: up_0055, down: down_0055 },
   { name: '0056_fix_routine_scorecard_null_slug',                 up: up_0056, down: down_0056 },
+  { name: '0057_create_conversation_keywords_table',              up: up_0057, down: down_0057 },
 ] as const;


### PR DESCRIPTION
## Summary — Conversation-Recall epic (01aZ), task LE0Z

Adds migration `0057_create_conversation_keywords_table.ts`: a standalone `conversation_keywords` table that is the substrate for the Conversation-Recall subconscious agent — the writer (V2UP) indexes salient terms per turn against thread id, and the reader's DB-search tool (G7bd) queries this table since `conversation_history` only stores title/summary, not full message content.

### Schema

- `id, term, thread_id, conversation_history_id (nullable FK), channel_id, agent_id, source (primary|subconscious|worker), first_seen, last_seen, hit_count`
- `UNIQUE(term, thread_id)` — upsert semantics for dedup-on-write (bump hit_count/last_seen instead of inserting a duplicate row)
- `pg_trgm` GIN index on `term` for fuzzy/substring match — consistent with the no-embeddings constraint (pgvector not available on install), same approach as migration 0041's `observations.content` trigram index
- index on `thread_id`; partial index on `conversation_history_id`

Numbering: task description assumed 0055 (stale — 0055/0056 already existed by the time this was written); this is 0057, next after `0056_fix_routine_scorecard_null_slug`.

### Verification

- SQL validated by executing the exact `up` statement against the live dev Postgres inside a transaction, then rolling back (confirmed via `to_regclass`—table left no trace post-rollback).
- Full-project `tsc --noEmit` OOMs on this box regardless of these changes (pre-existing, memory-documented constraint) — this migration follows the exact same template-literal shape as every other file in `migrations/`, so it carries the same type-safety profile as the rest of the registry.
- No model/tool code in this PR — scope is schema-only per the task description (V2UP/G7bd build the read/write logic on top of this table separately).

Schema-only, additive, no existing table touched. Human review, merge, and deploy remain separate gates.