### PR TITLE
fix(voice): restore conversational barge-in

### DIFF
--- a/pkg/rancher-desktop/composables/voice/VoiceBargeInDetector.ts
+++ b/pkg/rancher-desktop/composables/voice/VoiceBargeInDetector.ts
@@ -1,0 +1,47 @@
+export const DEFAULT_BARGE_IN_GRACE_MS = 400;
+
+export interface VoiceBargeInDetector {
+  update(speaking: boolean, playbackActive: boolean): boolean;
+  reset(): void;
+}
+
+export interface VoiceBargeInDetectorOptions {
+  graceMs?: number;
+  now?:     () => number;
+}
+
+/**
+ * Distinguishes deliberate speech from short VAD spikes while Sulla is talking.
+ * Returns true once per sustained-speech interruption.
+ */
+export function createVoiceBargeInDetector(
+  options: VoiceBargeInDetectorOptions = {},
+): VoiceBargeInDetector {
+  const graceMs = options.graceMs ?? DEFAULT_BARGE_IN_GRACE_MS;
+  const now = options.now ?? Date.now;
+  let speechStartedAt: number | null = null;
+
+  return {
+    update(speaking: boolean, playbackActive: boolean): boolean {
+      if (!speaking || !playbackActive) {
+        speechStartedAt = null;
+        return false;
+      }
+
+      const currentTime = now();
+      if (speechStartedAt === null) {
+        speechStartedAt = currentTime;
+        return false;
+      }
+
+      if (currentTime - speechStartedAt < graceMs) return false;
+
+      speechStartedAt = null;
+      return true;
+    },
+
+    reset(): void {
+      speechStartedAt = null;
+    },
+  };
+}

--- a/pkg/rancher-desktop/composables/voice/__tests__/VoiceBargeInDetector.test.ts
+++ b/pkg/rancher-desktop/composables/voice/__tests__/VoiceBargeInDetector.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { createVoiceBargeInDetector } from '../VoiceBargeInDetector';
+
+describe('VoiceBargeInDetector', () => {
+  it('interrupts only after sustained speech reaches the grace period', () => {
+    let now = 1_000;
+    const detector = createVoiceBargeInDetector({ now: () => now });
+
+    expect(detector.update(true, true)).toBe(false);
+    now += 399;
+    expect(detector.update(true, true)).toBe(false);
+    now += 1;
+    expect(detector.update(true, true)).toBe(true);
+  });
+
+  it('ignores speech when playback is inactive', () => {
+    let now = 1_000;
+    const detector = createVoiceBargeInDetector({ now: () => now });
+
+    expect(detector.update(true, false)).toBe(false);
+    now += 1_000;
+    expect(detector.update(true, false)).toBe(false);
+    expect(detector.update(true, true)).toBe(false);
+  });
+
+  it('resets the grace period when speech stops', () => {
+    let now = 1_000;
+    const detector = createVoiceBargeInDetector({ now: () => now });
+
+    expect(detector.update(true, true)).toBe(false);
+    now += 300;
+    expect(detector.update(false, true)).toBe(false);
+    now += 300;
+    expect(detector.update(true, true)).toBe(false);
+    now += 399;
+    expect(detector.update(true, true)).toBe(false);
+    now += 1;
+    expect(detector.update(true, true)).toBe(true);
+  });
+
+  it('supports an explicit reset between playback queues', () => {
+    const now = jest.fn<() => number>()
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(2_000)
+      .mockReturnValueOnce(2_399)
+      .mockReturnValueOnce(2_400);
+    const detector = createVoiceBargeInDetector({ now });
+
+    expect(detector.update(true, true)).toBe(false);
+    detector.reset();
+    expect(detector.update(true, true)).toBe(false);
+    expect(detector.update(true, true)).toBe(false);
+    expect(detector.update(true, true)).toBe(true);
+  });
+});

--- a/pkg/rancher-desktop/composables/voice/index.ts
+++ b/pkg/rancher-desktop/composables/voice/index.ts
@@ -1,6 +1,7 @@
 // Voice system — barrel exports
 export { TypedEventEmitter } from './TypedEventEmitter';
 export { TTSPlayerService, type TTSPlayerEvents, type TTSPlayerConfig } from './TTSPlayerService';
