### PR TITLE
feat(mcp): register browse_tools as native tool for Claude Code

### DIFF
--- a/pkg/rancher-desktop/agent/tools/meta/browse_tools.ts
+++ b/pkg/rancher-desktop/agent/tools/meta/browse_tools.ts
@@ -5,9 +5,11 @@ import { toolRegistry } from '../registry';
  * BrowseToolsWorker — read-only tool discovery.
  *
  * Returns ready-to-run `sulla <category>/<tool>` CLI invocations plus an
- * explicit reminder that these commands must be dispatched through the
- * `exec` tool (models routinely forget this and dead-end in a "how do I
- * call this" loop).
+ * explicit reminder that these commands must be dispatched through a shell
+ * tool — `exec` in the Lima-VM runtime, or the generic `Bash` tool on
+ * surfaces (e.g. this Claude Code MCP bridge) that don't carry a
+ * Sulla-branded exec — models routinely forget this and dead-end in a "how
+ * do I call this" loop.
  */
 
 /** Tools excluded from the listing — internal plumbing the agent already has */
@@ -36,13 +38,15 @@ const CATEGORY_TO_INTEGRATION: Record<string, string> = {
  */
 const INVOCATION_PREAMBLE = [
   'HOW TO CALL: every entry below is a shell command. Dispatch it through',
-  'your `exec` tool — do NOT try to call `sulla` as if it were a tool name.',
+  'your `exec` tool if you have one, or plain `Bash` if that is what your',
+  'surface provides — do NOT try to call `sulla` as if it were a tool name.',
   '',
   '  exec({ command: "sulla <category>/<tool> \'<json-args>\'" })',
+  '  Bash({ command: "sulla <category>/<tool> \'<json-args>\'" })',
   '',
   'CRITICAL — avoid this common failure mode:',
   '  ❌ WRONG: execute_workflow({ workflowId: "..." })  ← always fails, this is not how tools work',
-  '  ✅ RIGHT: exec({ command: "sulla <category>/<tool> \'<json-args>\'" })',
+  '  ✅ RIGHT: exec/Bash ({ command: "sulla <category>/<tool> \'<json-args>\'" })',
   '',
   'execute_workflow is ONLY for named Sulla routines/workflows. It is NEVER the',
   'correct dispatch method for tools listed here.',

--- a/pkg/rancher-desktop/main/MCPServerHost.ts
+++ b/pkg/rancher-desktop/main/MCPServerHost.ts
@@ -40,6 +40,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod';
 
 import { ApprovalService } from '@pkg/agent/services/ApprovalService';
+import { toolRegistry } from '@pkg/agent/tools/registry';
 import { activateWorkflowOnState } from '@pkg/agent/tools/workflow/execute_workflow';
 import {
   clampTimeout,
@@ -436,6 +437,40 @@ export class MCPServerHost {
         const resolution = await approvals.parkQuestion(questionId, clamped);
         return {
           content: [{ type: 'text' as const, text: formatQuestionResolution(normalized, resolution, clamped) }],
+        };
+      },
+    );
+
+    // browse_tools — native discovery for the full sulla CLI catalog. Claude
+    // Code otherwise only knows about the handful of tools registered above;
+    // this gives the primary agent a first-class way to search the other
+    // ~250 without any of them being individually registered as MCP tools —
+    // dispatches in-process straight to the same ToolRegistry-backed worker
+    // the CLI's `sulla meta/browse_tools` uses, so results (and the shell
+    // invocations it hands back) are identical either way.
+    server.registerTool(
+      'browse_tools',
+      {
+        description: [
+          'Discover available sulla CLI tools by category or keyword. Returns ready-to-run',
+          '`sulla <category>/<tool>` commands with descriptions and parameter JSON.',
+          'The commands it returns are NOT directly callable tools — you invoke each one by',
+          'passing the full command string to your shell tool (`exec` or `Bash`, whichever',
+          'this surface provides). NEVER call execute_workflow for anything listed here —',
+          'execute_workflow is only for named Sulla routines/workflows.',
+          'Call this before assuming a capability is unavailable.',
+        ].join(' '),
+        inputSchema: {
+          category: z.string().optional().describe('Tool category to list (e.g. docker, github, slack, redis, pg, calendar, n8n, kubectl, lima, vault, extensions, rdctl, meta, agents, project, github, memory, observation).'),
+          query:    z.string().optional().describe('Keyword to search tool names and descriptions across all categories.'),
+        },
+      },
+      async ({ category, query }) => {
+        const worker = await toolRegistry.getTool('browse_tools');
+        const result = await worker.call({ category, query });
+        return {
+          content: [{ type: 'text' as const, text: String(result.result ?? result.error ?? '') }],
+          isError: !result.success,
         };
       },
     );


### PR DESCRIPTION
## Why

MCPServerHost.buildMcpServer() only hand-registers 4 tools for Claude Code (ping, sulla_session_info, execute_workflow, ask_user_question). Everything else in the ~250-tool sulla CLI catalog was only reachable by remembering to shell out to "sulla meta/browse_tools" -- a step the primary agent routinely forgot, producing false "I don't have that tool" responses even when the tool existed.

Rejected alternative: registering all ~250 catalog tools as individual MCP tools. That reverses the whole point of the CLI catalog (one searchable dispatch surface instead of flooding the model's tool list), and ToolSearch-style deferred-tool mechanisms don't help here -- they only defer schemas for tools already registered by name, they don't discover an unregistered external catalog.

Also rejected: adding a new pre-turn subconscious agent to inject tool context. Only fires once before the primary agent's turn starts, can silently fail (parallel fan-out via Promise.allSettled, rate limits), and doesn't help mid-task when the model realizes partway through that it needs a capability it didn't know about at turn start.

## What

- Register browse_tools as a 5th native MCP tool in MCPServerHost.ts, dispatching in-process via toolRegistry.getTool('browse_tools') -- the same ToolRegistry-backed worker the CLI's sulla meta/browse_tools already uses. No shell-out, no duplicate schema definition.
- This keeps the catalog itself off the model's tool list (still one tool, not 250) while giving the primary agent a first-class, always-available way to search it at any point in its own reasoning loop -- not just pre-turn.
- Generalized browse_tools' INVOCATION_PREAMBLE, which hard-coded "dispatch through your exec tool." Not true on every surface -- e.g. this MCP bridge only carries generic Bash, not a Sulla-branded exec. Preamble now names both.

## Verification

- browse_tools.test.ts: 6/6 passed (preamble wording change didn't break existing assertions -- checked first, no test asserts the literal removed exec-only wording).
- No MCPServerHost test file exists yet; esbuild parse-check on the edited file passed clean (full tsc is OOM-gated on this repo per prior notes).

Gate: draft only, no merge/deploy without Jonathon review.
