### PR TITLE
fix(dispatcher): reclaim stale in-progress orphans

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0066_create_work_task_recovery_attempts.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0066_create_work_task_recovery_attempts.ts
@@ -1,0 +1,27 @@
+/**
+ * Durable audit ledger for deterministic in-progress orphan recovery.
+ *
+ * Recovery comments are the human-readable audit trail. This table supplies
+ * the monotonic attempt counter that prevents a repeatedly orphaned task from
+ * cycling through the dispatcher forever.
+ */
+
+export const up = `
+  CREATE TABLE IF NOT EXISTS work_task_recovery_attempts (
+    id                    TEXT        PRIMARY KEY,
+    task_id               TEXT        NOT NULL REFERENCES work_tasks(id),
+    attempt_number        INTEGER     NOT NULL,
+    outcome               TEXT        NOT NULL,
+    reason                TEXT        NOT NULL,
+    previous_status       TEXT        NOT NULL,
+    previous_assignee     TEXT,
+    previous_activity_at  TIMESTAMPTZ NOT NULL,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (task_id, attempt_number)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_work_task_recovery_attempts_task
+    ON work_task_recovery_attempts (task_id, attempt_number DESC);
+`;
+
+export const down = `DROP TABLE IF EXISTS work_task_recovery_attempts CASCADE;`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -53,6 +53,7 @@ import { up as up_0062, down as down_0062 } from './0062_create_work_task_dispat
 import { up as up_0063, down as down_0063 } from './0063_normalize_autonomous_task_ownership';
 import { up as up_0064, down as down_0064 } from './0064_add_verification_dispatches';
 import { up as up_0065, down as down_0065 } from './0065_create_work_task_waits';