+export { createVoiceBargeInDetector, DEFAULT_BARGE_IN_GRACE_MS, type VoiceBargeInDetector, type VoiceBargeInDetectorOptions } from './VoiceBargeInDetector';
 export { createVoiceTurnAccumulator, type VoiceTurnAccumulator, type VoiceTurnAccumulatorConfig } from './VoiceTurnAccumulator';
 export { useVoiceSession, type VoiceMode, type PipelineState, type UseVoiceSessionOptions, type UseVoiceSessionReturn } from './useVoiceSession';
 export { provideVoiceState, useVoiceState, type VoiceState } from './voiceStateProvider';

--- a/pkg/rancher-desktop/composables/voice/useVoiceSession.ts
+++ b/pkg/rancher-desktop/composables/voice/useVoiceSession.ts
@@ -22,8 +22,9 @@
 import { ref, readonly, watch, onUnmounted, type Ref } from 'vue';
 
 import { TTSPlayerService } from './TTSPlayerService';
-import { createVoiceTurnAccumulator } from './VoiceTurnAccumulator';
+import { createVoiceBargeInDetector } from './VoiceBargeInDetector';
 import { logBargeIn } from './VoiceLogger';
+import { createVoiceTurnAccumulator } from './VoiceTurnAccumulator';
 
 import { ipcRenderer as _ipcRenderer } from '@pkg/utils/ipcRenderer';
 
