### PR TITLE
fix(context): keep Heartbeat and subconscious context out of system prompt

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -115,16 +115,9 @@ export class ClaudeCodeService extends BaseLanguageModel {
   private readonly SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
 
   /**
-   * Redis key holding the hash of the stable <sulla_context> tier last stamped
-   * into ANY conversation on this install. The stable tier (platform rules +
-   * top-priority memory) is install-global, and it is ALSO carried by the
-   * byte-stable system prompt (soul/tooling + the observational_memory
-   * section), which is sent on every session — fresh or resumed. So a
-   * brand-new session already has this content via the system prompt; we use
-   * this persisted hash to skip re-stamping the ~6k tier into the first
-   * message of every fresh session (e.g. the heartbeat's per-cycle
-   * conversations). It only needs to ride the message when its content
-   * actually changes — see buildUserMessageContextPrefix.
+   * Redis key holding the hash of the stable platform/environment context last
+   * stamped into any conversation on this install. Subconscious output is not
+   * part of this tier; it travels only in the synthetic assistant message.
    */
   private readonly STABLE_CTX_KEY = 'claude_code_stable_ctx_hash';
 
@@ -485,10 +478,10 @@ export class ClaudeCodeService extends BaseLanguageModel {
   }
 
   /**
-   * Extract the last user message. Walks backward to find the newest
-   * user-role content, flattening string + content-block shapes. When a
-   * --resume session exists, this is all we send — Claude already has
-   * everything earlier in its session state.
+   * Extract the latest turn for a resumed session. A dedicated synthetic
+   * assistant context message may immediately precede the user message; it
+   * must be replayed because Claude's stored session does not contain this
+   * turn's newly generated subconscious context.
    *
    * Image blocks are saved to disk and their paths injected into the text
    * so the Claude Code agent can read them with the Read tool.
@@ -519,7 +512,17 @@ export class ClaudeCodeService extends BaseLanguageModel {
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].role === 'user') {
         const text = msgToText(messages[i]).trim();
-        if (text) return text;
+        if (text) {
+          const turn: string[] = [];
+          let contextIdx = i - 1;
+          while (contextIdx >= 0 && messages[contextIdx].role === 'assistant' && (messages[contextIdx] as any).metadata?._synthetic) {
+            const assistantText = msgToText(messages[contextIdx]).trim();
+            if (assistantText) turn.unshift(`Assistant:\n${ assistantText }`);
+            contextIdx--;
+          }
+          turn.push(`User:\n${ text }`);
+          return turn.join('\n\n');
+        }
       }
     }
     // Fallback — pick any extractable text so a tool_result-dominated turn
@@ -683,30 +686,12 @@ Every time, in this order:
 This is a hard rule, not a suggestion: catalog and docs first, improvise last.
 </environment>`);
 
-    // High-priority observational memory
-    try {
-      const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');
-      const { parseJson } = await import('../services/JsonParseService');
-      const raw     = await SullaSettingsModel.get('observationalMemory', '[]');
-      const entries = parseJson(raw);
-      if (Array.isArray(entries)) {
-        const high = (entries as any[]).filter(e =>
-          ['critical', 'high'].includes((e?.priority ?? '').toLowerCase()),
-        );
-        if (high.length > 0) {
-          const lines = high.map((e: any) => `- ${ e.content ?? '' }`).join('\n');
-          stableParts.push(`<observational_memory>\n${ lines }\n</observational_memory>`);
-        }
-      }
-    } catch { /* non-fatal */ }
-
     const parts: string[] = [];
 
     // Decide whether to stamp the stable tier into this message.
     //
-    // The stable tier is redundant with the byte-stable system prompt (which
-    // carries the same platform rules + top-priority memory and is sent on
-    // EVERY session, fresh or resumed). So it only needs to ride the message
+    // The stable tier is redundant with the byte-stable system prompt's
+    // platform rules. It only needs to ride the message
     // when its content has CHANGED since a conversation last saw it — repeating
     // it verbatim otherwise just multiplies token cost in the permanent history.
     //
@@ -714,7 +699,7 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
     //     earlier this session. Unchanged → skip (existing dedup). Changed →
     //     re-send, because a resumed session never re-receives the system prompt.
     //   - Fresh session (new convId, empty per-conv hash): the system prompt has
-    //     ALREADY delivered the current stable content, so seed this
+    //     already delivered the platform rules, so seed this
     //     conversation's baseline from the install-global hash instead of
     //     force-sending. Only send if the global hash is missing/stale (first
     //     call, Redis down, or the content genuinely changed) — a safe fallback.
@@ -736,57 +721,6 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
     try {
       await redisClient.set(this.STABLE_CTX_KEY, stableHash, this.SESSION_TTL_SECONDS);
     } catch { /* Redis unavailable — non-fatal, we simply re-send next new session */ }