+import { up as up_0066, down as down_0066 } from './0066_create_work_task_recovery_attempts';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -107,4 +108,5 @@ export const migrationsRegistry = [
   { name: '0063_normalize_autonomous_task_ownership',              up: up_0063, down: down_0063 },
   { name: '0064_add_verification_dispatches',                       up: up_0064, down: down_0064 },
   { name: '0065_create_work_task_waits',                            up: up_0065, down: down_0065 },
+  { name: '0066_create_work_task_recovery_attempts',                up: up_0066, down: down_0066 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -33,7 +33,56 @@ export interface ClaimedDispatch {
   task:     WorkTaskRecord;
 }
 
+export type InProgressExclusionReason =
+  | 'archived'
+  | 'epic_closed'
+  | 'human_or_unknown_owner'
+  | 'non_autonomous_label'
+  | 'live_dispatch'
+  | 'active_child'
+  | 'recent_activity'
+  | 'active_agent_job'
+  | 'linked_external_operation';
+
+export interface InProgressClassificationRow extends WorkTaskRecord {
+  epic_open:            boolean;
+  autonomous_owner:     boolean;
+  autonomous_labels:    boolean;
+  has_live_dispatch:    boolean;
+  has_active_child:     boolean;
+  stale_activity:       boolean;
+  has_active_agent_job: boolean;
+  recovery_attempts:    string | number;
+}
+
+export interface RecoverableInProgressCandidate {
+  task:             WorkTaskRecord;
+  fingerprint:      string;
+  attemptCount:     number;
+  exclusionReasons: InProgressExclusionReason[];
+}
+
+export interface OrphanRecoveryResult {
+  taskId:         string;
+  outcome:        'recovered' | 'blocked_ceiling' | 'cas_miss';
+  attemptNumber?: number;
+}
+
 const CLOSED_EPIC_STATUSES = ['done', 'cancelled', 'parked', 'blocked'];
+
+export function classifyInProgressRow(row: InProgressClassificationRow): InProgressExclusionReason[] {
+  const reasons: InProgressExclusionReason[] = [];
+  if (row.archived) reasons.push('archived');
+  if (!row.epic_open) reasons.push('epic_closed');
+  if (!row.autonomous_owner) reasons.push('human_or_unknown_owner');
+  if (!row.autonomous_labels) reasons.push('non_autonomous_label');
+  if (row.has_live_dispatch) reasons.push('live_dispatch');
+  if (row.has_active_child) reasons.push('active_child');
+  if (!row.stale_activity) reasons.push('recent_activity');
+  if (row.has_active_agent_job) reasons.push('active_agent_job');
+  return reasons;
+}
+
 export class WorkTaskDispatchModel {
   static async claimNext(agentId: string): Promise<ClaimedDispatch | null> {
     return postgresClient.transaction(async(client) => {
@@ -207,6 +256,164 @@ export class WorkTaskDispatchModel {
       [kind ?? null],
     );
     return Number(row?.count || 0);
+  }
+
+  /**
+   * Classify in-progress tasks without changing them. This is deliberately the
+   * same eligibility surface used by recovery, so the default report-only
+   * rollout measures what an enabled pass would do.
+   */
+  static async findRecoverableInProgress(staleMinutes = 360, limit = 100): Promise<RecoverableInProgressCandidate[]> {
+    const rows = await postgresClient.query<InProgressClassificationRow>(`
+      SELECT t.*,
+             (e.id IS NOT NULL AND e.archived = false AND NOT (e.status = ANY($1::text[]))) AS epic_open,
+             (t.assignee IS NULL OR LOWER(t.assignee) = ANY($2::text[])) AS autonomous_owner,
+             NOT EXISTS (
+               SELECT 1 FROM unnest(COALESCE(t.labels, '{}')) AS label
+                WHERE LOWER(label) = ANY($3::text[])
+             ) AS autonomous_labels,
+             EXISTS (
+               SELECT 1 FROM work_task_dispatches d
+                WHERE d.task_id = t.id AND d.status = 'running'
+             ) AS has_live_dispatch,
+             EXISTS (
+               SELECT 1 FROM work_tasks child
+                WHERE child.parent_id = t.id
+                  AND child.archived = false
+                  AND child.status NOT IN ('done', 'cancelled', 'parked')
+             ) AS has_active_child,
+             (t.last_activity_at <= now() - ($4 * interval '1 minute')) AS stale_activity,
+             EXISTS (
+               SELECT 1 FROM agent_jobs j
+                WHERE j.status = 'running'
+                  AND (j.job_id = t.source_ref OR COALESCE(j.results, '[]'::jsonb)::text LIKE '%' || t.id || '%')
+             ) AS has_active_agent_job,
+             (SELECT COUNT(*)::text FROM work_task_recovery_attempts a WHERE a.task_id = t.id) AS recovery_attempts
+        FROM work_tasks t
+        LEFT JOIN work_epics e ON e.id = t.epic_id
+       WHERE t.status = 'in_progress'
+       ORDER BY t.last_activity_at ASC, t.id ASC
+       LIMIT $5
+    `, [CLOSED_EPIC_STATUSES, AUTONOMOUS_TASK_ASSIGNEES, NON_AUTONOMOUS_TASK_LABELS, staleMinutes, Math.max(1, limit)]);
+
+    return rows.map((row) => {
+      const {
+        epic_open: _epicOpen,
+        autonomous_owner: _autonomousOwner,
+        autonomous_labels: _autonomousLabels,
+        has_live_dispatch: _hasLiveDispatch,
+        has_active_child: _hasActiveChild,
+        stale_activity: _staleActivity,
+        has_active_agent_job: _hasActiveAgentJob,
+        recovery_attempts: recoveryAttempts,
+        ...task
+      } = row;
+      return {
+        task:             task as WorkTaskRecord,
+        fingerprint:      row.last_activity_at,
+        attemptCount:     Number(recoveryAttempts || 0),
+        exclusionReasons: classifyInProgressRow(row),
+      };
+    });
+  }
+
+  /**
+   * Recover snapshots under row locks. Every eligibility predicate and the
+   * activity fingerprint is re-checked after locking; any concurrent edit or
+   * comment therefore wins and produces a harmless CAS miss.
+   */
+  static async recoverOrphanedInProgress(
+    candidates: RecoverableInProgressCandidate[],
+    batchSize = 1,
+    retryCeiling = 3,
+  ): Promise<OrphanRecoveryResult[]> {
+    const eligible = candidates.filter(candidate => candidate.exclusionReasons.length === 0).slice(0, Math.max(0, batchSize));
+    if (eligible.length === 0) return [];
+
+    return postgresClient.transaction(async(client: PoolClient) => {
+      const results: OrphanRecoveryResult[] = [];
+      for (const candidate of eligible) {
+        const locked = await client.query<WorkTaskRecord>(`
+          SELECT t.*
+            FROM work_tasks t
+            JOIN work_epics e ON e.id = t.epic_id
+           WHERE t.id = $1
+             AND t.status = 'in_progress'
+             AND t.archived = false
+             AND e.archived = false
+             AND NOT (e.status = ANY($2::text[]))
+             AND (t.assignee IS NULL OR LOWER(t.assignee) = ANY($3::text[]))
+             AND NOT EXISTS (
+               SELECT 1 FROM unnest(COALESCE(t.labels, '{}')) AS label
+                WHERE LOWER(label) = ANY($4::text[])
+             )
+             AND NOT EXISTS (
+               SELECT 1 FROM work_task_dispatches d
+                WHERE d.task_id = t.id AND d.status = 'running'
+             )
+             AND NOT EXISTS (
+               SELECT 1 FROM work_tasks child
+                WHERE child.parent_id = t.id
+                  AND child.archived = false
+                  AND child.status NOT IN ('done', 'cancelled', 'parked')
+             )
+             AND NOT EXISTS (
+               SELECT 1 FROM agent_jobs j
+                WHERE j.status = 'running'
+                  AND (j.job_id = t.source_ref OR COALESCE(j.results, '[]'::jsonb)::text LIKE '%' || t.id || '%')
+             )
+             AND t.last_activity_at = $5::timestamptz
+           FOR UPDATE OF t SKIP LOCKED
+        `, [candidate.task.id, CLOSED_EPIC_STATUSES, AUTONOMOUS_TASK_ASSIGNEES, NON_AUTONOMOUS_TASK_LABELS, candidate.fingerprint]);
+
+        const task = locked.rows[0];
+        if (!task) {
+          results.push({ taskId: candidate.task.id, outcome: 'cas_miss' });
+          continue;
+        }
+
+        const count = await client.query<{ count: string }>(
+          `SELECT COUNT(*)::text AS count FROM work_task_recovery_attempts WHERE task_id = $1`,
+          [task.id],
+        );
+        const attemptNumber = Number(count.rows[0]?.count || 0) + 1;
+        const outcome = attemptNumber >= Math.max(1, retryCeiling) ? 'blocked_ceiling' : 'recovered';
+        const nextStatus = outcome === 'recovered' ? 'todo' : 'blocked';
+        const nextAssignee = outcome === 'recovered' ? TASK_ASSIGNEES.dispatcher : TASK_ASSIGNEES.heartbeat;
+        const reason = outcome === 'recovered'
+          ? 'stale autonomous in_progress task had no live owner or operation'
+          : `recovery retry ceiling reached (${ retryCeiling })`;
+        const auditId = `recovery-${ randomUUID() }`;
+        const undo = `restore status=in_progress, assignee=${ task.assignee ?? 'unassigned' }, and review activity at ${ task.last_activity_at }`;
+
+        await client.query(`
+          INSERT INTO work_task_recovery_attempts
+            (id, task_id, attempt_number, outcome, reason, previous_status, previous_assignee, previous_activity_at)
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        `, [auditId, task.id, attemptNumber, outcome, reason, task.status, task.assignee, task.last_activity_at]);
+
+        await client.query(`
+          WITH inserted AS (
+            INSERT INTO work_task_comments (id, task_id, body, author)
+            VALUES ($1, $2, $3, 'dispatcher')
+          )
+          UPDATE work_tasks
+             SET status = $4,
+                 assignee = $5,
+                 updated_at = now(),
+                 last_moved_at = now(),
+                 last_activity_at = now(),
+                 last_moved_by = 'dispatcher'
+           WHERE id = $2
+        `, [
+          `comment-${ randomUUID() }`, task.id,
+          `Orphan recovery attempt ${ attemptNumber }: ${ reason }. Prior owner: ${ task.assignee ?? 'unassigned' }. Prior activity: ${ task.last_activity_at }. Outcome: ${ nextStatus }/${ nextAssignee }. Undo path: ${ undo }.`,
+          nextStatus, nextAssignee,
+        ]);
+        results.push({ taskId: task.id, outcome, attemptNumber });
+      }
+      return results;
+    });
   }
 
   static async touch(id: string): Promise<void> {

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals'
 
 import { postgresClient } from '../../PostgresClient';
 import { WorkItemsModel } from '../WorkItemsModel';
-import { WorkTaskDispatchModel } from '../WorkTaskDispatchModel';
+import { classifyInProgressRow, WorkTaskDispatchModel } from '../WorkTaskDispatchModel';
 
 describe('WorkTaskDispatchModel', () => {
   let originalTransaction: any;
@@ -66,7 +66,7 @@ describe('WorkTaskDispatchModel', () => {
   });
 
   it('returns null without mutating when no eligible task exists', async() => {
-    const query = jest.fn(() => Promise.resolve({ rows: [] }));
+    const query = jest.fn(() => Promise.resolve({ rows: [] })) as any;
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     await expect(WorkTaskDispatchModel.claimNext('opus-worker')).resolves.toBeNull();
@@ -243,5 +243,97 @@ describe('WorkTaskDispatchModel', () => {
     )).resolves.toBe('BLOCKED');
     expect(query.mock.calls[4][1]).toEqual(['task-2', 'blocked', 'heartbeat']);
     expect(query.mock.calls[3][1][2]).toContain('retry ceiling');
+  });
+
+  it('classifies the full in-progress safety matrix', () => {
+    const eligible = {
+      id:                   'task-1',
+      archived:             false,
+      epic_open:            true,
+      autonomous_owner:     true,
+      autonomous_labels:    true,
+      has_live_dispatch:    false,
+      has_active_child:     false,
+      stale_activity:       true,
+      has_active_agent_job: false,
+    } as any;
+    expect(classifyInProgressRow(eligible)).toEqual([]);
+    expect(classifyInProgressRow({
+      ...eligible,
+      archived:             true,
+      epic_open:            false,
+      autonomous_owner:     false,
+      autonomous_labels:    false,
+      has_live_dispatch:    true,
+      has_active_child:     true,
+      stale_activity:       false,
+      has_active_agent_job: true,
+    })).toEqual([
+      'archived', 'epic_closed', 'human_or_unknown_owner', 'non_autonomous_label',
+      'live_dispatch', 'active_child', 'recent_activity', 'active_agent_job',
+    ]);
+  });
+
+  it('uses the configured stale boundary and includes durable operation checks in report-only classification', async() => {
+    const originalQuery = postgresClient.query;
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+    try {
+      await WorkTaskDispatchModel.findRecoverableInProgress(360, 25);
+      const [sql, values] = (postgresClient.query as any).mock.calls[0];
+      expect(sql).toContain("last_activity_at <= now() - ($4 * interval '1 minute')");
+      expect(sql).toContain("j.status = 'running'");
+      expect(sql).toContain("d.status = 'running'");
+      expect(values).toEqual(expect.arrayContaining([360, 25]));
+    } finally {
+      (postgresClient as any).query = originalQuery;
+    }
+  });
+
+  it('treats a concurrent activity change as a CAS miss without auditing or moving the task', async() => {
+    const query: any = jest.fn(() => Promise.resolve({ rows: [] }));
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+    const candidate = {
+      task: { id: 'task-1' }, fingerprint: '2026-08-23T10:00:00.000Z', attemptCount: 0, exclusionReasons: [],
+    } as any;
+
+    await expect(WorkTaskDispatchModel.recoverOrphanedInProgress([candidate], 1, 3))
+      .resolves.toEqual([{ taskId: 'task-1', outcome: 'cas_miss' }]);
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0]).toContain('t.last_activity_at = $5::timestamptz');
+    expect(query.mock.calls[0][0]).toContain('FOR UPDATE OF t SKIP LOCKED');
+  });
+
+  it('audits and requeues an orphan, then blocks at the retry ceiling', async() => {
+    const task = {
+      id:               'task-1',
+      status:           'in_progress',
+      assignee:         'dispatcher',
+      last_activity_at: '2026-08-23T10:00:00.000Z',
+    } as any;
+    const candidate = {
+      task, fingerprint: task.last_activity_at, attemptCount: 1, exclusionReasons: [],
+    } as any;
+
+    const recoveredQuery = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [task] })
+      .mockResolvedValueOnce({ rows: [{ count: '1' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query: recoveredQuery }));
+    await expect(WorkTaskDispatchModel.recoverOrphanedInProgress([candidate], 1, 3))
+      .resolves.toEqual([{ taskId: 'task-1', outcome: 'recovered', attemptNumber: 2 }]);
+    expect(recoveredQuery.mock.calls[2][0]).toContain('work_task_recovery_attempts');
+    expect(recoveredQuery.mock.calls[3][0]).toContain('INSERT INTO work_task_comments');
+    expect(recoveredQuery.mock.calls[3][1]).toEqual(expect.arrayContaining(['todo', 'dispatcher']));
+
+    const ceilingQuery = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [task] })
+      .mockResolvedValueOnce({ rows: [{ count: '2' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query: ceilingQuery }));
+    await expect(WorkTaskDispatchModel.recoverOrphanedInProgress([candidate], 1, 3))
+      .resolves.toEqual([{ taskId: 'task-1', outcome: 'blocked_ceiling', attemptNumber: 3 }]);
+    expect(ceilingQuery.mock.calls[3][1]).toEqual(expect.arrayContaining(['blocked', 'heartbeat']));
   });
 });

--- a/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
@@ -4,7 +4,9 @@
 // and shows desktop notifications instead of WebSocket chat messages.
 
 import { BaseNode } from './BaseNode';
+import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { WorkItemsModel } from '../database/models/WorkItemsModel';
+import { WorkTaskDispatchModel } from '../database/models/WorkTaskDispatchModel';
 import { runSubconsciousMiddleware } from '../middleware/SubconsciousMiddleware';
 import { throwIfAborted } from '../services/AbortService';
 import { buildRoutinesDigest } from '../tools/workflow/routines_digest';
@@ -161,8 +163,8 @@ export class HeartbeatNode extends BaseNode {
     if (!isToolCallLoop) {
       let laneHealth = '';
       try {
-        const reportOpts = (state.metadata as any).heartbeatReportOpts
-          ?? await this.resolveHeartbeatProjectReportOpts();
+        const reportOpts = (state.metadata as any).heartbeatReportOpts ??
+          await this.resolveHeartbeatProjectReportOpts();
         laneHealth = await this.buildLaneHealthDigest(reportOpts);
       } catch (err) {
         console.warn(`[HeartbeatNode] Lane-health digest skipped: ${ (err as Error).message }`);
@@ -800,11 +802,24 @@ export class HeartbeatNode extends BaseNode {
     const latestCommentAt = await WorkItemsModel.latestCommentAtByTask(
       leafInProgress.map(task => task.id),
     );
+    const recoveryEnabled = await SullaSettingsModel.get('taskDispatcherInProgressRecoveryEnabled', false);
+    const deterministicRecoveryIds = new Set<string>();
+    if (recoveryEnabled === true || recoveryEnabled === 'true') {
+      const candidates = await WorkTaskDispatchModel.findRecoverableInProgress(STALE_IN_PROGRESS_HOURS * 60, 100);
+      for (const candidate of candidates) {
+        // An exact GitHub reference needs the dispatcher's remote activity
+        // check. Keep it visible here until that check classifies it.
+        if (candidate.exclusionReasons.length === 0 && !candidate.task.github_issue) {
+          deterministicRecoveryIds.add(candidate.task.id);
+        }
+      }
+    }
     for (const task of leafInProgress) {
-      const movedMs   = Date.parse(task.last_moved_at);
+      if (deterministicRecoveryIds.has(task.id)) continue;
+      const movedMs = Date.parse(task.last_moved_at);
       const commentMs = Date.parse(latestCommentAt.get(task.id) ?? '');
       const lastActivityMs = Math.max(
-        Number.isFinite(movedMs)   ? movedMs   : -Infinity,
+        Number.isFinite(movedMs) ? movedMs : -Infinity,
         Number.isFinite(commentMs) ? commentMs : -Infinity,
       );
       if (!Number.isFinite(lastActivityMs)) continue;

--- a/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
@@ -9,6 +9,8 @@ const getEpicMock: any = jest.fn();
 const getTaskMock: any = jest.fn();
 const listCommentsMock: any = jest.fn();
 const latestCommentAtByTaskMock: any = jest.fn();
+const settingsGetMock: any = jest.fn();
+const findRecoverableInProgressMock: any = jest.fn();
 
 jest.unstable_mockModule('../BaseNode', () => ({
   BaseNode: class MockBaseNode {
@@ -21,15 +23,23 @@ jest.unstable_mockModule('../BaseNode', () => ({
 
 jest.unstable_mockModule('../../database/models/WorkItemsModel', () => ({
   WorkItemsModel: {
-    ensureTables: ensureTablesMock,
-    listProjects: listProjectsMock,
-    listTasks:    listTasksMock,
-    getProject:   getProjectMock,
-    getEpic:      getEpicMock,
-    getTask:      getTaskMock,
-    listComments: listCommentsMock,
+    ensureTables:          ensureTablesMock,
+    listProjects:          listProjectsMock,
+    listTasks:             listTasksMock,
+    getProject:            getProjectMock,
+    getEpic:               getEpicMock,
+    getTask:               getTaskMock,
+    listComments:          listCommentsMock,
     latestCommentAtByTask: latestCommentAtByTaskMock,
   },
+}));
+
+jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
+  SullaSettingsModel: { get: settingsGetMock },
+}));
+
+jest.unstable_mockModule('../../database/models/WorkTaskDispatchModel', () => ({
+  WorkTaskDispatchModel: { findRecoverableInProgress: findRecoverableInProgressMock },
 }));
 
 jest.unstable_mockModule('../../prompts/projectReport', () => ({
@@ -72,7 +82,11 @@ describe('HeartbeatNode Projects context injection', () => {
     getTaskMock.mockReset();
     listCommentsMock.mockReset();
     latestCommentAtByTaskMock.mockReset();
+    settingsGetMock.mockReset();
+    findRecoverableInProgressMock.mockReset();
     latestCommentAtByTaskMock.mockResolvedValue(new Map());
+    settingsGetMock.mockImplementation((_key: string, fallback: unknown) => Promise.resolve(fallback));
+    findRecoverableInProgressMock.mockResolvedValue([]);
 
     ensureTablesMock.mockResolvedValue(undefined);
     buildProjectReportMock.mockResolvedValue('# Project report\n\n## Next up\n- [critical] Hydrate me (id task1)');
@@ -160,19 +174,46 @@ describe('HeartbeatNode Projects context injection', () => {
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         {
-          id: 'blocked1', project_id: 'proj1', epic_id: 'epic1', parent_id: null,
-          title: 'Blocked first', description: 'Needs recovery.', status: 'blocked',
-          priority: 'critical', assignee: 'heartbeat', labels: [], due_at: null, github_issue: null,
+          id:           'blocked1',
+          project_id:   'proj1',
+          epic_id:      'epic1',
+          parent_id:    null,
+          title:        'Blocked first',
+          description:  'Needs recovery.',
+          status:       'blocked',
+          priority:     'critical',
+          assignee:     'heartbeat',
+          labels:       [],
+          due_at:       null,
+          github_issue: null,
         },
         {
-          id: 'planning1', project_id: 'proj1', epic_id: 'epic1', parent_id: null,
-          title: 'Planning active', description: 'Council running.', status: 'planning',
-          priority: 'critical', assignee: 'heartbeat', labels: [], due_at: null, github_issue: null,
+          id:           'planning1',
+          project_id:   'proj1',
+          epic_id:      'epic1',
+          parent_id:    null,
+          title:        'Planning active',
+          description:  'Council running.',
+          status:       'planning',
+          priority:     'critical',
+          assignee:     'heartbeat',
+          labels:       [],
+          due_at:       null,
+          github_issue: null,
         },
         {
-          id: 'action1', project_id: 'proj1', epic_id: 'epic1', parent_id: null,
-          title: 'Actionable peer', description: 'Ship this.', status: 'todo',
-          priority: 'critical', assignee: 'heartbeat', labels: [], due_at: null, github_issue: null,
+          id:           'action1',
+          project_id:   'proj1',
+          epic_id:      'epic1',
+          parent_id:    null,
+          title:        'Actionable peer',
+          description:  'Ship this.',
+          status:       'todo',
+          priority:     'critical',
+          assignee:     'heartbeat',
+          labels:       [],
+          due_at:       null,
+          github_issue: null,
         },
       ])
       .mockResolvedValueOnce([]);
@@ -196,14 +237,32 @@ describe('HeartbeatNode Projects context injection', () => {
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         {
-          id: 'planning1', project_id: 'proj1', epic_id: 'epic1', parent_id: null,
-          title: 'Planning active', description: 'Council running.', status: 'planning',
-          priority: 'critical', assignee: 'heartbeat', labels: [], due_at: null, github_issue: null,
+          id:           'planning1',
+          project_id:   'proj1',
+          epic_id:      'epic1',
+          parent_id:    null,
+          title:        'Planning active',
+          description:  'Council running.',
+          status:       'planning',
+          priority:     'critical',
+          assignee:     'heartbeat',
+          labels:       [],
+          due_at:       null,
+          github_issue: null,
         },
         {
-          id: 'blocked1', project_id: 'proj1', epic_id: 'epic1', parent_id: null,
-          title: 'Blocked recovery', description: 'Needs council.', status: 'blocked',
-          priority: 'critical', assignee: 'heartbeat', labels: [], due_at: null, github_issue: null,
+          id:           'blocked1',
+          project_id:   'proj1',
+          epic_id:      'epic1',
+          parent_id:    null,
+          title:        'Blocked recovery',
+          description:  'Needs council.',
+          status:       'blocked',
+          priority:     'critical',
+          assignee:     'heartbeat',
+          labels:       [],
+          due_at:       null,
+          github_issue: null,
         },
       ])
       .mockResolvedValueOnce([]);
@@ -548,6 +607,10 @@ describe('HeartbeatNode lane-health digest (Sw8c)', () => {
     listTasksMock.mockReset();
     latestCommentAtByTaskMock.mockReset();
     latestCommentAtByTaskMock.mockResolvedValue(new Map());
+    settingsGetMock.mockReset();
+    settingsGetMock.mockImplementation((_key: string, fallback: unknown) => Promise.resolve(fallback));
+    findRecoverableInProgressMock.mockReset();
+    findRecoverableInProgressMock.mockResolvedValue([]);
   });
 
   it('returns empty when the lane is healthy (single fresh in_progress, nothing off-lane)', async() => {
@@ -607,6 +670,25 @@ describe('HeartbeatNode lane-health digest (Sw8c)', () => {
     expect(digest).not.toContain('LANE DRIFT');
     // Only two queries — no third heartbeat-assignee probe.
     expect(listTasksMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves deterministic stale recovery to the dispatcher when recovery is enabled', async() => {
+    listTasksMock
+      .mockResolvedValueOnce([
+        { id: 'task1', project_id: 'proj1', title: 'Recoverable orphan', last_moved_at: staleIso },
+      ])
+      .mockResolvedValueOnce([]);
+    settingsGetMock.mockResolvedValue(true);
+    findRecoverableInProgressMock.mockResolvedValue([{
+      task: { id: 'task1', github_issue: null }, exclusionReasons: [],
+    }]);
+
+    const node = await makeNode();
+    const digest = await node.buildLaneHealthDigest({ assignee: 'heartbeat' });
+
+    expect(findRecoverableInProgressMock).toHaveBeenCalledWith(360, 100);
+    expect(digest).not.toContain('STALE');
+    expect(digest).toBe('');
   });
 
   it('excludes a parent task from DUPLICATE ACTIVE and STALE (parent + one subtask is healthy)', async() => {
@@ -707,8 +789,8 @@ describe('HeartbeatNode next-action digest (S75N)', () => {
       comment('c2', 'Made progress on hydration.'),
       comment('c3', 'Shipped the guard.'),
       comment('c4',
-        'Landed the audit trail. Remaining P1s under o8SF: Di0x (playbooks) and grbz (cycle budget). '
-        + 'Next step: implement next-action extraction. PR #579 still open; #577 already merged.',
+        'Landed the audit trail. Remaining P1s under o8SF: Di0x (playbooks) and grbz (cycle budget). ' +
+        'Next step: implement next-action extraction. PR #579 still open; #577 already merged.',
         'sulla', '2026-08-17T13:03:00.000Z'),
     ];
     const digest = node.buildNextActionDigest(comments, ['Di0x', 'grbz', 'S75N']);

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -1,7 +1,10 @@
+import { Octokit } from '@octokit/rest';
+
 import { AbortService } from './AbortService';
 import { resolvePullRequestHead } from './GitHubPullRequestHeadService';
 import { GraphRegistry } from './GraphRegistry';
 import { isInsideWindow } from './HeartbeatService';
+import { getIntegrationService } from './IntegrationService';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { WorkItemsModel, type WorkTaskRecord } from '../database/models/WorkItemsModel';
 import { WorkTaskDispatchModel, type ClaimedDispatch, type VerificationVerdict } from '../database/models/WorkTaskDispatchModel';
@@ -15,6 +18,9 @@ const DEFAULT_CONCURRENCY = 3;
 const DEFAULT_AGENT_ID = 'opus-worker';
 const DEFAULT_VERIFIER_AGENT_ID = 'codex-test';
 const DEFAULT_VERIFIER_TIMEOUT_MINUTES = 45;
+const DEFAULT_IN_PROGRESS_STALE_MINUTES = 360;
+const DEFAULT_RECOVERY_BATCH_SIZE = 1;
+const DEFAULT_RECOVERY_RETRY_CEILING = 3;
 const VERIFIER_TOOLS = [
   'file_search', 'read_file',
   'git_status', 'git_diff', 'git_log', 'git_blame',
@@ -89,12 +95,79 @@ export class TaskDispatcherService {
       const window = await SullaSettingsModel.get('heartbeatWindow', null);
       if (window && !isInsideWindow(window)) return;
 
+      await this.checkInProgressRecovery();
       await this.fillExecutionPool();
       await this.fillVerificationPool();
     } catch (err) {
       console.error('[TaskDispatcher] Dispatch check failed:', err);
     } finally {
       this.checking = false;
+    }
+  }
+
+  private async checkInProgressRecovery(): Promise<void> {
+    const enabledSetting = await SullaSettingsModel.get('taskDispatcherInProgressRecoveryEnabled', false);
+    const enabled = enabledSetting === true || enabledSetting === 'true';
+    const staleConfigured = Number(await SullaSettingsModel.get(
+      'taskDispatcherInProgressStaleMinutes', DEFAULT_IN_PROGRESS_STALE_MINUTES,
+    ));
+    const batchConfigured = Number(await SullaSettingsModel.get(
+      'taskDispatcherRecoveryBatchSize', DEFAULT_RECOVERY_BATCH_SIZE,
+    ));
+    const ceilingConfigured = Number(await SullaSettingsModel.get(
+      'taskDispatcherRecoveryRetryCeiling', DEFAULT_RECOVERY_RETRY_CEILING,
+    ));
+    const staleMinutes = Math.max(15, staleConfigured || DEFAULT_IN_PROGRESS_STALE_MINUTES);
+    const batchSize = Math.max(1, Math.min(25, batchConfigured || DEFAULT_RECOVERY_BATCH_SIZE));
+    const retryCeiling = Math.max(1, Math.min(10, ceilingConfigured || DEFAULT_RECOVERY_RETRY_CEILING));
+    const candidates = await WorkTaskDispatchModel.findRecoverableInProgress(staleMinutes, 100);
+
+    for (const candidate of candidates.filter(item => item.exclusionReasons.length === 0 && item.task.github_issue)) {
+      if (await this.hasActiveLinkedPullRequest(candidate.task.github_issue!)) {
+        candidate.exclusionReasons.push('linked_external_operation');
+      }
+    }
+
+    const eligible = candidates.filter(candidate => candidate.exclusionReasons.length === 0);
+    const excludedCounts = candidates.flatMap(candidate => candidate.exclusionReasons)
+      .reduce<Record<string, number>>((counts, reason) => {
+        counts[reason] = (counts[reason] || 0) + 1;
+        return counts;
+      }, {});
+    console.log('[TaskDispatcher] In-progress recovery report', {
+      mode:     enabled ? 'enabled' : 'report-only',
+      scanned:  candidates.length,
+      eligible: eligible.length,
+      excluded: excludedCounts,
+      staleMinutes,
+      batchSize,
+      retryCeiling,
+    });
+
+    if (!enabled || eligible.length === 0) return;
+    const recovered = await WorkTaskDispatchModel.recoverOrphanedInProgress(eligible, batchSize, retryCeiling);
+    const counts = recovered.reduce<Record<string, number>>((outcomes, result) => {
+      outcomes[result.outcome] = (outcomes[result.outcome] || 0) + 1;
+      return outcomes;
+    }, {});
+    console.warn('[TaskDispatcher] In-progress recovery outcomes', counts);
+  }
+
+  private async hasActiveLinkedPullRequest(reference: string): Promise<boolean> {
+    const match = /^(?:https?:\/\/github\.com\/)?([^/\s]+)\/([^/#\s]+?)(?:\/pull\/|#)(\d+)$/i.exec(reference.trim());
+    if (!match) return false;
+    try {
+      const token = await getIntegrationService().getIntegrationValue('github', 'token');
+      if (!token) return true;
+      const octokit = new Octokit({ auth: token.value });
+      const { data } = await octokit.pulls.get({
+        owner: match[1], repo: match[2], pull_number: Number(match[3]),
+      });
+      return data.state === 'open';
+    } catch (err: any) {
+      if (err?.status === 404) return false;
+      console.warn(`[TaskDispatcher] Linked PR check failed for ${ reference }; excluding candidate`, err);
+      return true;
     }
   }
 

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const settingsGetMock: any = jest.fn();
 const recoverStaleMock: any = jest.fn(() => Promise.resolve([]));
+const findRecoverableInProgressMock: any = jest.fn(() => Promise.resolve([]));
+const recoverOrphanedInProgressMock: any = jest.fn(() => Promise.resolve([]));
 const countRunningMock: any = jest.fn(() => Promise.resolve(0));
 const claimNextMock: any = jest.fn(() => Promise.resolve(null));
 const claimNextReviewMock: any = jest.fn(() => Promise.resolve(null));
@@ -21,6 +23,8 @@ jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
 jest.unstable_mockModule('../../database/models/WorkTaskDispatchModel', () => ({
   WorkTaskDispatchModel: {
     recoverStale: recoverStaleMock,
+    findRecoverableInProgress: findRecoverableInProgressMock,
+    recoverOrphanedInProgress: recoverOrphanedInProgressMock,
     countRunning: countRunningMock,
     claimNext:    claimNextMock,
     claimNextReview: claimNextReviewMock,
@@ -67,6 +71,8 @@ describe('TaskDispatcherService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     recoverStaleMock.mockResolvedValue([]);
+    findRecoverableInProgressMock.mockResolvedValue([]);
+    recoverOrphanedInProgressMock.mockResolvedValue([]);
     countRunningMock.mockResolvedValue(0);
     claimNextMock.mockResolvedValue(null);
     claimNextReviewMock.mockResolvedValue(null);
@@ -97,6 +103,38 @@ describe('TaskDispatcherService', () => {
 
     expect(recoverStaleMock).toHaveBeenCalledWith(0);
     expect(countRunningMock).toHaveBeenCalled();
+  });
+
+  it('reports in-progress candidates without mutating while rollout is disabled', async() => {
+    findRecoverableInProgressMock.mockResolvedValue([{ task: { id: 'task-1' }, exclusionReasons: [] }]);
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+
+    await service.initialize();
+    service.destroy();
+
+    expect(findRecoverableInProgressMock).toHaveBeenCalledWith(360, 100);
+    expect(recoverOrphanedInProgressMock).not.toHaveBeenCalled();
+  });
+
+  it('recovers before normal refill when explicitly enabled and honors the batch and retry caps', async() => {
+    const candidate = { task: { id: 'task-1', github_issue: null }, exclusionReasons: [] };
+    findRecoverableInProgressMock.mockResolvedValue([candidate]);
+    settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+      if (key === 'heartbeatEnabled' || key === 'taskDispatcherInProgressRecoveryEnabled') return Promise.resolve(true);
+      if (key === 'taskDispatcherRecoveryBatchSize') return Promise.resolve(2);
+      if (key === 'taskDispatcherRecoveryRetryCeiling') return Promise.resolve(4);
+      return Promise.resolve(fallback);
+    });
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+
+    await service.initialize();
+    service.destroy();
+
+    expect(recoverOrphanedInProgressMock).toHaveBeenCalledWith([candidate], 2, 4);
+    expect(recoverOrphanedInProgressMock.mock.invocationCallOrder[0])
+      .toBeLessThan(countRunningMock.mock.invocationCallOrder[0]);
   });
 
   it('claims mechanically, executes the assigned worker, and returns completed work for review', async() => {


### PR DESCRIPTION
Closes #662.

Stacked directly on approved durable-wait head 9667b7096bf3ee26ee6c7fdc761cbe1c33296ebe. Migration order is now deterministic: 0063 ownership, 0064 verifier, 0065 durable waits, 0066 stale recovery.

Adds report-only stale in_progress classification, transactionally rechecked CAS recovery, durable attempt and Projects audit records, human/gated/live-operation exclusions, exact linked-PR fail-closed checks, bounded batches and retry ceilings, and Heartbeat handoff for deterministic candidates. Recovery uses the shared autonomous ownership contract from the predecessor stack and remains disabled by default.

Verification at head 759cea56d29cb3f7ee27f3c7dddddead0baea5d4:
- combined ownership, verifier, wait, and recovery suite: 15 suites, 95 tests passed
- scoped ESLint: 0 errors; remaining warnings are predecessor style debt
- TaskDispatcherService and WorkTaskDispatchModel esbuild parse: passed
- 8 GB agent typecheck completed with only predecessor repository baseline diagnostics and no changed-file diagnostics
- git diff --check passed

No merge, deploy, restart, setting change, runtime enablement, or production migration was performed.