### PR TITLE
fix(agent): separate stable identity from transport channel

### DIFF
--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -14,6 +14,7 @@ import { throwIfAborted } from '../services/AbortService';
 import { parseJson } from '../services/JsonParseService';
 import { getWebSocketClientService } from '../services/WebSocketClientService';
 import { toolRegistry } from '../tools/registry';
+import { resolveAgentIdentity } from '../utils/agentIdentity';
 import { stripProtocolTags, stripProtocolTagsStreaming } from '../utils/stripProtocolTags';
 import { resolveSullaProjectsDir, resolveSullaSkillsDir, resolveSullaAgentsDir, resolveSullaCodebaseDir, findAgentDir, resolveSullaHomeDir, resolveSullaDocsDir } from '../utils/sullaPaths';
 
@@ -602,8 +603,9 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     state: ThreadState,
     options: PromptEnrichmentOptions,
   ): Promise<string> {
-    // Resolve the agent ID and config from graph state
-    const agentId = String(state.metadata.wsChannel || '').trim();
+    // Agent identity is stable; wsChannel may be rewritten to the delivery
+    // transport (for example mobile-relay) after graph creation.
+    const agentId = resolveAgentIdentity(state.metadata);
     const agentMeta = (state.metadata as any).agent as AgentConfig | undefined;
 
     // Build template variables
@@ -904,7 +906,7 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
    * Planning pipeline agents (observer, thinker, etc.) opt out via config.yaml.
    */
   protected async shouldInjectObservationsForAgent(state: BaseThreadState): Promise<boolean> {
-    const agentId = String(state.metadata.wsChannel || '').trim();
+    const agentId = resolveAgentIdentity(state.metadata);
     if (!agentId) return true;
 
     try {

--- a/pkg/rancher-desktop/agent/nodes/Graph.ts
+++ b/pkg/rancher-desktop/agent/nodes/Graph.ts
@@ -88,6 +88,11 @@ export interface BaseThreadState {
     action:                'direct_answer' | 'ask_clarification' | 'use_tools' | 'create_plan' | 'run_again';
     threadId:              string;
     wsChannel:             string;
+    /**
+     * Stable agent identity set when the graph is created. Unlike wsChannel,
+     * this is not rewritten when a turn arrives through another transport.
+     */
+    agentId?:              string;
     /** Conversation logger ID — set by workflow agent handler or graph creator */
     conversationId?:       string;
     /** Parent conversation ID (e.g. the workflow execution that spawned this graph) */

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -1695,6 +1695,7 @@ async function buildHeartbeatState(wsChannel: string, prompt: string): Promise<A
       action:               'use_tools',
       threadId,
       wsChannel,
+      agentId:              wsChannel,
       cycleComplete:        false,
       waitingForUser:       false,
       isSubAgent:           false,
@@ -1756,6 +1757,7 @@ async function buildAgentState(wsChannel: string, threadId?: string, graphOpts?:
       action:    'direct_answer',
       threadId:  id,
       wsChannel,
+      agentId:   wsChannel,
 
       cycleComplete:  false,
       waitingForUser: false,

--- a/pkg/rancher-desktop/agent/utils/__tests__/agentIdentity.test.ts
+++ b/pkg/rancher-desktop/agent/utils/__tests__/agentIdentity.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { resolveAgentIdentity } from '../agentIdentity';
+
+describe('resolveAgentIdentity', () => {
+  it('keeps the graph-created identity when the delivery channel changes', () => {
+    const metadata = {
+      agentId:   'sulla-desktop',
+      wsChannel: 'mobile-relay',
+    };
+
+    expect(resolveAgentIdentity(metadata)).toBe('sulla-desktop');
+  });
+
+  it('falls back to wsChannel for older state without agentId', () => {
+    expect(resolveAgentIdentity({ wsChannel: 'heartbeat' })).toBe('heartbeat');
+  });
+
+  it('trims identity values and handles missing metadata', () => {
+    expect(resolveAgentIdentity({ agentId: '  operator  ', wsChannel: 'mobile-relay' })).toBe('operator');
+    expect(resolveAgentIdentity(undefined)).toBe('');
+  });
+});

--- a/pkg/rancher-desktop/agent/utils/agentIdentity.ts
+++ b/pkg/rancher-desktop/agent/utils/agentIdentity.ts
@@ -1,0 +1,13 @@
+export interface AgentIdentityMetadata {
+  agentId?:   string;
+  wsChannel?: string;
+}
+
+/**
+ * Resolve the stable agent identity independently from its current transport.
+ * Older/restored states may not have agentId yet, so wsChannel remains a
+ * compatibility fallback.
+ */
+export function resolveAgentIdentity(metadata: AgentIdentityMetadata | null | undefined): string {
+  return String(metadata?.agentId || metadata?.wsChannel || '').trim();
+}


### PR DESCRIPTION
## Why

`wsChannel` currently serves two jobs: stable agent identity and mutable delivery transport. Mobile/Slack routing can rewrite it after graph creation, causing prompt-directory overrides and observation policy to be resolved under the transport name instead of the configured agent.

This recovers the good orphaned work found in the primary checkout and tracks it under Sulla Projects task WCgA.

## What

- Adds `metadata.agentId` as the stable graph-created identity.
- Initializes it in primary agent and Heartbeat state builders.
- Resolves prompt overrides and observation-injection policy from `agentId`.
- Retains `wsChannel` fallback for restored/older states.
- Adds a small shared resolver with regression coverage for `agentId=sulla-desktop` plus `wsChannel=mobile-relay`.

## Verification

- Focused Jest: 2 suites, 6/6 tests passed.
- esbuild parse check passed for all touched production TypeScript files.
- `git diff --check` passed.
- Full `tsc --noEmit` was attempted with a 6144 MB heap and was OOM-killed without emitting a diagnostic; this is the known full-typecheck environment constraint.

Draft only; no deployment/rebuild included.