### PR TITLE
feat(subconscious): add Conversation Writer agent (V2UP)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0057_create_conversation_keywords_table.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0057_create_conversation_keywords_table.ts
@@ -1,0 +1,57 @@
+/**
+ * Migration 0057 — Create conversation_keywords index table.
+ *
+ * Substrate for the Conversation-Recall subconscious agent (epic 01aZ): the
+ * writer indexes salient terms per turn against thread/conversation id, and
+ * the reader's DB-search tool (G7bd) queries this table instead of scanning
+ * conversation_history (which stores only title/summary, not full content).
+ *
+ * Standalone table, not a conversation_history column — a conversation
+ * produces many keywords over its lifetime, so this is a one-to-many child,
+ * same shape as observations vs identity_observations.
+ *
+ * `source` distinguishes which loop wrote the term (primary chat vs a
+ * subconscious/worker channel) since those already use separate channel_id
+ * namespaces per the standing rule that domain loops stay separate.
+ *
+ * UNIQUE(term, thread_id) makes re-seeing a term in the same thread an
+ * upsert (bump hit_count / last_seen) instead of a duplicate row.
+ *
+ * pg_trgm GIN index on term for fuzzy/substring match — consistent with the
+ * no-embeddings constraint (pgvector isn't available on install; same
+ * approach as migration 0041's observations.content trigram index).
+ */
+
+export const up = `
+  CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+  CREATE TABLE IF NOT EXISTS conversation_keywords (
+    id                       TEXT        PRIMARY KEY,
+    term                     TEXT        NOT NULL,
+    thread_id                TEXT        NOT NULL,
+    conversation_history_id  TEXT        REFERENCES conversation_history(id),
+    channel_id               TEXT,
+    agent_id                 TEXT,
+    source                   TEXT        NOT NULL DEFAULT 'primary',
+    first_seen               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    hit_count                INTEGER     NOT NULL DEFAULT 1,
+    CONSTRAINT conversation_keywords_source_check
+      CHECK (source IN ('primary', 'subconscious', 'worker'))
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_conversation_keywords_thread
+    ON conversation_keywords (thread_id);
+
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_conversation_keywords_term_thread
+    ON conversation_keywords (term, thread_id);
+
+  CREATE INDEX IF NOT EXISTS idx_conversation_keywords_term_trgm
+    ON conversation_keywords USING gin (term gin_trgm_ops);
+
+  CREATE INDEX IF NOT EXISTS idx_conversation_keywords_conversation_history
+    ON conversation_keywords (conversation_history_id)
+    WHERE conversation_history_id IS NOT NULL;
+`;
+
+export const down = `DROP TABLE IF EXISTS conversation_keywords CASCADE;`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -44,6 +44,7 @@ import { up as up_0053, down as down_0053 } from './0053_allow_environment_ident
 import { up as up_0054, down as down_0054 } from './0054_allow_projects_identity_domain';
 import { up as up_0055, down as down_0055 } from './0055_add_system_and_content_hash_to_workflows';
 import { up as up_0056, down as down_0056 } from './0056_fix_routine_scorecard_null_slug';