-
-    // Observation context from observation-recall agent (targeted DB observations)
-    const observationContext = (state?.metadata as any)?.observationContext;
-    if (observationContext && typeof observationContext === 'string' && observationContext.trim()) {
-      parts.push(`<observation_context>\n${ observationContext.trim() }\n</observation_context>`);
-    }
-
-    const userObservationContext = (state?.metadata as any)?.userObservationContext;
-    if (userObservationContext && typeof userObservationContext === 'string' && userObservationContext.trim()) {
-      parts.push(`<user_observations>\n${ userObservationContext.trim() }\n</user_observations>`);
-    }
-
-    const selfObservationContext = (state?.metadata as any)?.selfObservationContext;
-    if (selfObservationContext && typeof selfObservationContext === 'string' && selfObservationContext.trim()) {
-      parts.push(`<self_observations>\n${ selfObservationContext.trim() }\n</self_observations>`);
-    }
-
-    const businessObservationContext = (state?.metadata as any)?.businessObservationContext;
-    if (businessObservationContext && typeof businessObservationContext === 'string' && businessObservationContext.trim()) {
-      parts.push(`<business_observations>\n${ businessObservationContext.trim() }\n</business_observations>`);
-    }
-
-    const worldObservationContext = (state?.metadata as any)?.worldObservationContext;
-    if (worldObservationContext && typeof worldObservationContext === 'string' && worldObservationContext.trim()) {
-      parts.push(`<world_observations>\n${ worldObservationContext.trim() }\n</world_observations>`);
-    }
-
-    const environmentObservationContext = (state?.metadata as any)?.environmentObservationContext;
-    if (environmentObservationContext && typeof environmentObservationContext === 'string' && environmentObservationContext.trim()) {
-      parts.push(`<environment_observations>\n${ environmentObservationContext.trim() }\n</environment_observations>`);
-    }
-
-    const projectsObservationContext = (state?.metadata as any)?.projectsObservationContext;
-    if (projectsObservationContext && typeof projectsObservationContext === 'string' && projectsObservationContext.trim()) {
-      parts.push(`<projects_observations>\n${ projectsObservationContext.trim() }\n</projects_observations>`);
-    }
-
-    const skillsObservationContext = (state?.metadata as any)?.skillsObservationContext;
-    if (skillsObservationContext && typeof skillsObservationContext === 'string' && skillsObservationContext.trim()) {
-      parts.push(`<skills_observations>\n${ skillsObservationContext.trim() }\n</skills_observations>`);
-    }
-
-    // Conversation Reader output (relevant prior conversation content).
-    // Nothing sets state.metadata.conversationContext yet — the recall
-    // dispatch is deferred to Sulla Projects task drqq — but this build path
-    // is wired the same as the other recall contexts so that task only needs
-    // to set the metadata field.
-    const conversationContext = (state?.metadata as any)?.conversationContext;
-    if (conversationContext && typeof conversationContext === 'string' && conversationContext.trim()) {
-      parts.push(`<conversation_context>\n${ conversationContext.trim() }\n</conversation_context>`);
-    }
 
     if (parts.length === 0) return '';
     return `<sulla_context>\n${ parts.join('\n\n') }\n</sulla_context>`;

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -382,10 +382,10 @@ export class CodexService extends BaseLanguageModel {
   }
 
   /**
-   * Extract the last user message. Walks backward to find the newest
-   * user-role content, flattening string + content-block shapes. When a
-   * resume session exists, this is all we send — codex already has
-   * everything earlier in its session state.
+   * Extract the latest turn for a resumed session. A dedicated synthetic
+   * assistant context message may immediately precede the user message; it
+   * must be replayed because Codex's stored session does not contain this
+   * turn's newly generated subconscious context.
    */
   private extractLatestUserMessage(messages: ChatMessage[]): string {
     const blockToText = (b: any): string => {
@@ -413,7 +413,17 @@ export class CodexService extends BaseLanguageModel {
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].role === 'user') {
         const text = msgToText(messages[i]).trim();
-        if (text) return text;
+        if (text) {
+          const turn: string[] = [];
+          let contextIdx = i - 1;
+          while (contextIdx >= 0 && messages[contextIdx].role === 'assistant' && (messages[contextIdx] as any).metadata?._synthetic) {
+            const assistantText = msgToText(messages[contextIdx]).trim();
+            if (assistantText) turn.unshift(`Assistant:\n${ assistantText }`);
+            contextIdx--;
+          }
+          turn.push(`User:\n${ text }`);
+          return turn.join('\n\n');
+        }
       }
     }
     // Fallback — pick any extractable text so a tool_result-dominated turn
