### PR TITLE
fix(workflows): launch stateful CLI runs

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkflowExecutionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkflowExecutionModel.ts
@@ -106,6 +106,18 @@ export class WorkflowExecutionModel extends BaseModel<WorkflowExecutionAttribute
     );
   }
 
+  /** Retire a source run only when it is still active. Restart must not
+   * rewrite completed/failed history, but it also must not leave a zombie
+   * eligible for the concurrent-run guard or boot recovery. */
+  static async markSupersededIfActive(executionId: string): Promise<void> {
+    await postgresClient.query(
+      `UPDATE workflow_executions
+       SET status = 'failed', completed_at = NOW(), error = 'superseded_by_checkpoint_restart', updated_at = NOW()
+       WHERE execution_id = $1 AND status IN ('running', 'suspended')`,
+      [executionId],
+    );
+  }
+
   /** Find all suspended executions, newest first. Used by boot recovery. */
   static async findSuspended(): Promise<WorkflowExecutionModel[]> {
     const rows = await postgresClient.queryAll(

--- a/pkg/rancher-desktop/agent/tools/workflow/__tests__/restart_from_checkpoint.spec.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/__tests__/restart_from_checkpoint.spec.ts
@@ -2,18 +2,22 @@ import { jest } from '@jest/globals';
 
 const mockFindCheckpointBefore = jest.fn<() => Promise<any>>();
 const mockFindByNode = jest.fn<() => Promise<any>>();
+const mockFindByExecution = jest.fn<() => Promise<any[]>>();
 const mockMarkRunning = jest.fn<() => Promise<void>>();
+const mockMarkSupersededIfActive = jest.fn<() => Promise<void>>();
 
 jest.unstable_mockModule('../../../database/models/WorkflowCheckpointModel', () => ({
   WorkflowCheckpointModel: {
     findCheckpointBefore: mockFindCheckpointBefore,
     findByNode:            mockFindByNode,
+    findByExecution:       mockFindByExecution,
   },
 }));
 
 jest.unstable_mockModule('../../../database/models/WorkflowExecutionModel', () => ({
   WorkflowExecutionModel: {
-    markRunning: mockMarkRunning,
+    markRunning:            mockMarkRunning,
+    markSupersededIfActive: mockMarkSupersededIfActive,
   },
 }));
 
@@ -43,9 +47,11 @@ describe('RestartFromCheckpointWorker', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockFindCheckpointBefore.mockResolvedValue(checkpoint());
+    mockFindCheckpointBefore.mockResolvedValue(null);
     mockFindByNode.mockResolvedValue(null);
+    mockFindByExecution.mockResolvedValue([checkpoint()]);
     mockMarkRunning.mockResolvedValue(undefined);
+    mockMarkSupersededIfActive.mockResolvedValue(undefined);
   });
 
   test('fails closed when a mutating restart has no graph state', async() => {
@@ -58,6 +64,7 @@ describe('RestartFromCheckpointWorker', () => {
     expect(result.successBoolean).toBe(false);
     expect(result.responseString).toContain('No agent state available');
     expect(mockFindCheckpointBefore).not.toHaveBeenCalled();
+    expect(mockFindByExecution).not.toHaveBeenCalled();
     expect(mockMarkRunning).not.toHaveBeenCalled();
   });
 
@@ -73,6 +80,7 @@ describe('RestartFromCheckpointWorker', () => {
     const response = JSON.parse(result.responseString);
 
     expect(result.successBoolean).toBe(true);
+    expect(mockMarkSupersededIfActive).toHaveBeenCalledWith('wfp-original');
     expect(mockMarkRunning).toHaveBeenCalledWith(expect.objectContaining({
       executionId: response.executionId,
       workflowId:  'core-routine-dream-about-human',

--- a/pkg/rancher-desktop/agent/tools/workflow/__tests__/restart_from_checkpoint.spec.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/__tests__/restart_from_checkpoint.spec.ts
@@ -1,0 +1,99 @@
+import { jest } from '@jest/globals';
+
+const mockFindCheckpointBefore = jest.fn<() => Promise<any>>();
+const mockFindByNode = jest.fn<() => Promise<any>>();
+const mockMarkRunning = jest.fn<() => Promise<void>>();
+
+jest.unstable_mockModule('../../../database/models/WorkflowCheckpointModel', () => ({
+  WorkflowCheckpointModel: {
+    findCheckpointBefore: mockFindCheckpointBefore,
+    findByNode:            mockFindByNode,
+  },
+}));
+
+jest.unstable_mockModule('../../../database/models/WorkflowExecutionModel', () => ({
+  WorkflowExecutionModel: {
+    markRunning: mockMarkRunning,
+  },
+}));
+
+let RestartFromCheckpointWorker: typeof import('../restart_from_checkpoint').RestartFromCheckpointWorker;
+
+function checkpoint() {
+  return {
+    attributes: {
+      node_label:     'Lenses Complete',
+      playbook_state: {
+        executionId:      'wfp-original',
+        workflowId:       'core-routine-dream-about-human',
+        status:           'running',
+        definition:       { id: 'core-routine-dream-about-human', name: 'Dreaming About My Human' },
+        currentNodeIds:   ['node-dah-prune'],
+        completedNodeIds: ['node-dah-merge'],
+        nodeOutputs:      { 'node-dah-merge': { result: 'done' } },
+      },
+    },
+  };
+}
+
+describe('RestartFromCheckpointWorker', () => {
+  beforeAll(async() => {
+    ({ RestartFromCheckpointWorker } = await import('../restart_from_checkpoint'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindCheckpointBefore.mockResolvedValue(checkpoint());
+    mockFindByNode.mockResolvedValue(null);
+    mockMarkRunning.mockResolvedValue(undefined);
+  });
+
+  test('fails closed when a mutating restart has no graph state', async() => {
+    const worker = new RestartFromCheckpointWorker();
+    const result = await (worker as any)._validatedCall({
+      executionId: 'wfp-original',
+      nodeId:      'node-dah-prune',
+    });
+
+    expect(result.successBoolean).toBe(false);
+    expect(result.responseString).toContain('No agent state available');
+    expect(mockFindCheckpointBefore).not.toHaveBeenCalled();
+    expect(mockMarkRunning).not.toHaveBeenCalled();
+  });
+
+  test('persists and attaches the exact restarted execution before success', async() => {
+    const state: any = { metadata: {} };
+    const worker = new RestartFromCheckpointWorker();
+    worker.setState(state);
+
+    const result = await (worker as any)._validatedCall({
+      executionId: 'wfp-original',
+      nodeId:      'node-dah-prune',
+    });
+    const response = JSON.parse(result.responseString);
+
+    expect(result.successBoolean).toBe(true);
+    expect(mockMarkRunning).toHaveBeenCalledWith(expect.objectContaining({
+      executionId: response.executionId,
+      workflowId:  'core-routine-dream-about-human',
+    }));
+    expect(state.metadata.activeWorkflow.executionId).toBe(response.executionId);
+    expect(state.metadata.activeWorkflow.currentNodeIds).toContain('node-dah-prune');
+  });
+
+  test('does not claim success when execution persistence fails', async() => {
+    mockMarkRunning.mockRejectedValue(new Error('database offline'));
+    const state: any = { metadata: {} };
+    const worker = new RestartFromCheckpointWorker();
+    worker.setState(state);
+
+    const result = await (worker as any)._validatedCall({
+      executionId: 'wfp-original',
+      nodeId:      'node-dah-prune',
+    });
+
+    expect(result.successBoolean).toBe(false);
+    expect(result.responseString).toContain('database offline');
+    expect(state.metadata.activeWorkflow).toBeUndefined();
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/workflow/restart_from_checkpoint.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/restart_from_checkpoint.ts
@@ -62,6 +62,17 @@ export class RestartFromCheckpointWorker extends BaseTool {
       };
     }
 
+    // Restart is stateful: the rebuilt playbook must be attached to a graph
+    // that will actually execute it. CLI callers are bound to a detached
+    // graph by chatCompletionsServer; fail closed if another caller forgets
+    // to provide one instead of returning a fabricated restart id.
+    if (!this.state) {
+      return {
+        successBoolean: false,
+        responseString: 'No agent state available. Restart must run through an agent loop or the stateful Sulla CLI dispatcher.',
+      };
+    }
+
     // Restart from a specific node — load the checkpoint BEFORE that node
     const beforeCheckpoint = await WorkflowCheckpointModel.findCheckpointBefore(executionId, nodeId);
 
@@ -119,10 +130,27 @@ export class RestartFromCheckpointWorker extends BaseTool {
       }
     }
 
-    // Load the rebuilt state into the agent's metadata
-    if (this.state) {
-      (this.state).metadata.activeWorkflow = rebuiltState;
+    // Persist before claiming success. PlaybookController updates an existing
+    // execution row; without this insert a restart can run yet remain absent
+    // from workflow history and the concurrent-run guard.
+    try {
+      const { WorkflowExecutionModel } = await import('../../database/models/WorkflowExecutionModel');
+      await WorkflowExecutionModel.markRunning({
+        executionId:  rebuiltState.executionId,
+        workflowId:   savedState.workflowId,
+        workflowName: savedState.definition.name,
+        workflowSlug: savedState.workflowId,
+      });
+    } catch (err) {
+      return {
+        successBoolean: false,
+        responseString: `Failed to persist restarted execution: ${ err instanceof Error ? err.message : String(err) }`,
+      };
     }
+
+    // Load the rebuilt state into the agent's metadata.
+    this.state.metadata = this.state.metadata ?? {};
+    this.state.metadata.activeWorkflow = rebuiltState;
 
     const nodeLabel = checkpointToUse.attributes.node_label || nodeId;
     console.log(`[RestartFromCheckpoint] Restarting workflow "${ savedState.definition.name }" from node "${ nodeLabel }" — new executionId=${ rebuiltState.executionId }`);

--- a/pkg/rancher-desktop/agent/tools/workflow/restart_from_checkpoint.ts
+++ b/pkg/rancher-desktop/agent/tools/workflow/restart_from_checkpoint.ts
@@ -74,7 +74,20 @@ export class RestartFromCheckpointWorker extends BaseTool {
     }
 
     // Restart from a specific node — load the checkpoint BEFORE that node
-    const beforeCheckpoint = await WorkflowCheckpointModel.findCheckpointBefore(executionId, nodeId);
+    let beforeCheckpoint = await WorkflowCheckpointModel.findCheckpointBefore(executionId, nodeId);
+
+    // A failed/unrun frontier node has no checkpoint of its own, so the model
+    // cannot locate a predecessor by target sequence. In that case the latest
+    // saved playbook state is the valid predecessor when it names the target
+    // in currentNodeIds (the exact post-merge core-dreaming recovery shape).
+    if (!beforeCheckpoint) {
+      const checkpoints = await WorkflowCheckpointModel.findByExecution(executionId);
+      const latest = checkpoints[checkpoints.length - 1];
+      const latestState = latest?.attributes.playbook_state as unknown as WorkflowPlaybookState | undefined;
+      if (latest && latestState?.currentNodeIds?.includes(nodeId)) {
+        beforeCheckpoint = latest;
+      }
+    }
 
     // If no checkpoint before (node is first), use the node's own checkpoint but reset it
     let checkpointToUse = beforeCheckpoint;
@@ -135,6 +148,7 @@ export class RestartFromCheckpointWorker extends BaseTool {
     // from workflow history and the concurrent-run guard.
     try {
       const { WorkflowExecutionModel } = await import('../../database/models/WorkflowExecutionModel');
+      await WorkflowExecutionModel.markSupersededIfActive(executionId);
       await WorkflowExecutionModel.markRunning({
         executionId:  rebuiltState.executionId,
         workflowId:   savedState.workflowId,

--- a/pkg/rancher-desktop/main/__tests__/statefulCliWorkflowTool.spec.ts
+++ b/pkg/rancher-desktop/main/__tests__/statefulCliWorkflowTool.spec.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockExecute = jest.fn<() => Promise<void>>();
+const mockDelete = jest.fn();
+const mockGetGraph = jest.fn<() => Promise<any>>();
+const mockMarkFailed = jest.fn<(executionId: string, error: string) => Promise<void>>();
+
+jest.unstable_mockModule('@pkg/agent/services/GraphRegistry', () => ({
+  GraphRegistry: {
+    getOrCreateAgentGraph: mockGetGraph,
+    delete:                mockDelete,
+  },
+}));
+
+jest.unstable_mockModule('@pkg/agent/database/models/WorkflowExecutionModel', () => ({
+  WorkflowExecutionModel: {
+    markFailed: mockMarkFailed,
+  },
+}));
+
+let callStatefulWorkflowTool: typeof import('../statefulCliWorkflowTool').callStatefulWorkflowTool;
+let needsStatefulWorkflowDispatch: typeof import('../statefulCliWorkflowTool').needsStatefulWorkflowDispatch;
+
+class FakeTool {
+  schemaDef = {};
+  name = 'execute_workflow';
+  description = 'test';
+  metadata = {};
+  state: any;
+  success = true;
+
+  setState(state: any) { this.state = state }
+  call() {
+    if (this.success) {
+      this.state.metadata.activeWorkflow = { executionId: 'wfp-detached' };
+    }
+    return Promise.resolve({ success: this.success });
+  }
+}
+
+describe('stateful CLI workflow dispatch', () => {
+  beforeAll(async() => {
+    ({ callStatefulWorkflowTool, needsStatefulWorkflowDispatch } = await import('../statefulCliWorkflowTool'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExecute.mockResolvedValue(undefined);
+    mockMarkFailed.mockResolvedValue(undefined);
+    mockGetGraph.mockResolvedValue({
+      graph: { execute: mockExecute },
+      state: { metadata: {} },
+    });
+  });
+
+  it('only binds mutating workflow calls', () => {
+    expect(needsStatefulWorkflowDispatch('execute_workflow', {})).toBe(true);
+    expect(needsStatefulWorkflowDispatch('restart_from_checkpoint', { executionId: 'wfp', nodeId: 'node' })).toBe(true);
+    expect(needsStatefulWorkflowDispatch('restart_from_checkpoint', { executionId: 'wfp' })).toBe(false);
+  });
+
+  it('uses a fresh worker, launches the graph, and cleans up on completion', async() => {
+    const cached = new FakeTool();
+    const result = await callStatefulWorkflowTool(cached, 'execute_workflow', {});
+
+    expect(result.success).toBe(true);
+    expect(cached.state).toBeUndefined();
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not launch a failed tool and removes the detached graph', async() => {
+    class FailingTool extends FakeTool {
+      success = false;
+    }
+    await callStatefulWorkflowTool(new FailingTool(), 'execute_workflow', {});
+
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the execution failed and cleans up when the graph rejects', async() => {
+    mockExecute.mockRejectedValue(new Error('graph exploded'));
+    await callStatefulWorkflowTool(new FakeTool(), 'execute_workflow', {});
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(mockMarkFailed).toHaveBeenCalledWith('wfp-detached', expect.stringContaining('graph exploded'));
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pkg/rancher-desktop/main/chatCompletionsServer.ts
+++ b/pkg/rancher-desktop/main/chatCompletionsServer.ts
@@ -1202,30 +1202,9 @@ export class ChatCompletionsServer {
         // calls to a fresh detached graph and start that graph only after the
         // tool has attached an active playbook. Read-only checkpoint listing
         // remains stateless and does not create a graph.
-        const needsWorkflowState = toolName === 'execute_workflow' ||
-          (toolName === 'restart_from_checkpoint' && Boolean(params.executionId && params.nodeId));
-        if (needsWorkflowState) {
-          const { GraphRegistry } = await import('@pkg/agent/services/GraphRegistry');
-          const invocationId = `cli-${ toolName }-${ Date.now().toString(36) }-${ Math.random().toString(36).slice(2, 8) }`;
-          const graphResult = await GraphRegistry.getOrCreateAgentGraph('sulla-desktop', invocationId);
-          const graph = (graphResult as { graph: unknown }).graph as { execute: (state: unknown) => Promise<unknown> };
-          const state = (graphResult as { state: Record<string, any> }).state;
-
-          // Registry workers are cached. Use a fresh instance so state from a
-          // detached CLI run cannot leak into another concurrent tool call.
-          const boundTool = new tool.constructor();
-          boundTool.schemaDef = tool.schemaDef;
-          boundTool.name = tool.name;
-          boundTool.description = tool.description;
-          boundTool.metadata = { ...tool.metadata };
-          boundTool.setState(state);
-
-          const result = await boundTool.call(params);
-          if (result.success && state.metadata?.activeWorkflow) {
-            graph.execute(state).catch((err) => {
-              console.error(`[ChatCompletionsAPI] detached ${ toolName } execution failed:`, err);
-            });
-          }
+        const { callStatefulWorkflowTool, needsStatefulWorkflowDispatch } = await import('./statefulCliWorkflowTool');
+        if (needsStatefulWorkflowDispatch(toolName, params)) {
+          const result = await callStatefulWorkflowTool(tool, toolName, params);
           return res.json({ success: true, result });
         }
 

--- a/pkg/rancher-desktop/main/chatCompletionsServer.ts
+++ b/pkg/rancher-desktop/main/chatCompletionsServer.ts
@@ -1197,6 +1197,38 @@ export class ChatCompletionsServer {
           }
         }
 
+        // Workflow activation tools mutate live graph state. The CLI endpoint
+        // normally invokes stateless cached workers, so bind mutating workflow
+        // calls to a fresh detached graph and start that graph only after the
+        // tool has attached an active playbook. Read-only checkpoint listing
+        // remains stateless and does not create a graph.
+        const needsWorkflowState = toolName === 'execute_workflow' ||
+          (toolName === 'restart_from_checkpoint' && Boolean(params.executionId && params.nodeId));
+        if (needsWorkflowState) {
+          const { GraphRegistry } = await import('@pkg/agent/services/GraphRegistry');
+          const invocationId = `cli-${ toolName }-${ Date.now().toString(36) }-${ Math.random().toString(36).slice(2, 8) }`;
+          const graphResult = await GraphRegistry.getOrCreateAgentGraph('sulla-desktop', invocationId);
+          const graph = (graphResult as { graph: unknown }).graph as { execute: (state: unknown) => Promise<unknown> };
+          const state = (graphResult as { state: Record<string, any> }).state;
+
+          // Registry workers are cached. Use a fresh instance so state from a
+          // detached CLI run cannot leak into another concurrent tool call.
+          const boundTool = new tool.constructor();
+          boundTool.schemaDef = tool.schemaDef;
+          boundTool.name = tool.name;
+          boundTool.description = tool.description;
+          boundTool.metadata = { ...tool.metadata };
+          boundTool.setState(state);
+
+          const result = await boundTool.call(params);
+          if (result.success && state.metadata?.activeWorkflow) {
+            graph.execute(state).catch((err) => {
+              console.error(`[ChatCompletionsAPI] detached ${ toolName } execution failed:`, err);
+            });
+          }
+          return res.json({ success: true, result });
+        }
+
         const result = await tool.call(params);
         return res.json({ success: true, result });
       }

--- a/pkg/rancher-desktop/main/statefulCliWorkflowTool.ts
+++ b/pkg/rancher-desktop/main/statefulCliWorkflowTool.ts
@@ -1,0 +1,52 @@
+import { WorkflowExecutionModel } from '@pkg/agent/database/models/WorkflowExecutionModel';
+import { GraphRegistry } from '@pkg/agent/services/GraphRegistry';
+
+interface StatefulTool {
+  schemaDef:   Record<string, unknown>;
+  name:        string;
+  description: string;
+  metadata:    Record<string, unknown>;
+  setState:    (state: Record<string, any>) => void;
+  call:        (params: Record<string, unknown>) => Promise<any>;
+}
+
+export function needsStatefulWorkflowDispatch(toolName: string, params: Record<string, unknown>): boolean {
+  return toolName === 'execute_workflow' ||
+    (toolName === 'restart_from_checkpoint' && Boolean(params.executionId && params.nodeId));
+}
+
+export async function callStatefulWorkflowTool(
+  tool: StatefulTool,
+  toolName: string,
+  params: Record<string, unknown>,
+): Promise<any> {
+  const invocationId = `cli-${ toolName }-${ Date.now().toString(36) }-${ Math.random().toString(36).slice(2, 8) }`;
+  const graphResult = await GraphRegistry.getOrCreateAgentGraph('sulla-desktop', invocationId);
+  const graph = graphResult.graph as { execute: (state: unknown) => Promise<unknown> };
+  const state = graphResult.state as Record<string, any>;
+
+  // Registry workers are cached. A fresh instance prevents graph state from
+  // leaking into another concurrent CLI call.
+  const ToolConstructor = tool.constructor as new () => StatefulTool;
+  const boundTool = new ToolConstructor();
+  boundTool.schemaDef = tool.schemaDef;
+  boundTool.name = tool.name;
+  boundTool.description = tool.description;
+  boundTool.metadata = { ...tool.metadata };
+  boundTool.setState(state);
+
+  const result = await boundTool.call(params);
+  const activeExecutionId = state.metadata?.activeWorkflow?.executionId as string | undefined;
+  if (!result.success || !activeExecutionId) {
+    GraphRegistry.delete(invocationId);
+    return result;
+  }
+
+  graph.execute(state)
+    .catch(async(err) => {
+      await WorkflowExecutionModel.markFailed(activeExecutionId, `detached_graph_failed: ${ err instanceof Error ? err.message : String(err) }`);
+    })
+    .finally(() => GraphRegistry.delete(invocationId));
+
+  return result;
+}

--- a/resources/sulla-docs/workflows/authoring.md
+++ b/resources/sulla-docs/workflows/authoring.md
@@ -149,7 +149,9 @@ sulla meta/restart_from_checkpoint '{"workflowId":"daily-planning"}'
 # List checkpoints in a run:
 sulla meta/restart_from_checkpoint '{"executionId":"wfp-..."}'
 
-# Restart from a specific node (re-runs that node + everything after):
+# Restart from a specific node (re-runs that node + everything after).
+# Builds before the stateful CLI dispatcher fix can return a restart id
+# without launching a graph; upgrade before relying on CLI restart.
 sulla meta/restart_from_checkpoint '{
   "executionId": "wfp-...",
   "nodeId":      "the-node-that-failed"


### PR DESCRIPTION
Fixes the CLI workflow execution surface uncovered by Projects task 5Xhm.

Root cause:
- CLI internal tools were called without graph state, so execute_workflow rejected the call.
- restart_from_checkpoint skipped state attachment but still returned a fabricated success id without an execution row, graph, checkpoint, or log.

Changes:
- bind mutating CLI execute/restart calls to a fresh detached graph
- use a fresh worker per call so cached tool state cannot leak across invocations
- support restarting the first unrun frontier node from the latest checkpoint
- retire only active source executions before creating the replacement row
- fail closed when restart has no state or persistence fails
- clean detached graphs on tool failure/completion and mark graph rejections failed
- add restart/dispatcher regression coverage and correct source docs

Verification:
- focused Jest: 2 suites / 7 tests passed
- focused changed-file ESLint passed
- chat server + restart worker esbuild bundles passed
- git diff --check passed

Runtime acceptance remains gated on merge, rebuild/restart, then one supervised core-dreaming run with execution-row/checkpoint/log proof. The production schedule stays disabled.