### PR TITLE
fix(chat): keep post-loop subconscious writers silent

### DIFF
--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -1883,6 +1883,17 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     // their emissions render in the chat bubble but don't affect run-state.
     messageType: 'assistant_message' | 'subconscious_message' = 'assistant_message',
   ): Promise<boolean> {
+    // Post-turn subconscious writers are fire-and-forget observers. Their
+    // graph runs after the primary graph has already emitted completion, so
+    // ANY chat emission from them can reopen the finished run in the UI.
+    // Keep this guard at the shared WebSocket boundary: provider streaming,
+    // activity callbacks, tool rendering, and SubconsciousAgentNode narration
+    // all eventually pass through here, while a guard in the subclass only
+    // catches the last of those paths.
+    if ((state.metadata as any).subconsciousSilent === true) {
+      return true;
+    }
+
     // Defence-in-depth: strip agent protocol XML before any user-visible output
     content = stripProtocolTags(content);
     // Segment-boundary sentinels (streaming_complete, thinking_complete)

--- a/pkg/rancher-desktop/agent/nodes/__tests__/BaseNode.conversationLogging.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/BaseNode.conversationLogging.test.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const logMessageMock: any = jest.fn();
 const logToolCallMock: any = jest.fn();
+const wsSendMock: any = jest.fn(async() => true);
 
 // BaseNode reaches the conversation logger through a lazy `require(...)`
 // inside a try/catch (deliberate — avoids a hard import cycle). Under
@@ -84,7 +85,7 @@ jest.unstable_mockModule('../../services/JsonParseService', () => ({
 
 jest.unstable_mockModule('../../services/WebSocketClientService', () => ({
   getWebSocketClientService: jest.fn(() => ({
-    send:        jest.fn(async() => true),
+    send:        wsSendMock,
     onMessage:   jest.fn(),
     connect:     jest.fn(() => true),
     isConnected: jest.fn(() => true),
@@ -112,6 +113,7 @@ describe('BaseNode conversation logging', () => {
   beforeEach(() => {
     logMessageMock.mockReset();
     logToolCallMock.mockReset();
+    wsSendMock.mockClear();
   });
 
   const buildState = () => ({
@@ -186,6 +188,36 @@ describe('BaseNode conversation logging', () => {
     await node.send(state, 'streaming_complete');
     await node.send(state, 'thinking_complete');
 
+    expect(logMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('suppresses every WebSocket emission from a silent post-turn subconscious writer', async() => {
+    const { BaseNode } = await import('../BaseNode');
+
+    class TestNode extends BaseNode<any> {
+      async execute(state: any) {
+        return { state, decision: { type: 'end' as const }, response: '' };
+      }
+
+      async send(state: any, content: string, kind: string, messageType: 'assistant_message' | 'subconscious_message' = 'assistant_message') {
+        return this.wsChatMessage(state, content, 'assistant', kind, undefined, messageType);
+      }
+    }
+
+    const node = new TestNode('test-node', 'TestNode');
+    const state = buildState();
+    state.metadata.isSubAgent = true;
+    state.metadata.subconsciousSilent = true;
+    state.metadata.parentWsChannel = 'sulla-desktop';
+
+    // These cover the shared provider-stream paths that bypassed
+    // SubconsciousAgentNode.emitThinking() and reopened graphRunning after
+    // the primary loop had completed.
+    await node.send(state, 'Provider is still thinking', 'thinking');
+    await node.send(state, 'partial observer output', 'streaming');
+    await node.send(state, '', 'thinking_complete', 'subconscious_message');
+
+    expect(wsSendMock).not.toHaveBeenCalled();
     expect(logMessageMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Problem
Post-turn subconscious writers run after `graph_execution_complete`. Although their explicit narration was marked silent, provider activity and streaming callbacks inherited from `BaseNode` bypassed that subclass guard. Parent-channel activity arrived as `assistant_message`, which set `graphRunning` back to true and left the chat UI looking active after the primary loop stopped.

## Fix
Gate `subconsciousSilent` at the shared `BaseNode.wsChatMessage()` boundary. This suppresses every user-visible writer emission, including provider thinking, streaming chunks, tool UI, and completion sentinels. Pre-turn recall remains visible because recall states are not marked silent.

## Verification
`node --experimental-vm-modules node_modules/.bin/jest pkg/rancher-desktop/agent/nodes/__tests__/BaseNode.conversationLogging.test.ts pkg/rancher-desktop/agent/database/models/__tests__/MessageDispatcher.thinking.test.ts --runInBand`

2 suites passed, 10/10 tests passed.