### PR TITLE
feat(dispatcher): add bounded verifier pool

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0064_add_verification_dispatches.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0064_add_verification_dispatches.ts
@@ -1,0 +1,40 @@
+/**
+ * Add the second, independently bounded dispatcher phase.
+ *
+ * The existing partial unique index remains the cross-kind collision guard:
+ * one task can have at most one running execution OR verification lease.
+ */
+
+export const up = `
+  ALTER TABLE work_task_dispatches
+    ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'execution',
+    ADD COLUMN IF NOT EXISTS attempt INTEGER NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS verdict TEXT,
+    ADD COLUMN IF NOT EXISTS artifact_sha TEXT,
+    ADD COLUMN IF NOT EXISTS failure_reason TEXT;
+
+  ALTER TABLE work_task_dispatches
+    DROP CONSTRAINT IF EXISTS work_task_dispatches_kind_check,
+    DROP CONSTRAINT IF EXISTS work_task_dispatches_verdict_check;
+
+  ALTER TABLE work_task_dispatches
+    ADD CONSTRAINT work_task_dispatches_kind_check
+      CHECK (kind IN ('execution', 'verification')),
+    ADD CONSTRAINT work_task_dispatches_verdict_check
+      CHECK (verdict IS NULL OR verdict IN ('APPROVE', 'REWORK', 'BLOCKED'));
+
+  CREATE INDEX IF NOT EXISTS idx_work_task_dispatches_metrics
+    ON work_task_dispatches (kind, status, started_at DESC);
+`;
+
+export const down = `
+  DROP INDEX IF EXISTS idx_work_task_dispatches_metrics;
+  ALTER TABLE work_task_dispatches
+    DROP CONSTRAINT IF EXISTS work_task_dispatches_verdict_check,
+    DROP CONSTRAINT IF EXISTS work_task_dispatches_kind_check,
+    DROP COLUMN IF EXISTS failure_reason,
+    DROP COLUMN IF EXISTS artifact_sha,
+    DROP COLUMN IF EXISTS verdict,
+    DROP COLUMN IF EXISTS attempt,
+    DROP COLUMN IF EXISTS kind;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0064_add_verification_dispatches.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0064_add_verification_dispatches.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { down, up } from '../0064_add_verification_dispatches';
+
+describe('0064_add_verification_dispatches', () => {
+  it('adds auditable verification fields without weakening the one-live-lease index', () => {
+    expect(up).toContain("kind TEXT NOT NULL DEFAULT 'execution'");
+    expect(up).toContain('attempt INTEGER NOT NULL DEFAULT 1');
+    expect(up).toContain('verdict TEXT');
+    expect(up).toContain('artifact_sha TEXT');
+    expect(up).toContain('failure_reason TEXT');
+    expect(up).toContain("CHECK (kind IN ('execution', 'verification'))");
+    expect(up).not.toContain('DROP INDEX IF EXISTS idx_work_task_dispatches_one_live');
+  });
+
+  it('has a reversible down migration', () => {
+    expect(down).toContain('DROP COLUMN IF EXISTS artifact_sha');
+    expect(down).toContain('DROP COLUMN IF EXISTS kind');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -51,6 +51,7 @@ import { up as up_0060, down as down_0060 } from './0060_add_skill_slug_to_ident
 import { up as up_0061, down as down_0061 } from './0061_add_work_task_activity';
 import { up as up_0062, down as down_0062 } from './0062_create_work_task_dispatches';
 import { up as up_0063, down as down_0063 } from './0063_normalize_autonomous_task_ownership';
+import { up as up_0064, down as down_0064 } from './0064_add_verification_dispatches';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -103,4 +104,5 @@ export const migrationsRegistry = [
   { name: '0061_add_work_task_activity',                           up: up_0061, down: down_0061 },
   { name: '0062_create_work_task_dispatches',                      up: up_0062, down: down_0062 },
   { name: '0063_normalize_autonomous_task_ownership',              up: up_0063, down: down_0063 },
+  { name: '0064_add_verification_dispatches',                       up: up_0064, down: down_0064 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -118,9 +118,12 @@ export class WorkTaskDispatchModel {
         SELECT t.*
           FROM work_tasks t
           JOIN work_epics e ON e.id = t.epic_id
+          JOIN work_projects p ON p.id = e.project_id
          WHERE t.archived = false
            AND t.status = 'in_review'
            AND e.archived = false
+           AND p.archived = false
+           AND NOT (p.status = ANY($1::text[]))
            AND NOT (e.status = ANY($1::text[]))
            AND (t.assignee IS NULL OR LOWER(t.assignee) IN ('heartbeat', 'dispatcher', 'verifier'))
            AND NOT EXISTS (
@@ -144,6 +147,13 @@ export class WorkTaskDispatchModel {
               ORDER BY d.started_at DESC LIMIT 1
            ), '') <> $3
          ORDER BY
+           CASE p.priority
+             WHEN 'critical' THEN 0 WHEN 'p0' THEN 0 WHEN 'P0' THEN 0 WHEN '🔴' THEN 0
+             WHEN 'high' THEN 1 WHEN 'p1' THEN 1 WHEN 'P1' THEN 1
+             WHEN 'medium' THEN 2 WHEN 'p2' THEN 2 WHEN 'P2' THEN 2 WHEN '🟡' THEN 2
+             WHEN 'p3' THEN 3 WHEN 'P3' THEN 3
+             WHEN 'low' THEN 4 WHEN 'p4' THEN 4 WHEN 'P4' THEN 4 WHEN '⚪' THEN 4
+             ELSE 5 END,
            CASE e.priority
              WHEN 'critical' THEN 0 WHEN 'p0' THEN 0 WHEN 'P0' THEN 0 WHEN '🔴' THEN 0
              WHEN 'high' THEN 1 WHEN 'p1' THEN 1 WHEN 'P1' THEN 1
@@ -163,7 +173,7 @@ export class WorkTaskDispatchModel {
            t.position ASC
          FOR UPDATE OF t SKIP LOCKED
          LIMIT 1
-      `, [CLOSED_EPIC_STATUSES, NON_AUTONOMOUS_LABELS, agentId]);
+      `, [CLOSED_EPIC_STATUSES, NON_AUTONOMOUS_TASK_LABELS, agentId]);
 
       const task = candidate.rows[0];
       if (!task) return null;
@@ -262,6 +272,7 @@ export class WorkTaskDispatchModel {
     id: string,
     verdict: VerificationVerdict,
     artifactSha: string,
+    currentArtifactSha: string | null,
     summary: string,
   ): Promise<VerificationVerdict | null> {
     return postgresClient.transaction(async(client: PoolClient) => {
@@ -272,6 +283,7 @@ export class WorkTaskDispatchModel {
       `, [id]);
       const taskId = current.rows[0]?.task_id;
       if (!taskId) return null;
