### PR TITLE
fix(codex): expose graph-bound native workflow tools

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -4,12 +4,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { BaseLanguageModel, type ChatMessage, type NormalizedResponse, type StreamCallbacks, FinishReason } from './BaseLanguageModel';
-import { ensureCodexAuthFile, codexAuthPath, codexHomeDir } from '../util/codexAuthFile';
+import { buildCodexMcpOverrides, CODEX_MCP_TOKEN_ENV } from './codexMcpConfig';
 import { redisClient } from '../database/RedisClient';
-import Logging from '@pkg/utils/logging';
-import paths from '@pkg/utils/paths';
+import { ensureCodexAuthFile, codexAuthPath, codexHomeDir } from '../util/codexAuthFile';
 
 import type { BaseThreadState } from '@pkg/agent/nodes/Graph';
+import { getMCPServerHost, type RegisteredSession } from '@pkg/main/MCPServerHost';
+import Logging from '@pkg/utils/logging';
+import paths from '@pkg/utils/paths';
 
 const log = Logging.background;
 
@@ -23,6 +25,7 @@ const PREWARM_IDLE_REAP_MS = 60_000;
  */
 interface CodexPrewarmRecord {
   proc:            childProcess.ChildProcessWithoutNullStreams;
+  mcpSession:      RegisteredSession | null;
   model:           string;
   existingSession: string | undefined;
   createdAt:       number;
@@ -39,7 +42,8 @@ interface CodexPrewarmRecord {
  * loop, tool execution, and context management inside the CLI process, so
  * from Sulla's perspective it behaves as a "one-shot completion" peer. Tool
  * work happens internally (shell, file edits, and the `sulla` CLI which is
- * on PATH in the VM — no MCP wiring needed for native tool access).
+ * on PATH in the VM). State-mutating Sulla tools are supplied through the
+ * same short-lived, graph-bound MCP bridge used by Claude Code.
  *
  * Auth: ~/.codex/auth.json, written by CodexOAuth on sign-in and on every
  * scheduled token refresh. The host home is mounted into the Lima VM, and
@@ -151,7 +155,7 @@ export class CodexService extends BaseLanguageModel {
    * process before the turn's prompt exists — runCodex and prewarm both
    * write the prompt to stdin themselves, at different times.
    */
-  private buildSpawnArgs(p: { existingSession?: string }): string[] {
+  private buildSpawnArgs(p: { existingSession?: string; mcpSession?: RegisteredSession | null }): string[] {
     const shq = (s: string) => `'${ s.replace(/'/g, "'\\''") }'`;
 
     const codexArgs = ['codex', 'exec'];
@@ -163,6 +167,11 @@ export class CodexService extends BaseLanguageModel {
       '--dangerously-bypass-approvals-and-sandbox',
       '--skip-git-repo-check',
     );
+    if (p.mcpSession) {
+      for (const override of buildCodexMcpOverrides(p.mcpSession)) {
+        codexArgs.push('-c', shq(override));
+      }
+    }
     if (this.model && this.model !== 'codex') {
       codexArgs.push('--model', shq(this.model));
     }
@@ -178,7 +187,10 @@ export class CodexService extends BaseLanguageModel {
     // `exec` replaces the inner sh with codex so there's no shell layer
     // between the SSH session and the CLI — best chance of signal
     // propagation when we kill limactl on the host side.
-    const innerCmd = `export CODEX_HOME=${ hostCodexHome } HOME=${ hostHome }; exec ${ codexArgs.join(' ') }`;
+    const mcpTokenExport = p.mcpSession
+      ? ` ${ CODEX_MCP_TOKEN_ENV }=${ shq(p.mcpSession.id) }`
+      : '';
+    const innerCmd = `export CODEX_HOME=${ hostCodexHome } HOME=${ hostHome }${ mcpTokenExport }; exec ${ codexArgs.join(' ') }`;
     return ['shell', '0', '--', 'sh', '-c', innerCmd];
   }
 
@@ -209,15 +221,22 @@ export class CodexService extends BaseLanguageModel {
 
       const existingSession = await this.getSession(convId);
 
+      let mcpSession: RegisteredSession | null = null;
+      try {
+        const host = getMCPServerHost();
+        if (host.running) mcpSession = host.registerSession(state);
+      } catch { /* continue without sulla-native tools */ }
+
       const limactlPath = paths.limactl;
       const limaHome = paths.lima;
-      const args = this.buildSpawnArgs({ existingSession });
+      const args = this.buildSpawnArgs({ existingSession, mcpSession });
       const proc = childProcess.spawn(limactlPath, args, {
         env: { ...process.env, LIMA_HOME: limaHome, TERM: 'dumb' },
       });
 
       const record: CodexPrewarmRecord = {
         proc,
+        mcpSession,
         model:     this.model || 'codex',
         existingSession,
         createdAt: Date.now(),
@@ -275,6 +294,7 @@ export class CodexService extends BaseLanguageModel {
   private killPrewarmRecord(rec: CodexPrewarmRecord): void {
     if (rec.reapTimer) { clearTimeout(rec.reapTimer); rec.reapTimer = null; }
     try { rec.proc.kill('SIGTERM'); } catch { /* already dead */ }
+    try { rec.mcpSession?.revoke() } catch { /* already revoked */ }
   }
 
   override getContextWindow(): number {
@@ -640,9 +660,30 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
     // multiplexing channel (same failure mode ClaudeCodeService hit).
     const speculative = await this.speculativeBootEnabled();
     const adopted = speculative ? this.claimPrewarm(convId, this.model || 'codex', existingSession) : null;
-    const args = this.buildSpawnArgs({ existingSession });
+
+    let mcpSession: RegisteredSession | null = adopted?.mcpSession ?? null;
+    if (mcpSession && options.state) {
+      try { getMCPServerHost().rebindSession(mcpSession.id, options.state) } catch { /* continue with prewarm binding */ }
+    } else if (!mcpSession && options.state) {
+      try {
+        const host = getMCPServerHost();
+        if (host.running) {
+          mcpSession = host.registerSession(options.state);
+          log.log(`[CodexService] MCP session minted — url=${ mcpSession.url }`);
+        }
+      } catch (err) {
+        log.log(`[CodexService] MCP session setup failed, continuing without sulla-native tools: ${ (err as Error)?.message ?? err }`);
+      }
+    }
+    const args = this.buildSpawnArgs({ existingSession, mcpSession });
 
     return await new Promise((resolve, reject) => {
+      let mcpCleaned = false;
+      const cleanupMcp = () => {
+        if (mcpCleaned) return;
+        mcpCleaned = true;
+        try { mcpSession?.revoke() } catch { /* already revoked */ }
+      };
       let proc: childProcess.ChildProcessWithoutNullStreams;
       let adoptedSpawned = false;
       if (adopted) {
@@ -875,11 +916,13 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
 
       proc.on('error', (err) => {
         options.signal?.removeEventListener('abort', onAbort);
+        cleanupMcp();
         reject(err);
       });
 
       proc.on('close', (code) => {
         options.signal?.removeEventListener('abort', onAbort);
+        cleanupMcp();
         if (stdoutBuffer.trim()) processLine(stdoutBuffer);
 
         // Binary missing — checked BEFORE the resume heuristic: sh's

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { BaseLanguageModel, type ChatMessage, type NormalizedResponse, type StreamCallbacks, FinishReason } from './BaseLanguageModel';
-import { buildCodexMcpOverrides, CODEX_MCP_TOKEN_ENV } from './codexMcpConfig';
+import { bindCodexMcpSession, buildCodexMcpOverrides, CODEX_MCP_TOKEN_ENV } from './codexMcpConfig';
 import { redisClient } from '../database/RedisClient';
 import { ensureCodexAuthFile, codexAuthPath, codexHomeDir } from '../util/codexAuthFile';
 
@@ -662,14 +662,13 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
     const adopted = speculative ? this.claimPrewarm(convId, this.model || 'codex', existingSession) : null;
 
     let mcpSession: RegisteredSession | null = adopted?.mcpSession ?? null;
-    if (mcpSession && options.state) {
-      try { getMCPServerHost().rebindSession(mcpSession.id, options.state) } catch { /* continue with prewarm binding */ }
-    } else if (!mcpSession && options.state) {
+    if (options.state) {
       try {
         const host = getMCPServerHost();
-        if (host.running) {
-          mcpSession = host.registerSession(options.state);
-          log.log(`[CodexService] MCP session minted — url=${ mcpSession.url }`);
+        const boundSession = bindCodexMcpSession(host, options.state, mcpSession);
+        if (boundSession !== mcpSession) {
+          mcpSession = boundSession;
+          if (mcpSession) log.log(`[CodexService] MCP session minted — url=${ mcpSession.url }`);
         }
       } catch (err) {
         log.log(`[CodexService] MCP session setup failed, continuing without sulla-native tools: ${ (err as Error)?.message ?? err }`);

--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/CodexMcpBridge.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/CodexMcpBridge.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 
-import { buildCodexMcpOverrides, CODEX_MCP_TOKEN_ENV } from '../codexMcpConfig';
+import { bindCodexMcpSession, buildCodexMcpOverrides, CODEX_MCP_TOKEN_ENV } from '../codexMcpConfig';
+
+import type { BaseThreadState } from '@pkg/agent/nodes/Graph';
+import type { RegisteredSession } from '@pkg/main/MCPServerHost';
 
 describe('CodexService MCP bridge', () => {
   it('injects the graph-bound Sulla MCP server without writing persistent Codex config', () => {
@@ -17,5 +20,38 @@ describe('CodexService MCP bridge', () => {
 
   it('does not add MCP configuration when no graph state session is available', () => {
     expect(buildCodexMcpOverrides()).toEqual([]);
+  });
+
+  it('rebinds an adopted token to the current live graph state', () => {
+    const previousState = { metadata: { threadId: 'previous' } } as BaseThreadState;
+    const currentState = { metadata: { threadId: 'current' } } as BaseThreadState;
+    const session: RegisteredSession = { id: 'token', url: 'http://host/mcp', header: 'Bearer token', revoke: jest.fn() };
+    let registeredState: BaseThreadState | undefined;
+    const host = {
+      running:         true,
+      registerSession: (state: BaseThreadState) => { registeredState = state; return session },
+      rebindSession:   jest.fn<(id: string, state: BaseThreadState) => boolean>().mockReturnValue(true),
+    };
+
+    expect(bindCodexMcpSession(host, currentState, session)).toBe(session);
+    expect(host.rebindSession).toHaveBeenCalledWith('token', currentState);
+    expect(host.rebindSession).not.toHaveBeenCalledWith('token', previousState);
+    expect(registeredState).toBeUndefined();
+  });
+
+  it('replaces an expired adopted token with a session bound to the current state', () => {
+    const currentState = { metadata: { threadId: 'current' } } as BaseThreadState;
+    const expired: RegisteredSession = { id: 'expired', url: 'http://host/mcp', header: 'Bearer expired', revoke: jest.fn() };
+    const replacement: RegisteredSession = { id: 'fresh', url: 'http://host/mcp', header: 'Bearer fresh', revoke: jest.fn() };
+    let registeredState: BaseThreadState | undefined;
+    const host = {
+      running:         true,
+      registerSession: (state: BaseThreadState) => { registeredState = state; return replacement },
+      rebindSession:   jest.fn<(id: string, state: BaseThreadState) => boolean>().mockReturnValue(false),
+    };
+
+    expect(bindCodexMcpSession(host, currentState, expired)).toBe(replacement);
+    expect(expired.revoke).toHaveBeenCalledTimes(1);
+    expect(registeredState).toBe(currentState);
   });
 });

--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/CodexMcpBridge.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/CodexMcpBridge.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { buildCodexMcpOverrides, CODEX_MCP_TOKEN_ENV } from '../codexMcpConfig';
+
+describe('CodexService MCP bridge', () => {
+  it('injects the graph-bound Sulla MCP server without writing persistent Codex config', () => {
+    const overrides = buildCodexMcpOverrides({
+      url: 'http://host.lima.internal:43123/mcp',
+    });
+
+    expect(overrides).toEqual([
+      'mcp_servers.sulla-native.url="http://host.lima.internal:43123/mcp"',
+      'mcp_servers.sulla-native.bearer_token_env_var="SULLA_MCP_SESSION_TOKEN"',
+    ]);
+    expect(CODEX_MCP_TOKEN_ENV).toBe('SULLA_MCP_SESSION_TOKEN');
+  });
+
+  it('does not add MCP configuration when no graph state session is available', () => {
+    expect(buildCodexMcpOverrides()).toEqual([]);
+  });
+});

--- a/pkg/rancher-desktop/agent/languagemodels/codexMcpConfig.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/codexMcpConfig.ts
@@ -1,0 +1,14 @@
+export const CODEX_MCP_TOKEN_ENV = 'SULLA_MCP_SESSION_TOKEN';
+
+interface CodexMcpSessionConfig {
+  url: string;
+}
+
+/** Per-process Codex CLI overrides for Sulla's graph-bound MCP bridge. */
+export function buildCodexMcpOverrides(session?: CodexMcpSessionConfig | null): string[] {
+  if (!session) return [];
+  return [
+    `mcp_servers.sulla-native.url=${ JSON.stringify(session.url) }`,
+    `mcp_servers.sulla-native.bearer_token_env_var=${ JSON.stringify(CODEX_MCP_TOKEN_ENV) }`,
+  ];
+}

--- a/pkg/rancher-desktop/agent/languagemodels/codexMcpConfig.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/codexMcpConfig.ts
@@ -1,7 +1,30 @@
+import type { BaseThreadState } from '@pkg/agent/nodes/Graph';
+import type { RegisteredSession } from '@pkg/main/MCPServerHost';
+
 export const CODEX_MCP_TOKEN_ENV = 'SULLA_MCP_SESSION_TOKEN';
 
 interface CodexMcpSessionConfig {
   url: string;
+}
+
+interface CodexMcpSessionHost {
+  running: boolean;
+  registerSession(state: BaseThreadState): RegisteredSession;
+  rebindSession(id: string, state: BaseThreadState): boolean;
+}
+
+/** Bind an existing token to this turn, minting a replacement if it expired. */
+export function bindCodexMcpSession(
+  host: CodexMcpSessionHost,
+  state: BaseThreadState,
+  existing?: RegisteredSession | null,
+): RegisteredSession | null {
+  if (!host.running) return existing ?? null;
+  if (existing && host.rebindSession(existing.id, state)) return existing;
+  if (existing) {
+    try { existing.revoke() } catch { /* already revoked */ }
+  }
+  return host.registerSession(state);
 }
 
 /** Per-process Codex CLI overrides for Sulla's graph-bound MCP bridge. */


### PR DESCRIPTION
## What changed

Codex turns now receive Sulla native tools through the existing graph-bound MCP bridge, matching Claude Code. The provider mints a short-lived MCP session, passes Codex per-process HTTP MCP overrides plus a bearer-token environment variable, carries the binding through speculative prewarm, rebinds it on adoption, and revokes it when the process exits. No persistent Codex config is written.

This unblocks native execute_workflow calls that need live BaseThreadState, including the isolated BUSINESS-only Thinker acceptance in Projects task T195/sADe. Existing workflow scope, trigger, and concurrent-run guards still execute inside activateWorkflowOnState.

## Verification

Focused Jest CodexMcpBridge.test.ts passed 2/2. esbuild parse and bundle of CodexService.ts passed. The installed Codex CLI accepted both overrides and reported sulla-native enabled with bearer-token auth. ESLint reports only pre-existing CodexService.ts violations; the new helper and test add none.

No workflow was run, no schedule was enabled, and no runtime deployment was performed.