### PR TITLE
feat(db): add explicit hidden flag to conversation_history (scjd) [rebased]

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0058_add_hidden_to_conversation_history.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0058_add_hidden_to_conversation_history.ts
@@ -1,0 +1,47 @@
+/**
+ * Migration 0058 — Add explicit hidden flag to conversation_history.
+ *
+ * Part of the Conversation-Recall subconscious agent epic (01aZ), task scjd.
+ *
+ * Today "hidden from the user-facing history UI" is implicit: 4 query sites
+ * in ConversationHistoryModel (getRecent/search/getByDateRange, all filtered
+ * the same way) exclude rows via `channel_id NOT LIKE 'subconscious%'`. That
+ * pattern only catches the `subconscious:<agent>` channel namespace — it
+ * misses the worker/dispatch channels (`codex-test`, `thinker-worker`,
+ * `opus-worker`, `fable-planner`) confirmed live in the DB, which are
+ * internal machinery too but currently surface in history queries.
+ *
+ * This migration makes the concept an explicit column instead of a string
+ * match, and backfills it for both categories above. Verified against the
+ * live dev Postgres inside a rolled-back transaction: the backfill UPDATE
+ * touches exactly 5,813 rows — the sum of every `subconscious:*` channel
+ * (2081 + 2081 + 1348 + 105 + 4) plus the 4 named worker channels
+ * (102 + 70 + 12 + 10), with zero rows caught outside that set.
+ *
+ * Follow-up (not in this migration): a separate long tail of
+ * observer-prefixed channels (`observer-market`, `observer-operations`,
+ * `Observer`, `Thinker`, `Goals Cascade Refresher`, etc., ~50 rows total)
+ * looks like legacy identity-observer machinery too, but isn't named in
+ * scjd's acceptance criteria and its provenance wasn't confirmed against
+ * current code — left visible pending a deliberate decision rather than
+ * silently hidden.
+ */
+
+export const up = `
+  ALTER TABLE conversation_history ADD COLUMN IF NOT EXISTS hidden BOOLEAN NOT NULL DEFAULT FALSE;
+
+  CREATE INDEX IF NOT EXISTS idx_conv_history_hidden ON conversation_history(hidden);
+
+  UPDATE conversation_history
+  SET hidden = TRUE
+  WHERE hidden = FALSE
+    AND (
+      channel_id ILIKE 'subconscious%'
+      OR channel_id = ANY(ARRAY['codex-test', 'thinker-worker', 'opus-worker', 'fable-planner'])
+    );
+`;
+
+export const down = `
+  DROP INDEX IF EXISTS idx_conv_history_hidden;
+  ALTER TABLE conversation_history DROP COLUMN IF EXISTS hidden;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -45,6 +45,7 @@ import { up as up_0054, down as down_0054 } from './0054_allow_projects_identity
 import { up as up_0055, down as down_0055 } from './0055_add_system_and_content_hash_to_workflows';
 import { up as up_0056, down as down_0056 } from './0056_fix_routine_scorecard_null_slug';
 import { up as up_0057, down as down_0057 } from './0057_create_conversation_keywords_table';
+import { up as up_0058, down as down_0058 } from './0058_add_hidden_to_conversation_history';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -91,4 +92,5 @@ export const migrationsRegistry = [
   { name: '0055_add_system_and_content_hash_to_workflows',       up: up_0055, down: down_0055 },
   { name: '0056_fix_routine_scorecard_null_slug',                 up: up_0056, down: down_0056 },
   { name: '0057_create_conversation_keywords_table',              up: up_0057, down: down_0057 },
+  { name: '0058_add_hidden_to_conversation_history',               up: up_0058, down: down_0058 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/ConversationHistoryModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/ConversationHistoryModel.ts
@@ -28,6 +28,7 @@ export interface ConversationHistoryRecord {
   training_file?: string;
   last_summary?:  string;
   pinned:         boolean;
+  hidden:         boolean;
 }
 
 export interface RecordConversationInput {
@@ -47,6 +48,22 @@ export interface RecordConversationInput {
   training_file?: string;
   last_summary?:  string;
   pinned?:        boolean;
+  /** Explicit override. Omit to let recordConversation() derive it from channel_id (see isHiddenChannel). */
+  hidden?:        boolean;
+}
+
+/**
+ * Internal machinery channels that must never surface in user-facing
+ * history: the `subconscious:<agent>` namespace (memory-recall, observation
+ * writer/recall, summarizer, dreaming loops) plus the named worker/dispatch
+ * channels agents are spawned on. Mirrors migration 0058's backfill
+ * predicate — keep the two in sync if this set changes.
+ */
+const HIDDEN_WORKER_CHANNELS = new Set(['codex-test', 'thinker-worker', 'opus-worker', 'fable-planner']);
+
+function isHiddenChannel(channelId?: string | null): boolean {
+  if (!channelId) return false;
+  return channelId.startsWith('subconscious') || HIDDEN_WORKER_CHANNELS.has(channelId);
 }
 
 export class ConversationHistoryModel {
@@ -79,7 +96,8 @@ export class ConversationHistoryModel {
           log_file        TEXT,
           training_file   TEXT,  -- reference only; NEVER auto-delete (used for local model training)
           last_summary    TEXT,
-          pinned          BOOLEAN DEFAULT FALSE
+          pinned          BOOLEAN DEFAULT FALSE,
+          hidden          BOOLEAN NOT NULL DEFAULT FALSE
         )
       `);
 