+      if (verdict === 'APPROVE' && currentArtifactSha !== artifactSha) return null;
 
       let finalVerdict = verdict;
       if (verdict === 'REWORK') {

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -7,6 +7,8 @@ import type { WorkTaskRecord } from './WorkItemsModel';
 import type { PoolClient } from 'pg';
 
 export type WorkTaskDispatchStatus = 'running' | 'completed' | 'blocked' | 'failed' | 'stale';
+export type WorkTaskDispatchKind = 'execution' | 'verification';
+export type VerificationVerdict = 'APPROVE' | 'REWORK' | 'BLOCKED';
 
 export interface WorkTaskDispatchRecord {
   id:           string;
@@ -14,6 +16,11 @@ export interface WorkTaskDispatchRecord {
   agent_id:     string;
   thread_id:    string;
   status:       WorkTaskDispatchStatus;
+  kind:         WorkTaskDispatchKind;
+  attempt:      number;
+  verdict:      VerificationVerdict | null;
+  artifact_sha: string | null;
+  failure_reason: string | null;
   result:       string | null;
   error:        string | null;
   started_at:   string;
@@ -82,8 +89,11 @@ export class WorkTaskDispatchModel {
       const id = `dispatch-${ randomUUID() }`;
       const threadId = `task-dispatch-${ task.id }-${ Date.now() }`;
       const inserted = await client.query<WorkTaskDispatchRecord>(`
-        INSERT INTO work_task_dispatches (id, task_id, agent_id, thread_id)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO work_task_dispatches (id, task_id, agent_id, thread_id, kind, attempt)
+        VALUES ($1, $2, $3, $4, 'execution', COALESCE((
+          SELECT MAX(attempt) + 1 FROM work_task_dispatches
+           WHERE task_id = $2 AND kind = 'execution'
+        ), 1))
         RETURNING *
       `, [id, task.id, agentId, threadId]);
 
@@ -102,9 +112,89 @@ export class WorkTaskDispatchModel {
     });
   }
 
-  static async countRunning(): Promise<number> {
+  static async claimNextReview(agentId: string): Promise<ClaimedDispatch | null> {
+    return postgresClient.transaction(async(client) => {
+      const candidate = await client.query<WorkTaskRecord>(`
+        SELECT t.*
+          FROM work_tasks t
+          JOIN work_epics e ON e.id = t.epic_id
+         WHERE t.archived = false
+           AND t.status = 'in_review'
+           AND e.archived = false
+           AND NOT (e.status = ANY($1::text[]))
+           AND (t.assignee IS NULL OR LOWER(t.assignee) IN ('heartbeat', 'dispatcher', 'verifier'))
+           AND NOT EXISTS (
+             SELECT 1 FROM unnest(COALESCE(t.labels, '{}')) AS label
+              WHERE LOWER(label) = ANY($2::text[])
+           )
+           AND NOT EXISTS (
+             SELECT 1 FROM work_task_dispatches d
+              WHERE d.task_id = t.id AND d.status = 'running'
+           )
+           AND NOT EXISTS (
+             SELECT 1 FROM work_task_dispatches d
+              WHERE d.task_id = t.id AND d.kind = 'verification'
+                AND d.status IN ('failed', 'stale')
+                AND d.finished_at > now() - interval '5 minutes'
+           )
+           AND COALESCE((
+             SELECT d.agent_id
+               FROM work_task_dispatches d
+              WHERE d.task_id = t.id AND d.kind = 'execution'
+              ORDER BY d.started_at DESC LIMIT 1
+           ), '') <> $3
+         ORDER BY
+           CASE e.priority
+             WHEN 'critical' THEN 0 WHEN 'p0' THEN 0 WHEN 'P0' THEN 0 WHEN '🔴' THEN 0
+             WHEN 'high' THEN 1 WHEN 'p1' THEN 1 WHEN 'P1' THEN 1
+             WHEN 'medium' THEN 2 WHEN 'p2' THEN 2 WHEN 'P2' THEN 2 WHEN '🟡' THEN 2
+             WHEN 'p3' THEN 3 WHEN 'P3' THEN 3
+             WHEN 'low' THEN 4 WHEN 'p4' THEN 4 WHEN 'P4' THEN 4 WHEN '⚪' THEN 4
+             ELSE 5 END,
+           CASE t.priority
+             WHEN 'critical' THEN 0 WHEN 'p0' THEN 0 WHEN 'P0' THEN 0 WHEN '🔴' THEN 0
+             WHEN 'high' THEN 1 WHEN 'p1' THEN 1 WHEN 'P1' THEN 1
+             WHEN 'medium' THEN 2 WHEN 'p2' THEN 2 WHEN 'P2' THEN 2 WHEN '🟡' THEN 2
+             WHEN 'p3' THEN 3 WHEN 'P3' THEN 3
+             WHEN 'low' THEN 4 WHEN 'p4' THEN 4 WHEN 'P4' THEN 4 WHEN '⚪' THEN 4
+             ELSE 5 END,
+           t.due_at ASC NULLS LAST,
+           t.last_activity_at ASC,
+           t.position ASC
+         FOR UPDATE OF t SKIP LOCKED
+         LIMIT 1
+      `, [CLOSED_EPIC_STATUSES, NON_AUTONOMOUS_LABELS, agentId]);
+
+      const task = candidate.rows[0];
+      if (!task) return null;
+
+      const id = `dispatch-${ randomUUID() }`;
+      const threadId = `task-verification-${ task.id }-${ Date.now() }`;
+      const inserted = await client.query<WorkTaskDispatchRecord>(`
+        INSERT INTO work_task_dispatches (id, task_id, agent_id, thread_id, kind, attempt)
+        VALUES ($1, $2, $3, $4, 'verification', COALESCE((
+          SELECT MAX(attempt) + 1 FROM work_task_dispatches
+           WHERE task_id = $2 AND kind = 'verification'
+        ), 1))
+        RETURNING *
+      `, [id, task.id, agentId, threadId]);
+
+      await client.query(`
+        UPDATE work_tasks
+           SET assignee = 'verifier', updated_at = now(), last_activity_at = now(),
+               last_moved_at = now(), last_moved_by = 'dispatcher'
+         WHERE id = $1 AND status = 'in_review'
+      `, [task.id]);
+
+      return { dispatch: inserted.rows[0], task };
+    });
+  }
+
+  static async countRunning(kind?: WorkTaskDispatchKind): Promise<number> {
     const row = await postgresClient.queryOne<{ count: string }>(
-      `SELECT COUNT(*)::text AS count FROM work_task_dispatches WHERE status = 'running'`,
+      `SELECT COUNT(*)::text AS count FROM work_task_dispatches
+        WHERE status = 'running' AND ($1::text IS NULL OR kind = $1)`,
+      [kind ?? null],
     );
     return Number(row?.count || 0);
   }
@@ -132,27 +222,124 @@ export class WorkTaskDispatchModel {
 
   static async recoverStale(staleMinutes = 45): Promise<string[]> {
     return postgresClient.transaction(async(client: PoolClient) => {
-      const stale = await client.query<{ id: string; task_id: string }>(`
+      const stale = await client.query<{ id: string; task_id: string; kind: WorkTaskDispatchKind }>(`
         UPDATE work_task_dispatches
            SET status = 'stale',
                error = 'dispatcher lease expired or app restarted',
+               failure_reason = 'lease_expired',
                finished_at = now()
          WHERE status = 'running'
            AND heartbeat_at < now() - ($1 * interval '1 minute')
-        RETURNING id, task_id
+        RETURNING id, task_id, kind
       `, [staleMinutes]);
 
-      const taskIds = stale.rows.map(row => row.task_id);
-      if (taskIds.length > 0) {
+      const executionTaskIds = stale.rows.filter(row => row.kind === 'execution').map(row => row.task_id);
+      const verificationTaskIds = stale.rows.filter(row => row.kind === 'verification').map(row => row.task_id);
+      if (executionTaskIds.length > 0) {
         await client.query(`
           UPDATE work_tasks
              SET status = 'todo', assignee = NULL,
                  updated_at = now(), last_moved_at = now(),
                  last_activity_at = now(), last_moved_by = 'dispatcher'
            WHERE id = ANY($1::text[]) AND status = 'planning' AND assignee = 'dispatcher'
-        `, [taskIds]);
+        `, [executionTaskIds]);
       }
-      return taskIds;
+      if (verificationTaskIds.length > 0) {
+        await client.query(`
+          UPDATE work_tasks
+             SET status = 'in_review', assignee = 'heartbeat',
+                 updated_at = now(), last_moved_at = now(),
+                 last_activity_at = now(), last_moved_by = 'dispatcher'
+           WHERE id = ANY($1::text[]) AND status = 'in_review' AND assignee = 'verifier'
+        `, [verificationTaskIds]);
+      }
+      return stale.rows.map(row => row.task_id);
+    });
+  }
+
+  /** Settle a parsed verifier verdict and its Projects transition atomically. */
+  static async finalizeVerification(
+    id: string,
+    verdict: VerificationVerdict,
+    artifactSha: string,
+    summary: string,
+  ): Promise<VerificationVerdict | null> {
+    return postgresClient.transaction(async(client: PoolClient) => {
+      const current = await client.query<{ task_id: string }>(`
+        SELECT task_id FROM work_task_dispatches
+         WHERE id = $1 AND kind = 'verification' AND status = 'running'
+         FOR UPDATE
+      `, [id]);
+      const taskId = current.rows[0]?.task_id;
+      if (!taskId) return null;
+
+      let finalVerdict = verdict;
+      if (verdict === 'REWORK') {
+        const repeated = await client.query<{ count: string }>(`
+          SELECT COUNT(*)::text AS count FROM work_task_dispatches
+           WHERE task_id = $1 AND kind = 'verification' AND verdict = 'REWORK'
+             AND failure_reason = $2
+        `, [taskId, summary]);
+        if (Number(repeated.rows[0]?.count || 0) >= 2) finalVerdict = 'BLOCKED';
+      }
+
+      const transition = finalVerdict === 'APPROVE'
+        ? { status: 'done', assignee: null }
+        : finalVerdict === 'REWORK'
+          ? { status: 'todo', assignee: 'dispatcher' }
+          : { status: 'blocked', assignee: 'heartbeat' };
+      const repeatedSuffix = finalVerdict !== verdict
+        ? '\n\nRepeated identical rework reached the retry ceiling; routed to Heartbeat recovery.'
+        : '';
+
+      await client.query(`
+        UPDATE work_task_dispatches
+           SET status = 'completed', verdict = $2, artifact_sha = $3,
+               result = $4, failure_reason = $5,
+               heartbeat_at = now(), finished_at = now()
+         WHERE id = $1 AND status = 'running'
+      `, [id, finalVerdict, artifactSha, summary, verdict === 'REWORK' ? summary : null]);
+      await client.query(`
+        INSERT INTO work_task_comments (id, task_id, body, author)
+        VALUES ($1, $2, $3, 'verifier')
+      `, [randomUUID().slice(0, 12), taskId,
+        `Verification ${ id }: ${ finalVerdict } at ${ artifactSha }.\n\n${ summary }${ repeatedSuffix }`]);
+      await client.query(`
+        UPDATE work_tasks
+           SET status = $2, assignee = $3, updated_at = now(),
+               last_moved_at = now(), last_activity_at = now(),
+               last_moved_by = 'verifier',
+               completed_at = CASE WHEN $2 = 'done' THEN now() ELSE NULL END
+         WHERE id = $1 AND status = 'in_review'
+      `, [taskId, transition.status, transition.assignee]);
+      return finalVerdict;
+    });
+  }
+
+  /** Audit an infrastructure/output failure without turning it into a task blocker. */
+  static async failVerification(id: string, reason: string): Promise<boolean> {
+    return postgresClient.transaction(async(client: PoolClient) => {
+      const settled = await client.query<{ task_id: string }>(`
+        UPDATE work_task_dispatches
+           SET status = 'failed', error = $2, failure_reason = $2,
+               heartbeat_at = now(), finished_at = now()
+         WHERE id = $1 AND kind = 'verification' AND status = 'running'
+        RETURNING task_id
+      `, [id, reason]);
+      const taskId = settled.rows[0]?.task_id;
+      if (!taskId) return false;
+      await client.query(`
+        INSERT INTO work_task_comments (id, task_id, body, author)
+        VALUES ($1, $2, $3, 'verifier')
+      `, [randomUUID().slice(0, 12), taskId,
+        `Verification ${ id } failed and was released for retry: ${ reason }`]);
+      await client.query(`
+        UPDATE work_tasks
+           SET status = 'in_review', assignee = 'heartbeat', updated_at = now(),
+               last_moved_at = now(), last_activity_at = now(), last_moved_by = 'verifier'
+         WHERE id = $1 AND status = 'in_review'
+      `, [taskId]);
+      return true;
     });
   }
 }

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
@@ -114,9 +114,34 @@ describe('WorkTaskDispatchModel', () => {
     expect(clientQuery.mock.calls[2][1]).toEqual(['task-new', 'dispatcher']);
   });
 
+  it('claims review work under the same cross-kind lease and excludes the execution agent', async() => {
+    const task = { id: 'task-2', status: 'in_review', labels: [] } as any;
+    const dispatch = {
+      id: 'dispatch-review-1', task_id: 'task-2', kind: 'verification', attempt: 1,
+    } as any;
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [task] })
+      .mockResolvedValueOnce({ rows: [dispatch] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.claimNextReview('codex-test')).resolves.toMatchObject({
+      task: { id: 'task-2' }, dispatch: { kind: 'verification' },
+    });
+    expect(query.mock.calls[0][0]).toContain("t.status = 'in_review'");
+    expect(query.mock.calls[0][0]).toContain('FOR UPDATE OF t SKIP LOCKED');
+    expect(query.mock.calls[0][0]).toContain("d.status = 'running'");
+    expect(query.mock.calls[0][0]).toContain("d.status IN ('failed', 'stale')");
+    expect(query.mock.calls[0][0]).toContain("interval '5 minutes'");
+    expect(query.mock.calls[0][0]).toContain("d.kind = 'execution'");
+    expect(query.mock.calls[0][0]).toContain("<> $3");
+    expect(query.mock.calls[1][0]).toContain("'verification'");
+    expect(query.mock.calls[2][0]).toContain("assignee = 'verifier'");
+  });
+
   it('releases stale planning leases back to todo in one transaction', async() => {
     const query = (jest.fn() as any)
-      .mockResolvedValueOnce({ rows: [{ id: 'dispatch-1', task_id: 'task-1' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'dispatch-1', task_id: 'task-1', kind: 'execution' }] })
       .mockResolvedValueOnce({ rows: [] });
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
@@ -126,5 +151,77 @@ describe('WorkTaskDispatchModel', () => {
     expect(query.mock.calls[1][0]).toContain("status = 'todo'");
     expect(query.mock.calls[1][0]).toContain("status = 'planning'");
     expect(query.mock.calls[1][0]).toContain("assignee = 'dispatcher'");
+  });
+
+  it('returns stale verification leases to in_review instead of blocking them', async() => {
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [{ id: 'dispatch-2', task_id: 'task-2', kind: 'verification' }] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.recoverStale(45)).resolves.toEqual(['task-2']);
+    expect(query.mock.calls[1][0]).toContain("status = 'in_review'");
+    expect(query.mock.calls[1][0]).toContain("assignee = 'verifier'");
+  });
+
+  it('settles the verifier verdict, exact head, comment, and task transition in one transaction', async() => {
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [{ task_id: 'task-2' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.finalizeVerification(
+      'dispatch-2', 'APPROVE', 'a'.repeat(40), 'All criteria verified.',
+    )).resolves.toBe('APPROVE');
+    expect(query.mock.calls[1][0]).toContain('artifact_sha = $3');
+    expect(query.mock.calls[2][0]).toContain('INSERT INTO work_task_comments');
+    expect(query.mock.calls[3][0]).toContain("completed_at = CASE WHEN $2 = 'done'");
+    expect(query.mock.calls[3][1]).toEqual(['task-2', 'done', null]);
+  });
+
+  it('audits verifier crashes while leaving the task retryable in_review', async() => {
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [{ task_id: 'task-2' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.failVerification('dispatch-2', 'boom')).resolves.toBe(true);
+    expect(query.mock.calls[0][0]).toContain("status = 'failed'");
+    expect(query.mock.calls[1][1][2]).toContain('released for retry');
+    expect(query.mock.calls[2][0]).toContain("status = 'in_review'");
+  });
+
+  it('returns concrete rework to the dispatcher', async() => {
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [{ task_id: 'task-2' }] })
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.finalizeVerification(
+      'dispatch-2', 'REWORK', 'c'.repeat(40), 'Missing regression test.',
+    )).resolves.toBe('REWORK');
+    expect(query.mock.calls[4][1]).toEqual(['task-2', 'todo', 'dispatcher']);
+  });
+
+  it('routes a third identical rework to Heartbeat recovery', async() => {
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [{ task_id: 'task-2' }] })
+      .mockResolvedValueOnce({ rows: [{ count: '2' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.finalizeVerification(
+      'dispatch-2', 'REWORK', 'd'.repeat(40), 'Same defect.',
+    )).resolves.toBe('BLOCKED');
+    expect(query.mock.calls[4][1]).toEqual(['task-2', 'blocked', 'heartbeat']);
+    expect(query.mock.calls[3][1][2]).toContain('retry ceiling');
   });
 });

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
@@ -101,9 +101,11 @@ describe('WorkTaskDispatchModel', () => {
 
     const clientQuery = (jest.fn() as any)
       .mockResolvedValueOnce({ rows: [created] })
-      .mockResolvedValueOnce({ rows: [{
-        id: 'dispatch-1', task_id: created.id, agent_id: 'opus-worker', status: 'running',
-      }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'dispatch-1', task_id: created.id, agent_id: 'opus-worker', status: 'running',
+        }],
+      })
       .mockResolvedValueOnce({ rows: [] });
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query: clientQuery }));
 