@@ -539,23 +549,6 @@ Every time, in this order:
 This is a hard rule, not a suggestion: catalog and docs first, improvise last.
 </environment>`);
 
-    // High-priority observational memory
-    try {
-      const { SullaSettingsModel } = await import('../database/models/SullaSettingsModel');
-      const { parseJson } = await import('../services/JsonParseService');
-      const raw     = await SullaSettingsModel.get('observationalMemory', '[]');
-      const entries = parseJson(raw);
-      if (Array.isArray(entries)) {
-        const high = (entries as any[]).filter(e =>
-          ['critical', 'high'].includes((e?.priority ?? '').toLowerCase()),
-        );
-        if (high.length > 0) {
-          const lines = high.map((e: any) => `- ${ e.content ?? '' }`).join('\n');
-          stableParts.push(`<observational_memory>\n${ lines }\n</observational_memory>`);
-        }
-      }
-    } catch { /* non-fatal */ }
-
     const parts: string[] = [];
 
     // Only send the stable tier when it's new to this session or has changed
@@ -564,57 +557,6 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
     const stableHash = crypto.createHash('sha1').update(stableText).digest('hex');
     if (opts.isNewSession || this.lastStableContextHash.get(opts.convId) !== stableHash) {
       parts.push(stableText);
-    }
-
-    // Observation context from observation-recall agent (targeted DB observations)
-    const observationContext = (state?.metadata as any)?.observationContext;
-    if (observationContext && typeof observationContext === 'string' && observationContext.trim()) {
-      parts.push(`<observation_context>\n${ observationContext.trim() }\n</observation_context>`);
-    }
-
-    const userObservationContext = (state?.metadata as any)?.userObservationContext;
-    if (userObservationContext && typeof userObservationContext === 'string' && userObservationContext.trim()) {
-      parts.push(`<user_observations>\n${ userObservationContext.trim() }\n</user_observations>`);
-    }
-
-    const selfObservationContext = (state?.metadata as any)?.selfObservationContext;
-    if (selfObservationContext && typeof selfObservationContext === 'string' && selfObservationContext.trim()) {
-      parts.push(`<self_observations>\n${ selfObservationContext.trim() }\n</self_observations>`);
-    }
-
-    const businessObservationContext = (state?.metadata as any)?.businessObservationContext;
-    if (businessObservationContext && typeof businessObservationContext === 'string' && businessObservationContext.trim()) {
-      parts.push(`<business_observations>\n${ businessObservationContext.trim() }\n</business_observations>`);
-    }
-
-    const worldObservationContext = (state?.metadata as any)?.worldObservationContext;
-    if (worldObservationContext && typeof worldObservationContext === 'string' && worldObservationContext.trim()) {
-      parts.push(`<world_observations>\n${ worldObservationContext.trim() }\n</world_observations>`);
-    }
-
-    const environmentObservationContext = (state?.metadata as any)?.environmentObservationContext;
-    if (environmentObservationContext && typeof environmentObservationContext === 'string' && environmentObservationContext.trim()) {
-      parts.push(`<environment_observations>\n${ environmentObservationContext.trim() }\n</environment_observations>`);
-    }
-
-    const projectsObservationContext = (state?.metadata as any)?.projectsObservationContext;
-    if (projectsObservationContext && typeof projectsObservationContext === 'string' && projectsObservationContext.trim()) {
-      parts.push(`<projects_observations>\n${ projectsObservationContext.trim() }\n</projects_observations>`);
-    }
-
-    const skillsObservationContext = (state?.metadata as any)?.skillsObservationContext;
-    if (skillsObservationContext && typeof skillsObservationContext === 'string' && skillsObservationContext.trim()) {
-      parts.push(`<skills_observations>\n${ skillsObservationContext.trim() }\n</skills_observations>`);
-    }
-
-    // Conversation Reader output (relevant prior conversation content).
-    // Nothing sets state.metadata.conversationContext yet — the recall
-    // dispatch is deferred to Sulla Projects task drqq — but this build path
-    // is wired the same as the other recall contexts so that task only needs
-    // to set the metadata field.
-    const conversationContext = (state?.metadata as any)?.conversationContext;
-    if (conversationContext && typeof conversationContext === 'string' && conversationContext.trim()) {
-      parts.push(`<conversation_context>\n${ conversationContext.trim() }\n</conversation_context>`);
     }
 
     if (parts.length === 0) return { prefix: '', stableHash };

--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/CliAssistantContext.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/CliAssistantContext.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { ClaudeCodeService } from '../ClaudeCodeService';
+import { CodexService } from '../CodexService';
+
+describe.each([
+  ['Claude Code', () => new ClaudeCodeService()],
+  ['Codex', () => new CodexService()],
+])('%s resumed-turn assistant context', (_name, createService) => {
+  it('replays contiguous synthetic assistant messages before the latest user message', () => {
+    const service = createService();
+    const messages: any[] = [
+      { role: 'user', content: 'old user' },
+      { role: 'assistant', content: 'old real answer' },
+      {
+        role: 'assistant',
+        content: '<human_identity_context>\nidentity\n</human_identity_context>',
+        metadata: { source: 'subconscious_context', _synthetic: true },
+      },
+      {
+        role: 'assistant',
+        content: '<project_report>\nwork\n</project_report>',
+        metadata: { source: 'project_report', _synthetic: true },
+      },
+      { role: 'user', content: 'current user' },
+    ];
+
+    const text = (service as any).extractLatestUserMessage(messages);
+
+    expect(text).toBe([
+      'Assistant:\n<human_identity_context>\nidentity\n</human_identity_context>',
+      'Assistant:\n<project_report>\nwork\n</project_report>',
+      'User:\ncurrent user',
+    ].join('\n\n'));
+    expect(text).not.toContain('old real answer');
+  });
+});

--- a/pkg/rancher-desktop/agent/nodes/AgentNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/AgentNode.ts
@@ -148,7 +148,7 @@ export class AgentNode extends BaseNode {
           state.messages.splice(insertIdx, 0, {
             role:     'assistant',
             content:  `<project_report>\n${ report }\n</project_report>`,
-            metadata: { source: 'project_report' },
+            metadata: { source: 'project_report', _synthetic: true },
           });
         }
       } catch (err) {
@@ -156,69 +156,7 @@ export class AgentNode extends BaseNode {
       }
     }
 
-    // Merge observation context into the last assistant message
-    // (or create one) so the primary agent sees it as information it already has.
-    // Strip any blocks injected on previous turns / earlier loop iterations
-    // first — this merge must replace, never accumulate (the mutated message
-    // is persisted with the thread state).
-    this.stripInjectedContextBlocks(state);
-    const observationContext     = (state.metadata as any).observationContext;
-    const userObservationContext = (state.metadata as any).userObservationContext;
-    const selfObservationContext = (state.metadata as any).selfObservationContext;
-    const businessObservationContext = (state.metadata as any).businessObservationContext;
-    const worldObservationContext = (state.metadata as any).worldObservationContext;
-    const environmentObservationContext = (state.metadata as any).environmentObservationContext;
-    const combinedContextParts: string[] = [];
-    if (observationContext) combinedContextParts.push(`<observation_context>\n${ observationContext }\n</observation_context>`);
-    if (userObservationContext) combinedContextParts.push(`<user_observations>\n${ userObservationContext }\n</user_observations>`);
-    if (selfObservationContext) combinedContextParts.push(`<self_observations>\n${ selfObservationContext }\n</self_observations>`);
-    if (businessObservationContext) combinedContextParts.push(`<business_observations>\n${ businessObservationContext }\n</business_observations>`);
-    if (worldObservationContext) combinedContextParts.push(`<world_observations>\n${ worldObservationContext }\n</world_observations>`);
-    if (environmentObservationContext) combinedContextParts.push(`<environment_observations>\n${ environmentObservationContext }\n</environment_observations>`);
-    const projectsObservationContext = (state.metadata as any).projectsObservationContext;
-    if (projectsObservationContext) combinedContextParts.push(`<projects_observations>\n${ projectsObservationContext }\n</projects_observations>`);
-    const skillsObservationContext = (state.metadata as any).skillsObservationContext;
-    if (skillsObservationContext) combinedContextParts.push(`<skills_observations>\n${ skillsObservationContext }\n</skills_observations>`);
-
-    // Conversation Reader output (relevant PRIOR conversation content, as
-    // opposed to this thread's own observations). Nothing sets this yet —
-    // the recall dispatch is deferred to Sulla Projects task drqq — but the
-    // inject side of the plumbing is wired here so that task only needs to
-    // set state.metadata.conversationContext.
-    const conversationContext = (state.metadata as any).conversationContext;
-    if (conversationContext) combinedContextParts.push(`<conversation_context>\n${ conversationContext }\n</conversation_context>`);
-
-    if (combinedContextParts.length > 0) {
-      const contextBlock = `\n\n${ combinedContextParts.join('\n\n') }`;
-      let merged = false;
-      for (let i = state.messages.length - 1; i >= 0; i--) {
-        if (state.messages[i].role === 'assistant') {
-          const msg = state.messages[i];
-          if (typeof msg.content === 'string') {
-            // Plain string content — append directly
-            msg.content += contextBlock;
-          } else if (Array.isArray(msg.content)) {
-            // Content blocks array (e.g. [{type:'text', text:'...'}, ...])
-            // Append a new text block with the context
-            msg.content.push({ type: 'text', text: contextBlock });
-          } else {
-            // Unknown format — wrap as string
-            msg.content = (msg.content ? JSON.stringify(msg.content) : '') + contextBlock;
-          }
-          merged = true;
-          break;
-        }
-      }
-      if (!merged) {
-        // First turn — no assistant message yet, insert one before the last user message
-        const insertIdx = Math.max(0, state.messages.length - 1);
-        state.messages.splice(insertIdx, 0, {
-          role:     'assistant',
-          content:  contextBlock.trim(),
-          metadata: { source: 'recall', _synthetic: true },
-        });
-      }
-    }
+    this.injectSubconsciousAssistantContext(state);
 
     // ----------------------------------------------------------------
     // 2. EXECUTE — LLM reads conversation, calls tools, responds

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -735,6 +735,15 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     // Build the prompt using the section-based builder
     const built = await SystemPromptBuilder.build(buildCtx);
 
+    // Subconscious/dream-consolidated identity is context, not policy. Keep it
+    // out of the system prompt and hand it to the shared assistant-message
+    // injector used by both AgentNode and HeartbeatNode.
+    const routedAssistantSections = new Map(
+      built.assistantContextSections.map(section => [section.id, section.content.trim()]),
+    );
+    (state.metadata as any).humanIdentityContext = routedAssistantSections.get('user') || '';
+    (state.metadata as any).observationalMemoryContext = routedAssistantSections.get('observational_memory') || '';
+
     // Store Anthropic cache blocks on state metadata for AnthropicService pickup
     if (built.anthropicSystem) {
       (state.metadata as any).__anthropicSystemBlocks = built.anthropicSystem;
@@ -821,7 +830,7 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
 
   /**
    * Remove previously injected subconscious context blocks
-   * (<observation_context>, <user_observations>, <conversation_context>,
+   * (<human_identity_context>, <observational_memory>, <observation_context>, <user_observations>, <conversation_context>,
    * <routine_digest>, <lane_health>) from all
    * assistant messages, so the per-turn merge below replaces rather than
    * accumulates. Two accumulation paths existed without this:
@@ -832,8 +841,8 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
    * Also drops first-turn synthetic carrier messages once emptied.
    */
   protected stripInjectedContextBlocks(state: BaseThreadState): void {
-    const BLOCK_RE = /\n*<(observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|skills_observations|conversation_context|routine_digest|lane_health)>[\s\S]*?<\/\1>/g;
-    const MARKER_RE = /<(?:observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|skills_observations|conversation_context|routine_digest|lane_health)>/;
+    const BLOCK_RE = /\n*<(human_identity_context|observational_memory|observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|skills_observations|conversation_context|routine_digest|lane_health)>[\s\S]*?<\/\1>/g;
+    const MARKER_RE = /<(?:human_identity_context|observational_memory|observation_context|user_observations|self_observations|business_observations|world_observations|environment_observations|projects_observations|skills_observations|conversation_context|routine_digest|lane_health)>/;
 
     for (const msg of state.messages) {
       if (msg.role !== 'assistant') continue;
@@ -857,6 +866,53 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
       if (typeof m.content === 'string') return m.content.trim().length > 0;
       if (Array.isArray(m.content)) return m.content.length > 0;
       return true;
+    });
+  }
+
+  /**
+   * Put every subconscious-produced context block in one dedicated synthetic
+   * assistant message immediately before the latest user turn. Never append
+   * these blocks to a real historical assistant response: resumed CLI sessions
+   * already own that history and would not observe an in-place mutation.
+   */
+  protected injectSubconsciousAssistantContext(state: BaseThreadState): void {
+    this.stripInjectedContextBlocks(state);
+
+    const metadata = state.metadata as any;
+    const fields: Array<[string, string]> = [
+      ['human_identity_context', 'humanIdentityContext'],
+      ['observational_memory', 'observationalMemoryContext'],
+      ['observation_context', 'observationContext'],
+      ['user_observations', 'userObservationContext'],
+      ['self_observations', 'selfObservationContext'],
+      ['business_observations', 'businessObservationContext'],
+      ['world_observations', 'worldObservationContext'],
+      ['environment_observations', 'environmentObservationContext'],
+      ['projects_observations', 'projectsObservationContext'],
+      ['skills_observations', 'skillsObservationContext'],
+      ['conversation_context', 'conversationContext'],
+    ];
+    const blocks = fields.flatMap(([tag, key]) => {
+      const value = metadata[key];
+      return typeof value === 'string' && value.trim()
+        ? [`<${ tag }>\n${ value.trim() }\n</${ tag }>`]
+        : [];
+    });
+    if (blocks.length === 0) return;
+
+    state.messages = state.messages.filter((message: any) =>
+      message?.metadata?.source !== 'subconscious_context');
+    let insertIdx = state.messages.length;
+    for (let i = state.messages.length - 1; i >= 0; i--) {
+      if (state.messages[i].role === 'user') {
+        insertIdx = i;
+        break;
+      }
+    }
+    state.messages.splice(insertIdx, 0, {
+      role:     'assistant',
+      content:  blocks.join('\n\n'),
+      metadata: { source: 'subconscious_context', _synthetic: true },
     });
   }
 

--- a/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
@@ -126,10 +126,9 @@ export class HeartbeatNode extends BaseNode {
       await this.injectTurnContext(state, { isHeartbeat: true });
     }
 
-    // Strip previously injected context blocks so downstream merges replace
-    // rather than accumulate across turns and tool-loop iterations (the
-    // message is persisted).
-    this.stripInjectedContextBlocks(state);
+    // Subconscious recall and dream-consolidated identity are always carried
+    // by a dedicated assistant message, never the Heartbeat system prompt.
+    this.injectSubconsciousAssistantContext(state);
     if (!isToolCallLoop) {
       await this.injectHeartbeatProjectReport(state);
     }

--- a/pkg/rancher-desktop/agent/nodes/__tests__/BaseNode.stripInjectedContextBlocks.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/BaseNode.stripInjectedContextBlocks.test.ts
@@ -162,4 +162,78 @@ describe('BaseNode.stripInjectedContextBlocks', () => {
 
     expect(state.messages[0].content).toBe('Please recall <conversation_context>not a real block</conversation_context>');
   });
+
+  it('injects all subconscious output into one fresh assistant message before the latest user turn', async() => {
+    const { BaseNode } = await import('../BaseNode');
+
+    class TestNode extends BaseNode<any> {
+      async execute(state: any) {
+        return { state, decision: { type: 'end' as const } };
+      }
+
+      injectContext(state: any) {
+        this.injectSubconsciousAssistantContext(state);
+      }
+    }
+
+    const node = new TestNode('test-node', 'TestNode');
+    const state: any = {
+      messages: [
+        { role: 'user', content: 'old turn' },
+        { role: 'assistant', content: 'real historical answer' },
+        { role: 'user', content: 'current turn' },
+      ],
+      metadata: {
+        humanIdentityContext:    'durable human identity',
+        observationalMemoryContext: 'top observations',
+        observationContext:      'targeted recall',
+        conversationContext:     'prior conversation',
+      },
+    };
+
+    (node as any).injectContext(state);
+
+    expect(state.messages.map((message: any) => message.role)).toEqual([
+      'user', 'assistant', 'assistant', 'user',
+    ]);
+    expect(state.messages[1].content).toBe('real historical answer');
+    expect(state.messages[2].metadata).toEqual({ source: 'subconscious_context', _synthetic: true });
+    expect(state.messages[2].content).toContain('<human_identity_context>\ndurable human identity\n</human_identity_context>');
+    expect(state.messages[2].content).toContain('<observational_memory>\ntop observations\n</observational_memory>');
+    expect(state.messages[2].content).toContain('<observation_context>\ntargeted recall\n</observation_context>');
+    expect(state.messages[2].content).toContain('<conversation_context>\nprior conversation\n</conversation_context>');
+  });
+
+  it('replaces the prior synthetic context carrier instead of accumulating it', async() => {
+    const { BaseNode } = await import('../BaseNode');
+
+    class TestNode extends BaseNode<any> {
+      async execute(state: any) {
+        return { state, decision: { type: 'end' as const } };
+      }
+
+      injectContext(state: any) {
+        this.injectSubconsciousAssistantContext(state);
+      }
+    }
+
+    const node = new TestNode('test-node', 'TestNode');
+    const state: any = {
+      messages: [
+        {
+          role: 'assistant',
+          content: '<human_identity_context>\nstale\n</human_identity_context>',
+          metadata: { source: 'subconscious_context', _synthetic: true },
+        },
+        { role: 'user', content: 'current turn' },
+      ],
+      metadata: { humanIdentityContext: 'fresh' },
+    };
+
+    (node as any).injectContext(state);
+
+    expect(state.messages).toHaveLength(2);
+    expect(state.messages[0].content).toContain('fresh');
+    expect(state.messages[0].content).not.toContain('stale');
+  });
 });

--- a/pkg/rancher-desktop/agent/prompts/SystemPromptBuilder.ts
+++ b/pkg/rancher-desktop/agent/prompts/SystemPromptBuilder.ts
@@ -8,7 +8,8 @@
  * - Sections are registered factories that return content or null (skip)
  * - Cache boundary splits stable vs dynamic content for Anthropic KV cache
  * - Prompt modes (full/minimal/none) control which sections are included
- * - Agent config .md files can override any section by matching the section ID
+ * - Agent config .md files can override sections by matching the section ID
+ *   (except Heartbeat's frozen operator contract)
  */
 
 import type { ChatMode } from '../controllers/ChatController';
@@ -179,11 +180,21 @@ class SystemPromptBuilderImpl {
       // Skip if mode doesn't match
       if (!reg.modes.has(ctx.mode)) continue;
 
+      // Heartbeat's operator contract is frozen and DB-backed. Legacy files in
+      // ~/sulla/agents/heartbeat previously leaked in through two paths:
+      // heartbeat.md replaced the registered heartbeat section, while files
+      // such as PLAYBOOK.md were concatenated into agent_prompt. Both paths
+      // made stale install-local doctrine outrank the shipped contract.
+      if (ctx.isHeartbeat && id === 'agent_prompt') continue;
+      const isFrozenHeartbeatSection = ctx.isHeartbeat && id === 'heartbeat';
+
       // Skip if agent config excludes this section
-      if (ctx.excludeSections.has(id)) continue;
+      if (ctx.excludeSections.has(id) && !isFrozenHeartbeatSection) continue;
 
       // Check for agent config override
-      const override = ctx.agentSectionOverrides.get(id);
+      const override = isFrozenHeartbeatSection
+        ? undefined
+        : ctx.agentSectionOverrides.get(id);
       if (override !== undefined) {
         // Use override content with the factory's default priority/stability
         // We still call the factory to get the default metadata (priority, cacheStability)

--- a/pkg/rancher-desktop/agent/prompts/SystemPromptBuilder.ts
+++ b/pkg/rancher-desktop/agent/prompts/SystemPromptBuilder.ts
@@ -66,8 +66,10 @@ export interface PromptBuildContext {
   /** Sections to exclude entirely (from config.yaml exclude_sections) */
   excludeSections:       Set<string>;
   /**
-   * DB-backed system-prompt sections (SystemPromptSectionModel), keyed by id —
-   * the editable CORE layer. Enabled rows only. For a REGISTERED section id the
+   * DB-backed prompt sections (SystemPromptSectionModel), keyed by id — the
+   * editable CORE layer. Enabled rows only. The subconscious-produced `user`
+   * row is returned as assistant context instead of system content. For any
+   * other REGISTERED section id the
    * content replaces the baked factory content (unless an agent .md override is
    * present, which still wins, or the section is generated — see isGenerated).
    * A row whose id has no registered factory is injected as a NEW section using
@@ -109,6 +111,12 @@ export interface BuiltPrompt {
   anthropicSystem?: AnthropicSystemBlock[];
   /** Which sections were included in the build */
   includedSections: string[];
+  /**
+   * Contextual sections that must be delivered as assistant-role context,
+   * never as system instructions. This includes the `observational_memory`
+   * recall section and the dream-consolidated DB `user` section.
+   */
+  assistantContextSections: PromptSection[];
   /**
    * Heartbeat-only: runtime invariant check of the composed prompt — confirms
    * the deployed continuous-operator wording is present and the #581 STOP-ceiling
@@ -170,11 +178,13 @@ class SystemPromptBuilderImpl {
       return {
         text:             ctx.basePrompt || 'You are a personal assistant operating inside Sulla Desktop.',
         includedSections: [],
+        assistantContextSections: [],
       };
     }
 
     // Collect sections
     const builtSections: PromptSection[] = [];
+    const assistantContextSections: PromptSection[] = [];
 
     for (const [id, reg] of this.sections) {
       // Skip if mode doesn't match
@@ -261,13 +271,28 @@ class SystemPromptBuilderImpl {
         if (this.sections.has(id)) continue;
         if (ctx.excludeSections.has(id)) continue;
         if (!row.content?.trim()) continue;
-        builtSections.push({
+        const section = {
           id,
           content:        row.content,
           priority:       row.priority,
           cacheStability: row.cacheStability,
-        });
+        };
+        if (id === 'user') {
+          assistantContextSections.push(section);
+        } else {
+          builtSections.push(section);
+        }
       }
+    }
+
+    // Observational memory is subconscious context, not governing policy.
+    // Factories still build it normally, but it leaves the system section list
+    // here and travels through the same assistant-role carrier as the DB user
+    // identity section.
+    for (let i = builtSections.length - 1; i >= 0; i--) {
+      if (builtSections[i].id !== 'observational_memory') continue;
+      assistantContextSections.unshift(builtSections[i]);
+      builtSections.splice(i, 1);
     }
 
     // Sort by priority
@@ -358,7 +383,7 @@ class SystemPromptBuilderImpl {
       }
     }
 
-    return { text, anthropicSystem, includedSections, heartbeatInvariants };
+    return { text, anthropicSystem, includedSections, assistantContextSections, heartbeatInvariants };
   }
 }
 

--- a/pkg/rancher-desktop/agent/prompts/__tests__/SystemPromptBuilder.assistantContext.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/SystemPromptBuilder.assistantContext.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { SystemPromptBuilder, type PromptBuildContext } from '../SystemPromptBuilder';
+
+describe('SystemPromptBuilder assistant context routing', () => {
+  it('keeps the subconscious-produced user section out of the system prompt', async() => {
+    const ctx: PromptBuildContext = {
+      mode:                  'full',
+      agentId:               'test-agent',
+      agentConfig:           null,
+      provider:              'openai',
+      chatMode:              'text',
+      trustLevel:            'trusted',
+      isSubAgent:            false,
+      isHeartbeat:           false,
+      wsChannel:             'test',
+      templateVars:          {},
+      agentSectionOverrides: new Map(),
+      excludeSections:       new Set(),
+      dbSections:            new Map([
+        ['user', {
+          content: 'dream-consolidated human identity',
+          priority: 35,
+          cacheStability: 'semi-stable',
+          isGenerated: false,
+        }],
+        ['custom_policy', {
+          content: 'explicit custom system policy',
+          priority: 36,
+          cacheStability: 'stable',
+          isGenerated: false,
+        }],
+      ]),
+      basePrompt: '',
+    };
+
+    const built = await SystemPromptBuilder.build(ctx);
+
+    expect(built.text).not.toContain('dream-consolidated human identity');
+    expect(built.includedSections).not.toContain('user');
+    expect(built.assistantContextSections).toEqual([
+      expect.objectContaining({ id: 'user', content: 'dream-consolidated human identity' }),
+    ]);
+    expect(built.text).toContain('explicit custom system policy');
+    expect(built.includedSections).toContain('custom_policy');
+  });
+
+  it('routes the registered observational-memory section out of system text too', async() => {
+    SystemPromptBuilder.register('observational_memory', () => ({
+      id: 'observational_memory',
+      content: 'top-ten recalled observations',
+      priority: 37,
+      cacheStability: 'semi-stable',
+    }), ['full']);
+
+    try {
+      const built = await SystemPromptBuilder.build({
+        mode: 'full',
+        agentId: 'test-agent',
+        agentConfig: null,
+        provider: 'openai',
+        chatMode: 'text',
+        trustLevel: 'trusted',
+        isSubAgent: false,
+        isHeartbeat: false,
+        wsChannel: 'test',
+        templateVars: {},
+        agentSectionOverrides: new Map(),
+        excludeSections: new Set(),
+        basePrompt: '',
+      });
+
+      expect(built.text).not.toContain('top-ten recalled observations');
+      expect(built.includedSections).not.toContain('observational_memory');
+      expect(built.assistantContextSections).toEqual([
+        expect.objectContaining({ id: 'observational_memory', content: 'top-ten recalled observations' }),
+      ]);
+    } finally {
+      SystemPromptBuilder.unregister('observational_memory');
+    }
+  });
+});

--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatInvariants.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatInvariants.test.ts
@@ -82,6 +82,38 @@ describe('SystemPromptBuilder heartbeat invariant wiring', () => {
     expect(built.heartbeatInvariants?.ok).toBe(true);
   });
 
+  it('does not let install-local markdown replace or append to the frozen heartbeat contract', async () => {
+    SystemPromptBuilder.register('agent_prompt', () => ({
+      id:             'agent_prompt',
+      content:        'STALE LOCAL PLAYBOOK CONTENT',
+      priority:       90,
+      cacheStability: 'stable',
+    }), ['full']);
+    SystemPromptBuilder.register('heartbeat', () => ({
+      id:             'heartbeat',
+      content:        heartbeatPrompt,
+      priority:       110,
+      cacheStability: 'stable',
+    }), ['full']);
+
+    const built = await SystemPromptBuilder.build(baseCtx({
+      agentConfig: {
+        prompt: 'STALE LOCAL PLAYBOOK CONTENT',
+      },
+      agentSectionOverrides: new Map([
+        ['heartbeat', 'STALE LOCAL HEARTBEAT OVERRIDE'],
+      ]),
+      excludeSections: new Set(['heartbeat']),
+    }));
+
+    expect(built.includedSections).toContain('heartbeat');
+    expect(built.includedSections).not.toContain('agent_prompt');
+    expect(built.text).toContain('## Orchestrator Mode — Fan Out, Then Verify');
+    expect(built.text).not.toContain('STALE LOCAL HEARTBEAT OVERRIDE');
+    expect(built.text).not.toContain('STALE LOCAL PLAYBOOK CONTENT');
+    expect(built.heartbeatInvariants?.ok).toBe(true);
+  });
+
   it('flags a stale/reverted heartbeat build', async () => {
     SystemPromptBuilder.register('heartbeat', () => ({
       id:             'heartbeat',

--- a/pkg/rancher-desktop/agent/prompts/generateClaudeCodeMemoryFile.ts
+++ b/pkg/rancher-desktop/agent/prompts/generateClaudeCodeMemoryFile.ts
@@ -4,7 +4,8 @@
  * written — no cherry-picking, no section markers, no partial injection.
  *
  * Called on every Claude Code session spawn AND whenever observational memory
- * is updated (add/remove_observational_memory tools) so the file stays current.
+ * is updated. Subconscious observation and identity context is intentionally
+ * excluded by SystemPromptBuilder and delivered in an assistant message.
  */
 
 import * as fs from 'fs';

--- a/pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts
+++ b/pkg/rancher-desktop/agent/prompts/sections/observationalMemory.ts
@@ -1,7 +1,7 @@
 /**
- * Observational Memory Section — Injects a slim set of top-priority
- * observations into the system prompt so the active LLM has baseline
- * "what I know about this user/business" context.
+ * Observational Memory Section — Builds a slim set of top-priority
+ * observations for assistant-role injection so the active LLM has baseline
+ * "what I know about this user/business" context without polluting policy.
  *
  * PRIMARY PATH: reads the top 10 critical/high-priority active rows from the
  * observations Postgres table (cheap direct query, no LLM involved).
@@ -14,9 +14,8 @@
  * Full memory (all observations) is accessible via the observation-recall
  * subconscious agent or via the search_observations / list_observations tools.
  *
- * Cache stability: 'semi-stable' — top-N snapshot changes infrequently
- * relative to the turn rate, so it doesn't bust the stable prompt cache
- * on every turn.
+ * Cache stability remains descriptive metadata; SystemPromptBuilder routes
+ * this section out of system content and into its assistant-context result.
  */
 
 import { ObservationsModel } from '../../database/models/ObservationsModel';
@@ -26,7 +25,7 @@ import { formatDateOnly } from '../../utils/formatDateOnly';
 
 import type { PromptBuildContext, PromptSection } from '../SystemPromptBuilder';
 
-/** Max observations to inject into the system prompt. */
+/** Max observations to inject into the assistant context message. */
 const TOP_N = 10;
 
 interface ObservationEntry {


### PR DESCRIPTION
## Root causes proven from the raw Heartbeat request log

The logged role=system payload was being inflated through three independent paths:

- install-local Heartbeat Markdown replaced or appended to the frozen operator contract;
- the registered observational_memory factory inserted the full top-priority memory block into system content;
- the dream-consolidated DB user section was injected as a custom system section.

CodexService and ClaudeCodeService then duplicated per-turn observation, identity, skills, projects, and conversation recall inside the outgoing user prefix for resumed CLI sessions.

## Fix

- Heartbeat ignores install-local heartbeat overrides, generic agent_prompt files, and local exclusions of its frozen contract.
- SystemPromptBuilder routes observational_memory and the DB user identity section out of system text.
- BaseNode creates one replace-only synthetic assistant message immediately before the latest user turn.
- AgentNode and HeartbeatNode share that same injection path.
- Fresh CLI sessions receive the assistant message through the full role-labeled transcript.
- Resumed Codex and Claude sessions replay contiguous synthetic Assistant messages before the current User message.
- Removed the duplicated subconscious blocks and legacy high-priority observational-memory copy from both CLI user-prefix builders.

The live install-local Markdown files were also moved into ~/sulla/agents/heartbeat/retired-prompt-files/; that reversible local cleanup is intentionally outside this product diff.

## Verification

- Focused regression suites pass: system routing, assistant-carrier replacement, Codex/Claude resumed-turn replay, Heartbeat prompt coverage, and Heartbeat invariants.
- Full tsc --noEmit passed at the implementation checkpoint.
- Final incremental tsc --noEmit passed with a 4096 MB heap after a repeat full run was killed by host memory pressure.
- git diff --check passed.
- Existing broader HeartbeatNode.workContext suite has three failures from newer main mocks (undefined selected-item arrays / report scope), unrelated to these changed paths; prompt and invariant suites remain green.

Refs Projects task QAw7.