### PR TITLE
feat(subconscious): log-folder search tool for the Conversation Reader (DxHy)

### DIFF
--- a/pkg/rancher-desktop/agent/tools/meta/__tests__/search_conversation_logs.test.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/__tests__/search_conversation_logs.test.ts
@@ -1,0 +1,149 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockGetFileAssociations: any = jest.fn(() => Promise.resolve({ log_file: null, training_file: null }));
+
+jest.unstable_mockModule('../../../database/models/ConversationHistoryModel', () => ({
+  ConversationHistoryModel: { getFileAssociations: mockGetFileAssociations },
+}));
+
+async function loadWorker() {
+  const { SearchConversationLogsWorker } = await import('../search_conversation_logs');
+  const w = new SearchConversationLogsWorker();
+  w.name = 'search_conversation_logs';
+  w.description = 'search_conversation_logs';
+  w.schemaDef = {
+    thread_id: { type: 'string', optional: true },
+    keyword:   { type: 'string', optional: true },
+    since:     { type: 'string', optional: true },
+    days:      { type: 'number', optional: true },
+    limit:     { type: 'number', optional: true },
+  } as any;
+  return w;
+}
+
+describe('SearchConversationLogsWorker', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sulla-log-search-'));
+    fs.mkdirSync(path.join(tmpDir, 'logs'), { recursive: true });
+    originalHome = process.env.SULLA_HOME_DIR;
+    process.env.SULLA_HOME_DIR = tmpDir;
+    mockGetFileAssociations.mockReset();
+    mockGetFileAssociations.mockResolvedValue({ log_file: null, training_file: null });
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.SULLA_HOME_DIR;
+    else process.env.SULLA_HOME_DIR = originalHome;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function logsDir(): string {
+    return path.join(tmpDir, 'logs');
+  }
+
+  function writeLog(name: string, content: string) {
+    fs.writeFileSync(path.join(logsDir(), name), content);
+  }
+
+  it('resolves both the channel log and the jsonl stream for a thread id', async() => {
+    writeLog('sulla-desktop_abc-123.log', 'line one\nline two\n');
+    writeLog('conv_abc-123.jsonl', '{"type":"message"}\n');
+    writeLog('mobile-relay_other-456.log', 'unrelated\n');
+
+    const result = await (await loadWorker()).invoke({ thread_id: 'abc-123' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('sulla-desktop_abc-123.log');
+    expect(result.result).toContain('conv_abc-123.jsonl');
+    expect(result.result).not.toContain('mobile-relay_other-456.log');
+  });
+
+  it('sanitizes the thread id the same way SullaLogger does when matching filenames', async() => {
+    writeLog('sulla-desktop_weird_id_here.log', 'hello\n');
+
+    const result = await (await loadWorker()).invoke({ thread_id: 'weird/id:here' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('sulla-desktop_weird_id_here.log');
+  });
+
+  it('falls back to conversation_history.log_file when the filename does not match', async() => {
+    writeLog('legacy-name.log', 'from db association\n');
+    mockGetFileAssociations.mockResolvedValue({ log_file: 'legacy-name.log', training_file: null });
+
+    const result = await (await loadWorker()).invoke({ thread_id: 'db-only-id' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('legacy-name.log');
+  });
+
+  it('reports no files found for an unknown thread id', async() => {
+    const result = await (await loadWorker()).invoke({ thread_id: 'does-not-exist' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('No log files found');
+  });
+
+  it('excludes global non-thread-scoped logs from a directory-wide scan', async() => {
+    writeLog('chat.log', 'global noise\n');
+    writeLog('index.jsonl', 'global noise\n');
+    writeLog('sulla-desktop_thread-1.log', 'real conversation\n');
+
+    const result = await (await loadWorker()).invoke({});
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('sulla-desktop_thread-1.log');
+    expect(result.result).not.toContain('chat.log');
+    expect(result.result).not.toContain('index.jsonl');
+  });
+
+  it('filters a directory-wide scan by recency window (days)', async() => {
+    const recentPath = path.join(logsDir(), 'sulla-desktop_recent.log');
+    const oldPath = path.join(logsDir(), 'sulla-desktop_old.log');
+    fs.writeFileSync(recentPath, 'recent\n');
+    fs.writeFileSync(oldPath, 'old\n');
+    const tenDaysAgo = Date.now() - 10 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(oldPath, new Date(tenDaysAgo), new Date(tenDaysAgo));
+
+    const result = await (await loadWorker()).invoke({ days: 1 });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('sulla-desktop_recent.log');
+    expect(result.result).not.toContain('sulla-desktop_old.log');
+  });
+
+  it('filters to matching content lines when keyword is provided', async() => {
+    writeLog('sulla-desktop_thread-2.log', 'nothing interesting\nfound the FK-integrity bug\nmore noise\n');
+
+    const result = await (await loadWorker()).invoke({ thread_id: 'thread-2', keyword: 'FK-integrity' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('found the FK-integrity bug');
+    expect(result.result).not.toContain('nothing interesting');
+  });
+
+  it('reports no matches when the keyword is not found', async() => {
+    writeLog('sulla-desktop_thread-3.log', 'nothing relevant here\n');
+
+    const result = await (await loadWorker()).invoke({ thread_id: 'thread-3', keyword: 'zzz-not-present' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('No lines matching');
+  });
+
+  it('handles a missing log directory gracefully', async() => {
+    fs.rmSync(logsDir(), { recursive: true, force: true });
+
+    const result = await (await loadWorker()).invoke({ thread_id: 'anything' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('does not exist yet');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/meta/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/manifests.ts
@@ -15,6 +15,20 @@ export const metaToolManifests: ToolManifest[] = [
     loader:         () => import('./add_observational_memory'),
   },
   {
+    name:        'search_conversation_logs',
+    description: 'Read-only search over ~/sulla/logs/ for the Conversation Reader. Pass thread_id to resolve that conversation\'s specific log file(s) (channel-scoped .log plus the conv_<id>.jsonl event stream); omit it to scan all thread-scoped log files within a recency window (since / days). Add keyword to filter to matching content lines instead of whole-file listings/previews. Excludes global non-thread-scoped infra logs (chat.log, dispatcher.log, index.log, etc).',
+    category:    'observation',
+    schemaDef:   {
+      thread_id: { type: 'string', optional: true, description: 'Conversation/thread id to resolve log files for. Provide this or rely on the recency window below.' },
+      keyword:   { type: 'string', optional: true, description: 'Case-insensitive substring to filter matched files down to content lines.' },
+      since:     { type: 'string', optional: true, description: 'ISO 8601 timestamp lower bound for the recency window (ignored when thread_id is set).' },
+      days:      { type: 'number', optional: true, description: 'Recency window in days from now, used when since is omitted (ignored when thread_id is set).' },
+      limit:     { type: 'number', optional: true, description: 'Max files or matching lines to return (default 50, max 200).' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./search_conversation_logs'),
+  },
+  {
     name:        'exec',
     description: 'Run any shell command inside a fully isolated sandboxed Linux VM with root access. This is ALSO how you invoke every `sulla <category>/<tool>` CLI command surfaced by browse_tools — pass the full `sulla ...` command string as the `command` arg (e.g. command: "sulla github/create_issue \'{\\"title\\":\\"bug\\"}\'"). Safe to install packages, compile code, delete files, or run any system command.',
     category:    'meta',

--- a/pkg/rancher-desktop/agent/tools/meta/search_conversation_logs.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/search_conversation_logs.ts
@@ -1,0 +1,208 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ConversationHistoryModel } from '../../database/models/ConversationHistoryModel';
+import { resolveSullaLogsDir } from '../../utils/sullaPaths';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Log files with no embedded thread/conversation id — global infra logs,
+ * never candidates for thread-scoped or recency-window search. Audited
+ * 2026-08-21 against the live log dir (task DxHy).
+ */
+const GLOBAL_LOG_FILES = new Set([
+  'frontend-graph.log',
+  'chat.log',
+  'dispatcher.log',
+  'index.log',
+  'index.jsonl',
+  'persona.log',
+  'playbook-debug.log',
+  'background-web-requests.log',
+]);
+
+const MAX_FILES_SCANNED = 500;
+const MAX_BYTES_PER_FILE = 512 * 1024;
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+// Matches the sanitization SullaLogger applies when building filenames
+// (resolveFilePath / resolveJsonlPath in SullaLogger.ts) — must stay in
+// sync with that logic or thread-id lookups silently miss.
+function sanitizeId(id: string): string {
+  return id.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 200);
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isThreadScopedLogFile(name: string): boolean {
+  if (GLOBAL_LOG_FILES.has(name)) return false;
+  return name.endsWith('.log') || name.endsWith('.jsonl');
+}
+
+/** Read up to the last maxBytes of a file — cheap tail for large logs. */
+function readTail(filePath: string, maxBytes: number): string {
+  const stat = fs.statSync(filePath);
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const start = Math.max(0, stat.size - maxBytes);
+    const length = stat.size - start;
+    const buf = Buffer.alloc(length);
+    fs.readSync(fd, buf, 0, length, start);
+    return buf.toString('utf8');
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/**
+ * Read-only search over ~/sulla/logs/ for the Conversation Reader. Two
+ * lookup modes:
+ *  - thread_id: resolve the specific <channel>_<id>.log / conv_<id>.jsonl
+ *    file(s) for that conversation (filename sanitization matches
+ *    SullaLogger; conversation_history.log_file is consulted as a
+ *    secondary, more robust source).
+ *  - no thread_id: scan all thread-scoped files within a recency window
+ *    (since / days), excluding the fixed set of global non-thread logs.
+ * Optional `keyword` filters matched files down to content lines. Content
+ * search is only as useful as what BaseNode actually logs for assistant
+ * turns — see task 7BAO; filename/recency lookup does not depend on that.
+ */
+export class SearchConversationLogsWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const threadId = typeof input.thread_id === 'string' ? input.thread_id.trim() : '';
+    const keyword = typeof input.keyword === 'string' ? input.keyword.trim().toLowerCase() : '';
+    const days = input.days !== undefined && Number.isFinite(Number(input.days)) ? Number(input.days) : undefined;
+    const since = typeof input.since === 'string' ? input.since.trim() : '';
+    const limit = Math.min(Math.max(Number(input.limit) || DEFAULT_LIMIT, 1), MAX_LIMIT);
+
+    let dir: string;
+    try {
+      dir = resolveSullaLogsDir();
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Could not resolve log directory: ${ err?.message || err }` };
+    }
+
+    if (!fs.existsSync(dir)) {
+      return { successBoolean: true, responseString: `Log directory ${ dir } does not exist yet — no logs to search.` };
+    }
+
+    let cutoffMs: number | undefined;
+    if (since) {
+      const t = Date.parse(since);
+      if (!Number.isNaN(t)) cutoffMs = t;
+    } else if (days !== undefined) {
+      cutoffMs = Date.now() - days * 24 * 60 * 60 * 1000;
+    }
+
+    let candidates: string[];
+
+    if (threadId) {
+      const safeId = sanitizeId(threadId);
+      const logPattern = new RegExp(`_${ escapeRegExp(safeId) }\\.log$`);
+      const jsonlName = `conv_${ safeId }.jsonl`;
+      const allFiles = fs.readdirSync(dir);
+      candidates = allFiles.filter(f => logPattern.test(f) || f === jsonlName);
+
+      try {
+        const assoc = await ConversationHistoryModel.getFileAssociations(threadId);
+        if (assoc.log_file) {
+          const base = path.basename(assoc.log_file);
+          if (!candidates.includes(base) && fs.existsSync(path.join(dir, base))) {
+            candidates.push(base);
+          }
+        }
+      } catch {
+        // DB lookup is a best-effort enrichment; filename matching alone still works.
+      }
+
+      if (candidates.length === 0) {
+        return {
+          successBoolean: true,
+          responseString: `No log files found for thread ${ threadId } (looked for *_${ safeId }.log and ${ jsonlName }).`,
+        };
+      }
+    } else {
+      const withStats = fs.readdirSync(dir)
+        .filter(isThreadScopedLogFile)
+        .map(f => {
+          try {
+            return { f, mtimeMs: fs.statSync(path.join(dir, f)).mtimeMs };
+          } catch {
+            return null;
+          }
+        })
+        .filter((x): x is { f: string; mtimeMs: number } => x !== null)
+        .filter(x => cutoffMs === undefined || x.mtimeMs >= cutoffMs)
+        .sort((a, b) => b.mtimeMs - a.mtimeMs)
+        .slice(0, MAX_FILES_SCANNED);
+      candidates = withStats.map(x => x.f);
+
+      if (candidates.length === 0) {
+        return {
+          successBoolean: true,
+          responseString: cutoffMs !== undefined
+            ? `No thread-scoped log files modified since ${ new Date(cutoffMs).toISOString() }.`
+            : 'No thread-scoped log files found.',
+        };
+      }
+
+      if (!keyword) {
+        const preview = candidates.slice(0, limit).join('\n');
+        const overflow = candidates.length > limit
+          ? `\n… (${ candidates.length - limit } more — narrow with keyword or a shorter window)`
+          : '';
+        return {
+          successBoolean: true,
+          responseString: `${ candidates.length } thread-scoped log file(s) in the recency window:\n${ preview }${ overflow }`,
+        };
+      }
+    }
+
+    if (!keyword) {
+      const sections = candidates.map((f) => {
+        try {
+          const tail = readTail(path.join(dir, f), 4096).trim();
+          const lastLines = tail.split('\n').slice(-10).join('\n');
+          return `── ${ f } ──\n${ lastLines }`;
+        } catch (err: any) {
+          return `── ${ f } ── (read failed: ${ err?.message || err })`;
+        }
+      });
+      return { successBoolean: true, responseString: sections.join('\n\n') };
+    }
+
+    const matches: string[] = [];
+    for (const f of candidates) {
+      if (matches.length >= limit) break;
+      let content: string;
+      try {
+        content = readTail(path.join(dir, f), MAX_BYTES_PER_FILE);
+      } catch {
+        continue;
+      }
+      for (const line of content.split('\n')) {
+        if (matches.length >= limit) break;
+        if (line.toLowerCase().includes(keyword)) {
+          matches.push(`${ f }: ${ line.slice(0, 500) }`);
+        }
+      }
+    }
+
+    if (matches.length === 0) {
+      return {
+        successBoolean: true,
+        responseString: `No lines matching "${ keyword }" found across ${ candidates.length } candidate log file(s).`,
+      };
+    }
+    return {
+      successBoolean: true,
+      responseString: `${ matches.length } matching line(s) for "${ keyword }":\n${ matches.join('\n') }`,
+    };
+  }
+}


### PR DESCRIPTION
## Summary -- task DxHy

Read-only search tool over ~/sulla/logs/ for the upcoming Conversation Reader subconscious agent (epic 01aZ). Two lookup modes:

- thread_id: resolves the specific log file(s) for a conversation -- the channel-scoped <channel>_<id>.log plus the conv_<id>.jsonl event stream, using the same filename sanitization SullaLogger applies. Falls back to conversation_history.log_file from the DB when the filename doesn't match (handles legacy/edge-case naming).
- No thread_id: scans all thread-scoped log files within a recency window (since / days), excluding the fixed set of global non-thread-scoped infra logs (chat.log, dispatcher.log, index.log, index.jsonl, frontend-graph.log, persona.log, playbook-debug.log, background-web-requests.log) confirmed by the DxHy audit across all log producers.

Optional keyword filters either mode down to matching content lines (case-insensitive substring, capped read via tail-of-file for large logs).

### Scope note

Per the task description, content-search usefulness is gated on task 7BAO (assistant content is currently logged blank) -- that is a separate already-in-review fix (PR #636). This tool's filename/recency resolution does not depend on it and is fully functional today; keyword search is built and tested against synthetic fixtures and will pick up real content once 7BAO lands.

Not yet wired into any agent's toolset -- that is task RpvD (Conversation Reader agent) / drqq (GraphRegistry fan-out wiring), tracked separately.

### Verification

- tsc --noEmit: clean, 0 errors (full project, not just this file).
- ESLint on changed files: clean (pre-existing warnings in manifests.ts are unrelated key-spacing style on other entries).
- Focused Jest: search_conversation_logs.test.ts, 9/9 passed -- thread-id filename resolution, sanitization parity with SullaLogger, DB log_file fallback, unknown-thread handling, global-log exclusion, recency-window filtering, keyword filtering (hit and miss), and missing-log-dir handling.

Human review, merge, and deploy remain separate gates.