+import { up as up_0057, down as down_0057 } from './0057_create_conversation_keywords_table';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -89,4 +90,5 @@ export const migrationsRegistry = [
   { name: '0054_allow_projects_identity_domain',                 up: up_0054, down: down_0054 },
   { name: '0055_add_system_and_content_hash_to_workflows',       up: up_0055, down: down_0055 },
   { name: '0056_fix_routine_scorecard_null_slug',                 up: up_0056, down: down_0056 },
+  { name: '0057_create_conversation_keywords_table',              up: up_0057, down: down_0057 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/ConversationKeywordsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/ConversationKeywordsModel.ts
@@ -1,0 +1,72 @@
+import { postgresClient } from '../PostgresClient';
+
+export type ConversationKeywordSource = 'primary' | 'subconscious' | 'worker';
+
+export interface ConversationKeywordRecord {
+  id: string;
+  term: string;
+  thread_id: string;
+  conversation_history_id: string | null;
+  channel_id: string | null;
+  agent_id: string | null;
+  source: ConversationKeywordSource;
+  first_seen: string | Date;
+  last_seen: string | Date;
+  hit_count: number;
+}
+
+export interface UpsertConversationKeywordsInput {
+  terms: string[];
+  thread_id: string;
+  conversation_history_id?: string | null;
+  channel_id?: string | null;
+  agent_id?: string | null;
+  source?: ConversationKeywordSource;
+}
+
+/** Canonical form used by the UNIQUE(term, thread_id) index. */
+export function normalizeConversationKeyword(term: string): string {
+  return term.normalize('NFKC').trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+}
+
+function makeId(): string {
+  return `ck_${ Date.now().toString(36) }_${ Math.random().toString(36).slice(2, 12) }`;
+}
+
+export class ConversationKeywordsModel {
+  private static readonly TABLE = 'conversation_keywords';
+
+  /** Atomically insert each canonical term, or bump its hit count on repeat. */
+  static async upsertMany(input: UpsertConversationKeywordsInput): Promise<ConversationKeywordRecord[]> {
+    const threadId = input.thread_id?.trim();
+    if (!threadId) throw new Error('thread_id is required');
+
+    const terms = Array.from(new Set(
+      (input.terms || [])
+        .filter((term): term is string => typeof term === 'string')
+        .map(normalizeConversationKeyword)
+        .filter(Boolean),
+    )).slice(0, 100);
+
+    const source = input.source ?? 'subconscious';
+    const rows: ConversationKeywordRecord[] = [];
+    for (const term of terms) {
+      const result = await postgresClient.query<ConversationKeywordRecord>(
+        `INSERT INTO ${ ConversationKeywordsModel.TABLE }
+           (id, term, thread_id, conversation_history_id, channel_id, agent_id, source)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT (term, thread_id) DO UPDATE SET
+           conversation_history_id = COALESCE(EXCLUDED.conversation_history_id, ${ ConversationKeywordsModel.TABLE }.conversation_history_id),
+           channel_id              = COALESCE(EXCLUDED.channel_id, ${ ConversationKeywordsModel.TABLE }.channel_id),
+           agent_id                = COALESCE(EXCLUDED.agent_id, ${ ConversationKeywordsModel.TABLE }.agent_id),
+           source                  = EXCLUDED.source,
+           last_seen               = NOW(),
+           hit_count               = ${ ConversationKeywordsModel.TABLE }.hit_count + 1
+         RETURNING *`,
+        [makeId(), term, threadId, input.conversation_history_id ?? null, input.channel_id ?? null, input.agent_id ?? null, source],
+      );
+      if (result[0]) rows.push(result[0]);
+    }
+    return rows;
+  }
+}

--- a/pkg/rancher-desktop/agent/database/models/__tests__/ConversationKeywordsModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/ConversationKeywordsModel.test.ts
@@ -1,0 +1,40 @@
+import { postgresClient } from '../../PostgresClient';
+import { ConversationKeywordsModel, normalizeConversationKeyword } from '../ConversationKeywordsModel';
+import { jest } from '@jest/globals';
+
+describe('ConversationKeywordsModel', () => {
+  const originalQuery = postgresClient.query;
+
+  beforeEach(() => {
+    postgresClient.query = jest.fn(async() => [{ term: 'sulla', thread_id: 'thread-1', hit_count: 1 }]) as any;
+  });
+
+  afterEach(() => {
+    postgresClient.query = originalQuery;
+  });
+
+  it('canonicalizes case and whitespace', () => {
+    expect(normalizeConversationKeyword('  SULLA   Desktop  ')).toBe('sulla desktop');
+  });
+
+  it('deduplicates a batch and emits an atomic unique-key upsert', async() => {
+    const rows = await ConversationKeywordsModel.upsertMany({
+      terms: [' Sulla ', 'sulla', 'Postgres'],
+      thread_id: 'thread-1',
+      channel_id: 'chat',
+      source: 'subconscious',
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(postgresClient.query).toHaveBeenCalledTimes(2);
+    const [sql, params] = (postgresClient.query as any).mock.calls[0];
+    expect(sql).toContain('ON CONFLICT (term, thread_id) DO UPDATE');
+    expect(sql).toContain('hit_count');
+    expect(params.slice(1)).toEqual(['sulla', 'thread-1', null, 'chat', null, 'subconscious']);
+  });
+
+  it('does not write an empty term set', async() => {
+    await expect(ConversationKeywordsModel.upsertMany({ terms: ['  ', ''], thread_id: 'thread-1' })).resolves.toEqual([]);
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+});

--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -335,8 +335,9 @@ export function runSubconsciousObservationWriters(
   launch('world-observer', () => runIdentityObserver(state, 'world'));
   launch('environment-observer', () => runIdentityObserver(state, 'environment'));
   launch('projects-observer', () => runIdentityObserver(state, 'projects'));
+  launch('conversation-writer', () => runConversationWriter(state));
 
-  console.log(`[SubconsciousMiddleware] Post-turn writers launched (observation + human/agent/business/world/environment/projects) | messages: ${ state.messages.length }`);
+  console.log(`[SubconsciousMiddleware] Post-turn writers launched (observation + human/agent/business/world/environment/projects/conversation-keywords) | messages: ${ state.messages.length }`);
 }
 
 // ============================================================================
@@ -685,6 +686,19 @@ async function runIdentityObserver(state: BaseThreadState, domain: string): Prom
     console.log(`[SubconsciousMiddleware:IdentityObserver:${ domain }] Completed in ${ Date.now() - startTime }ms | iterations: ${ iterations }, status: ${ agentMeta.status }`);
   } catch (error) {
     console.error(`[SubconsciousMiddleware:IdentityObserver:${ domain }] Failed in ${ Date.now() - startTime }ms:`, error instanceof Error ? error.message : error);
+  }
+}
+
+/** Fire-and-forget post-episode keyword indexer. */
+async function runConversationWriter(state: BaseThreadState): Promise<void> {
+  const startTime = Date.now();
+  try {
+    const { graph, state: subState, threadId } = await GraphRegistry.createConversationWriter(state);
+    console.log(`[SubconsciousMiddleware:ConversationWriter] Started | threadId: ${ threadId }`);
+    await graph.execute(subState, 'subconscious', { maxIterations: 3 });
+    console.log(`[SubconsciousMiddleware:ConversationWriter] Completed in ${ Date.now() - startTime }ms | iterations: ${ (subState.metadata as any).iterations || 0 }`);
+  } catch (error) {
+    console.error('[SubconsciousMiddleware:ConversationWriter] Failed:', error instanceof Error ? error.message : error);
   }
 }
 

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -7,6 +7,10 @@ import { Graph, createHeartbeatGraph, createAgentGraph, createSubconsciousGraph,
 import { saveThreadState, loadThreadState } from '../nodes/ThreadStateStore';
 import { toolRegistry } from '../tools/registry';
 import { resolveSullaAgentsDir, resolveAllAgentsDirs, findAgentDir } from '../utils/sullaPaths';
+import { buildObserverTranscriptMessage } from '../utils/observerTranscript';
+export { buildObserverTranscriptMessage } from '../utils/observerTranscript';
+import { CONVERSATION_WRITER_TOOLS } from '../utils/conversationWriterPolicy';
+export { CONVERSATION_WRITER_TOOLS } from '../utils/conversationWriterPolicy';
 
 // Side-effect: ensure tool manifests are registered before any graph runs
 import '../tools/manifests';
@@ -62,6 +66,26 @@ const IDENTITY_OBSERVATION_RECALL_TOOLS: string[] = [
   'search_identity_observations',
   'list_identity_observations',
 ];
+
+/** Conversation Writer: the single DB-only keyword upsert tool. */
+const CONVERSATION_WRITER_PROMPT = `You are the Conversation Writer, a silent post-episode observer.
+
+Your ONLY job is to scan the completed conversation transcript for a small set
+of durable, salient search terms that would help a later reader find this turn.
+Write only meaningful proper nouns, product/project names, technical terms,
+decisions, entities, and distinctive phrases. Do not write stopwords, generic
+verbs, prose, secrets, credentials, tokens, private payloads, or whole
+sentences. Do not infer facts that are not present in the transcript.
+
+You are NOT the primary agent. Do not continue the work described in the
+transcript. Do not answer the user, browse, call APIs, read or write files, run
+commands, use source control, or use any tool except the provided keyword DB
+upsert tool. If no salient terms are present, finish without calling the tool.
+
+When terms are present, call upsert_conversation_keywords exactly once with the
+deduplicated salient terms and the parent metadata supplied in the task. Use
+source="subconscious". The DB layer canonicalizes and deduplicates by
+(term, thread_id), so never emit duplicate spellings in the same batch.`;
 
 /** Projects recall also needs read-only access to live Projects work-state:
  *  keyword search to find relevant items, plus drill-down to pull a hit's full
@@ -1143,6 +1167,42 @@ export const GraphRegistry = {
     return { graph, state, threadId: state.metadata.threadId };
   },
 
+  /** Create the post-episode Conversation Writer. It receives a flat
+   * transcript and only the keyword DB writer, so it cannot become an actor. */
+  createConversationWriter: async function(parentState: BaseThreadState): Promise<{
+    graph:    Graph<BaseThreadState>;
+    state:    BaseThreadState;
+    threadId: string;
+  }> {
+    const parentMeta = parentState.metadata as any;
+    const parentThreadId = String(parentMeta.threadId || parentMeta.conversationId || '');
+    if (!parentThreadId) throw new Error('Conversation Writer requires a parent thread id');
+
+    const graph = createSubconsciousGraph();
+    const state = await buildSubconsciousState({
+      systemPrompt: CONVERSATION_WRITER_PROMPT,
+      tools:        CONVERSATION_WRITER_TOOLS,
+      userMessage:  `Scan the completed turn and index salient terms only. Parent metadata (copy exactly into the tool call): ${ JSON.stringify({
+        thread_id:                parentThreadId,
+        conversation_history_id:  parentMeta.conversationHistoryId || parentMeta.conversation_history_id || null,
+        channel_id:               parentMeta.channelId || parentMeta.channel_id || parentMeta.wsChannel || null,
+        agent_id:                 parentMeta.agentId || parentMeta.agent_id || null,
+        source:                   'subconscious',
+      }) }`,
+      messages:     [...parentState.messages],
+      contextWindow: 30,
+      observeAsTranscript: true,
+      parentAbortSignal: (parentMeta.options as any)?.abort,
+      agentLabel: 'conversation-writer',
+      silent: true,
+      parentWsChannel: String(parentMeta.wsChannel || ''),
+      parentConversationId: parentThreadId,
+      workflowNodeId: parentMeta.workflowNodeId,
+      workflowParentChannel: parentMeta.workflowParentChannel,
+    });
+    return { graph, state, threadId: state.metadata.threadId };
+  },
+
   /**
    * Create an Identity Observation Recall graph — read-only search/list of
    * domain-keyed identity observations. The recall agent selects observations
@@ -1611,73 +1671,6 @@ function windowedContext(messages: any[], windowSize: number, maxBlockChars: num
 
     return m;
   });
-}
-
-/**
- * Render one message's content as a compact plain-text line for an observer
- * transcript. tool_use / tool_result blocks are described in prose ("[called
- * tool X …]", "[tool result …]") rather than replayed as structural blocks —
- * the observer only needs to know what happened, not to sit inside a live
- * tool-calling turn it might feel compelled to continue.
- */
-function observerBlocksToText(content: any): string {
-  if (typeof content === 'string') return content;
-  if (!Array.isArray(content)) return content == null ? '' : JSON.stringify(content);
-
-  const parts: string[] = [];
-  for (const b of content) {
-    if (!b || typeof b !== 'object') { if (b != null) parts.push(String(b)); continue }
-    if (b.type === 'text' && typeof b.text === 'string') {
-      parts.push(b.text);
-    } else if (b.type === 'tool_use') {
-      const input = b.input ? ` ${ JSON.stringify(b.input).slice(0, 300) }` : '';
-      parts.push(`[called tool ${ b.name || 'unknown' }${ input }]`);
-    } else if (b.type === 'tool_result') {
-      const inner = typeof b.content === 'string'
-        ? b.content
-        : Array.isArray(b.content)
-          ? b.content.map((c: any) => (c?.type === 'text' && typeof c.text === 'string' ? c.text : c?.type === 'image' ? '[image omitted]' : '')).filter(Boolean).join('\n')
-          : JSON.stringify(b.content ?? '');
-      parts.push(`[tool result] ${ inner }`);
-    } else if (b.type === 'image') {
-      parts.push('[image omitted]');
-    } else {
-      parts.push(JSON.stringify(b));
-    }
-  }
-  return parts.join('\n');
-}
-
-/**
- * Flatten a windowed conversation context into a single observer message: a
- * plain-text transcript bracketed by explicit markers, preceded by a hard
- * observe-don't-act instruction and followed by the caller's task prompt. The
- * absence of any real assistant/tool_use/tool_result message structure — plus
- * the explicit framing — is what stops the observer from continuing the
- * assistant's work instead of recording memory about it.
- */
-function buildObserverTranscriptMessage(context: any[], userMessage: string): string {
-  const lines: string[] = [];
-  for (const m of context) {
-    if (!m || m.role === 'system') continue;                 // observer has its own system prompt
-    if (m?.metadata?.source === 'subconscious') continue;    // skip prior subconscious injections
-    const who = m.role === 'assistant' ? 'Assistant' : m.role === 'user' ? 'User' : (m.role || 'unknown');
-    const text = observerBlocksToText(m.content).trim();
-    if (!text) continue;
-    lines.push(`${ who }: ${ text }`);
-  }
-  const transcript = lines.join('\n\n') || '(no prior conversation)';
-
-  return [
-    'You are a silent OBSERVER of the conversation below. Your ONLY job is to analyze it and record memory through your provided database tools.',
-    'You are NOT a participant. Do NOT continue the assistant\'s work, do NOT take any action the conversation describes, and do NOT read, write, or edit files, run commands, browse, or use source control. Only observe and record.',
-    '',
-    '=== BEGIN CONVERSATION TRANSCRIPT ===',
-    transcript,
-    '=== END CONVERSATION TRANSCRIPT ===',
-    '',
-    userMessage,
-  ].join('\n');
 }
 
 async function buildSubconsciousState(opts: {

--- a/pkg/rancher-desktop/agent/services/__tests__/ConversationWriter.lockdown.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/ConversationWriter.lockdown.test.ts
@@ -1,0 +1,28 @@
+import { buildObserverTranscriptMessage } from '../../utils/observerTranscript';
+import { CONVERSATION_WRITER_TOOLS } from '../../utils/conversationWriterPolicy';
+
+describe('Conversation Writer observer lockdown', () => {
+  it('flattens native tool blocks into plain text instead of replaying them', () => {
+    const message = buildObserverTranscriptMessage([
+      { role: 'user', content: 'Index the Sulla decision.' },
+      { role: 'assistant', content: [
+        { type: 'text', text: 'I will inspect it.' },
+        { type: 'tool_use', name: 'exec', input: { command: 'cat secrets' } },
+      ] },
+      { role: 'user', content: [{ type: 'tool_result', content: 'secret output' }] },
+    ], 'Index salient terms only.');
+
+    expect(message).toContain('[called tool exec');
+    expect(message).toContain('[tool result] secret output');
+    expect(message).not.toContain('"type":"tool_use"');
+    expect(message).toContain('You are a silent OBSERVER');
+    expect(message).toContain('Index salient terms only.');
+  });
+
+  it('structurally allows only the keyword database writer', () => {
+    expect(CONVERSATION_WRITER_TOOLS).toEqual(['upsert_conversation_keywords']);
+    expect(CONVERSATION_WRITER_TOOLS).not.toContain('exec');
+    expect(CONVERSATION_WRITER_TOOLS).not.toContain('file_search');
+    expect(CONVERSATION_WRITER_TOOLS).not.toContain('browser_open');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/meta/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/manifests.ts
@@ -2,6 +2,21 @@ import type { ToolManifest } from '../registry';
 
 export const metaToolManifests: ToolManifest[] = [
   {
+    name:        'upsert_conversation_keywords',
+    description: 'Observer-only database writer for salient terms from the completed conversation turn. Canonicalizes and upserts terms by (term, thread_id), bumping hit_count and last_seen on repeats.',
+    category:    'observation',
+    schemaDef:   {
+      terms:                    { type: 'array', description: 'Salient terms only (not stopwords, prose, or secrets); maximum 100.', items: { type: 'string' } },
+      thread_id:                { type: 'string', description: 'Parent conversation thread id.' },
+      conversation_history_id:  { type: 'string', optional: true, nullable: true, description: 'Parent conversation_history row id, when known.' },
+      channel_id:               { type: 'string', optional: true, nullable: true, description: 'Parent channel id, when known.' },
+      agent_id:                 { type: 'string', optional: true, nullable: true, description: 'Parent agent id, when known.' },
+      source:                   { type: 'enum', optional: true, default: 'subconscious', enum: ['primary', 'subconscious', 'worker'], description: 'Writer source; use subconscious here.' },
+    },
+    operationTypes: ['create', 'update'],
+    loader:         () => import('./upsert_conversation_keywords'),
+  },
+  {
     name:        'add_observational_memory',
     description: 'Use this tool to store the observations you make into long-term memory.',
     category:    'observation',

--- a/pkg/rancher-desktop/agent/tools/meta/upsert_conversation_keywords.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/upsert_conversation_keywords.ts
@@ -1,0 +1,23 @@
+import { ConversationKeywordsModel, ConversationKeywordSource } from '../../database/models/ConversationKeywordsModel';
+import { BaseTool, ToolResponse } from '../base';
+
+export class UpsertConversationKeywordsWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    try {
+      const rows = await ConversationKeywordsModel.upsertMany({
+        terms: input.terms,
+        thread_id: input.thread_id,
+        conversation_history_id: input.conversation_history_id,
+        channel_id: input.channel_id,
+        agent_id: input.agent_id,
+        source: input.source as ConversationKeywordSource | undefined,
+      });
+      return { successBoolean: true, responseString: `Indexed ${ rows.length } canonical conversation keyword(s) for thread ${ input.thread_id }.` };
+    } catch (error: any) {
+      return { successBoolean: false, responseString: `Failed to index conversation keywords: ${ error?.message || error }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/utils/conversationWriterPolicy.ts
+++ b/pkg/rancher-desktop/agent/utils/conversationWriterPolicy.ts
@@ -1,0 +1,4 @@
+/** Strict native allowlist for the post-episode Conversation Writer. */
+export const CONVERSATION_WRITER_TOOLS: string[] = [
+  'upsert_conversation_keywords',
+];

--- a/pkg/rancher-desktop/agent/utils/observerTranscript.ts
+++ b/pkg/rancher-desktop/agent/utils/observerTranscript.ts
@@ -1,0 +1,50 @@
+/**
+ * Convert agentic messages into a single plain-text observer transcript.
+ * Structural tool_use/tool_result blocks are rendered as prose so an observer
+ * cannot mistake the completed episode for a live actor session.
+ */
+function observerBlocksToText(content: any): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return content == null ? '' : JSON.stringify(content);
+
+  const parts: string[] = [];
+  for (const b of content) {
+    if (!b || typeof b !== 'object') { if (b != null) parts.push(String(b)); continue }
+    if (b.type === 'text' && typeof b.text === 'string') parts.push(b.text);
+    else if (b.type === 'tool_use') {
+      const input = b.input ? ` ${ JSON.stringify(b.input).slice(0, 300) }` : '';
+      parts.push(`[called tool ${ b.name || 'unknown' }${ input }]`);
+    } else if (b.type === 'tool_result') {
+      const inner = typeof b.content === 'string'
+        ? b.content
+        : Array.isArray(b.content)
+          ? b.content.map((c: any) => (c?.type === 'text' && typeof c.text === 'string' ? c.text : c?.type === 'image' ? '[image omitted]' : '')).filter(Boolean).join('\n')
+          : JSON.stringify(b.content ?? '');
+      parts.push(`[tool result] ${ inner }`);
+    } else if (b.type === 'image') parts.push('[image omitted]');
+    else parts.push(JSON.stringify(b));
+  }
+  return parts.join('\n');
+}
+
+export function buildObserverTranscriptMessage(context: any[], userMessage: string): string {
+  const lines: string[] = [];
+  for (const m of context) {
+    if (!m || m.role === 'system') continue;
+    if (m?.metadata?.source === 'subconscious') continue;
+    const who = m.role === 'assistant' ? 'Assistant' : m.role === 'user' ? 'User' : (m.role || 'unknown');
+    const text = observerBlocksToText(m.content).trim();
+    if (text) lines.push(`${ who }: ${ text }`);
+  }
+  const transcript = lines.join('\n\n') || '(no prior conversation)';
+  return [
+    'You are a silent OBSERVER of the conversation below. Your ONLY job is to analyze it and record memory through your provided database tools.',
+    'You are NOT a participant. Do NOT continue the assistant\'s work, do NOT take any action the conversation describes, and do NOT read, write, or edit files, run commands, browse, or use source control. Only observe and record.',
+    '',
+    '=== BEGIN CONVERSATION TRANSCRIPT ===',
+    transcript,
+    '=== END CONVERSATION TRANSCRIPT ===',
+    '',
+    userMessage,
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary

Builds the Conversation Writer subconscious agent for Sulla Projects epic 01aZ / task V2UP. It runs after the completed episode alongside the existing post-turn observers and indexes salient terms into conversation_keywords.

## Dependency

This PR depends on draft PR #638 (feat/conversation-keywords-migration) merging first. The branch is based on #638's migration branch so the 0057_create_conversation_keywords_table substrate is present for local verification. Merge #638 before this PR.

## Implemented

- Added ConversationKeywordsModel.upsertMany with NFKC/case/whitespace canonicalization and atomic UNIQUE(term, thread_id) upserts that bump hit_count / last_seen.
- Added the DB-only upsert_conversation_keywords subconscious tool with parent thread/history/channel/agent/source metadata.
- Added a silent post-episode Conversation Writer graph using the shared flattened observer transcript helper.
- Added strict structural tool lockdown: the writer allowlist contains only upsert_conversation_keywords; no filesystem, shell, browser, source-control, or actor tools.
- Wired it only into the post-turn writer set; it is not part of pre-turn recall.
- Added focused regression tests for dedup/upsert and transcript/tool lockdown.

## Verification

- Focused Jest: 2 suites, 5 tests passed
- NODE_OPTIONS=--max-old-space-size=6144 node_modules/.bin/tsc --noEmit: passed
- git diff --check: passed

Do not merge until #638 is merged and Jonathon reviews this draft PR.