@@ -106,12 +124,13 @@ export class ConversationHistoryModel {
    */
   static async recordConversation(meta: RecordConversationInput): Promise<void> {
     try {
+      const hidden = meta.hidden ?? isHiddenChannel(meta.channel_id);
       await postgresClient.query(`
         INSERT INTO ${ ConversationHistoryModel.TABLE }
           (id, thread_id, session_id, type, title, summary, url, favicon,
            channel_id, agent_id, tab_id, status, log_file, training_file,
-           last_summary, pinned, created_at, last_active_at)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, NOW(), NOW())
+           last_summary, pinned, hidden, created_at, last_active_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW(), NOW())
         ON CONFLICT (id) DO UPDATE SET
           thread_id      = COALESCE(EXCLUDED.thread_id, ${ ConversationHistoryModel.TABLE }.thread_id),
           session_id     = COALESCE(EXCLUDED.session_id, ${ ConversationHistoryModel.TABLE }.session_id),
@@ -128,6 +147,7 @@ export class ConversationHistoryModel {
           training_file  = COALESCE(EXCLUDED.training_file, ${ ConversationHistoryModel.TABLE }.training_file),
           last_summary   = COALESCE(EXCLUDED.last_summary, ${ ConversationHistoryModel.TABLE }.last_summary),
           pinned         = COALESCE(EXCLUDED.pinned, ${ ConversationHistoryModel.TABLE }.pinned),
+          hidden         = EXCLUDED.hidden OR ${ ConversationHistoryModel.TABLE }.hidden,
           last_active_at = NOW()
       `, [
         meta.id,
@@ -146,6 +166,7 @@ export class ConversationHistoryModel {
         meta.training_file ?? null,
         meta.last_summary ?? null,
         meta.pinned ?? false,
+        hidden,
       ]);
     } catch (err) {
       console.error('[ConversationHistoryModel] Failed to record conversation:', err);
@@ -241,7 +262,7 @@ export class ConversationHistoryModel {
         return await postgresClient.query<ConversationHistoryRecord>(`
           SELECT * FROM ${ ConversationHistoryModel.TABLE }
           WHERE type = $1 AND status != 'deleted'
-            AND (channel_id NOT LIKE 'subconscious%' OR channel_id IS NULL)
+            AND hidden = FALSE
           ORDER BY last_active_at DESC
           LIMIT $2
         `, [type, limit]);
@@ -249,7 +270,7 @@ export class ConversationHistoryModel {
       return await postgresClient.query<ConversationHistoryRecord>(`
         SELECT * FROM ${ ConversationHistoryModel.TABLE }
         WHERE status != 'deleted'
-          AND (channel_id NOT LIKE 'subconscious%' OR channel_id IS NULL)
+          AND hidden = FALSE
         ORDER BY last_active_at DESC
         LIMIT $1
       `, [limit]);
@@ -268,7 +289,7 @@ export class ConversationHistoryModel {
       return await postgresClient.query<ConversationHistoryRecord>(`
         SELECT * FROM ${ ConversationHistoryModel.TABLE }
         WHERE (title ILIKE $1 OR summary ILIKE $1) AND status != 'deleted'
-          AND (channel_id NOT LIKE 'subconscious%' OR channel_id IS NULL)
+          AND hidden = FALSE
         ORDER BY last_active_at DESC
         LIMIT 100
       `, [pattern]);
@@ -286,7 +307,7 @@ export class ConversationHistoryModel {
       return await postgresClient.query<ConversationHistoryRecord>(`
         SELECT * FROM ${ ConversationHistoryModel.TABLE }
         WHERE created_at >= $1 AND created_at <= $2 AND status != 'deleted'
-          AND (channel_id NOT LIKE 'subconscious%' OR channel_id IS NULL)
+          AND hidden = FALSE
         ORDER BY last_active_at DESC
       `, [from.toISOString(), to.toISOString()]);
     } catch (err) {

--- a/pkg/rancher-desktop/agent/database/models/__tests__/ConversationHistoryModel.hidden.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/ConversationHistoryModel.hidden.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+import { postgresClient } from '../../PostgresClient';
+import { ConversationHistoryModel } from '../ConversationHistoryModel';
+
+describe('ConversationHistoryModel — hidden flag', () => {
+  let originalQuery: any;
+
+  beforeAll(() => {
+    originalQuery = postgresClient.query;
+  });
+
+  afterEach(() => {
+    (postgresClient as any).query = originalQuery;
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['subconscious:memory-recall', true],
+    ['subconscious:observation', true],
+    ['subconscious', true],
+    ['codex-test', true],
+    ['thinker-worker', true],
+    ['opus-worker', true],
+    ['fable-planner', true],
+    ['sulla-desktop', false],
+    ['mobile-relay', false],
+    [undefined, false],
+  ])('derives hidden=%s for channel_id %s when not explicitly set', async(channelId, expected) => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await ConversationHistoryModel.recordConversation({
+      id:         'conv1',
+      type:       'graph',
+      channel_id: channelId as string | undefined,
+    });
+
+    const [, params] = (postgresClient.query as jest.Mock).mock.calls[0] as [string, unknown[]];
+    expect(params[params.length - 1]).toBe(expected);
+  });
+
+  it('respects an explicit hidden override regardless of channel_id', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await ConversationHistoryModel.recordConversation({
+      id:         'conv2',
+      type:       'chat',
+      channel_id: 'sulla-desktop',
+      hidden:     true,
+    });
+
+    const [, params] = (postgresClient.query as jest.Mock).mock.calls[0] as [string, unknown[]];
+    expect(params[params.length - 1]).toBe(true);
+  });
+
+  it('filters hidden rows out of getRecent/search/getByDateRange via the hidden column', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await ConversationHistoryModel.getRecent(10);
+    await ConversationHistoryModel.search('foo');
+    await ConversationHistoryModel.getByDateRange(new Date(0), new Date());
+
+    const calls = (postgresClient.query as jest.Mock).mock.calls as [string, unknown[]][];
+    for (const [sql] of calls) {
+      expect(sql).toContain('hidden = FALSE');
+      expect(sql).not.toContain("NOT LIKE 'subconscious%'");
+    }
+  });
+});


### PR DESCRIPTION
Rebase of #639 onto current main to resolve the migrations/index.ts conflict created by #638/#640 merging first (both #639 and #638 appended a migration entry at the same array location). Content is otherwise identical to #639 -- same migration 0058, same model/test changes. Conflict resolved by keeping both entries in numeric order (0057 then 0058). Re-ran ConversationHistoryModel.hidden.test.ts post-rebase: 12/12 passed. Supersedes #639.