### PR TITLE
fix(codex): log completed tool events

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/BaseLanguageModel.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/BaseLanguageModel.ts
@@ -73,9 +73,10 @@ export interface StreamCallbacks {
    * write one conversation-log entry (tool name, key input, result size/
    * error) without the caller needing to correlate call/result itself.
    *
-   * Currently only ClaudeCodeService fires this — CLI tool execution
-   * happens inside the spawned `claude -p` process, invisible to Sulla's
-   * own ToolExecutor, so this is the only place that sees it.
+   * CLI-backed providers fire this because their tool execution happens
+   * inside the spawned provider process, invisible to Sulla's own
+   * ToolExecutor. Claude Code correlates tool_use/tool_result blocks; Codex
+   * normalizes completed command and MCP items from its JSON event stream.
    */
   onToolEvent?: (event: {
     toolUseId:  string;

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 
 import { BaseLanguageModel, type ChatMessage, type NormalizedResponse, type StreamCallbacks, FinishReason } from './BaseLanguageModel';
 import { bindCodexMcpSession, buildCodexMcpOverrides, CODEX_MCP_TOKEN_ENV } from './codexMcpConfig';
+import { emitCodexToolEvent } from './codexToolEvents';
 import { redisClient } from '../database/RedisClient';
 import { ensureCodexAuthFile, codexAuthPath, codexHomeDir } from '../util/codexAuthFile';
 
@@ -824,6 +825,7 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
               const activity = activityForItem(item);
               if (activity) emitActivity(activity);
             }
+            emitCodexToolEvent(parsed.type, item, callbacks.onToolEvent);
             if (kind === 'error' && parsed.type === 'item.completed') {
               errored = true;
               if (typeof item.message === 'string') errorMessage = item.message;

--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/CodexToolEvents.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/CodexToolEvents.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { codexToolEventForItem, emitCodexToolEvent } from '../codexToolEvents';
+
+describe('CodexService tool-event normalization', () => {
+  it('captures completed command execution details and failures', () => {
+    expect(codexToolEventForItem({
+      id:                'item-1',
+      type:              'command_execution',
+      command:           'printf hello',
+      cwd:               '/workspace',
+      aggregated_output: 'hello',
+      exit_code:         7,
+      status:            'failed',
+    })).toEqual({
+      toolUseId:   'item-1',
+      toolName:    'command_execution',
+      input:       { command: 'printf hello', cwd: '/workspace' },
+      resultChars: 5,
+      isError:     true,
+    });
+  });
+
+  it('captures MCP tool arguments and structured result size', () => {
+    const result = { content: [{ type: 'text', text: 'project data' }] };
+
+    expect(codexToolEventForItem({
+      id:        'item-2',
+      type:      'mcp_tool_call',
+      server:    'sulla-native',
+      tool:      'project_get_project_item',
+      arguments: { id: '7BAO' },
+      result,
+      status:    'completed',
+    })).toEqual({
+      toolUseId:   'item-2',
+      toolName:    'sulla-native/project_get_project_item',
+      input:       { id: '7BAO' },
+      resultChars: JSON.stringify(result).length,
+      isError:     undefined,
+    });
+  });
+
+  it('ignores non-tool and unidentifiable items', () => {
+    expect(codexToolEventForItem({ id: 'item-3', type: 'agent_message', text: 'done' })).toBeNull();
+    expect(codexToolEventForItem({ type: 'mcp_tool_call', tool: 'missing_id' })).toBeNull();
+  });
+
+  it('forwards only completed tool items to the stream callback', () => {
+    const callback = jest.fn();
+    const item = {
+      id:                'item-4',
+      type:              'command_execution',
+      command:           'pwd',
+      aggregated_output: '/workspace',
+      exit_code:         0,
+      status:            'completed',
+    };
+
+    emitCodexToolEvent('item.started', item, callback);
+    expect(callback).not.toHaveBeenCalled();
+
+    emitCodexToolEvent('item.completed', item, callback);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({
+      toolUseId: 'item-4',
+      toolName:  'command_execution',
+      isError:   undefined,
+    }));
+  });
+});

--- a/pkg/rancher-desktop/agent/languagemodels/codexToolEvents.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/codexToolEvents.ts
@@ -1,0 +1,80 @@
+export interface CodexToolEvent {
+  toolUseId:   string;
+  toolName:    string;
+  input?:      unknown;
+  resultChars: number;
+  isError?:    boolean;
+}
+
+function serializedLength(value: unknown): number {
+  if (typeof value === 'string') return value.length;
+  if (value === undefined || value === null) return 0;
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return String(value).length;
+  }
+}
+
+/** Normalize a completed `codex exec --json` tool item for conversation logs. */
+export function codexToolEventForItem(item: any): CodexToolEvent | null {
+  const kind = item?.item_type ?? item?.type;
+  const toolUseId = item?.id ?? item?.call_id;
+  if (typeof toolUseId !== 'string' || !toolUseId) return null;
+
+  const failed = item?.status === 'failed' || item?.status === 'error' || Boolean(item?.error);
+
+  switch (kind) {
+  case 'command_execution': {
+    const result = item.aggregated_output ?? item.output ?? item.stderr ?? item.stdout;
+    return {
+      toolUseId,
+      toolName:    'command_execution',
+      input:       { command: item.command, cwd: item.cwd },
+      resultChars: serializedLength(result),
+      isError:     failed || (typeof item.exit_code === 'number' && item.exit_code !== 0) || undefined,
+    };
+  }
+  case 'mcp_tool_call': {
+    const server = typeof item.server === 'string' && item.server ? `${ item.server }/` : '';
+    const tool = typeof item.tool === 'string' && item.tool ? item.tool : 'mcp_tool_call';
+    return {
+      toolUseId,
+      toolName:    `${ server }${ tool }`,
+      input:       item.arguments ?? item.input,
+      resultChars: serializedLength(item.result ?? item.output ?? item.error),
+      isError:     failed || undefined,
+    };
+  }
+  case 'web_search':
+    return {
+      toolUseId,
+      toolName:    'web_search',
+      input:       { query: item.query },
+      resultChars: serializedLength(item.result ?? item.output),
+      isError:     failed || undefined,
+    };
+  case 'file_change':
+    return {
+      toolUseId,
+      toolName:    'file_change',
+      input:       { changes: item.changes },
+      resultChars: serializedLength(item.changes),
+      isError:     failed || undefined,
+    };
+  default:
+    return null;
+  }
+}
+
+/** Forward exactly one completed Codex tool item to the stream callback. */
+export function emitCodexToolEvent(
+  eventType: string,
+  item: any,
+  callback?: (event: CodexToolEvent) => void,
+): void {
+  if (eventType !== 'item.completed' || !callback) return;
+  const event = codexToolEventForItem(item);
+  if (!event) return;
+  try { callback(event) } catch { /* provider callbacks are best-effort */ }
+}


### PR DESCRIPTION
## Why
PR #636 fixed assistant text and Claude CLI tool logging, but a fresh Codex worker still produced no tool_use/tool_result records. CodexService parsed completed command and MCP items only for UI activity and never forwarded them through StreamCallbacks.onToolEvent.

## What changed
- normalize completed Codex command_execution, mcp_tool_call, web_search, and file_change items
- forward one callback only when the item completes
- record key input, result character count, and failure state
- update the callback contract comment to cover both CLI-backed providers

## Verification
- CodexToolEvents.test.ts
- BaseNode.conversationLogging.test.ts
- 2 suites / 11 tests passed
- new helper and test pass ESLint

Projects task: 7BAO

Runtime acceptance still requires rebuild/restart plus one fresh Codex tool-using turn.