### PR TITLE
fix(vault): verify browser autofill target and fields

### DIFF
--- a/pkg/rancher-desktop/agent/tools/integrations/__tests__/vault_autofill.test.ts
+++ b/pkg/rancher-desktop/agent/tools/integrations/__tests__/vault_autofill.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @jest-environment node
+ */
+import vm from 'node:vm';
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockGetIntegrationValue = jest.fn();
+const mockResolveBridge = jest.fn<(assetId?: string) => Promise<unknown>>();
+
+const mockService = {
+  initialize:          jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  getAccounts:         jest.fn<() => Promise<unknown[]>>().mockResolvedValue([]),
+  getIntegrationValue: mockGetIntegrationValue,
+};
+
+jest.unstable_mockModule('../../../services/IntegrationService', () => ({
+  getIntegrationService: () => mockService,
+}));
+
+jest.unstable_mockModule('../../browser/resolve_bridge', () => ({
+  resolveBridge:    mockResolveBridge,
+  isBridgeResolved: (result: any) => Boolean(result?.bridge),
+}));
+
+async function loadModule() {
+  return import('../vault_autofill');
+}
+
+function makeBridge(assetId: string, fillResult: Record<string, unknown>) {
+  return {
+    assetId,
+    getPageUrl:       jest.fn<() => Promise<string>>().mockResolvedValue('https://github.com/login'),
+    execInPageStrict: jest.fn<() => Promise<unknown>>().mockResolvedValue(fillResult),
+  };
+}
+
+async function call(input: Record<string, unknown>) {
+  const { VaultAutofillWorker } = await loadModule();
+  const worker = new VaultAutofillWorker();
+
+  return (worker as any)._validatedCall(input);
+}
+
+beforeEach(() => {
+  mockResolveBridge.mockReset();
+  mockGetIntegrationValue.mockReset();
+  mockGetIntegrationValue.mockImplementation((_accountType, property) => Promise.resolve({
+    value: {
+      website_url: 'https://github.com/login',
+      llm_access:   'autofill',
+      username:     'saved-user',
+      password:     'saved-password',
+    }[property as string],
+  }));
+});
+
+describe('VaultAutofillWorker', () => {
+  it('targets the active tab when assetId is omitted and requires verified fields', async() => {
+    const bridge = makeBridge('active-tab', {
+      success: true, runtimeReady: true, usernameOk: true, passwordOk: true,
+    });
+    mockResolveBridge.mockResolvedValue({ bridge, assetId: 'active-tab' });
+
+    const result = await call({ account_id: 'credential-1' });
+
+    expect(mockResolveBridge).toHaveBeenCalledWith(undefined);
+    expect(bridge.execInPageStrict).toHaveBeenCalledTimes(1);
+    expect(result.successBoolean).toBe(true);
+    expect(result.responseString).toContain('[active-tab]');
+    expect(result.responseString).toContain('verified non-empty credential fields');
+    expect(result.responseString).not.toContain('saved-password');
+  });
+
+  it('targets an explicitly requested background tab', async() => {
+    const bridge = makeBridge('background-tab', {
+      success: true, runtimeReady: true, usernameOk: true, passwordOk: true,
+    });
+    mockResolveBridge.mockResolvedValue({ bridge, assetId: 'background-tab' });
+
+    const result = await call({ account_id: 'credential-1', assetId: 'background-tab' });
+
+    expect(mockResolveBridge).toHaveBeenCalledWith('background-tab');
+    expect(result.successBoolean).toBe(true);
+    expect(result.responseString).toContain('[background-tab]');
+  });
+
+  it('returns a truthful target-specific failure when the browser runtime is not loaded', async() => {
+    const bridge = makeBridge('partial-runtime-tab', {
+      success:      false,
+      runtimeReady: false,
+      usernameOk:   false,
+      passwordOk:   false,
+      error:        'Browser runtime is not loaded',
+    });
+    mockResolveBridge.mockResolvedValue({ bridge, assetId: 'partial-runtime-tab' });
+
+    const result = await call({ account_id: 'credential-1', assetId: 'partial-runtime-tab' });
+
+    expect(result.successBoolean).toBe(false);
+    expect(result.responseString).toContain('[partial-runtime-tab]');
+    expect(result.responseString).toContain('Browser runtime is not loaded');
+    expect(result.responseString).not.toContain('was filled');
+  });
+
+  it('fails when setValue does not leave every expected field non-empty', async() => {
+    const bridge = makeBridge('active-tab', {
+      success:      false,
+      runtimeReady: true,
+      usernameOk:   true,
+      passwordOk:   false,
+      error:        'The page did not retain non-empty password field values',
+    });
+    mockResolveBridge.mockResolvedValue({ bridge, assetId: 'active-tab' });
+
+    const result = await call({ account_id: 'credential-1' });
+
+    expect(result.successBoolean).toBe(false);
+    expect(result.responseString).toContain('did not retain non-empty password');
+    expect(result.responseString).not.toContain('was filled');
+  });
+
+  it('refuses to fill a target tab on a different origin', async() => {
+    const bridge = makeBridge('wrong-origin-tab', {
+      success: true, runtimeReady: true, usernameOk: true, passwordOk: true,
+    });
+    bridge.getPageUrl.mockResolvedValue('https://example.com/login');
+    mockResolveBridge.mockResolvedValue({ bridge, assetId: 'wrong-origin-tab' });
+
+    const result = await call({ account_id: 'credential-1', assetId: 'wrong-origin-tab' });
+
+    expect(result.successBoolean).toBe(false);
+    expect(result.responseString).toContain('[wrong-origin-tab]');
+    expect(result.responseString).toContain('does not match credential origin');
+    expect(bridge.execInPageStrict).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildAutofillScript', () => {
+  it('fills and proves both expected fields without returning their values', async() => {
+    const { buildAutofillScript } = await loadModule();
+    const usernameField = { value: '' };
+    const passwordField = { value: '', closest: () => null, parentElement: null };
+    const form = {
+      hasLoginForm:   true,
+      usernameField,
+      passwordField,
+      usernameHandle: '@vault-username',
+      passwordHandle: '@vault-password',
+    };
+    const window = {
+      sullaBridge: {
+        detectLoginForm: () => form,
+        setValue:        (handle: string, value: string) => {
+          if (handle === '@vault-username') usernameField.value = value;
+          if (handle === '@vault-password') passwordField.value = value;
+          return true;
+        },
+      },
+    };
+
+    const result = await vm.runInNewContext(
+      buildAutofillScript('saved-user', 'saved-password'),
+      { window, document: { body: {} }, setTimeout: jest.fn(), Promise, Boolean, String },
+    );
+
+    expect(result).toEqual({
+      success: true, runtimeReady: true, usernameOk: true, passwordOk: true,
+    });
+    expect(usernameField.value).toBe('saved-user');
+    expect(passwordField.value).toBe('saved-password');
+    expect(JSON.stringify(result)).not.toContain('saved-password');
+  });
+
+  it('reports an uninitialized page runtime without touching credentials', async() => {
+    const { buildAutofillScript } = await loadModule();
+    const result = await vm.runInNewContext(
+      buildAutofillScript('saved-user', 'saved-password'),
+      { window: {}, document: { body: {} }, setTimeout: jest.fn(), Promise, Boolean, String },
+    );
+
+    expect(result).toEqual(expect.objectContaining({
+      success: false, runtimeReady: false, error: 'Browser runtime is not loaded',
+    }));
+    expect(JSON.stringify(result)).not.toContain('saved-password');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/integrations/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/integrations/manifests.ts
@@ -67,11 +67,12 @@ export const integrationsToolManifests: ToolManifest[] = [
   },
   {
     name:        'vault_autofill',
-    description: 'Autofill a login form on the current browser tab with saved vault credentials. The password is injected directly into the browser — it never appears in this conversation. Requires the credential to have AI access set to "autofill" or "full".',
+    description: 'Autofill a login form on the active browser tab, or an explicitly requested background tab, with saved vault credentials. Success is returned only after the target tab proves the expected fields are non-empty. The password is injected directly into the browser — it never appears in this conversation. Requires the credential to have AI access set to "autofill" or "full".',
     category:    'vault',
     schemaDef:   {
       origin:     { type: 'string', optional: true, description: 'The website origin to match (e.g. "https://github.com"). If omitted, uses account_id directly.' },
       account_id: { type: 'string', optional: true, description: 'The specific vault account ID to use for autofill. If omitted, matches by origin.' },
+      assetId:    { type: 'string', optional: true, description: 'Specific browser tab assetId to fill, including a background tab. If omitted, targets the active tab.' },
     },
     operationTypes: ['update'],
     loader:         () => import('./vault_autofill'),

--- a/pkg/rancher-desktop/agent/tools/integrations/vault_autofill.ts
+++ b/pkg/rancher-desktop/agent/tools/integrations/vault_autofill.ts
@@ -1,36 +1,141 @@
 import { getIntegrationService } from '../../services/IntegrationService';
 import { BaseTool, ToolResponse } from '../base';
+import { isBridgeResolved, resolveBridge } from '../browser/resolve_bridge';
+
+interface AutofillResult {
+  success:      boolean;
+  runtimeReady: boolean;
+  usernameOk:   boolean;
+  passwordOk:   boolean;
+  error?:       string;
+}
 
 /**
- * Vault Autofill Tool — triggers autofill on a browser tab login form.
- * The password flows directly from the vault to the browser tab via
- * BrowserTabViewManager — it NEVER appears in the LLM context or tool response.
+ * Build the page-side autofill operation. Only booleans cross back into the
+ * tool response; credential values remain inside the page execution call.
+ */
+export function buildAutofillScript(username: string, password: string): string {
+  return `
+    (async function() {
+      var b = window.sullaBridge;
+      if (!b || typeof b.detectLoginForm !== 'function' || typeof b.setValue !== 'function') {
+        return {
+          success: false,
+          runtimeReady: false,
+          usernameOk: false,
+          passwordOk: false,
+          error: 'Browser runtime is not loaded',
+        };
+      }
+
+      var f = b.detectLoginForm();
+      if (!f || !f.hasLoginForm) {
+        return {
+          success: false,
+          runtimeReady: true,
+          usernameOk: false,
+          passwordOk: false,
+          error: 'No login form found',
+        };
+      }
+
+      var usernameExpected = ${ JSON.stringify(Boolean(username)) };
+      var passwordExpected = ${ JSON.stringify(Boolean(password)) };
+      var usernameSet = !usernameExpected;
+      var passwordSet = !passwordExpected;
+
+      if (usernameExpected && f.usernameHandle) {
+        usernameSet = b.setValue(f.usernameHandle, ${ JSON.stringify(username) });
+      }
+      if (passwordExpected && f.passwordHandle) {
+        passwordSet = b.setValue(f.passwordHandle, ${ JSON.stringify(password) });
+      }
+
+      // Give synchronous input/change handlers and one microtask a chance to
+      // reject or clear the assignment before claiming success.
+      await Promise.resolve();
+
+      var usernameOk = !usernameExpected || (
+        usernameSet && f.usernameField && String(f.usernameField.value || '').length > 0
+      );
+      var passwordOk = !passwordExpected || (
+        passwordSet && f.passwordField && String(f.passwordField.value || '').length > 0
+      );
+      var success = Boolean(usernameOk && passwordOk);
+
+      if (!success) {
+        var failed = [];
+        if (!usernameOk) failed.push('username');
+        if (!passwordOk) failed.push('password');
+        return {
+          success: false,
+          runtimeReady: true,
+          usernameOk: Boolean(usernameOk),
+          passwordOk: Boolean(passwordOk),
+          error: 'The page did not retain non-empty ' + failed.join(' and ') + ' field values',
+        };
+      }
+
+      // Preserve the existing autofill contract: submit only after both
+      // expected fields have been proven non-empty.
+      setTimeout(function() {
+        var pwEl = f.passwordField;
+        var form = pwEl && pwEl.closest ? pwEl.closest('form') : null;
+        if (form) {
+          if (typeof form.requestSubmit === 'function') { form.requestSubmit(); }
+          else { form.submit(); }
+        } else {
+          var container = pwEl ? pwEl.parentElement : document.body;
+          for (var d = 0; d < 5 && container; d++) {
+            var btn = container.querySelector('button[type="submit"], input[type="submit"], button:not([type])');
+            if (btn) { btn.click(); break; }
+            container = container.parentElement;
+          }
+        }
+      }, 200);
+
+      return {
+        success: true,
+        runtimeReady: true,
+        usernameOk: Boolean(usernameOk),
+        passwordOk: Boolean(passwordOk),
+      };
+    })();
+  `;
+}
+
+/**
+ * Vault Autofill Tool — fills a login form in the active browser tab, or in
+ * an explicitly requested background tab. Passwords never enter the tool
+ * response or LLM context.
  */
 export class VaultAutofillWorker extends BaseTool {
   name = '';
   description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
-    const { origin, account_id } = input;
+    const { origin, assetId } = input;
 
     try {
       const service = getIntegrationService();
       await service.initialize();
 
-      // Find matching account
-      let targetAccountId = account_id;
+      let targetAccountId = input['account_id'];
+      let credentialOrigin: string | undefined;
 
       if (!targetAccountId && origin) {
         const accounts = await service.getAccounts('website');
         for (const acct of accounts) {
-          const urlValue = await service.getIntegrationValue('website', 'website_url', acct.account_id);
+          const savedAccountId = acct['account_id'];
+          const urlValue = await service.getIntegrationValue('website', 'website_url', savedAccountId);
           if (!urlValue?.value) continue;
           try {
             const savedOrigin = new URL(urlValue.value).origin;
             if (savedOrigin === origin) {
-              targetAccountId = acct.account_id;
+              targetAccountId = savedAccountId;
+              credentialOrigin = savedOrigin;
               break;
             }
-          } catch { /* invalid URL */ }
+          } catch { /* invalid saved URL */ }
         }
       }
 
@@ -41,7 +146,20 @@ export class VaultAutofillWorker extends BaseTool {
         };
       }
 
-      // Check LLM access level
+      if (!credentialOrigin) {
+        const urlValue = await service.getIntegrationValue('website', 'website_url', targetAccountId);
+        if (urlValue?.value) {
+          try { credentialOrigin = new URL(urlValue.value).origin } catch { /* invalid saved URL */ }
+        }
+      }
+
+      if (origin && credentialOrigin && origin !== credentialOrigin) {
+        return {
+          successBoolean: false,
+          responseString: `Credential origin ${ credentialOrigin } does not match requested origin ${ origin }.`,
+        };
+      }
+
       const llmAccessValue = await service.getIntegrationValue('website', 'llm_access', targetAccountId);
       const llmAccess = llmAccessValue?.value || 'autofill';
 
@@ -52,7 +170,6 @@ export class VaultAutofillWorker extends BaseTool {
         };
       }
 
-      // Get the credentials
       const usernameValue = await service.getIntegrationValue('website', 'username', targetAccountId);
       const passwordValue = await service.getIntegrationValue('website', 'password', targetAccountId);
       const username = usernameValue?.value || '';
@@ -65,73 +182,70 @@ export class VaultAutofillWorker extends BaseTool {
         };
       }
 
-      // Use BrowserTabViewManager to inject credentials directly into the active browser tab.
-      // This runs in the main process so we can access the tab view manager directly.
+      const resolution = await resolveBridge(assetId);
+      if (!isBridgeResolved(resolution)) return resolution;
+
+      let targetUrl: string;
       try {
-        const { BrowserTabViewManager } = await import('../../../window/browserTabViewManager');
-        const tabManager = BrowserTabViewManager.getInstance();
-
-        // Find the active browser tab that matches the origin
-        const views = (tabManager as any).views as Map<string, any>;
-        let filled = false;
-
-        for (const [tabId, view] of views) {
-          const tabUrl = view.webContents.getURL();
-          try {
-            const tabOrigin = new URL(tabUrl).origin;
-            if (origin && tabOrigin !== origin) continue;
-          } catch { continue }
-
-          // Inject credentials directly into the tab
-          const fillScript = `
-            (function() {
-              var b = window.sullaBridge;
-              if (!b) return { success: false, error: 'Bridge not available' };
-              var f = b.detectLoginForm();
-              if (!f || !f.hasLoginForm) return { success: false, error: 'No login form found' };
-              var uOk = false, pOk = false;
-              if (f.usernameHandle) uOk = b.setValue(f.usernameHandle, ${ JSON.stringify(username) });
-              if (f.passwordHandle) pOk = b.setValue(f.passwordHandle, ${ JSON.stringify(password) });
-              // Auto-submit after filling
-              setTimeout(function() {
-                var pwEl = f.passwordField;
-                var form = pwEl && pwEl.closest ? pwEl.closest('form') : null;
-                if (form) {
-                  if (typeof form.requestSubmit === 'function') { form.requestSubmit(); }
-                  else { form.submit(); }
-                } else {
-                  var container = pwEl ? pwEl.parentElement : document.body;
-                  for (var d = 0; d < 5 && container; d++) {
-                    var btn = container.querySelector('button[type="submit"], input[type="submit"], button:not([type])');
-                    if (btn) { btn.click(); break; }
-                    container = container.parentElement;
-                  }
-                }
-              }, 200);
-              return { success: uOk || pOk, usernameOk: uOk, passwordOk: pOk };
-            })();
-          `;
-          await view.webContents.executeJavaScript(fillScript, true);
-          filled = true;
-          break;
-        }
-
-        if (!filled) {
-          return {
-            successBoolean: false,
-            responseString: `No browser tab found${ origin ? ` for ${ origin }` : '' }. Make sure a browser tab is open to the login page.`,
-          };
-        }
+        targetUrl = await resolution.bridge.getPageUrl();
       } catch (err) {
         return {
           successBoolean: false,
-          responseString: `Autofill injection failed: ${ err instanceof Error ? err.message : 'Unknown error' }`,
+          responseString: `[${ resolution.assetId }] Could not inspect the target tab URL: ${ err instanceof Error ? err.message : 'Unknown error' }`,
+        };
+      }
+
+      let targetOrigin: string;
+      try {
+        targetOrigin = new URL(targetUrl).origin;
+      } catch {
+        return {
+          successBoolean: false,
+          responseString: `[${ resolution.assetId }] Target tab has an invalid URL (${ targetUrl || 'empty' }); credentials were not filled.`,
+        };
+      }
+
+      const expectedOrigin = origin || credentialOrigin;
+      if (expectedOrigin && targetOrigin !== expectedOrigin) {
+        return {
+          successBoolean: false,
+          responseString: `[${ resolution.assetId }] Target tab origin ${ targetOrigin } does not match credential origin ${ expectedOrigin }; credentials were not filled.`,
+        };
+      }
+
+      let fillResult: AutofillResult;
+      try {
+        fillResult = await resolution.bridge.execInPageStrict(buildAutofillScript(username, password)) as AutofillResult;
+      } catch (err) {
+        return {
+          successBoolean: false,
+          responseString: `[${ resolution.assetId }] Autofill injection failed: ${ err instanceof Error ? err.message : 'Unknown error' }`,
+        };
+      }
+
+      if (!fillResult || typeof fillResult !== 'object') {
+        return {
+          successBoolean: false,
+          responseString: `[${ resolution.assetId }] Autofill returned no verification result; credentials were not confirmed in the target tab.`,
+        };
+      }
+
+      const verified = fillResult.success === true &&
+        fillResult.runtimeReady === true &&
+        (!username || fillResult.usernameOk === true) &&
+        (!password || fillResult.passwordOk === true);
+
+      if (!verified) {
+        const reason = fillResult.error || 'the page did not confirm the expected fields';
+        return {
+          successBoolean: false,
+          responseString: `[${ resolution.assetId }] Autofill failed for ${ targetOrigin }: ${ reason }.`,
         };
       }
 
       return {
         successBoolean: true,
-        responseString: `Autofill triggered for ${ username }. The password was filled directly in the browser — it was not included in this response.`,
+        responseString: `[${ resolution.assetId }] Autofill verified non-empty credential fields for ${ targetOrigin }. The password was not included in this response.`,
       };
     } catch (error) {
       return {

--- a/resources/sulla-docs/tools/inventory.md
+++ b/resources/sulla-docs/tools/inventory.md
@@ -150,7 +150,7 @@ sulla <category> --help          # what THIS install exposes right now
 - `sulla vault/vault_set_credential` — Create / update a credential.
 - `sulla vault/vault_set_active_account` — Set the default account for an integration.
 - `sulla vault/vault_list` — List saved website credentials (no passwords).
-- `sulla vault/vault_autofill` — Inject saved credentials into the active browser tab.
+- `sulla vault/vault_autofill` — Inject saved credentials into the active or explicitly targeted background browser tab, with origin and non-empty-field verification.
 - `sulla vault/vault_delete_credential` — Delete a credential property (requires `confirm:true`).
 
 → See [`tools/vault.md`](vault.md)

--- a/resources/sulla-docs/tools/vault.md
+++ b/resources/sulla-docs/tools/vault.md
@@ -36,7 +36,7 @@ This is the most important thing to understand. Every credential has one of four
 | `sulla vault/vault_set_credential` | Create or update one credential property (encrypted on write) |
 | `sulla vault/vault_set_active_account` | Mark which account is the default for an integration |
 | `sulla vault/vault_list` | List all saved website credentials (for autofill); passwords never returned |
-| `sulla vault/vault_autofill` | Trigger browser injection of stored username/password into the active tab |
+| `sulla vault/vault_autofill` | Inject stored username/password into the active tab, or an explicit background tab via `assetId`; success requires non-empty field verification |
 
 ## Common requests
 
@@ -70,13 +70,18 @@ sulla github_account_id/github '{"method":"GET","path":"/user/repos"}'
 The integration proxy injects the PAT from the vault. Agent never touches the token.
 
 ### "Autofill my password on this site"
-1. Make sure the user is on the site (check the active browser tab)
+1. Make sure the user is on the site and identify the intended browser tab
 2. Trigger:
    ```bash
    sulla vault/vault_autofill '{"origin":"https://github.com"}'
    ```
-3. The vault service finds the matching account, executes JS in the tab via `window.sullaBridge.detectLoginForm()` + `setValue()`, auto-submits after 200ms
-4. The password never appears in the tool response
+   To target a specific background tab, include its exact `assetId`:
+   ```bash
+   sulla vault/vault_autofill '{"origin":"https://github.com","assetId":"github-login"}'
+   ```
+3. The vault service resolves that exact tab through the browser registry, verifies its origin, fills via `window.sullaBridge.detectLoginForm()` + `setValue()`, and proves every expected field is non-empty before reporting success or auto-submitting
+4. If the target runtime is not initialized, the page rejects a value, or the origin differs, the tool returns a failure tied to the target `assetId`
+5. The password never appears in the tool response
 
 If no matching account: tell the user, offer to save one via `vault_set_credential`.
 


### PR DESCRIPTION
## What changed

- resolve autofill through the browser TabRegistry so the default is the active tab and `assetId` can explicitly target a background tab
- verify the actual target origin before credential injection
- consume the page execution result and fail on a missing/partial browser runtime
- prove every expected field is non-empty before reporting success or scheduling submit
- return target-specific failures without returning credential values
- document the new target and verification contract

## Regression coverage

- active-tab default targeting
- explicit background-tab targeting
- partially initialized runtime
- password field rejected/cleared by the page
- wrong-origin refusal
- direct generated-script proof that both fields fill while only booleans return

## Verification

- focused Jest: 7/7 passed
- focused ESLint: passed
- `git diff --check`: passed
- repo-wide agent TypeScript check attempted twice, but the VM killed both the default 2 GB run and the 8 GB retry for memory; Jest TypeScript compilation for the changed implementation/tests passed

Projects task: 6xEj