@@ -73,11 +74,6 @@ function formatDuration(seconds: number): string {
 // deliberately long so it never pre-empts a real utterance mid-thought — the old
 // 2000ms value collided with whisper's 2000ms chunk cadence and split utterances.
 const UTTERANCE_FALLBACK_MS = 8000;
-
-// How long the user must speak continuously before we treat it as a
-// barge-in and cut TTS off. Short sounds (coughs, "mm-hm", chair squeaks
-// the VAD flags as speech) should never kill Sulla mid-sentence.
-const BARGE_IN_GRACE_MS = 400;
 
 // ─── Composable ─────────────────────────────────────────────────
 
@@ -209,9 +205,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
 
   // ── VAD event handler (audio level meter + barge-in) ──
 
-  // Timestamp of the first VAD "speaking" frame while TTS was playing;
-  // 0 when the user is not speaking over Sulla.
-  let bargeInSpeechStart = 0;
+  const bargeInDetector = createVoiceBargeInDetector();
 
   const onMicVad = (_event: any, data: { speaking: boolean; level: number }) => {
     if (!isRecording.value) return;
@@ -219,16 +213,9 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
 
     // Barge-in: sustained user speech while Sulla is speaking stops TTS.
     // The grace period keeps brief noises from interrupting playback.
-    if (data.speaking && isTTSPlaying.value) {
-      if (bargeInSpeechStart === 0) {
-        bargeInSpeechStart = Date.now();
-      } else if (Date.now() - bargeInSpeechStart >= BARGE_IN_GRACE_MS) {
-        logBargeIn();
-        ttsPlayer.stop();
-        bargeInSpeechStart = 0;
-      }
-    } else {
-      bargeInSpeechStart = 0;
+    if (bargeInDetector.update(data.speaking, isTTSPlaying.value)) {
+      logBargeIn();
+      ttsPlayer.stop();
     }
   };
 
@@ -239,6 +226,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
     isRecording.value = true;
     pipelineState.value = 'LISTENING';
     turnAccumulator.reset();
+    bargeInDetector.reset();
     startDurationTimer();
 
     // Start mic with PCM format for whisper
@@ -269,6 +257,7 @@ export function useVoiceSession(options: UseVoiceSessionOptions): UseVoiceSessio
   function stopRecording() {
     console.log('[VoiceSession] stopRecording');
     isRecording.value = false;
+    bargeInDetector.reset();
 
     ipcRenderer.removeListener('gateway-transcript', onTranscript);
     ipcRenderer.removeListener('audio-driver:mic-vad', onMicVad);

--- a/pkg/rancher-desktop/pages/chat/services/VoiceSessionAdapter.ts
+++ b/pkg/rancher-desktop/pages/chat/services/VoiceSessionAdapter.ts
@@ -33,15 +33,19 @@
     TtsMessage + sets voice.phase='playing', queueEmpty clears.
 */
 
-import { ipcRenderer as _ipcRenderer } from '@pkg/utils/ipcRenderer';
+import { newMessageId, type MessageId } from '../types/chat';
 
-import { TTSPlayerService, createVoiceTurnAccumulator } from '@pkg/composables/voice';
+import {
+  TTSPlayerService,
+  createVoiceBargeInDetector,
+  createVoiceTurnAccumulator,
+} from '@pkg/composables/voice';
+import { logBargeIn } from '@pkg/composables/voice/VoiceLogger';
+import { ipcRenderer as _ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 import type { ChatController } from '../controller/ChatController';
 import type { InterimMessage, TtsMessage } from '../models/Message';
-import { newMessageId, type MessageId } from '../types/chat';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ipcRenderer = _ipcRenderer as any;
 
 /** Window-level TTS suppression toggle mirrored from the old path. */
@@ -55,7 +59,7 @@ export interface VoiceSessionAdapterOptions {
   /** Channel this adapter reports speak events against. */
   channelId?: string;
   /** Surfaces recoverable errors (missing whisper model, mic permission, …). */
-  onError?: (message: string) => void;
+  onError?:   (message: string) => void;
 }
 
 // Fallback commit delay (ms). PRIMARY end-of-turn trigger is the main-process
@@ -66,15 +70,20 @@ const UTTERANCE_FALLBACK_MS = 8000;
 
 export class VoiceSessionAdapter {
   private readonly controller: ChatController;
-  private readonly onError?: (message: string) => void;
+  private readonly onError?:   (message: string) => void;
 
   private readonly tts: TTSPlayerService;
 
-  private unsubs: Array<() => void> = [];
+  private unsubs: (() => void)[] = [];
 
   // Recording state — tracked locally, mirrored into controller.voice.
   private recording = false;
   private interimId: MessageId | null = null;
+  private recordingStartedAt = 0;
+  private lastLevel = 0;
+  private lastSpeaking = false;
+
+  private readonly bargeIn = createVoiceBargeInDetector();
 
   // Shared turn accumulation (partials → interim, transcript_turn → text, utterance_end →
   // commit). Same module the classic chat uses, so both surfaces behave identically.
@@ -89,22 +98,35 @@ export class VoiceSessionAdapter {
   private activeTtsMessageId: MessageId | null = null;
 
   // Bound IPC listeners so we can unregister on dispose().
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   private readonly onTranscript = (_event: any, msg: any) => this.handleTranscript(msg);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
   private readonly onMicVad = (_event: any, data: { speaking: boolean; level: number }) => {
     if (!this.recording) return;
+    this.lastLevel = Math.max(0, Math.min(1, data.level));
+    this.lastSpeaking = !!data.speaking;
+
+    if (this.bargeIn.update(this.lastSpeaking, this.tts.isPlaying)) {
+      logBargeIn();
+      this.tts.stop();
+    }
+
     const v = this.controller.voice.value;
     if (v.phase !== 'recording') return;
     this.controller.setVoice({
       ...v,
-      level:    Math.max(0, Math.min(1, data.level)),
-      speaking: !!data.speaking,
+      level:    this.lastLevel,
+      speaking: this.lastSpeaking,
     });
   };
 
   // Window-level ⌘/ shortcut bridge.
-  private readonly onWindowVoiceToggle = () => { void this.toggle(); };
+  private readonly onWindowVoiceToggle = () => {
+    this.toggle().catch((err) => {
+      console.error('[VoiceSessionAdapter] toggle failed', err);
+      this.onError?.('Voice capture failed to start.');
+    });
+  };
 
   // Speak bridge — PersonaAdapter listens for backend `speak` events
   // and re-dispatches them as this window event. We pick them up and
@@ -124,7 +146,7 @@ export class VoiceSessionAdapter {
 
     this.unsubs.push(
       this.tts.on('playbackStart', () => this.handleTtsStart()),
-      this.tts.on('queueEmpty',    () => this.handleTtsEnd()),
+      this.tts.on('queueEmpty', () => this.handleTtsEnd()),
     );
 
     window.addEventListener('chat:voice-toggle', this.onWindowVoiceToggle);
@@ -135,13 +157,16 @@ export class VoiceSessionAdapter {
 
   async toggle(): Promise<void> {
     if (this.recording) this.stop(true);
-    else                await this.start();
+    else await this.start();
   }
 
   async start(): Promise<void> {
     if (this.recording) return;
     this.recording = true;
     this.turn.reset();
+    this.bargeIn.reset();
+    this.lastLevel = 0;
+    this.lastSpeaking = false;
 
     // Drop in an interim message the transcript can render while we listen.
     this.spawnInterim();
@@ -163,8 +188,8 @@ export class VoiceSessionAdapter {
       return;
     }
 
-    ipcRenderer.on('gateway-transcript',       this.onTranscript);
-    ipcRenderer.on('audio-driver:mic-vad',     this.onMicVad);
+    ipcRenderer.on('gateway-transcript', this.onTranscript);
+    ipcRenderer.on('audio-driver:mic-vad', this.onMicVad);
   }
 
   /**
@@ -172,12 +197,13 @@ export class VoiceSessionAdapter {
    * @param commit  when true, send whatever transcript has accumulated;
    *                when false, drop it.
    */
-  stop(commit: boolean = true): void {
+  stop(commit = true): void {
     if (!this.recording) return;
     this.recording = false;
+    this.bargeIn.reset();
 
-    ipcRenderer.removeListener('gateway-transcript',    this.onTranscript);
-    ipcRenderer.removeListener('audio-driver:mic-vad',  this.onMicVad);
+    ipcRenderer.removeListener('gateway-transcript', this.onTranscript);
+    ipcRenderer.removeListener('audio-driver:mic-vad', this.onMicVad);
 
     // recording is already false, so commitTurn() below won't re-spawn an interim.
     if (commit) {
@@ -199,18 +225,19 @@ export class VoiceSessionAdapter {
 
   /** Create a fresh interim bubble and mark the voice UI as recording. */
   private spawnInterim(): void {
+    this.recordingStartedAt = Date.now();
     const interim: InterimMessage = {
       id:        newMessageId(),
       kind:      'interim',
       createdAt: Date.now(),
       text:      '',
-      startedAt: Date.now(),
+      startedAt: this.recordingStartedAt,
     };
     this.interimId = interim.id;
     this.controller.appendMessage(interim);
     this.controller.setVoice({
       phase:            'recording',
-      startedAt:        Date.now(),
+      startedAt:        this.recordingStartedAt,
       interimMessageId: interim.id,
       level:            0,
       speaking:         false,
@@ -232,7 +259,6 @@ export class VoiceSessionAdapter {
 
   // ─── Whisper transcript ───────────────────────────────────────────
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private handleTranscript(msg: any): void {
     if (!this.recording) return;
     this.turn.handleEvent(msg);
@@ -275,6 +301,7 @@ export class VoiceSessionAdapter {
   }
 
   private handleTtsStart(): void {
+    this.bargeIn.reset();
     // If we already have a TTS bubble in the transcript we leave it alone —
     // TTSPlayerService fires playbackStart for every sentence in the queue.
     if (!this.activeTtsMessageId) {
@@ -296,11 +323,21 @@ export class VoiceSessionAdapter {
   }
 
   private handleTtsEnd(): void {
+    this.bargeIn.reset();
     const id = this.activeTtsMessageId;
     this.activeTtsMessageId = null;
     if (id) this.controller.removeMessage(id);
     if (this.controller.voice.value.phase === 'playing') {
       this.controller.stopTTS(id ?? undefined);
+    }
+    if (this.recording && this.interimId) {
+      this.controller.setVoice({
+        phase:            'recording',
+        startedAt:        this.recordingStartedAt,
+        interimMessageId: this.interimId,
+        level:            this.lastLevel,
+        speaking:         this.lastSpeaking,
+      });
     }
   }
 }


### PR DESCRIPTION
## What changed

The current chat adapter kept the microphone open during TTS but ignored VAD while its UI phase was `playing`, so speaking over Sulla could not interrupt playback. This restores true conversational turn-taking:

- share one sustained-speech detector across both voice surfaces
- stop TTS after 400 ms of real speech while ignoring short noise spikes
- return the composer to its live listening state after playback or interruption
- surface shortcut-start failures instead of leaving a rejected promise

Projects task: PFhF

## Verification

- ESLint passed for all five touched source/test files
- Jest: 3 suites, 20 tests passed (`VoiceBargeInDetector`, `VoiceTurnAccumulator`, `SpeakExtractor`)
- esbuild parse passed for the detector, classic session, and current adapter
- `git diff --check` passed
- full repo TypeScript check reached the existing ~2 GB heap ceiling and exited OOM; no TypeScript diagnostic from touched code was emitted before the limit