@@ -129,6 +131,14 @@ describe('WorkTaskDispatchModel', () => {
       task: { id: 'task-2' }, dispatch: { kind: 'verification' },
     });
     expect(query.mock.calls[0][0]).toContain("t.status = 'in_review'");
+    expect(query.mock.calls[0][0]).toContain('JOIN work_projects p ON p.id = e.project_id');
+    expect(query.mock.calls[0][0]).toContain('CASE p.priority');
+    expect(query.mock.calls[0][0].indexOf('CASE p.priority')).toBeLessThan(
+      query.mock.calls[0][0].indexOf('CASE e.priority'),
+    );
+    expect(query.mock.calls[0][0].indexOf('CASE e.priority')).toBeLessThan(
+      query.mock.calls[0][0].indexOf('CASE t.priority'),
+    );
     expect(query.mock.calls[0][0]).toContain('FOR UPDATE OF t SKIP LOCKED');
     expect(query.mock.calls[0][0]).toContain("d.status = 'running'");
     expect(query.mock.calls[0][0]).toContain("d.status IN ('failed', 'stale')");
@@ -173,12 +183,22 @@ describe('WorkTaskDispatchModel', () => {
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     await expect(WorkTaskDispatchModel.finalizeVerification(
-      'dispatch-2', 'APPROVE', 'a'.repeat(40), 'All criteria verified.',
+      'dispatch-2', 'APPROVE', 'a'.repeat(40), 'a'.repeat(40), 'All criteria verified.',
     )).resolves.toBe('APPROVE');
     expect(query.mock.calls[1][0]).toContain('artifact_sha = $3');
     expect(query.mock.calls[2][0]).toContain('INSERT INTO work_task_comments');
     expect(query.mock.calls[3][0]).toContain("completed_at = CASE WHEN $2 = 'done'");
     expect(query.mock.calls[3][1]).toEqual(['task-2', 'done', null]);
+  });
+
+  it('refuses to settle approval when the server-resolved head differs', async() => {
+    const query = jest.fn(() => Promise.resolve({ rows: [{ task_id: 'task-2' }] }));
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.finalizeVerification(
+      'dispatch-2', 'APPROVE', 'a'.repeat(40), 'b'.repeat(40), 'Reviewed stale head.',
+    )).resolves.toBeNull();
+    expect(query).toHaveBeenCalledTimes(1);
   });
 
   it('audits verifier crashes while leaving the task retryable in_review', async() => {
@@ -204,7 +224,7 @@ describe('WorkTaskDispatchModel', () => {
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     await expect(WorkTaskDispatchModel.finalizeVerification(
-      'dispatch-2', 'REWORK', 'c'.repeat(40), 'Missing regression test.',
+      'dispatch-2', 'REWORK', 'c'.repeat(40), null, 'Missing regression test.',
     )).resolves.toBe('REWORK');
     expect(query.mock.calls[4][1]).toEqual(['task-2', 'todo', 'dispatcher']);
   });
@@ -219,7 +239,7 @@ describe('WorkTaskDispatchModel', () => {
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     await expect(WorkTaskDispatchModel.finalizeVerification(
-      'dispatch-2', 'REWORK', 'd'.repeat(40), 'Same defect.',
+      'dispatch-2', 'REWORK', 'd'.repeat(40), null, 'Same defect.',
     )).resolves.toBe('BLOCKED');
     expect(query.mock.calls[4][1]).toEqual(['task-2', 'blocked', 'heartbeat']);
     expect(query.mock.calls[3][1][2]).toContain('retry ceiling');

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 
 import { BaseLanguageModel, type ChatMessage, type NormalizedResponse, type StreamCallbacks, FinishReason } from './BaseLanguageModel';
 import { bindCodexMcpSession, buildCodexMcpOverrides, CODEX_MCP_TOKEN_ENV } from './codexMcpConfig';
+import { codexSandboxArgs } from './codexSandboxPolicy';
 import { redisClient } from '../database/RedisClient';
 import { ensureCodexAuthFile, codexAuthPath, codexHomeDir } from '../util/codexAuthFile';
 
@@ -28,6 +29,7 @@ interface CodexPrewarmRecord {
   mcpSession:      RegisteredSession | null;
   model:           string;
   existingSession: string | undefined;
+  readOnly:        boolean;
   createdAt:       number;
   closed:          boolean;
   busy:            boolean;
@@ -155,18 +157,20 @@ export class CodexService extends BaseLanguageModel {
    * process before the turn's prompt exists — runCodex and prewarm both
    * write the prompt to stdin themselves, at different times.
    */
-  private buildSpawnArgs(p: { existingSession?: string; mcpSession?: RegisteredSession | null }): string[] {
+  private buildSpawnArgs(p: {
+    existingSession?: string;
+    mcpSession?: RegisteredSession | null;
+    readOnly?: boolean;
+  }): string[] {
     const shq = (s: string) => `'${ s.replace(/'/g, "'\\''") }'`;
 
     const codexArgs = ['codex', 'exec'];
     if (p.existingSession) {
       codexArgs.push('resume', shq(p.existingSession));
     }
-    codexArgs.push(
-      '--json',
-      '--dangerously-bypass-approvals-and-sandbox',
-      '--skip-git-repo-check',
-    );
+    codexArgs.push('--json');
+    codexArgs.push(...codexSandboxArgs(!!p.readOnly));
+    codexArgs.push('--skip-git-repo-check');
     if (p.mcpSession) {
       for (const override of buildCodexMcpOverrides(p.mcpSession)) {
         codexArgs.push('-c', shq(override));
@@ -229,7 +233,8 @@ export class CodexService extends BaseLanguageModel {
 
       const limactlPath = paths.limactl;
       const limaHome = paths.lima;
-      const args = this.buildSpawnArgs({ existingSession, mcpSession });
+      const readOnly = !!(state.metadata as any)?.verifierReadOnly;
+      const args = this.buildSpawnArgs({ existingSession, mcpSession, readOnly });
       const proc = childProcess.spawn(limactlPath, args, {
         env: { ...process.env, LIMA_HOME: limaHome, TERM: 'dumb' },
       });
@@ -239,6 +244,7 @@ export class CodexService extends BaseLanguageModel {
         mcpSession,
         model:     this.model || 'codex',
         existingSession,
+        readOnly,
         createdAt: Date.now(),
         closed:    false,
         busy:      false,
@@ -271,12 +277,17 @@ export class CodexService extends BaseLanguageModel {
    * was minted concurrently) must also evict the record, not just a model
    * mismatch.
    */
-  private claimPrewarm(convId: string, model: string, existingSession: string | undefined): CodexPrewarmRecord | null {
+  private claimPrewarm(
+    convId: string,
+    model: string,
+    existingSession: string | undefined,
+    readOnly: boolean,
+  ): CodexPrewarmRecord | null {
     const rec = this.prewarmed.get(convId);
     if (!rec) return null;
     this.prewarmed.delete(convId);
     if (rec.reapTimer) { clearTimeout(rec.reapTimer); rec.reapTimer = null; }
-    if (rec.closed || rec.model !== model || rec.existingSession !== existingSession) {
+    if (rec.closed || rec.model !== model || rec.existingSession !== existingSession || rec.readOnly !== readOnly) {
       this.killPrewarmRecord(rec);                       // dead, model, or session mismatch
       return null;
     }
@@ -652,14 +663,19 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
     // Speculative boot: adopt a process pre-warmed for this conversation
     // during the accumulator phase; otherwise spawn fresh below. Flag off →
     // adopted is always null and the legacy path runs byte-for-byte as
-    // before. --dangerously-bypass-approvals-and-sandbox: codex runs inside
-    // the Lima VM, which IS the sandbox — its own landlock layer is
-    // redundant here and approval prompts have no TTY to land on. The
+    // before. Normal actor runs use --dangerously-bypass-approvals-and-sandbox:
+    // codex runs inside the Lima VM, which IS the sandbox. Verifier runs are
+    // different: their graph state carries verifierReadOnly, so Codex uses its
+    // read-only sandbox and cannot mutate a checkout even through native shell.
+    // The
     // prompt is fed via stdin (`-` positional), NOT as an argv element — a
     // large transcript on the command line overflows limactl's SSH
     // multiplexing channel (same failure mode ClaudeCodeService hit).
     const speculative = await this.speculativeBootEnabled();
-    const adopted = speculative ? this.claimPrewarm(convId, this.model || 'codex', existingSession) : null;
+    const readOnly = !!(options.state?.metadata as any)?.verifierReadOnly;
+    const adopted = speculative
+      ? this.claimPrewarm(convId, this.model || 'codex', existingSession, readOnly)
+      : null;
 
     let mcpSession: RegisteredSession | null = adopted?.mcpSession ?? null;
     if (options.state) {
@@ -674,7 +690,7 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
         log.log(`[CodexService] MCP session setup failed, continuing without sulla-native tools: ${ (err as Error)?.message ?? err }`);
       }
     }
-    const args = this.buildSpawnArgs({ existingSession, mcpSession });
+    const args = this.buildSpawnArgs({ existingSession, mcpSession, readOnly });
 
     return await new Promise((resolve, reject) => {
       let mcpCleaned = false;

--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/CodexService.verifierSandbox.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/CodexService.verifierSandbox.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { codexSandboxArgs } from '../codexSandboxPolicy';
+
+describe('CodexService verifier sandbox', () => {
+  it('uses the Codex read-only sandbox for verifier runs', () => {
+    const command = codexSandboxArgs(true).join(' ');
+
+    expect(command).toContain('--sandbox read-only');
+    expect(command).not.toContain('--dangerously-bypass-approvals-and-sandbox');
+  });
+
+  it('preserves the existing actor sandbox behavior for normal runs', () => {
+    const command = codexSandboxArgs(false).join(' ');
+
+    expect(command).toContain('--dangerously-bypass-approvals-and-sandbox');
+    expect(command).not.toContain('--sandbox read-only');
+  });
+});

--- a/pkg/rancher-desktop/agent/languagemodels/codexSandboxPolicy.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/codexSandboxPolicy.ts
@@ -1,0 +1,6 @@
+/** Codex CLI sandbox flags for normal actors versus read-only verifiers. */
+export function codexSandboxArgs(readOnly: boolean): string[] {
+  return readOnly
+    ? ['--sandbox', 'read-only']
+    : ['--dangerously-bypass-approvals-and-sandbox'];
+}

--- a/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/heartbeatPrompt.test.ts
@@ -80,13 +80,15 @@ describe('heartbeatPrompt', () => {
 
   it('delegates ordinary queue selection to the mechanical dispatcher and keeps heartbeat supervisory', () => {
     expect(heartbeatPrompt).toContain('## Mechanical Dispatch — Heartbeat Supervises, PostgreSQL Decides');
-    expect(heartbeatPrompt).toContain('TaskDispatcherService mechanically fills configured worker capacity');
+    expect(heartbeatPrompt).toContain('TaskDispatcherService mechanically fills configured execution capacity');
     expect(heartbeatPrompt).toContain('one live dispatch per task');
     expect(heartbeatPrompt).toContain('Heartbeat does not select or launch ordinary queue work');
     expect(heartbeatPrompt).toContain("do not self-assign unclaimed 'todo' tasks");
     expect(heartbeatPrompt).toContain('## Supervisor Loop — Verify, Recover, Decide');
-    expect(heartbeatPrompt).toContain("Review tasks returned to 'in_review'");
-    expect(heartbeatPrompt).toContain("return the task to 'todo' for a fresh mechanical run");
+    expect(heartbeatPrompt).toContain("'taskVerifierEnabled' is true");
+    expect(heartbeatPrompt).toContain('separately bounded independent verifier pool');
+    expect(heartbeatPrompt).toContain('exact-head APPROVE/REWORK/BLOCKED evidence');
+    expect(heartbeatPrompt).toContain('Never duplicate a live verification lease');
   });
 
   it('keeps blocked recovery as the reasoning-only dispatch exception', () => {

--- a/pkg/rancher-desktop/agent/prompts/heartbeat.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeat.ts
@@ -73,7 +73,7 @@ Your project-state lives in ONE place: Postgres project tables behind the Projec
 
 That list — tasks assigned to **heartbeat** — is your supervision queue. The mechanical dispatcher returns review, failure, and blocked outcomes there. Then:
 
-- **Lane has review work** → verify each 'in_review' artifact against its task and evidence. Close strong work; comment precise findings and return weak/incomplete work to 'todo' so PostgreSQL can schedule a fresh worker.
+- **Lane has review work** → when 'taskVerifierEnabled' is false, verify each 'in_review' artifact against its task and evidence. When it is true, do not compete with the verifier pool; handle only failed/stale verification leases, repeated rework, and blocked verdicts.
 - **Lane has blocked work** → do not ask Jonathon to solve it. Take the first task under **Blocked tasks — recovery planning**, move it to 'planning', and run the Blocked Recovery Council below. A task already in 'planning' has an active council and must not be dispatched again.
 - **Lane is empty** → inspect dispatcher health and the open board, then verify/prospect rather than claiming ordinary 'todo' work. TaskDispatcherService owns ordinary claims.
 - **Board is genuinely empty** → switch into the Prospector loop below: verify a real gap/opportunity and create or update the matching project/epic/task as 'todo'. The dispatcher ships executable work; you may directly perform QA/polish or gated preparation that is outside its lane.
@@ -95,7 +95,7 @@ Prospecting is **create-and-do**, never create-only: every discovered item gets 
 
 You are an **operator**, not a one-task worker. Work continuously across the portfolio: start at the highest lane with an actionable item and drive it to its irreversible edge, then move to the next actionable item — down the lanes and across projects — and keep operating until your context/budget for this wake is spent. The Projects board organizes your priorities; it does not cap you at one item per wake. Never end a wake idle:
 
-1. **Supervise** — ordinary 'todo' selection and worker launch belong to the Mechanical Dispatcher, not to your judgment. Start with returned work in your lane ('in_review', 'blocked', stale/failed dispatches, and the injected '<project_report>'). Verify artifacts, repair weak work, make reversible decisions, and close or requeue it. If Projects is empty, create the next verified project/epic/task from identity goals; the dispatcher will claim executable 'todo' work mechanically.
+1. **Supervise** — ordinary 'todo' selection and worker launch belong to the Mechanical Dispatcher, not to your judgment. Start with returned work in your lane ('in_review', 'blocked', stale/failed dispatches, and the injected '<project_report>'). When the verifier pool is enabled, let it claim ordinary 'in_review' artifacts and supervise only failures, repeated rework, and genuine blocks; when it is disabled, keep reviewing them yourself. Repair weak work, make reversible decisions, and close or requeue it. If Projects is empty, create the next verified project/epic/task from identity goals; the dispatcher will claim executable 'todo' work mechanically.
 2. **Verify** — resourceful QA on your Human's products (as recorded in the ledger and 'identity/business/'). Don't checklist — hunt: exercise states (loading/empty/error/overflow), interactions (click, type, submit), watch network for 4xx/5xx, diff shared components across pages, force the breakpoints. File real bugs to GitHub with repro + screenshot. One focused target per cycle, rotating.
 3. **Unblock** — use the injected **Blocked tasks — recovery planning** queue. Move its top task to 'planning', run the Blocked Recovery Council, choose your own recommendation, then return executable work to 'todo' for mechanical dispatch. Do not turn uncertainty into a Jonathon review request.
 4. **Polish** — maintenance, docs, memory/observation hygiene, small papercuts you noticed while doing other work.
@@ -104,7 +104,7 @@ You are an **operator**, not a one-task worker. Work continuously across the por
 
 ## Mechanical Dispatch — Heartbeat Supervises, PostgreSQL Decides
 
-Ordinary queue work no longer depends on you choosing to spawn it. The TaskDispatcherService mechanically fills configured worker capacity while Heartbeat is enabled and inside its configured time window. PostgreSQL chooses the next eligible 'todo' task by epic priority, task priority, due date, and oldest activity; an atomic row lock plus the 'work_task_dispatches' partial unique index enforce **one live dispatch per task**.
+Ordinary queue work no longer depends on you choosing to spawn it. The TaskDispatcherService mechanically fills configured execution capacity while Heartbeat is enabled and inside its configured time window. When 'taskVerifierEnabled' is true, it also fills a separately bounded independent verifier pool for eligible 'in_review' tasks. PostgreSQL chooses the next eligible task by epic priority, task priority, due date, and oldest activity; an atomic row lock plus the cross-kind 'work_task_dispatches' partial unique index enforce **one live dispatch per task**.
 
 **Heartbeat does not select or launch ordinary queue work.** Do not duplicate the dispatcher with 'spawn_agent', do not self-assign unclaimed 'todo' tasks, and do not treat a quiet wake as a reason to create a second dispatch path. Tasks labeled 'gated', 'decision', 'human', 'manual', or 'no-auto-dispatch' remain outside mechanical execution.
 
@@ -112,7 +112,7 @@ Ordinary queue work no longer depends on you choosing to spawn it. The TaskDispa
 
 Your fleet duties begin where deterministic scheduling ends:
 
-- Review tasks returned to 'in_review' and the attached dispatcher result. Inspect the branch, PR, diff, tests, and claimed artifact. Close only on evidence; otherwise comment concrete findings and return the task to 'todo' for a fresh mechanical run.
+- With 'taskVerifierEnabled' false, review tasks returned to 'in_review' and the attached dispatcher result yourself. With it true, the independent verifier pool owns ordinary artifact review and records exact-head APPROVE/REWORK/BLOCKED evidence; you handle only verifier failures, repeated rework, and genuine blocks. Never duplicate a live verification lease.
 - Investigate 'blocked' and failed dispatches. Resolve reversible uncertainty yourself, record the decision, and return executable work to 'todo'. Use the independent Blocked Recovery Council below only when deeper reasoning is actually required.
 - Watch for stale dispatch recovery. The service returns orphaned 'planning' leases to 'todo' after restart; verify repeated failures instead of letting a crash loop forever.
 - Preserve gates. Merges, deploys, spending, external communications, destructive shared-state changes, and other high-blast actions remain staged for Jonathon.
@@ -229,7 +229,7 @@ You MUST end with exactly one wrapper:
 ## Cycle Shape (summary)
 
 1. Boot from your lane: 'sulla project/list_project_items {"assignee":"heartbeat"}' (+ agents block, recall, '<project_report>'). No state file. Answer incoming messages first.
-2. Supervise dispatcher returns from the highest actionable lane downward: verify 'in_review', recover 'blocked'/failed/stale work, and make reversible decisions. PostgreSQL and TaskDispatcherService own ordinary 'todo' selection and launch; do not recreate that path in the LLM. Keep operating across projects for the whole wake.
+2. Supervise dispatcher returns from the highest actionable lane downward: review 'in_review' yourself only while the verifier pool is disabled; otherwise supervise failed/stale reviews, repeated rework, and 'blocked' work. PostgreSQL and TaskDispatcherService own ordinary selection and launch; do not recreate that path in the LLM. Keep operating across projects for the whole wake.
 3. Execute through the Unblock Ladder; stage to the irreversible edge.
 4. Verify your work like a skeptic.
 5. Bookkeep (ledger write-back + PRD). Self-audit. Ship the artifact. Status line = outcome.

--- a/pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts
+++ b/pkg/rancher-desktop/agent/prompts/heartbeatInvariants.ts
@@ -29,6 +29,8 @@ export const HEARTBEAT_REQUIRED_PHRASES = [
   'Heartbeat does not select or launch ordinary queue work',
   'Supervisor Loop',
   'TaskDispatcherService',
+  'separately bounded independent verifier pool',
+  'Never duplicate a live verification lease',
   'The Prospector',
   'Artifact-per-Cycle',
   // Blocked recovery (aQLP/haNi): independent high-reasoning planners,

--- a/pkg/rancher-desktop/agent/services/GitHubPullRequestHeadService.ts
+++ b/pkg/rancher-desktop/agent/services/GitHubPullRequestHeadService.ts
@@ -1,0 +1,59 @@
+import { Octokit } from '@octokit/rest';
+
+import { getIntegrationService } from './IntegrationService';
+
+export interface GitHubPullRequestReference {
+  owner:      string;
+  repo:       string;
+  pullNumber: number;
+}
+
+export interface GitHubPullRequestHead extends GitHubPullRequestReference {
+  sha: string;
+}
+
+export function extractPullRequestReference(
+  githubIssue: string | null,
+  comments: { body: string }[],
+): GitHubPullRequestReference | null {
+  const texts = [githubIssue || '', ...comments.map(comment => comment.body)];
+  let repository: { owner: string; repo: string } | null = null;
+  let reference: GitHubPullRequestReference | null = null;
+
+  for (const text of texts) {
+    for (const match of text.matchAll(/github\.com\/([^/\s]+)\/([^/#\s]+)\/pull\/(\d+)/gi)) {
+      reference = { owner: match[1], repo: match[2], pullNumber: Number(match[3]) };
+      repository = { owner: match[1], repo: match[2] };
+    }
+    const repositoryMatch = /(?:github\.com\/)?([^/\s]+)\/([^/#\s]+)#\d+/i.exec(text);
+    if (repositoryMatch) repository = { owner: repositoryMatch[1], repo: repositoryMatch[2] };
+    const shortPullMatches = [...text.matchAll(/\b(?:draft\s+)?PR\s*#(\d+)\b/gi)];
+    if (repository && shortPullMatches.length > 0) {
+      reference = {
+        ...repository,
+        pullNumber: Number(shortPullMatches[shortPullMatches.length - 1][1]),
+      };
+    }
+  }
+
+  return reference;
+}
+
+export async function resolvePullRequestHead(
+  githubIssue: string | null,
+  comments: { body: string }[],
+): Promise<GitHubPullRequestHead | null> {
+  const reference = extractPullRequestReference(githubIssue, comments);
+  if (!reference) return null;
+
+  const token = await getIntegrationService().getIntegrationValue('github', 'token');
+  if (!token) throw new Error('github_token_unavailable');
+
+  const octokit = new Octokit({ auth: token.value });
+  const { data } = await octokit.pulls.get({
+    owner:       reference.owner,
+    repo:        reference.repo,
+    pull_number: reference.pullNumber,
+  });
+  return { ...reference, sha: data.head.sha.toLowerCase() };
+}

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -3,14 +3,28 @@ import { GraphRegistry } from './GraphRegistry';
 import { isInsideWindow } from './HeartbeatService';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { WorkItemsModel, type WorkTaskRecord } from '../database/models/WorkItemsModel';
-import { WorkTaskDispatchModel, type ClaimedDispatch } from '../database/models/WorkTaskDispatchModel';
+import { WorkTaskDispatchModel, type ClaimedDispatch, type VerificationVerdict } from '../database/models/WorkTaskDispatchModel';
 import { extractAgentTurnOutcome } from '../tools/agents/agentTurnOutcome';
+import { toolRegistry } from '../tools/registry';
 import { findAgentDir } from '../utils/sullaPaths';
 
 const CHECK_INTERVAL_MS = 60_000;
 const LEASE_HEARTBEAT_MS = 120_000;
 const DEFAULT_CONCURRENCY = 3;
 const DEFAULT_AGENT_ID = 'opus-worker';
+const DEFAULT_VERIFIER_AGENT_ID = 'codex-test';
+const DEFAULT_VERIFIER_TIMEOUT_MINUTES = 45;
+const VERIFIER_TOOLS = [
+  'file_search', 'read_file',
+  'git_status', 'git_diff', 'git_log', 'git_blame',
+  'github_get_issue', 'github_get_pr', 'github_get_pr_files', 'github_check_runs',
+] as const;
+
+interface ParsedVerification {
+  verdict:      VerificationVerdict;
+  artifactSha:  string;
+  summary:      string;
+}
 
 let taskDispatcherServiceInstance: TaskDispatcherService | null = null;
 
@@ -74,25 +88,50 @@ export class TaskDispatcherService {
       const window = await SullaSettingsModel.get('heartbeatWindow', null);
       if (window && !isInsideWindow(window)) return;
 
-      const configured = Number(await SullaSettingsModel.get('taskDispatcherConcurrency', DEFAULT_CONCURRENCY));
-      const concurrency = Math.max(1, Math.min(10, configured || DEFAULT_CONCURRENCY));
-      const agentId = String(await SullaSettingsModel.get('taskDispatcherAgentId', DEFAULT_AGENT_ID)).trim() || DEFAULT_AGENT_ID;
-      if (!findAgentDir(agentId)) {
-        console.error(`[TaskDispatcher] Agent config "${ agentId }" does not exist; dispatch paused`);
-        return;
-      }
-
-      let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning());
-      while (freeSlots > 0 && this.initialized) {
-        const claim = await WorkTaskDispatchModel.claimNext(agentId);
-        if (!claim) break;
-        this.runClaim(claim).catch(err => console.error('[TaskDispatcher] Worker promise failed:', err));
-        freeSlots -= 1;
-      }
+      await this.fillExecutionPool();
+      await this.fillVerificationPool();
     } catch (err) {
       console.error('[TaskDispatcher] Dispatch check failed:', err);
     } finally {
       this.checking = false;
+    }
+  }
+
+  private async fillExecutionPool(): Promise<void> {
+    const configured = Number(await SullaSettingsModel.get('taskDispatcherConcurrency', DEFAULT_CONCURRENCY));
+    const concurrency = Math.max(1, Math.min(10, configured || DEFAULT_CONCURRENCY));
+    const agentId = String(await SullaSettingsModel.get('taskDispatcherAgentId', DEFAULT_AGENT_ID)).trim() || DEFAULT_AGENT_ID;
+    if (!findAgentDir(agentId)) {
+      console.error(`[TaskDispatcher] Agent config "${ agentId }" does not exist; execution paused`);
+      return;
+    }
+
+    let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning('execution'));
+    while (freeSlots > 0 && this.initialized) {
+      const claim = await WorkTaskDispatchModel.claimNext(agentId);
+      if (!claim) break;
+      this.runClaim(claim).catch(err => console.error('[TaskDispatcher] Worker promise failed:', err));
+      freeSlots -= 1;
+    }
+  }
+
+  private async fillVerificationPool(): Promise<void> {
+    const enabled = await SullaSettingsModel.get('taskVerifierEnabled', false);
+    if (!enabled) return;
+    const configured = Number(await SullaSettingsModel.get('taskVerifierConcurrency', DEFAULT_CONCURRENCY));
+    const concurrency = Math.max(1, Math.min(10, configured || DEFAULT_CONCURRENCY));
+    const agentId = String(await SullaSettingsModel.get('taskVerifierAgentId', DEFAULT_VERIFIER_AGENT_ID)).trim() || DEFAULT_VERIFIER_AGENT_ID;
+    if (!findAgentDir(agentId)) {
+      console.error(`[TaskDispatcher] Agent config "${ agentId }" does not exist; verification paused`);
+      return;
+    }
+
+    let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning('verification'));
+    while (freeSlots > 0 && this.initialized) {
+      const claim = await WorkTaskDispatchModel.claimNextReview(agentId);
+      if (!claim) break;
+      this.runClaim(claim).catch(err => console.error('[TaskDispatcher] Verifier promise failed:', err));
+      freeSlots -= 1;
     }
   }
 
@@ -107,12 +146,15 @@ export class TaskDispatcherService {
       },
       LEASE_HEARTBEAT_MS,
     );
+    let verifierTimeout: ReturnType<typeof setTimeout> | null = null;
+    let verifierTimedOut = false;
 
     try {
+      const isVerification = dispatch.kind === 'verification';
       await WorkItemsModel.addComment({
         task_id: task.id,
         author:  'dispatcher',
-        body:    `Mechanical dispatch started with ${ dispatch.agent_id } (dispatch ${ dispatch.id }).`,
+        body:    `${ isVerification ? 'Verification' : 'Mechanical dispatch' } started with ${ dispatch.agent_id } (dispatch ${ dispatch.id }, attempt ${ dispatch.attempt || 1 }).`,
       }).catch(err => console.error(`[TaskDispatcher] Could not write start comment for ${ dispatch.id }:`, err));
 
       const { graph, state } = await GraphRegistry.getOrCreateAgentGraph(
@@ -121,28 +163,88 @@ export class TaskDispatcherService {
         { isTrustedUser: 'trusted' },
       ) as { graph: any; state: any };
 
-      state.messages.push({ role: 'user', content: this.buildWorkerPrompt(task, dispatch.id) });
+      if (isVerification) {
+        const comments = await WorkItemsModel.listComments(task.id);
+        state.messages.push({ role: 'user', content: this.buildVerifierPrompt(task, dispatch.id, comments) });
+        const llmTools = await Promise.all(VERIFIER_TOOLS.map(name => toolRegistry.convertToolToLLM(name)));
+        state.llmTools = llmTools;
+        state.metadata.allowedToolNames = [...VERIFIER_TOOLS];
+        state.metadata.verifierReadOnly = true;
+      } else {
+        state.messages.push({ role: 'user', content: this.buildWorkerPrompt(task, dispatch.id) });
+      }
       state.metadata.isSubAgent = true;
       state.metadata.subAgentDepth = 1;
       state.metadata.workflowParentChannel = 'task-dispatcher';
       state.metadata.options ??= {};
       state.metadata.options.abort = abort;
 
+      const timeoutMinutes = isVerification
+        ? Math.max(1, Number(await SullaSettingsModel.get('taskVerifierTimeoutMinutes', DEFAULT_VERIFIER_TIMEOUT_MINUTES)) || DEFAULT_VERIFIER_TIMEOUT_MINUTES)
+        : 0;
+      verifierTimeout = isVerification
+        ? setTimeout(() => {
+          verifierTimedOut = true;
+          abort.abort();
+        }, timeoutMinutes * 60_000)
+        : null;
       const finalState = await graph.execute(state);
+      if (verifierTimeout) clearTimeout(verifierTimeout);
       const outcome = extractAgentTurnOutcome(finalState);
       const summary = outcome.text.slice(0, 8_000);
 
-      await this.finalizeClaim(claim, outcome.status, summary);
+      if (isVerification) {
+        if (verifierTimedOut) {
+          await WorkTaskDispatchModel.failVerification(dispatch.id, 'verifier_timeout');
+        } else {
+          const parsed = this.parseVerification(summary);
+          if (!parsed) {
+            await WorkTaskDispatchModel.failVerification(dispatch.id, 'malformed_verifier_output');
+          } else {
+            await WorkTaskDispatchModel.finalizeVerification(
+              dispatch.id, parsed.verdict, parsed.artifactSha, parsed.summary,
+            );
+          }
+        }
+      } else {
+        await this.finalizeClaim(claim, outcome.status, summary);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      await this.finalizeClaim(claim, 'failed', message);
+      if (dispatch.kind === 'verification') {
+        await WorkTaskDispatchModel.failVerification(
+          dispatch.id,
+          verifierTimedOut ? 'verifier_timeout' : message.slice(0, 2_000),
+        );
+      } else {
+        await this.finalizeClaim(claim, 'failed', message);
+      }
     } finally {
+      if (verifierTimeout) clearTimeout(verifierTimeout);
       clearInterval(leaseTimer);
       this.active.delete(dispatch.id);
       GraphRegistry.delete(dispatch.thread_id);
       if (this.initialized) {
         this.checkAndDispatch().catch(err => console.error('[TaskDispatcher] Refill check failed:', err));
       }
+    }
+  }
+
+  private parseVerification(output: string): ParsedVerification | null {
+    const matches = [...output.matchAll(/<VERIFIER_RESULT>([\s\S]*?)<\/VERIFIER_RESULT>/g)];
+    if (matches.length !== 1) return null;
+    try {
+      const parsed = JSON.parse(matches[0][1].trim());
+      if (!parsed || !['APPROVE', 'REWORK', 'BLOCKED'].includes(parsed.verdict)) return null;
+      if (typeof parsed.artifact_sha !== 'string' || !/^[a-f0-9]{40,64}$/i.test(parsed.artifact_sha)) return null;
+      if (typeof parsed.summary !== 'string' || !parsed.summary.trim()) return null;
+      return {
+        verdict: parsed.verdict,
+        artifactSha: parsed.artifact_sha.toLowerCase(),
+        summary: parsed.summary.trim().slice(0, 8_000),
+      };
+    } catch {
+      return null;
     }
   }
 
@@ -185,5 +287,39 @@ Description:
 ${ task.description || '(no description)' }
 
 Execute the task autonomously to the reversible edge. Inspect the real state first. For code work, use an isolated worktree/feature branch, verify the change, commit it, push it through the Sulla GitHub tools, and open a draft PR when possible. Do not merge, deploy, spend money, send external communications, or perform destructive shared-system actions. End with a concise artifact-and-verification summary. If a truly irreversible dependency remains, return BLOCKED with the exact requirement; reversible uncertainty is yours to decide.`;
+  }
+
+  private buildVerifierPrompt(task: WorkTaskRecord, dispatchId: string, comments: { author: string | null; body: string }[]): string {
+    const history = comments.map(comment => `- ${ comment.author || 'unknown' }: ${ comment.body }`).join('\n').slice(-24_000);
+    return `You are the independent verification worker for Projects task ${ task.id }.
+
+Title: ${ task.title }
+Priority: ${ task.priority }
+Project: ${ task.project_id }
+Epic: ${ task.epic_id ?? '(none)' }
+Verification dispatch: ${ dispatchId }
+GitHub artifact hint: ${ task.github_issue ?? '(inspect task history)' }
+
+Acceptance contract:
+${ task.description || '(no description)' }
+
+Dispatcher and task history:
+${ history || '(no comments)' }
+
+Review independently. Resolve the actual draft PR/branch and matching local worktree from the task and history. Read the current remote head through the GitHub tools, record the FULL exact head SHA, inspect the diff plus callers/consumers, map every acceptance criterion to evidence, and run focused tests/typecheck safely against the matching worktree. Include tenant, security, and regression analysis when relevant. Re-check the remote head immediately before your verdict; if it changed, do not approve until the matching new head is available and reviewed.
+
+You are read-only with respect to the product and shared systems. Do not edit files, checkout/fetch, commit, push, merge, deploy, spend money, change Projects state, or send external communications. Read-only inspection and tests are allowed. The dispatcher alone applies the transition.
+
+Choose exactly one verdict:
+- APPROVE: the exact reviewed head satisfies the acceptance contract.
+- REWORK: concrete, reversible defects or missing criteria remain.
+- BLOCKED: only a genuinely external/irreversible dependency prevents completion.
+
+Even for a BLOCKED verdict, use the normal completion wrapper around the machine block. Do not emit AGENT_BLOCKED; the dispatcher must receive and apply the structured verdict itself.
+
+Your final response must contain exactly one machine block in this shape (the normal agent completion wrapper may surround it):
+<VERIFIER_RESULT>{"verdict":"APPROVE|REWORK|BLOCKED","artifact_sha":"FULL_HEX_SHA","summary":"acceptance mapping, tests, and concrete findings"}</VERIFIER_RESULT>
+
+Any missing block, unknown verdict, abbreviated/non-hex SHA, or malformed JSON is treated as a verifier failure and leaves the task in_review for retry.`;
   }
 }

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -1,4 +1,5 @@
 import { AbortService } from './AbortService';
+import { resolvePullRequestHead } from './GitHubPullRequestHeadService';
 import { GraphRegistry } from './GraphRegistry';
 import { isInsideWindow } from './HeartbeatService';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
@@ -162,9 +163,9 @@ export class TaskDispatcherService {
         dispatch.thread_id,
         { isTrustedUser: 'trusted' },
       ) as { graph: any; state: any };
+      const comments = isVerification ? await WorkItemsModel.listComments(task.id) : [];
 
       if (isVerification) {
-        const comments = await WorkItemsModel.listComments(task.id);
         state.messages.push({ role: 'user', content: this.buildVerifierPrompt(task, dispatch.id, comments) });
         const llmTools = await Promise.all(VERIFIER_TOOLS.map(name => toolRegistry.convertToolToLLM(name)));
         state.llmTools = llmTools;
@@ -201,9 +202,21 @@ export class TaskDispatcherService {
           if (!parsed) {
             await WorkTaskDispatchModel.failVerification(dispatch.id, 'malformed_verifier_output');
           } else {
-            await WorkTaskDispatchModel.finalizeVerification(
-              dispatch.id, parsed.verdict, parsed.artifactSha, parsed.summary,
-            );
+            const currentHead = parsed.verdict === 'APPROVE'
+              ? await resolvePullRequestHead(task.github_issue, comments)
+              : null;
+            if (parsed.verdict === 'APPROVE' && !currentHead) {
+              await WorkTaskDispatchModel.failVerification(dispatch.id, 'pull_request_artifact_unresolved');
+            } else if (currentHead && currentHead.sha !== parsed.artifactSha) {
+              await WorkTaskDispatchModel.failVerification(
+                dispatch.id,
+                `artifact_head_changed:${ parsed.artifactSha }:${ currentHead.sha }`,
+              );
+            } else {
+              await WorkTaskDispatchModel.finalizeVerification(
+                dispatch.id, parsed.verdict, parsed.artifactSha, currentHead?.sha ?? null, parsed.summary,
+              );
+            }
           }
         }
       } else {

--- a/pkg/rancher-desktop/agent/services/__tests__/GitHubPullRequestHeadService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/GitHubPullRequestHeadService.test.ts
@@ -1,0 +1,33 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.unstable_mockModule('../IntegrationService', () => ({
+  getIntegrationService: jest.fn(),
+}));
+
+let extractPullRequestReference: (
+  githubIssue: string | null,
+  comments: { body: string }[],
+) => { owner: string; repo: string; pullNumber: number } | null;
+
+beforeAll(async() => {
+  ({ extractPullRequestReference } = await import('../GitHubPullRequestHeadService'));
+});
+
+describe('GitHubPullRequestHeadService', () => {
+  it('prefers the latest concrete pull request URL in task history', () => {
+    expect(extractPullRequestReference('merchantprotocol/sulla-desktop#660', [
+      { body: 'Draft PR https://github.com/merchantprotocol/sulla-desktop/pull/665 at the first head.' },
+      { body: 'Replacement PR https://github.com/merchantprotocol/sulla-desktop/pull/667 is ready.' },
+    ])).toEqual({ owner: 'merchantprotocol', repo: 'sulla-desktop', pullNumber: 667 });
+  });
+
+  it('resolves a short PR number against the task repository', () => {
+    expect(extractPullRequestReference('merchantprotocol/sulla-desktop#660', [
+      { body: 'Shipped to draft PR #665.' },
+    ])).toEqual({ owner: 'merchantprotocol', repo: 'sulla-desktop', pullNumber: 665 });
+  });
+
+  it('does not mistake the linked issue itself for a pull request', () => {
+    expect(extractPullRequestReference('merchantprotocol/sulla-desktop#660', [])).toBeNull();
+  });
+});

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -13,6 +13,7 @@ const addCommentMock: any = jest.fn(() => Promise.resolve());
 const updateTaskMock: any = jest.fn(() => Promise.resolve());
 const executeMock: any = jest.fn();
 const graphDeleteMock: any = jest.fn();
+const resolvePullRequestHeadMock: any = jest.fn();
 
 jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
   SullaSettingsModel: { get: settingsGetMock },
@@ -48,6 +49,9 @@ jest.unstable_mockModule('../GraphRegistry', () => ({
 jest.unstable_mockModule('../HeartbeatService', () => ({
   isInsideWindow: jest.fn(() => true),
 }));
+jest.unstable_mockModule('../GitHubPullRequestHeadService', () => ({
+  resolvePullRequestHead: resolvePullRequestHeadMock,
+}));
 jest.unstable_mockModule('../../utils/sullaPaths', () => ({
   findAgentDir: jest.fn(() => '/agents/opus-worker'),
 }));
@@ -66,6 +70,9 @@ describe('TaskDispatcherService', () => {
     countRunningMock.mockResolvedValue(0);
     claimNextMock.mockResolvedValue(null);
     claimNextReviewMock.mockResolvedValue(null);
+    resolvePullRequestHeadMock.mockResolvedValue({
+      owner: 'merchantprotocol', repo: 'sulla-desktop', pullNumber: 123, sha: 'a'.repeat(40),
+    });
     settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
       if (key === 'heartbeatEnabled') return Promise.resolve(true);
       return Promise.resolve(fallback);
@@ -178,8 +185,9 @@ describe('TaskDispatcherService', () => {
     expect(executeMock).toHaveBeenCalledTimes(3);
     expect(finalizeVerificationMock).toHaveBeenCalledTimes(3);
     expect(finalizeVerificationMock).toHaveBeenCalledWith(
-      'verify-1', 'APPROVE', 'a'.repeat(40), 'All criteria and focused tests passed.',
+      'verify-1', 'APPROVE', 'a'.repeat(40), 'a'.repeat(40), 'All criteria and focused tests passed.',
     );
+    expect(resolvePullRequestHeadMock).toHaveBeenCalledTimes(3);
     const verifierState = executeMock.mock.calls[0][0];
     expect(verifierState.metadata.allowedToolNames).toContain('git_diff');
     expect(verifierState.metadata.allowedToolNames).not.toContain('exec');
@@ -189,6 +197,55 @@ describe('TaskDispatcherService', () => {
     expect(verifierState.metadata.verifierReadOnly).toBe(true);
     expect(verifierState.messages[0].content).toContain('Re-check the remote head immediately before your verdict');
     expect(verifierState.messages[0].content).toContain('matching local worktree');
+  });
+
+  it('invalidates approval when the live PR head changed after review', async() => {
+    claimNextReviewMock
+      .mockResolvedValueOnce({
+        task: {
+          id:           'task-5',
+          title:        'Review',
+          description:  '',
+          project_id:   'p',
+          epic_id:      'e',
+          priority:     'p0',
+          github_issue: 'merchantprotocol/sulla-desktop#660',
+        },
+        dispatch: {
+          id:        'verify-5',
+          task_id:   'task-5',
+          agent_id:  'codex-test',
+          thread_id: 'v5',
+          kind:      'verification',
+          attempt:   1,
+        },
+      })
+      .mockResolvedValue(null);
+    settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+      if (key === 'heartbeatEnabled' || key === 'taskVerifierEnabled') return Promise.resolve(true);
+      return Promise.resolve(fallback);
+    });
+    resolvePullRequestHeadMock.mockResolvedValue({
+      owner: 'merchantprotocol', repo: 'sulla-desktop', pullNumber: 665, sha: 'c'.repeat(40),
+    });
+    executeMock.mockResolvedValue({
+      metadata: {
+        agent: { status: 'completed' },
+        finalSummary: `<VERIFIER_RESULT>{"verdict":"APPROVE","artifact_sha":"${ 'b'.repeat(40) }","summary":"Reviewed old head."}</VERIFIER_RESULT>`,
+      },
+      messages: [],
+    });
+
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    await new Promise(resolve => setTimeout(resolve, 10));
+    service.destroy();
+
+    expect(failVerificationMock).toHaveBeenCalledWith(
+      'verify-5', `artifact_head_changed:${ 'b'.repeat(40) }:${ 'c'.repeat(40) }`,
+    );
+    expect(finalizeVerificationMock).not.toHaveBeenCalled();
   });
 
   it.each(['APPROVE', 'REWORK', 'BLOCKED'] as const)('strictly parses %s with a full exact head', async(verdict) => {

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -4,7 +4,10 @@ const settingsGetMock: any = jest.fn();
 const recoverStaleMock: any = jest.fn(() => Promise.resolve([]));
 const countRunningMock: any = jest.fn(() => Promise.resolve(0));
 const claimNextMock: any = jest.fn(() => Promise.resolve(null));
+const claimNextReviewMock: any = jest.fn(() => Promise.resolve(null));
 const settleMock: any = jest.fn(() => Promise.resolve());
+const finalizeVerificationMock: any = jest.fn(() => Promise.resolve('APPROVE'));
+const failVerificationMock: any = jest.fn(() => Promise.resolve(true));
 const touchMock: any = jest.fn(() => Promise.resolve());
 const addCommentMock: any = jest.fn(() => Promise.resolve());
 const updateTaskMock: any = jest.fn(() => Promise.resolve());
@@ -19,12 +22,19 @@ jest.unstable_mockModule('../../database/models/WorkTaskDispatchModel', () => ({
     recoverStale: recoverStaleMock,
     countRunning: countRunningMock,
     claimNext:    claimNextMock,
+    claimNextReview: claimNextReviewMock,
     settle:       settleMock,
+    finalizeVerification: finalizeVerificationMock,
+    failVerification: failVerificationMock,
     touch:        touchMock,
   },
 }));
 jest.unstable_mockModule('../../database/models/WorkItemsModel', () => ({
-  WorkItemsModel: { addComment: addCommentMock, updateTask: updateTaskMock },
+  WorkItemsModel: {
+    addComment: addCommentMock,
+    updateTask: updateTaskMock,
+    listComments: jest.fn(() => Promise.resolve([{ author: 'worker', body: 'Draft PR #123 at head.' }])),
+  },
 }));
 jest.unstable_mockModule('../GraphRegistry', () => ({
   GraphRegistry: {
@@ -41,6 +51,13 @@ jest.unstable_mockModule('../HeartbeatService', () => ({
 jest.unstable_mockModule('../../utils/sullaPaths', () => ({
   findAgentDir: jest.fn(() => '/agents/opus-worker'),
 }));
+jest.unstable_mockModule('../../tools/registry', () => ({
+  toolRegistry: {
+    convertToolToLLM: jest.fn((name: string) => Promise.resolve({
+      type: 'function', function: { name, description: name, parameters: { type: 'object', properties: {} } },
+    })),
+  },
+}));
 
 describe('TaskDispatcherService', () => {
   beforeEach(() => {
@@ -48,10 +65,20 @@ describe('TaskDispatcherService', () => {
     recoverStaleMock.mockResolvedValue([]);
     countRunningMock.mockResolvedValue(0);
     claimNextMock.mockResolvedValue(null);
+    claimNextReviewMock.mockResolvedValue(null);
     settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
       if (key === 'heartbeatEnabled') return Promise.resolve(true);
       return Promise.resolve(fallback);
     });
+  });
+
+  it('dark-gates verification by default', async() => {
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    service.destroy();
+
+    expect(claimNextReviewMock).not.toHaveBeenCalled();
   });
 
   it('recovers orphaned leases before filling worker capacity', async() => {
@@ -102,5 +129,100 @@ describe('TaskDispatcherService', () => {
     expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
       status: 'in_review', assignee: 'heartbeat', actor: 'dispatcher',
     });
+  });
+
+  it('starts three independent review leases in one pass and settles exact-head approvals', async() => {
+    const claims = [1, 2, 3].map(i => ({
+      task: {
+        id:           `task-${ i }`,
+        title:        `Review ${ i }`,
+        description:  'Acceptance criteria.',
+        project_id:   'project-1',
+        epic_id:      'epic-1',
+        priority:     'high',
+        github_issue: null,
+      },
+      dispatch: {
+        id:        `verify-${ i }`,
+        task_id:   `task-${ i }`,
+        agent_id:  'codex-test',
+        thread_id: `verify-thread-${ i }`,
+        kind:      'verification',
+        attempt:   1,
+      },
+    }));
+    claimNextReviewMock
+      .mockResolvedValueOnce(claims[0])
+      .mockResolvedValueOnce(claims[1])
+      .mockResolvedValueOnce(claims[2])
+      .mockResolvedValue(null);
+    settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+      if (key === 'heartbeatEnabled' || key === 'taskVerifierEnabled') return Promise.resolve(true);
+      return Promise.resolve(fallback);
+    });
+    executeMock.mockResolvedValue({
+      metadata: {
+        agent: { status: 'completed' },
+        finalSummary: `<VERIFIER_RESULT>{"verdict":"APPROVE","artifact_sha":"${ 'a'.repeat(40) }","summary":"All criteria and focused tests passed."}</VERIFIER_RESULT>`,
+      },
+      messages: [],
+    });
+
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    await new Promise(resolve => setTimeout(resolve, 10));
+    service.destroy();
+
+    expect(claimNextReviewMock).toHaveBeenCalledTimes(4);
+    expect(executeMock).toHaveBeenCalledTimes(3);
+    expect(finalizeVerificationMock).toHaveBeenCalledTimes(3);
+    expect(finalizeVerificationMock).toHaveBeenCalledWith(
+      'verify-1', 'APPROVE', 'a'.repeat(40), 'All criteria and focused tests passed.',
+    );
+    const verifierState = executeMock.mock.calls[0][0];
+    expect(verifierState.metadata.allowedToolNames).toContain('git_diff');
+    expect(verifierState.metadata.allowedToolNames).not.toContain('exec');
+    expect(verifierState.metadata.allowedToolNames).not.toContain('git_commit');
+    expect(verifierState.metadata.allowedToolNames).not.toContain('git_push');
+    expect(verifierState.metadata.allowedToolNames).not.toContain('github_merge_pr');
+    expect(verifierState.metadata.verifierReadOnly).toBe(true);
+    expect(verifierState.messages[0].content).toContain('Re-check the remote head immediately before your verdict');
+    expect(verifierState.messages[0].content).toContain('matching local worktree');
+  });
+
+  it.each(['APPROVE', 'REWORK', 'BLOCKED'] as const)('strictly parses %s with a full exact head', async(verdict) => {
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService() as any;
+    expect(service.parseVerification(
+      `<VERIFIER_RESULT>{"verdict":"${ verdict }","artifact_sha":"${ 'b'.repeat(40) }","summary":"Evidence."}</VERIFIER_RESULT>`,
+    )).toEqual({ verdict, artifactSha: 'b'.repeat(40), summary: 'Evidence.' });
+    expect(service.parseVerification(
+      `<VERIFIER_RESULT>{"verdict":"${ verdict }","artifact_sha":"deadbeef","summary":"Evidence."}</VERIFIER_RESULT>`,
+    )).toBeNull();
+  });
+
+  it('rejects malformed verifier output without changing the task to blocked', async() => {
+    claimNextReviewMock
+      .mockResolvedValueOnce({
+        task: { id: 'task-4', title: 'Review', description: '', project_id: 'p', epic_id: 'e', priority: 'p0' },
+        dispatch: { id: 'verify-4', task_id: 'task-4', agent_id: 'codex-test', thread_id: 'v4', kind: 'verification', attempt: 1 },
+      })
+      .mockResolvedValue(null);
+    settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+      if (key === 'heartbeatEnabled' || key === 'taskVerifierEnabled') return Promise.resolve(true);
+      return Promise.resolve(fallback);
+    });
+    executeMock.mockResolvedValue({ metadata: { agent: { status: 'completed' }, finalSummary: 'APPROVE maybe' }, messages: [] });
+
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    await new Promise(resolve => setTimeout(resolve, 10));
+    service.destroy();
+
+    expect(failVerificationMock).toHaveBeenCalledWith('verify-4', 'malformed_verifier_output');
+    expect(finalizeVerificationMock).not.toHaveBeenCalled();
+    expect(updateTaskMock).not.toHaveBeenCalledWith('task-4', expect.objectContaining({ status: 'blocked' }));
   });
 });


### PR DESCRIPTION
## What changed

Implements #660 as a dark-by-default second dispatcher phase for `in_review` work, stacked on the exact ownership head from draft PR #663 (`c54fa69371563b8ee8a945a17117c4bf896c3530`).

- uses unique migration slot `0064`; #664 waits remains later `0065`, and #666 recovery remains later `0066`
- claims review work in project, epic, then task priority order
- starts independently bounded verification leases with separate settings and execution-worker exclusion
- resolves the current full PR head through authenticated GitHub immediately before settlement
- refuses atomic APPROVE settlement unless the server-resolved head equals the reviewed SHA
- preserves strict APPROVE/REWORK/BLOCKED parsing, retry behavior, read-only verifier tooling, and dark rollout

## Verification

- combined #663 ownership + #665 verifier suite: 10 suites, 60 tests passed
- scoped ESLint for verifier-owned/new files: passed
- both changed services parsed with esbuild
- `git diff --check` passed
- 8 GB agent typecheck completed and reported only pre-existing repository diagnostics outside this diff (Discord/missing dependency, unrelated model/tool tests, Redis, Slack, MCP host, and audio declarations); no #663/#665 changed-file diagnostics

No merge, deployment, runtime setting change, rollout enablement, or migration application was performed.