### PR TITLE
feat(heartbeat): add capability-aware lifecycle handoff

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0068_create_lifecycle_capabilities.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0068_create_lifecycle_capabilities.ts
@@ -1,0 +1,64 @@
+/**
+ * Capability-aware lifecycle ownership.
+ *
+ * The capability row is the control-plane truth; task-stage claims are the
+ * data-plane mutex.  Claims deliberately have no wall-clock expiry: a healthy
+ * long-running owner is not stale merely because work takes time.  Restart and
+ * recovery invalidate claims by runtime instance instead.
+ */
+
+export const up = `
+  CREATE TABLE IF NOT EXISTS lifecycle_capabilities (
+    capability_key      TEXT        PRIMARY KEY,
+    version             INTEGER     NOT NULL DEFAULT 1,
+    enabled             BOOLEAN     NOT NULL DEFAULT false,
+    health              TEXT        NOT NULL DEFAULT 'unavailable'
+      CHECK (health IN ('healthy', 'degraded', 'unavailable')),
+    active_owner        TEXT,
+    runtime_instance_id TEXT,
+    last_success_at     TIMESTAMPTZ,
+    exception_count     INTEGER     NOT NULL DEFAULT 0,
+    fallback_mode       TEXT        NOT NULL DEFAULT 'heartbeat'
+      CHECK (fallback_mode IN ('heartbeat', 'manual_hold', 'keep_current')),
+    fallback_active     BOOLEAN     NOT NULL DEFAULT true,
+    last_error          TEXT,
+    recovery_task_id    TEXT REFERENCES work_tasks(id),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+
+  CREATE TABLE IF NOT EXISTS work_task_stage_claims (
+    id                  TEXT        PRIMARY KEY,
+    task_id             TEXT        NOT NULL REFERENCES work_tasks(id),
+    capability_key      TEXT        NOT NULL REFERENCES lifecycle_capabilities(capability_key),
+    stage               TEXT        NOT NULL,
+    owner               TEXT        NOT NULL,
+    runtime_instance_id TEXT        NOT NULL,
+    status              TEXT        NOT NULL DEFAULT 'active'
+      CHECK (status IN ('active', 'released', 'recovered', 'cancelled')),
+    claimed_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    heartbeat_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    released_at         TIMESTAMPTZ
+  );
+
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_work_task_stage_claims_one_live
+    ON work_task_stage_claims (task_id, stage)
+    WHERE status = 'active';
+
+  CREATE INDEX IF NOT EXISTS idx_work_task_stage_claims_runtime
+    ON work_task_stage_claims (capability_key, runtime_instance_id, status);
+
+  INSERT INTO lifecycle_capabilities
+    (capability_key, version, enabled, health, fallback_mode, fallback_active)
+  VALUES
+    ('planning-council', 1, false, 'unavailable', 'heartbeat', true),
+    ('todo-execution', 1, false, 'unavailable', 'heartbeat', true),
+    ('in-review-verification', 1, false, 'unavailable', 'heartbeat', true),
+    ('durable-waits', 1, false, 'unavailable', 'heartbeat', true),
+    ('stale-recovery', 1, false, 'unavailable', 'heartbeat', true)
+  ON CONFLICT (capability_key) DO NOTHING;
+`;
+
+export const down = `
+  DROP TABLE IF EXISTS work_task_stage_claims CASCADE;
+  DROP TABLE IF EXISTS lifecycle_capabilities CASCADE;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0068_create_lifecycle_capabilities.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0068_create_lifecycle_capabilities.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { up } from '../0068_create_lifecycle_capabilities';
+
+describe('0068_create_lifecycle_capabilities', () => {
+  it('seeds all protected lifecycle capabilities and enforces one live stage owner', () => {
+    for (const key of [
+      'planning-council', 'todo-execution', 'in-review-verification',
+      'durable-waits', 'stale-recovery',
+    ]) {
+      expect(up).toContain(`('${ key }'`);
+    }
+    expect(up).toContain('idx_work_task_stage_claims_one_live');
+    expect(up).toContain("WHERE status = 'active'");
+    expect(up).not.toContain('expires_at');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -50,6 +50,7 @@ import { up as up_0059, down as down_0059 } from './0059_allow_skills_identity_d
 import { up as up_0060, down as down_0060 } from './0060_add_skill_slug_to_identity_observations';
 import { up as up_0061, down as down_0061 } from './0061_add_work_task_activity';
 import { up as up_0062, down as down_0062 } from './0062_create_work_task_dispatches';
+import { up as up_0068, down as down_0068 } from './0068_create_lifecycle_capabilities';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -101,4 +102,5 @@ export const migrationsRegistry = [
   { name: '0060_add_skill_slug_to_identity_observations',         up: up_0060, down: down_0060 },
   { name: '0061_add_work_task_activity',                           up: up_0061, down: down_0061 },
   { name: '0062_create_work_task_dispatches',                      up: up_0062, down: down_0062 },
+  { name: '0068_create_lifecycle_capabilities',                    up: up_0068, down: down_0068 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
@@ -169,42 +169,58 @@ export class LifecycleCapabilityModel {
     owner: string,
     runtimeInstanceId: string,
   ): Promise<ClaimResult> {
-    return postgresClient.transaction(async(client) => {
-      const capabilityResult = await client.query<LifecycleCapabilityRecord>(`
+    return postgresClient.transaction(client => LifecycleCapabilityModel.claimStageWithClient(
+      client,
+      taskId,
+      key,
+      stage,
+      owner,
+      runtimeInstanceId,
+    ));
+  }
+
+  static async claimStageWithClient(
+    client: PoolClient,
+    taskId: string,
+    key: LifecycleCapabilityKey,
+    stage: string,
+    owner: string,
+    runtimeInstanceId: string,
+  ): Promise<ClaimResult> {
+    const capabilityResult = await client.query<LifecycleCapabilityRecord>(`
         SELECT * FROM lifecycle_capabilities WHERE capability_key = $1 FOR UPDATE
       `, [key]);
-      const capability = capabilityResult.rows[0];
-      if (!capability) return { claimed: false, reason: `capability ${ key } is not registered` };
+    const capability = capabilityResult.rows[0];
+    if (!capability) return { claimed: false, reason: `capability ${ key } is not registered` };
 
-      const authorized = effectiveOwner(capability);
-      if (!authorized) {
-        return { claimed: false, reason: `${ key } is ${ capability.enabled ? capability.health : 'disabled' }; fallback ${ capability.fallback_mode } holds work` };
-      }
-      if (authorized !== owner) {
-        return { claimed: false, reason: `${ key } is owned by ${ authorized }` };
-      }
+    const authorized = effectiveOwner(capability);
+    if (!authorized) {
+      return { claimed: false, reason: `${ key } is ${ capability.enabled ? capability.health : 'disabled' }; fallback ${ capability.fallback_mode } holds work` };
+    }
+    if (authorized !== owner) {
+      return { claimed: false, reason: `${ key } is owned by ${ authorized }` };
+    }
 
-      const existing = await client.query<LifecycleStageClaim>(`
+    const existing = await client.query<LifecycleStageClaim>(`
         SELECT * FROM work_task_stage_claims
          WHERE task_id = $1 AND stage = $2 AND status = 'active'
          FOR UPDATE
       `, [taskId, stage]);
-      if (existing.rows[0]) {
-        const claim = existing.rows[0];
-        if (claim.owner === owner && claim.runtime_instance_id === runtimeInstanceId) {
-          return { claimed: true, claim };
-        }
-        return { claimed: false, reason: `${ stage } already claimed by ${ claim.owner }` };
+    if (existing.rows[0]) {
+      const claim = existing.rows[0];
+      if (claim.owner === owner && claim.runtime_instance_id === runtimeInstanceId) {
+        return { claimed: true, claim };
       }
+      return { claimed: false, reason: `${ stage } already claimed by ${ claim.owner }` };
+    }
 
-      const inserted = await client.query<LifecycleStageClaim>(`
+    const inserted = await client.query<LifecycleStageClaim>(`
         INSERT INTO work_task_stage_claims
           (id, task_id, capability_key, stage, owner, runtime_instance_id)
         VALUES ($1, $2, $3, $4, $5, $6)
         RETURNING *
       `, [`stage-${ randomUUID() }`, taskId, key, stage, owner, runtimeInstanceId]);
-      return { claimed: true, claim: inserted.rows[0] };
-    });
+    return { claimed: true, claim: inserted.rows[0] };
   }
 
   static async releaseStage(claimId: string, status: 'released' | 'cancelled' = 'released'): Promise<void> {

--- a/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
@@ -1,0 +1,334 @@
+import { randomUUID } from 'node:crypto';
+
+import { postgresClient } from '../PostgresClient';
+
+import type { PoolClient } from 'pg';
+
+export const LIFECYCLE_CAPABILITY_KEYS = [
+  'planning-council',
+  'todo-execution',
+  'in-review-verification',
+  'durable-waits',
+  'stale-recovery',
+] as const;
+
+export type LifecycleCapabilityKey = typeof LIFECYCLE_CAPABILITY_KEYS[number];
+export type LifecycleHealth = 'healthy' | 'degraded' | 'unavailable';
+export type LifecycleFallback = 'heartbeat' | 'manual_hold' | 'keep_current';
+
+export interface LifecycleCapabilityRecord {
+  capability_key:      LifecycleCapabilityKey;
+  version:             number;
+  enabled:             boolean;
+  health:              LifecycleHealth;
+  active_owner:        string | null;
+  runtime_instance_id: string | null;
+  last_success_at:     string | null;
+  exception_count:     number;
+  fallback_mode:       LifecycleFallback;
+  fallback_active:     boolean;
+  last_error:          string | null;
+  recovery_task_id:    string | null;
+  updated_at:          string;
+}
+
+export interface LifecycleStageClaim {
+  id:                  string;
+  task_id:             string;
+  capability_key:      LifecycleCapabilityKey;
+  stage:               string;
+  owner:               string;
+  runtime_instance_id: string;
+  status:              'active' | 'released' | 'recovered' | 'cancelled';
+  claimed_at:          string;
+  heartbeat_at:        string;
+  released_at:         string | null;
+}
+
+export interface CapabilityReport {
+  key:                LifecycleCapabilityKey;
+  version?:           number;
+  enabled:            boolean;
+  health:             LifecycleHealth;
+  owner?:             string | null;
+  runtimeInstanceId?: string | null;
+  fallbackMode:       LifecycleFallback;
+  error?:             string | null;
+}
+
+export interface ClaimResult {
+  claimed: boolean;
+  reason?: string;
+  claim?:  LifecycleStageClaim;
+}
+
+const STATUS_CAPABILITY: Record<string, LifecycleCapabilityKey> = {
+  blocked:     'planning-council',
+  planning:    'planning-council',
+  todo:        'todo-execution',
+  in_progress: 'todo-execution',
+  in_review:   'in-review-verification',
+};
+
+function effectiveOwner(capability: LifecycleCapabilityRecord): string | null {
+  if (capability.enabled && capability.health === 'healthy' && capability.active_owner) {
+    return capability.active_owner;
+  }
+  if (capability.enabled && capability.health === 'degraded' && capability.fallback_mode === 'keep_current') {
+    return capability.active_owner;
+  }
+  if (capability.fallback_mode === 'heartbeat') return 'heartbeat';
+  return null;
+}
+
+export class LifecycleCapabilityModel {
+  static capabilityForStatus(status: string, labels: string[] = []): LifecycleCapabilityKey | null {
+    if (labels.some(label => ['durable-wait', 'waiting-external'].includes(label.toLowerCase()))) {
+      return 'durable-waits';
+    }
+    return STATUS_CAPABILITY[status] ?? null;
+  }
+
+  static async report(report: CapabilityReport): Promise<LifecycleCapabilityRecord> {
+    const fallbackActive = !(report.enabled && report.health === 'healthy' && report.owner);
+    const row = await postgresClient.queryOne<LifecycleCapabilityRecord>(`
+      INSERT INTO lifecycle_capabilities (
+        capability_key, version, enabled, health, active_owner,
+        runtime_instance_id, last_success_at, exception_count,
+        fallback_mode, fallback_active, last_error, updated_at
+      ) VALUES (
+        $1, $2, $3, $4, $5, $6,
+        CASE WHEN $4 = 'healthy' THEN now() ELSE NULL END,
+        CASE WHEN $4 = 'healthy' THEN 0 ELSE 1 END,
+        $7, $8, $9, now()
+      )
+      ON CONFLICT (capability_key) DO UPDATE SET
+        version = EXCLUDED.version,
+        enabled = EXCLUDED.enabled,
+        health = EXCLUDED.health,
+        active_owner = EXCLUDED.active_owner,
+        runtime_instance_id = EXCLUDED.runtime_instance_id,
+        last_success_at = CASE
+          WHEN EXCLUDED.health = 'healthy' THEN now()
+          ELSE lifecycle_capabilities.last_success_at END,
+        exception_count = CASE
+          WHEN EXCLUDED.health = 'healthy' THEN 0
+          WHEN lifecycle_capabilities.health = EXCLUDED.health
+            AND lifecycle_capabilities.last_error IS NOT DISTINCT FROM EXCLUDED.last_error
+            THEN lifecycle_capabilities.exception_count
+          ELSE lifecycle_capabilities.exception_count + 1 END,
+        fallback_mode = EXCLUDED.fallback_mode,
+        fallback_active = EXCLUDED.fallback_active,
+        last_error = EXCLUDED.last_error,
+        updated_at = now()
+      RETURNING *
+    `, [
+      report.key,
+      report.version ?? 1,
+      report.enabled,
+      report.health,
+      report.owner ?? null,
+      report.runtimeInstanceId ?? null,
+      report.fallbackMode,
+      fallbackActive,
+      report.error ?? null,
+    ]);
+    if (!row) throw new Error(`Failed to report lifecycle capability ${ report.key }`);
+
+    if (row.health === 'healthy' && row.recovery_task_id) {
+      await LifecycleCapabilityModel.resolveRecoveryTask(row);
+    } else if (row.health === 'degraded') {
+      await LifecycleCapabilityModel.ensureRecoveryTask(row);
+    }
+    return row;
+  }
+
+  /**
+   * Atomically recover claims owned by a previous process instance. There is
+   * intentionally no age predicate: restart identity, not elapsed time, proves
+   * the old owner is gone.
+   */
+  static async recoverPreviousRuntime(key: LifecycleCapabilityKey, runtimeInstanceId: string): Promise<string[]> {
+    return postgresClient.transaction(async(client) => {
+      const recovered = await client.query<{ task_id: string }>(`
+        UPDATE work_task_stage_claims
+           SET status = 'recovered', released_at = now()
+         WHERE capability_key = $1
+           AND status = 'active'
+           AND runtime_instance_id <> $2
+        RETURNING task_id
+      `, [key, runtimeInstanceId]);
+      return recovered.rows.map(row => row.task_id);
+    });
+  }
+
+  static async claimStage(
+    taskId: string,
+    key: LifecycleCapabilityKey,
+    stage: string,
+    owner: string,
+    runtimeInstanceId: string,
+  ): Promise<ClaimResult> {
+    return postgresClient.transaction(async(client) => {
+      const capabilityResult = await client.query<LifecycleCapabilityRecord>(`
+        SELECT * FROM lifecycle_capabilities WHERE capability_key = $1 FOR UPDATE
+      `, [key]);
+      const capability = capabilityResult.rows[0];
+      if (!capability) return { claimed: false, reason: `capability ${ key } is not registered` };
+
+      const authorized = effectiveOwner(capability);
+      if (!authorized) {
+        return { claimed: false, reason: `${ key } is ${ capability.enabled ? capability.health : 'disabled' }; fallback ${ capability.fallback_mode } holds work` };
+      }
+      if (authorized !== owner) {
+        return { claimed: false, reason: `${ key } is owned by ${ authorized }` };
+      }
+
+      const existing = await client.query<LifecycleStageClaim>(`
+        SELECT * FROM work_task_stage_claims
+         WHERE task_id = $1 AND stage = $2 AND status = 'active'
+         FOR UPDATE
+      `, [taskId, stage]);
+      if (existing.rows[0]) {
+        const claim = existing.rows[0];
+        if (claim.owner === owner && claim.runtime_instance_id === runtimeInstanceId) {
+          return { claimed: true, claim };
+        }
+        return { claimed: false, reason: `${ stage } already claimed by ${ claim.owner }` };
+      }
+
+      const inserted = await client.query<LifecycleStageClaim>(`
+        INSERT INTO work_task_stage_claims
+          (id, task_id, capability_key, stage, owner, runtime_instance_id)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING *
+      `, [`stage-${ randomUUID() }`, taskId, key, stage, owner, runtimeInstanceId]);
+      return { claimed: true, claim: inserted.rows[0] };
+    });
+  }
+
+  static async releaseStage(claimId: string, status: 'released' | 'cancelled' = 'released'): Promise<void> {
+    await postgresClient.query(`
+      UPDATE work_task_stage_claims
+         SET status = $2, released_at = now(), heartbeat_at = now()
+       WHERE id = $1 AND status = 'active'
+    `, [claimId, status]);
+  }
+
+  static async assertActorCanManageTask(
+    status: string,
+    labels: string[] | null,
+    actor: string,
+  ): Promise<void> {
+    if (actor !== 'heartbeat') return;
+    const key = LifecycleCapabilityModel.capabilityForStatus(status, labels ?? []);
+    if (!key) return;
+    const capability = await postgresClient.queryOne<LifecycleCapabilityRecord>(
+      'SELECT * FROM lifecycle_capabilities WHERE capability_key = $1',
+      [key],
+    );
+    // Old/incomplete rollout: no row means preserve the working Heartbeat path.
+    if (!capability) return;
+    const owner = effectiveOwner(capability);
+    if (owner !== 'heartbeat') {
+      throw new Error(`Lifecycle handoff denied: ${ key } is ${ capability.health } and owned by ${ owner ?? 'manual hold' }.`);
+    }
+  }
+
+  /** Remove stages owned by healthy protected services from Heartbeat's queue. */
+  static async filterHeartbeatEligible<T extends { status: string; labels?: string[] | null }>(tasks: T[]): Promise<T[]> {
+    if (tasks.length === 0) return tasks;
+    const rows = await postgresClient.query<LifecycleCapabilityRecord>(`
+      SELECT * FROM lifecycle_capabilities
+       WHERE capability_key = ANY($1::text[])
+    `, [[...LIFECYCLE_CAPABILITY_KEYS]]);
+    const byKey = new Map(rows.map(row => [row.capability_key, row]));
+
+    return tasks.filter((task) => {
+      const key = LifecycleCapabilityModel.capabilityForStatus(task.status, task.labels ?? []);
+      if (!key) return true;
+      const capability = byKey.get(key);
+      // Incomplete rollout preserves the current working Heartbeat owner.
+      return !capability || effectiveOwner(capability) === 'heartbeat';
+    });
+  }
+
+  static async buildDigest(): Promise<string> {
+    const rows = await postgresClient.query<LifecycleCapabilityRecord>(`
+      SELECT * FROM lifecycle_capabilities
+       WHERE capability_key = ANY($1::text[])
+       ORDER BY array_position($1::text[], capability_key)
+    `, [[...LIFECYCLE_CAPABILITY_KEYS]]);
+    if (rows.length === 0) return 'LIFECYCLE: control plane unavailable; Heartbeat retains legacy ownership.';
+    const compact = rows.map(row => {
+      const last = row.last_success_at ? new Date(row.last_success_at).toISOString() : 'never';
+      const owner = effectiveOwner(row) ?? 'hold';
+      return `${ row.capability_key }@${ row.version }=${ row.enabled ? row.health : 'disabled' } owner:${ owner } ok:${ last } ex:${ row.exception_count } fallback:${ row.fallback_mode }${ row.fallback_active ? '*' : '' }`;
+    });
+    return ['LIFECYCLE:', ...compact.map(line => `  • ${ line }`)].join('\n');
+  }
+
+  private static async ensureRecoveryTask(capability: LifecycleCapabilityRecord): Promise<void> {
+    await postgresClient.transaction(async(client: PoolClient) => {
+      const locked = await client.query<LifecycleCapabilityRecord>(
+        'SELECT * FROM lifecycle_capabilities WHERE capability_key = $1 FOR UPDATE',
+        [capability.capability_key],
+      );
+      const current = locked.rows[0];
+      if (current?.health !== 'degraded') return;
+      const id = `caprec-${ current.capability_key }`;
+      const context = await client.query<{ project_id: string; epic_id: string }>(`
+        SELECT p.id AS project_id, e.id AS epic_id
+          FROM work_projects p
+          JOIN work_epics e ON e.project_id = p.id AND e.archived = false
+         WHERE p.archived = false
+           AND p.status NOT IN ('done', 'cancelled', 'parked')
+           AND e.status NOT IN ('done', 'cancelled', 'parked')
+         ORDER BY (LOWER(COALESCE(p.owner, '')) = 'heartbeat') DESC,
+                  p.last_moved_at ASC, e.position ASC
+         LIMIT 1
+      `);
+      const target = context.rows[0];
+      if (!target) return;
+      await client.query(`
+        INSERT INTO work_tasks (
+          id, project_id, epic_id, title, description, status, priority,
+          assignee, labels, source, source_ref, created_by, last_moved_by
+        ) VALUES ($1, $2, $3, $4, $5, 'todo', 'critical', 'dispatcher',
+          ARRAY['systemic-recovery', 'lifecycle-capability'], 'system', $6,
+          'lifecycle-control-plane', 'lifecycle-control-plane')
+        ON CONFLICT (id) DO UPDATE SET
+          description = EXCLUDED.description,
+          status = CASE WHEN work_tasks.status IN ('done', 'cancelled', 'parked') THEN 'todo' ELSE work_tasks.status END,
+          priority = 'critical', archived = false, updated_at = now(), last_activity_at = now()
+      `, [
+        id,
+        target.project_id,
+        target.epic_id,
+        `Recover lifecycle capability: ${ current.capability_key }`,
+        `Capability ${ current.capability_key } is degraded. Owner: ${ current.active_owner ?? 'none' }. Error: ${ current.last_error ?? 'unknown' }. Exception count: ${ current.exception_count }. Restore health without bypassing its single-owner claim.`,
+        `lifecycle-capability:${ current.capability_key }`,
+      ]);
+      await client.query(
+        'UPDATE lifecycle_capabilities SET recovery_task_id = $2 WHERE capability_key = $1',
+        [current.capability_key, id],
+      );
+    });
+  }
+
+  private static async resolveRecoveryTask(capability: LifecycleCapabilityRecord): Promise<void> {
+    await postgresClient.transaction(async(client) => {
+      await client.query(`
+        UPDATE work_tasks
+           SET status = 'done', completed_at = now(), updated_at = now(),
+               last_moved_at = now(), last_activity_at = now(),
+               last_moved_by = 'lifecycle-control-plane'
+         WHERE id = $1 AND status NOT IN ('done', 'cancelled', 'parked')
+      `, [capability.recovery_task_id]);
+      await client.query(
+        'UPDATE lifecycle_capabilities SET recovery_task_id = NULL WHERE capability_key = $1',
+        [capability.capability_key],
+      );
+    });
+  }
+}

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
 import { postgresClient } from '../PostgresClient';
+import { LifecycleCapabilityModel, type LifecycleStageClaim } from './LifecycleCapabilityModel';
 
 import type { WorkTaskRecord } from './WorkItemsModel';
 import type { PoolClient } from 'pg';
@@ -21,15 +22,16 @@ export interface WorkTaskDispatchRecord {
 }
 
 export interface ClaimedDispatch {
-  dispatch: WorkTaskDispatchRecord;
-  task:     WorkTaskRecord;
+  dispatch:    WorkTaskDispatchRecord;
+  task:        WorkTaskRecord;
+  stage_claim: LifecycleStageClaim;
 }
 
 const CLOSED_EPIC_STATUSES = ['done', 'cancelled', 'parked', 'blocked'];
 const NON_AUTONOMOUS_LABELS = ['gated', 'decision', 'human', 'manual', 'no-auto-dispatch'];
 
 export class WorkTaskDispatchModel {
-  static async claimNext(agentId: string): Promise<ClaimedDispatch | null> {
+  static async claimNext(agentId: string, runtimeInstanceId: string): Promise<ClaimedDispatch | null> {
     return postgresClient.transaction(async(client) => {
       const candidate = await client.query<WorkTaskRecord>(`
         SELECT t.*
@@ -48,6 +50,10 @@ export class WorkTaskDispatchModel {
            AND NOT EXISTS (
              SELECT 1 FROM work_task_dispatches d
               WHERE d.task_id = t.id AND d.status = 'running'
+           )
+           AND NOT EXISTS (
+             SELECT 1 FROM work_task_stage_claims c
+              WHERE c.task_id = t.id AND c.stage = 'in_progress' AND c.status = 'active'
            )
            AND NOT EXISTS (
              SELECT 1 FROM work_tasks child
@@ -80,6 +86,16 @@ export class WorkTaskDispatchModel {
       const task = candidate.rows[0];
       if (!task) return null;
 
+      const stageClaim = await LifecycleCapabilityModel.claimStageWithClient(
+        client,
+        task.id,
+        'todo-execution',
+        'in_progress',
+        'dispatcher',
+        runtimeInstanceId,
+      );
+      if (!stageClaim.claimed || !stageClaim.claim) return null;
+
       const id = `dispatch-${ randomUUID() }`;
       const threadId = `task-dispatch-${ task.id }-${ Date.now() }`;
       const inserted = await client.query<WorkTaskDispatchRecord>(`
@@ -88,18 +104,22 @@ export class WorkTaskDispatchModel {
         RETURNING *
       `, [id, task.id, agentId, threadId]);
 
-      await client.query(`
+      const updated = await client.query<WorkTaskRecord>(`
         UPDATE work_tasks
-           SET status = 'planning',
+           SET status = 'in_progress',
                assignee = 'dispatcher',
                updated_at = now(),
                last_moved_at = now(),
                last_activity_at = now(),
                last_moved_by = 'dispatcher'
-         WHERE id = $1
+         WHERE id = $1 AND status = 'todo'
+        RETURNING *
       `, [task.id]);
+      if (!updated.rows[0]) {
+        throw new Error(`Atomic dispatch lost task ${ task.id } before execution handoff`);
+      }
 
-      return { dispatch: inserted.rows[0], task };
+      return { dispatch: inserted.rows[0], task: updated.rows[0], stage_claim: stageClaim.claim };
     });
   }
 
@@ -150,7 +170,7 @@ export class WorkTaskDispatchModel {
              SET status = 'todo', assignee = NULL,
                  updated_at = now(), last_moved_at = now(),
                  last_activity_at = now(), last_moved_by = 'dispatcher'
-           WHERE id = ANY($1::text[]) AND status = 'planning' AND assignee = 'dispatcher'
+           WHERE id = ANY($1::text[]) AND status = 'in_progress' AND assignee = 'dispatcher'
         `, [taskIds]);
       }
       return taskIds;

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -166,6 +166,15 @@ export class WorkTaskDispatchModel {
       const taskIds = stale.rows.map(row => row.task_id);
       if (taskIds.length > 0) {
         await client.query(`
+          UPDATE work_task_stage_claims
+             SET status = 'recovered', released_at = now(), heartbeat_at = now()
+           WHERE task_id = ANY($1::text[])
+             AND capability_key = 'todo-execution'
+             AND stage = 'in_progress'
+             AND status = 'active'
+        `, [taskIds]);
+
+        await client.query(`
           UPDATE work_tasks
              SET status = 'todo', assignee = NULL,
                  updated_at = now(), last_moved_at = now(),

--- a/pkg/rancher-desktop/agent/database/models/__tests__/LifecycleCapabilityModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/LifecycleCapabilityModel.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { postgresClient } from '../../PostgresClient';
+import { LifecycleCapabilityModel } from '../LifecycleCapabilityModel';
+
+describe('LifecycleCapabilityModel', () => {
+  const originalQuery = postgresClient.query;
+  const originalQueryOne = postgresClient.queryOne;
+  const originalTransaction = postgresClient.transaction;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    (postgresClient as any).query = originalQuery;
+    (postgresClient as any).queryOne = originalQueryOne;
+    (postgresClient as any).transaction = originalTransaction;
+  });
+
+  it('denies Heartbeat while a healthy protected owner is active', async() => {
+    (postgresClient as any).queryOne = jest.fn(() => Promise.resolve({
+      capability_key: 'planning-council',
+      enabled:        true,
+      health:         'healthy',
+      active_owner:   'planning-council',
+      fallback_mode:  'heartbeat',
+    }));
+
+    await expect(LifecycleCapabilityModel.assertActorCanManageTask('planning', [], 'heartbeat'))
+      .rejects.toThrow('owned by planning-council');
+  });
+
+  it('keeps the legacy Heartbeat owner during incomplete rollout', async() => {
+    (postgresClient as any).queryOne = jest.fn(() => Promise.resolve(null));
+
+    await expect(LifecycleCapabilityModel.assertActorCanManageTask('in_review', [], 'heartbeat'))
+      .resolves.toBeUndefined();
+  });
+
+  it('lets Heartbeat claim an unavailable capability with explicit fallback', async() => {
+    const capability = {
+      capability_key: 'in-review-verification',
+      enabled:        true,
+      health:         'unavailable',
+      active_owner:   'review-routine',
+      fallback_mode:  'heartbeat',
+    } as any;
+    const inserted = {
+      id:                  'stage-1',
+      task_id:             'task-1',
+      capability_key:      'in-review-verification',
+      stage:               'in_review',
+      owner:               'heartbeat',
+      runtime_instance_id: 'hb-1',
+      status:              'active',
+    } as any;
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [capability] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [inserted] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(LifecycleCapabilityModel.claimStage(
+      'task-1', 'in-review-verification', 'in_review', 'heartbeat', 'hb-1',
+    )).resolves.toMatchObject({ claimed: true, claim: { id: 'stage-1' } });
+  });
+
+  it('returns the same claim for a duplicate wake and rejects a second owner', async() => {
+    const capability = {
+      capability_key: 'stale-recovery',
+      enabled:        false,
+      health:         'unavailable',
+      active_owner:   null,
+      fallback_mode:  'heartbeat',
+    } as any;
+    const existing = {
+      id:                  'stage-1',
+      task_id:             'task-1',
+      stage:               'stale-recovery',
+      owner:               'heartbeat',
+      runtime_instance_id: 'wake-1',
+      status:              'active',
+    } as any;
+    let query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [capability] })
+      .mockResolvedValueOnce({ rows: [existing] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+    await expect(LifecycleCapabilityModel.claimStage(
+      'task-1', 'stale-recovery', 'stale-recovery', 'heartbeat', 'wake-1',
+    )).resolves.toMatchObject({ claimed: true, claim: { id: 'stage-1' } });
+
+    query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [{ ...capability, enabled: true, health: 'healthy', active_owner: 'recovery-service' }] })
+      .mockResolvedValueOnce({ rows: [existing] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+    await expect(LifecycleCapabilityModel.claimStage(
+      'task-1', 'stale-recovery', 'stale-recovery', 'heartbeat', 'wake-2',
+    )).resolves.toMatchObject({ claimed: false, reason: 'stale-recovery is owned by recovery-service' });
+  });
+
+  it('recovers only claims from a previous runtime, never by age', async() => {
+    const query: any = jest.fn(() => Promise.resolve({ rows: [{ task_id: 'task-1' }] }));
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(LifecycleCapabilityModel.recoverPreviousRuntime('todo-execution', 'runtime-new'))
+      .resolves.toEqual(['task-1']);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('runtime_instance_id <> $2'),
+      ['todo-execution', 'runtime-new'],
+    );
+    expect((query).mock.calls[0][0]).not.toContain('interval');
+  });
+
+  it('renders compact truthful state for all lifecycle capabilities', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([
+      {
+        capability_key:  'planning-council',
+        version:         2,
+        enabled:         true,
+        health:          'healthy',
+        active_owner:    'planning-council',
+        last_success_at: '2026-08-23T20:00:00.000Z',
+        exception_count: 0,
+        fallback_mode:   'heartbeat',
+        fallback_active: false,
+      },
+      {
+        capability_key:  'todo-execution',
+        version:         1,
+        enabled:         false,
+        health:          'unavailable',
+        active_owner:    null,
+        last_success_at: null,
+        exception_count: 1,
+        fallback_mode:   'manual_hold',
+        fallback_active: true,
+      },
+    ]));
+
+    const digest = await LifecycleCapabilityModel.buildDigest();
+    expect(digest).toContain('planning-council@2=healthy owner:planning-council');
+    expect(digest).toContain('todo-execution@1=disabled owner:hold');
+    expect(digest).toContain('fallback:manual_hold*');
+  });
+
+  it('hides healthy protected stages and preserves explicit Heartbeat fallbacks', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([
+      {
+        capability_key: 'planning-council',
+        enabled:        true,
+        health:         'healthy',
+        active_owner:   'planning-council',
+        fallback_mode:  'heartbeat',
+      },
+      {
+        capability_key: 'todo-execution',
+        enabled:        true,
+        health:         'unavailable',
+        active_owner:   'dispatcher',
+        fallback_mode:  'heartbeat',
+      },
+      {
+        capability_key: 'in-review-verification',
+        enabled:        false,
+        health:         'unavailable',
+        active_owner:   null,
+        fallback_mode:  'manual_hold',
+      },
+    ]));
+    const tasks = [
+      { id: 'plan', status: 'planning' },
+      { id: 'todo', status: 'todo' },
+      { id: 'review', status: 'in_review' },
+      { id: 'backlog', status: 'backlog' },
+    ];
+
+    await expect(LifecycleCapabilityModel.filterHeartbeatEligible(tasks))
+      .resolves.toEqual([tasks[1], tasks[3]]);
+  });
+
+  it('deduplicates a degraded capability into one deterministic recovery task', async() => {
+    const degraded = {
+      capability_key:      'durable-waits',
+      version:             1,
+      enabled:             true,
+      health:              'degraded',
+      active_owner:        'wait-monitor',
+      runtime_instance_id: 'wait-1',
+      last_success_at:     null,
+      exception_count:     3,
+      fallback_mode:       'heartbeat',
+      fallback_active:     true,
+      last_error:          'provider unavailable',
+      recovery_task_id:    null,
+    } as any;
+    (postgresClient as any).queryOne = jest.fn(() => Promise.resolve(degraded));
+    const query: any = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [degraded] })
+      .mockResolvedValueOnce({ rows: [{ project_id: 'project-1', epic_id: 'epic-1' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await LifecycleCapabilityModel.report({
+      key:               'durable-waits',
+      enabled:           true,
+      health:            'degraded',
+      owner:             'wait-monitor',
+      runtimeInstanceId: 'wait-1',
+      fallbackMode:      'heartbeat',
+      error:             'provider unavailable',
+    });
+
+    expect(query.mock.calls[2][0]).toContain('ON CONFLICT (id) DO UPDATE');
+    expect(query.mock.calls[2][1][0]).toBe('caprec-durable-waits');
+    expect(query.mock.calls[3][1]).toEqual(['durable-waits', 'caprec-durable-waits']);
+  });
+
+  it('closes the systemic recovery item when the capability becomes healthy', async() => {
+    const healthy = {
+      capability_key:      'durable-waits',
+      version:             1,
+      enabled:             true,
+      health:              'healthy',
+      active_owner:        'wait-monitor',
+      runtime_instance_id: 'wait-2',
+      last_success_at:     '2026-08-23T20:00:00.000Z',
+      exception_count:     0,
+      fallback_mode:       'heartbeat',
+      fallback_active:     false,
+      last_error:          null,
+      recovery_task_id:    'caprec-durable-waits',
+    } as any;
+    (postgresClient as any).queryOne = jest.fn(() => Promise.resolve(healthy));
+    const query: any = jest.fn(() => Promise.resolve({ rows: [] }));
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await LifecycleCapabilityModel.report({
+      key:               'durable-waits',
+      enabled:           true,
+      health:            'healthy',
+      owner:             'wait-monitor',
+      runtimeInstanceId: 'wait-2',
+      fallbackMode:      'heartbeat',
+    });
+
+    expect(query.mock.calls[0][0]).toContain("SET status = 'done'");
+    expect(query.mock.calls[0][1]).toEqual(['caprec-durable-waits']);
+    expect(query.mock.calls[1][0]).toContain('SET recovery_task_id = NULL');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
@@ -33,36 +33,133 @@ describe('WorkTaskDispatchModel', () => {
       thread_id: 'thread-1',
       status:    'running',
     } as any;
+    const capability = {
+      capability_key: 'todo-execution',
+      enabled:        true,
+      health:         'healthy',
+      active_owner:   'dispatcher',
+      fallback_mode:  'heartbeat',
+    } as any;
+    const stageClaim = {
+      id:                  'stage-1',
+      task_id:             'task-1',
+      capability_key:      'todo-execution',
+      stage:               'in_progress',
+      owner:               'dispatcher',
+      runtime_instance_id: 'runtime-1',
+      status:              'active',
+    } as any;
+    const executingTask = { ...task, status: 'in_progress', assignee: 'dispatcher' };
     const query = (jest.fn() as any)
       .mockResolvedValueOnce({ rows: [task] })
+      .mockResolvedValueOnce({ rows: [capability] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [stageClaim] })
       .mockResolvedValueOnce({ rows: [dispatch] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [executingTask] });
 
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
-    const claimed = await WorkTaskDispatchModel.claimNext('opus-worker');
+    const claimed = await WorkTaskDispatchModel.claimNext('opus-worker', 'runtime-1');
 
-    expect(claimed).toMatchObject({ task: { id: 'task-1' }, dispatch: { task_id: 'task-1' } });
+    expect(claimed).toMatchObject({
+      task:        { id: 'task-1', status: 'in_progress', assignee: 'dispatcher' },
+      dispatch:    { task_id: 'task-1' },
+      stage_claim: { id: 'stage-1', stage: 'in_progress' },
+    });
     expect(query.mock.calls[0][0]).toContain('FOR UPDATE OF t SKIP LOCKED');
     expect(query.mock.calls[0][0]).toContain("t.status = 'todo'");
     expect(query.mock.calls[0][0]).toContain('work_task_dispatches');
     expect(query.mock.calls[0][0]).toContain("FROM unnest(COALESCE(t.labels, '{}')) AS label");
     expect(query.mock.calls[0][0]).toContain('child.parent_id = t.id');
     expect(query.mock.calls[0][0]).toContain('t.due_at ASC NULLS LAST');
-    expect(query.mock.calls[1][0]).toContain('INSERT INTO work_task_dispatches');
-    expect(query.mock.calls[2][0]).toContain("status = 'planning'");
-    expect(query.mock.calls[2][0]).toContain("assignee = 'dispatcher'");
+    expect(query.mock.calls[0][0]).toContain("c.stage = 'in_progress'");
+    expect(query.mock.calls[1][0]).toContain('lifecycle_capabilities');
+    expect(query.mock.calls[3][0]).toContain('INSERT INTO work_task_stage_claims');
+    expect(query.mock.calls[4][0]).toContain('INSERT INTO work_task_dispatches');
+    expect(query.mock.calls[5][0]).toContain("status = 'in_progress'");
+    expect(query.mock.calls[5][0]).toContain("assignee = 'dispatcher'");
+    expect(query.mock.calls[5][0]).toContain('RETURNING *');
   });
 
   it('returns null without mutating when no eligible task exists', async() => {
     const query = jest.fn(() => Promise.resolve({ rows: [] }));
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
-    await expect(WorkTaskDispatchModel.claimNext('opus-worker')).resolves.toBeNull();
+    await expect(WorkTaskDispatchModel.claimNext('opus-worker', 'runtime-1')).resolves.toBeNull();
     expect(query).toHaveBeenCalledTimes(1);
   });
 
-  it('releases stale planning leases back to todo in one transaction', async() => {
+  it('leaves the real task and dispatch shapes untouched when lifecycle ownership is denied', async() => {
+    const task = {
+      id:          'task-1',
+      project_id:  'project-1',
+      epic_id:     'epic-1',
+      title:       'Ship it',
+      description: '',
+      status:      'todo',
+      priority:    'high',
+      labels:      [],
+    } as any;
+    const protectedCapability = {
+      capability_key: 'todo-execution',
+      enabled:        true,
+      health:         'healthy',
+      active_owner:   'replacement-executor',
+      fallback_mode:  'heartbeat',
+    } as any;
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [task] })
+      .mockResolvedValueOnce({ rows: [protectedCapability] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.claimNext('opus-worker', 'runtime-1')).resolves.toBeNull();
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls.some(([sql]: [string]) => sql.includes('INSERT INTO work_task_dispatches'))).toBe(false);
+    expect(query.mock.calls.some(([sql]: [string]) => sql.includes('UPDATE work_tasks'))).toBe(false);
+  });
+
+  it('loses a racing stage claim without creating a dispatch or changing the task', async() => {
+    const task = {
+      id:          'task-1',
+      project_id:  'project-1',
+      epic_id:     'epic-1',
+      title:       'Ship it',
+      description: '',
+      status:      'todo',
+      priority:    'high',
+      labels:      [],
+    } as any;
+    const capability = {
+      capability_key: 'todo-execution',
+      enabled:        true,
+      health:         'healthy',
+      active_owner:   'dispatcher',
+      fallback_mode:  'heartbeat',
+    } as any;
+    const racingClaim = {
+      id:                  'stage-other',
+      task_id:             'task-1',
+      stage:               'in_progress',
+      owner:               'dispatcher',
+      runtime_instance_id: 'runtime-other',
+      status:              'active',
+    } as any;
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [task] })
+      .mockResolvedValueOnce({ rows: [capability] })
+      .mockResolvedValueOnce({ rows: [racingClaim] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.claimNext('opus-worker', 'runtime-1')).resolves.toBeNull();
+
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(query.mock.calls.some(([sql]: [string]) => sql.includes('INSERT INTO work_task_dispatches'))).toBe(false);
+    expect(query.mock.calls.some(([sql]: [string]) => sql.includes('UPDATE work_tasks'))).toBe(false);
+  });
+
+  it('releases stale execution leases back to todo in one transaction', async() => {
     const query = (jest.fn() as any)
       .mockResolvedValueOnce({ rows: [{ id: 'dispatch-1', task_id: 'task-1' }] })
       .mockResolvedValueOnce({ rows: [] });
@@ -72,7 +169,7 @@ describe('WorkTaskDispatchModel', () => {
     expect(query.mock.calls[0][0]).toContain("status = 'stale'");
     expect(query.mock.calls[0][0]).toContain("interval '1 minute'");
     expect(query.mock.calls[1][0]).toContain("status = 'todo'");
-    expect(query.mock.calls[1][0]).toContain("status = 'planning'");
+    expect(query.mock.calls[1][0]).toContain("status = 'in_progress'");
     expect(query.mock.calls[1][0]).toContain("assignee = 'dispatcher'");
   });
 });

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
@@ -159,17 +159,40 @@ describe('WorkTaskDispatchModel', () => {
     expect(query.mock.calls.some(([sql]: [string]) => sql.includes('UPDATE work_tasks'))).toBe(false);
   });
 
-  it('releases stale execution leases back to todo in one transaction', async() => {
+  it('releases stale dispatch and stage ownership before making the task reclaimable', async() => {
     const query = (jest.fn() as any)
       .mockResolvedValueOnce({ rows: [{ id: 'dispatch-1', task_id: 'task-1' }] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] });
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     await expect(WorkTaskDispatchModel.recoverStale(45)).resolves.toEqual(['task-1']);
     expect(query.mock.calls[0][0]).toContain("status = 'stale'");
     expect(query.mock.calls[0][0]).toContain("interval '1 minute'");
-    expect(query.mock.calls[1][0]).toContain("status = 'todo'");
-    expect(query.mock.calls[1][0]).toContain("status = 'in_progress'");
-    expect(query.mock.calls[1][0]).toContain("assignee = 'dispatcher'");
+    expect(query.mock.calls[1][0]).toContain('UPDATE work_task_stage_claims');
+    expect(query.mock.calls[1][0]).toContain("status = 'recovered'");
+    expect(query.mock.calls[1][0]).toContain("capability_key = 'todo-execution'");
+    expect(query.mock.calls[1][0]).toContain("stage = 'in_progress'");
+    expect(query.mock.calls[1][0]).toContain("status = 'active'");
+    expect(query.mock.calls[1][1]).toEqual([['task-1']]);
+    expect(query.mock.calls[2][0]).toContain("status = 'todo'");
+    expect(query.mock.calls[2][0]).toContain("status = 'in_progress'");
+    expect(query.mock.calls[2][0]).toContain("assignee = 'dispatcher'");
+    expect(query.mock.calls[2][1]).toEqual([['task-1']]);
+
+    const candidateSql = await captureCandidateSql();
+    expect(candidateSql).toContain("c.stage = 'in_progress'");
+    expect(candidateSql).toContain("c.status = 'active'");
   });
 });
+
+async function captureCandidateSql(): Promise<string> {
+  let candidateSql = '';
+  const query = jest.fn((sql: string) => {
+    candidateSql = sql;
+    return Promise.resolve({ rows: [] });
+  });
+  (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+  await WorkTaskDispatchModel.claimNext('opus-worker', 'runtime-1');
+  return candidateSql;
+}

--- a/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/HeartbeatNode.ts
@@ -4,6 +4,7 @@
 // and shows desktop notifications instead of WebSocket chat messages.
 
 import { BaseNode } from './BaseNode';
+import { LifecycleCapabilityModel } from '../database/models/LifecycleCapabilityModel';
 import { WorkItemsModel } from '../database/models/WorkItemsModel';
 import { runSubconsciousMiddleware } from '../middleware/SubconsciousMiddleware';
 import { throwIfAborted } from '../services/AbortService';
@@ -141,6 +142,17 @@ export class HeartbeatNode extends BaseNode {
     // tool-call loop), and failure here (e.g. views not yet migrated) must never
     // break the cycle — skip silently.
     if (!isToolCallLoop) {
+      let lifecycleDigest = '';
+      try {
+        lifecycleDigest = await LifecycleCapabilityModel.buildDigest();
+      } catch (err) {
+        console.warn(`[HeartbeatNode] Lifecycle digest skipped: ${ (err as Error).message }`);
+      }
+      if (lifecycleDigest) {
+        const lifecycleBlock = `\n\n<lifecycle_capabilities>\n${ lifecycleDigest }\n</lifecycle_capabilities>`;
+        this.mergeHeartbeatContextBlock(state, lifecycleBlock, 'lifecycle_capabilities');
+      }
+
       let routineDigest = '';
       try {
         routineDigest = await buildRoutinesDigest();
@@ -502,7 +514,7 @@ export class HeartbeatNode extends BaseNode {
       const { buildProjectReport } = await import('../prompts/projectReport');
       const reportOpts = await this.resolveHeartbeatProjectReportOpts();
       (state.metadata as any).heartbeatReportOpts = reportOpts;
-      const report = await buildProjectReport({ ...reportOpts, nextLimit: 12 });
+      const report = await buildProjectReport({ ...reportOpts, nextLimit: 12, lifecycleAware: true });
       if (!report) return;
 
       const scope = reportOpts.projectId
@@ -525,7 +537,8 @@ export class HeartbeatNode extends BaseNode {
   }
 
   private async buildSelectedHeartbeatWorkItemContext(state: BaseThreadState, reportOpts: { projectId?: string; assignee?: string }): Promise<string> {
-    const candidates = await WorkItemsModel.listTasks({ ...reportOpts, limit: 500 });
+    const listedCandidates = await WorkItemsModel.listTasks({ ...reportOpts, limit: 500 });
+    const candidates = await LifecycleCapabilityModel.filterHeartbeatEligible(listedCandidates);
     // Match projectReport's section order: hydrate executable work first. If
     // the lane is fully blocked, hydrate the top recovery-planning candidate.
     // A task already in planning is never selected for duplicate dispatch.

--- a/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/HeartbeatNode.workContext.test.ts
@@ -9,6 +9,7 @@ const getEpicMock: any = jest.fn();
 const getTaskMock: any = jest.fn();
 const listCommentsMock: any = jest.fn();
 const latestCommentAtByTaskMock: any = jest.fn();
+const filterHeartbeatEligibleMock: any = jest.fn((tasks: any[]) => Promise.resolve(tasks));
 
 jest.unstable_mockModule('../BaseNode', () => ({
   BaseNode: class MockBaseNode {
@@ -29,6 +30,13 @@ jest.unstable_mockModule('../../database/models/WorkItemsModel', () => ({
     getTask:      getTaskMock,
     listComments: listCommentsMock,
     latestCommentAtByTask: latestCommentAtByTaskMock,
+  },
+}));
+
+jest.unstable_mockModule('../../database/models/LifecycleCapabilityModel', () => ({
+  LifecycleCapabilityModel: {
+    buildDigest:             jest.fn(() => Promise.resolve('LIFECYCLE: test')),
+    filterHeartbeatEligible: filterHeartbeatEligibleMock,
   },
 }));
 
@@ -73,6 +81,7 @@ describe('HeartbeatNode Projects context injection', () => {
     listCommentsMock.mockReset();
     latestCommentAtByTaskMock.mockReset();
     latestCommentAtByTaskMock.mockResolvedValue(new Map());
+    filterHeartbeatEligibleMock.mockImplementation((tasks: any[]) => Promise.resolve(tasks));
 
     ensureTablesMock.mockResolvedValue(undefined);
     buildProjectReportMock.mockResolvedValue('# Project report\n\n## Next up\n- [critical] Hydrate me (id task1)');
@@ -152,6 +161,7 @@ describe('HeartbeatNode Projects context injection', () => {
       commentCount: 1,
     });
     expect(state.messages[1].role).toBe('user');
+    expect(buildProjectReportMock).toHaveBeenCalledWith(expect.objectContaining({ lifecycleAware: true }));
   });
 
   it('skips blocked and planning tasks when actionable work exists', async() => {

--- a/pkg/rancher-desktop/agent/prompts/__tests__/projectReport.test.ts
+++ b/pkg/rancher-desktop/agent/prompts/__tests__/projectReport.test.ts
@@ -4,6 +4,7 @@ const ensureTablesMock: any = jest.fn();
 const listProjectsMock: any = jest.fn();
 const listEpicsMock: any = jest.fn();
 const listTasksMock: any = jest.fn();
+const filterHeartbeatEligibleMock: any = jest.fn((tasks: any[]) => Promise.resolve(tasks));
 
 jest.unstable_mockModule('../../database/models/WorkItemsModel', () => ({
   WorkItemsModel: {
@@ -12,6 +13,10 @@ jest.unstable_mockModule('../../database/models/WorkItemsModel', () => ({
     listEpics: listEpicsMock,
     listTasks: listTasksMock,
   },
+}));
+
+jest.unstable_mockModule('../../database/models/LifecycleCapabilityModel', () => ({
+  LifecycleCapabilityModel: { filterHeartbeatEligible: filterHeartbeatEligibleMock },
 }));
 
 describe('buildProjectReport activity rotation queues', () => {
@@ -27,6 +32,7 @@ describe('buildProjectReport activity rotation queues', () => {
         { id: 'planning', project_id: 'project-1', epic_id: 'epic-1', title: 'Council active', status: 'planning', priority: 'critical', assignee: 'heartbeat' },
         { id: 'action-new', project_id: 'project-1', epic_id: 'epic-1', title: 'Action newer', status: 'in_progress', priority: 'critical', assignee: 'heartbeat' },
       ]);
+    filterHeartbeatEligibleMock.mockImplementation((tasks: any[]) => Promise.resolve(tasks));
   });
 
   it('separates actionable, blocked recovery, and planning-in-flight work', async() => {
@@ -48,5 +54,18 @@ describe('buildProjectReport activity rotation queues', () => {
     expect(actionableSection).toContain('Action newer');
     expect(actionableSection).not.toContain('Blocked oldest');
     expect(actionableSection).not.toContain('Council active');
+  });
+
+  it('mechanically removes stages owned by healthy protected services from Heartbeat context', async() => {
+    filterHeartbeatEligibleMock.mockImplementation((tasks: any[]) => Promise.resolve(
+      tasks.filter(task => task.id === 'action-new'),
+    ));
+    const { buildProjectReport } = await import('../projectReport');
+    const report = await buildProjectReport({ assignee: 'heartbeat', lifecycleAware: true });
+
+    expect(report).toContain('Action newer');
+    expect(report).not.toContain('Action oldest');
+    expect(report).not.toContain('Blocked oldest');
+    expect(filterHeartbeatEligibleMock).toHaveBeenCalled();
   });
 });

--- a/pkg/rancher-desktop/agent/prompts/projectReport.ts
+++ b/pkg/rancher-desktop/agent/prompts/projectReport.ts
@@ -9,13 +9,15 @@
  * round-robin rotation whenever an agent edits or comments on a task.
  */
 
+import { LifecycleCapabilityModel } from '../database/models/LifecycleCapabilityModel';
 import { WorkItemsModel } from '../database/models/WorkItemsModel';
 
 export interface ProjectReportOpts {
-  hours?:     number;
-  nextLimit?: number;
-  projectId?: string;
-  assignee?:  string;
+  hours?:          number;
+  nextLimit?:      number;
+  projectId?:      string;
+  assignee?:       string;
+  lifecycleAware?: boolean;
 }
 
 function shorten(s: string): string {
@@ -65,7 +67,10 @@ export async function buildProjectReport(opts: ProjectReportOpts = {}): Promise<
 
   // OPEN QUEUES — WorkItemsModel already orders by epic priority → task
   // priority → oldest activity. Preserve that order while separating states.
-  const openRows = await WorkItemsModel.listTasks({ projectId, assignee, limit: 500 });
+  const listedOpenRows = await WorkItemsModel.listTasks({ projectId, assignee, limit: 500 });
+  const openRows = opts.lifecycleAware
+    ? await LifecycleCapabilityModel.filterHeartbeatEligible(listedOpenRows)
+    : listedOpenRows;
   const actionableRows = openRows.filter(t => t.status !== 'blocked' && t.status !== 'planning');
   const blockedRows = openRows.filter(t => t.status === 'blocked');
   const planningRows = openRows.filter(t => t.status === 'planning');

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -1,6 +1,7 @@
 import { AbortService } from './AbortService';
 import { GraphRegistry } from './GraphRegistry';
 import { isInsideWindow } from './HeartbeatService';
+import { LifecycleCapabilityModel } from '../database/models/LifecycleCapabilityModel';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { WorkItemsModel, type WorkTaskRecord } from '../database/models/WorkItemsModel';
 import { WorkTaskDispatchModel, type ClaimedDispatch } from '../database/models/WorkTaskDispatchModel';
@@ -11,6 +12,7 @@ const CHECK_INTERVAL_MS = 60_000;
 const LEASE_HEARTBEAT_MS = 120_000;
 const DEFAULT_CONCURRENCY = 3;
 const DEFAULT_AGENT_ID = 'opus-worker';
+const RUNTIME_INSTANCE_ID = `task-dispatcher-${ process.pid }-${ Date.now() }`;
 
 let taskDispatcherServiceInstance: TaskDispatcherService | null = null;
 
@@ -35,6 +37,8 @@ export class TaskDispatcherService {
   async initialize(): Promise<void> {
     if (this.initialized) return;
     this.initialized = true;
+
+    await LifecycleCapabilityModel.recoverPreviousRuntime('todo-execution', RUNTIME_INSTANCE_ID);
 
     // No graph promise survives a process/service restart. Release every live
     // database lease before taking new work so a crash cannot strand a task.
@@ -69,7 +73,18 @@ export class TaskDispatcherService {
     this.checking = true;
     try {
       const enabled = await SullaSettingsModel.get('heartbeatEnabled', false);
-      if (!enabled) return;
+      if (!enabled) {
+        await LifecycleCapabilityModel.report({
+          key:               'todo-execution',
+          enabled:           false,
+          health:            'unavailable',
+          owner:             null,
+          runtimeInstanceId: RUNTIME_INSTANCE_ID,
+          fallbackMode:      'manual_hold',
+          error:             'Heartbeat and mechanical dispatch are disabled by user setting.',
+        });
+        return;
+      }
 
       const window = await SullaSettingsModel.get('heartbeatWindow', null);
       if (window && !isInsideWindow(window)) return;
@@ -79,8 +94,26 @@ export class TaskDispatcherService {
       const agentId = String(await SullaSettingsModel.get('taskDispatcherAgentId', DEFAULT_AGENT_ID)).trim() || DEFAULT_AGENT_ID;
       if (!findAgentDir(agentId)) {
         console.error(`[TaskDispatcher] Agent config "${ agentId }" does not exist; dispatch paused`);
+        await LifecycleCapabilityModel.report({
+          key:               'todo-execution',
+          enabled:           true,
+          health:            'degraded',
+          owner:             'dispatcher',
+          runtimeInstanceId: RUNTIME_INSTANCE_ID,
+          fallbackMode:      'heartbeat',
+          error:             `Agent config ${ agentId } does not exist.`,
+        });
         return;
       }
+
+      await LifecycleCapabilityModel.report({
+        key:               'todo-execution',
+        enabled:           true,
+        health:            'healthy',
+        owner:             'dispatcher',
+        runtimeInstanceId: RUNTIME_INSTANCE_ID,
+        fallbackMode:      'heartbeat',
+      });
 
       let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning());
       while (freeSlots > 0 && this.initialized) {
@@ -91,6 +124,15 @@ export class TaskDispatcherService {
       }
     } catch (err) {
       console.error('[TaskDispatcher] Dispatch check failed:', err);
+      await LifecycleCapabilityModel.report({
+        key:               'todo-execution',
+        enabled:           true,
+        health:            'degraded',
+        owner:             'dispatcher',
+        runtimeInstanceId: RUNTIME_INSTANCE_ID,
+        fallbackMode:      'heartbeat',
+        error:             err instanceof Error ? err.message : String(err),
+      }).catch(reportErr => console.error('[TaskDispatcher] Capability report failed:', reportErr));
     } finally {
       this.checking = false;
     }
@@ -98,6 +140,18 @@ export class TaskDispatcherService {
 
   private async runClaim(claim: ClaimedDispatch): Promise<void> {
     const { dispatch, task } = claim;
+    const stageClaim = await LifecycleCapabilityModel.claimStage(
+      task.id,
+      'todo-execution',
+      'execution',
+      'dispatcher',
+      RUNTIME_INSTANCE_ID,
+    );
+    if (!stageClaim.claimed || !stageClaim.claim) {
+      await this.finalizeClaim(claim, 'failed', `Lifecycle ownership denied: ${ stageClaim.reason ?? 'unknown reason' }`);
+      return;
+    }
+    const liveStageClaim = stageClaim.claim;
     const abort = new AbortService();
     this.active.set(dispatch.id, abort);
     const leaseTimer = setInterval(
@@ -138,6 +192,8 @@ export class TaskDispatcherService {
       await this.finalizeClaim(claim, 'failed', message);
     } finally {
       clearInterval(leaseTimer);
+      await LifecycleCapabilityModel.releaseStage(liveStageClaim.id)
+        .catch(err => console.error(`[TaskDispatcher] Stage-claim release failed for ${ liveStageClaim.id }:`, err));
       this.active.delete(dispatch.id);
       GraphRegistry.delete(dispatch.thread_id);
       if (this.initialized) {

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -117,7 +117,7 @@ export class TaskDispatcherService {
 
       let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning());
       while (freeSlots > 0 && this.initialized) {
-        const claim = await WorkTaskDispatchModel.claimNext(agentId);
+        const claim = await WorkTaskDispatchModel.claimNext(agentId, RUNTIME_INSTANCE_ID);
         if (!claim) break;
         this.runClaim(claim).catch(err => console.error('[TaskDispatcher] Worker promise failed:', err));
         freeSlots -= 1;
@@ -139,19 +139,7 @@ export class TaskDispatcherService {
   }
 
   private async runClaim(claim: ClaimedDispatch): Promise<void> {
-    const { dispatch, task } = claim;
-    const stageClaim = await LifecycleCapabilityModel.claimStage(
-      task.id,
-      'todo-execution',
-      'execution',
-      'dispatcher',
-      RUNTIME_INSTANCE_ID,
-    );
-    if (!stageClaim.claimed || !stageClaim.claim) {
-      await this.finalizeClaim(claim, 'failed', `Lifecycle ownership denied: ${ stageClaim.reason ?? 'unknown reason' }`);
-      return;
-    }
-    const liveStageClaim = stageClaim.claim;
+    const { dispatch, task, stage_claim: liveStageClaim } = claim;
     const abort = new AbortService();
     this.active.set(dispatch.id, abort);
     const leaseTimer = setInterval(

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -12,10 +12,6 @@ const executeMock: any = jest.fn();
 const graphDeleteMock: any = jest.fn();
 const recoverPreviousRuntimeMock: any = jest.fn(() => Promise.resolve([]));
 const reportCapabilityMock: any = jest.fn(() => Promise.resolve({}));
-const claimStageMock: any = jest.fn(() => Promise.resolve({
-  claimed: true,
-  claim:   { id: 'stage-claim-1' },
-}));
 const releaseStageMock: any = jest.fn(() => Promise.resolve());
 
 jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
@@ -25,7 +21,6 @@ jest.unstable_mockModule('../../database/models/LifecycleCapabilityModel', () =>
   LifecycleCapabilityModel: {
     recoverPreviousRuntime: recoverPreviousRuntimeMock,
     report:                 reportCapabilityMock,
-    claimStage:             claimStageMock,
     releaseStage:           releaseStageMock,
   },
 }));
@@ -69,7 +64,6 @@ describe('TaskDispatcherService', () => {
     });
     recoverPreviousRuntimeMock.mockResolvedValue([]);
     reportCapabilityMock.mockResolvedValue({});
-    claimStageMock.mockResolvedValue({ claimed: true, claim: { id: 'stage-claim-1' } });
     releaseStageMock.mockResolvedValue(undefined);
   });
 
@@ -98,6 +92,7 @@ describe('TaskDispatcherService', () => {
       dispatch: {
         id: 'dispatch-1', task_id: 'task-1', agent_id: 'opus-worker', thread_id: 'thread-1',
       },
+      stage_claim: { id: 'stage-claim-1' },
     };
     claimNextMock
       .mockResolvedValueOnce(claim)
@@ -114,13 +109,10 @@ describe('TaskDispatcherService', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
     service.destroy();
 
-    expect(claimNextMock).toHaveBeenCalledWith('opus-worker');
+    expect(claimNextMock).toHaveBeenCalledWith('opus-worker', expect.stringContaining('task-dispatcher-'));
     expect(executeMock).toHaveBeenCalled();
     expect(settleMock).toHaveBeenCalledWith(
       'dispatch-1', 'completed', 'Draft PR opened and tests passed.', undefined,
-    );
-    expect(claimStageMock).toHaveBeenCalledWith(
-      'task-1', 'todo-execution', 'execution', 'dispatcher', expect.stringContaining('task-dispatcher-'),
     );
     expect(releaseStageMock).toHaveBeenCalledWith('stage-claim-1');
     expect(updateTaskMock).toHaveBeenCalledWith('task-1', {

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -10,9 +10,24 @@ const addCommentMock: any = jest.fn(() => Promise.resolve());
 const updateTaskMock: any = jest.fn(() => Promise.resolve());
 const executeMock: any = jest.fn();
 const graphDeleteMock: any = jest.fn();
+const recoverPreviousRuntimeMock: any = jest.fn(() => Promise.resolve([]));
+const reportCapabilityMock: any = jest.fn(() => Promise.resolve({}));
+const claimStageMock: any = jest.fn(() => Promise.resolve({
+  claimed: true,
+  claim:   { id: 'stage-claim-1' },
+}));
+const releaseStageMock: any = jest.fn(() => Promise.resolve());
 
 jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
   SullaSettingsModel: { get: settingsGetMock },
+}));
+jest.unstable_mockModule('../../database/models/LifecycleCapabilityModel', () => ({
+  LifecycleCapabilityModel: {
+    recoverPreviousRuntime: recoverPreviousRuntimeMock,
+    report:                 reportCapabilityMock,
+    claimStage:             claimStageMock,
+    releaseStage:           releaseStageMock,
+  },
 }));
 jest.unstable_mockModule('../../database/models/WorkTaskDispatchModel', () => ({
   WorkTaskDispatchModel: {
@@ -52,6 +67,10 @@ describe('TaskDispatcherService', () => {
       if (key === 'heartbeatEnabled') return Promise.resolve(true);
       return Promise.resolve(fallback);
     });
+    recoverPreviousRuntimeMock.mockResolvedValue([]);
+    reportCapabilityMock.mockResolvedValue({});
+    claimStageMock.mockResolvedValue({ claimed: true, claim: { id: 'stage-claim-1' } });
+    releaseStageMock.mockResolvedValue(undefined);
   });
 
   it('recovers orphaned leases before filling worker capacity', async() => {
@@ -62,6 +81,7 @@ describe('TaskDispatcherService', () => {
     service.destroy();
 
     expect(recoverStaleMock).toHaveBeenCalledWith(0);
+    expect(recoverPreviousRuntimeMock).toHaveBeenCalledWith('todo-execution', expect.stringContaining('task-dispatcher-'));
     expect(countRunningMock).toHaveBeenCalled();
   });
 
@@ -99,8 +119,31 @@ describe('TaskDispatcherService', () => {
     expect(settleMock).toHaveBeenCalledWith(
       'dispatch-1', 'completed', 'Draft PR opened and tests passed.', undefined,
     );
+    expect(claimStageMock).toHaveBeenCalledWith(
+      'task-1', 'todo-execution', 'execution', 'dispatcher', expect.stringContaining('task-dispatcher-'),
+    );
+    expect(releaseStageMock).toHaveBeenCalledWith('stage-claim-1');
     expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
       status: 'in_review', assignee: 'heartbeat', actor: 'dispatcher',
     });
+  });
+
+  it('turns user disablement into a visible manual hold without claiming work', async() => {
+    settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+      if (key === 'heartbeatEnabled') return Promise.resolve(false);
+      return Promise.resolve(fallback);
+    });
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    service.destroy();
+
+    expect(reportCapabilityMock).toHaveBeenCalledWith(expect.objectContaining({
+      key:          'todo-execution',
+      enabled:      false,
+      health:       'unavailable',
+      fallbackMode: 'manual_hold',
+    }));
+    expect(claimNextMock).not.toHaveBeenCalled();
   });
 });

--- a/pkg/rancher-desktop/agent/tools/project/__tests__/update_task.lifecycle.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/update_task.lifecycle.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { LifecycleCapabilityModel } from '../../../database/models/LifecycleCapabilityModel';
+import { WorkItemsModel } from '../../../database/models/WorkItemsModel';
+import { UpdateTaskWorker } from '../update_task';
+
+describe('update_task lifecycle ownership', () => {
+  const call = (input: any) => (new UpdateTaskWorker() as any)._validatedCall(input);
+  const task = (status: string) => ({
+    id:               'task-1',
+    epic_id:          'epic-1',
+    title:            'Protected work',
+    status,
+    priority:         'critical',
+    position:         0,
+    labels:           [],
+    last_moved_at:    new Date('2026-08-23T20:00:00Z'),
+    last_activity_at: new Date('2026-08-23T20:00:00Z'),
+  }) as any;
+
+  afterEach(() => { jest.restoreAllMocks() });
+
+  it.each([
+    ['in_review', 'done'],
+    ['planning', 'backlog'],
+  ])('does not let Heartbeat escape protected source stage %s via %s', async(source, destination) => {
+    jest.spyOn(WorkItemsModel, 'ensureTables').mockResolvedValue(undefined);
+    jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue(task(source));
+    const update = jest.spyOn(WorkItemsModel, 'updateTask');
+    const guard = jest.spyOn(LifecycleCapabilityModel, 'assertActorCanManageTask')
+      .mockRejectedValue(new Error(`Lifecycle handoff denied: ${ source } is owned by its routine.`));
+
+    const result = await call({ id: 'task-1', status: destination, actor: 'heartbeat' });
+
+    expect(result.successBoolean).toBe(false);
+    expect(result.responseString).toContain('Lifecycle handoff denied');
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(guard).toHaveBeenCalledWith(source, [], 'heartbeat');
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('checks a distinct protected destination after the current stage owner allows handoff', async() => {
+    jest.spyOn(WorkItemsModel, 'ensureTables').mockResolvedValue(undefined);
+    jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue(task('todo'));
+    const update = jest.spyOn(WorkItemsModel, 'updateTask');
+    const guard = jest.spyOn(LifecycleCapabilityModel, 'assertActorCanManageTask')
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('Lifecycle handoff denied: in-review-verification is owned by verifier-service.'));
+
+    const result = await call({ id: 'task-1', status: 'in_review', actor: 'heartbeat' });
+
+    expect(result.successBoolean).toBe(false);
+    expect(guard.mock.calls).toEqual([
+      ['todo', [], 'heartbeat'],
+      ['in_review', [], 'heartbeat'],
+    ]);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('preserves explicit fallback and legacy-rollout moves when both guards allow them', async() => {
+    const current = task('planning');
+    const updated = { ...current, status: 'backlog' };
+    jest.spyOn(WorkItemsModel, 'ensureTables').mockResolvedValue(undefined);
+    jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue(current);
+    const update = jest.spyOn(WorkItemsModel, 'updateTask').mockResolvedValue(updated);
+    const guard = jest.spyOn(LifecycleCapabilityModel, 'assertActorCanManageTask').mockResolvedValue(undefined);
+
+    const result = await call({ id: 'task-1', status: 'backlog', actor: 'heartbeat' });
+
+    expect(result.successBoolean).toBe(true);
+    expect(guard.mock.calls).toEqual([
+      ['planning', [], 'heartbeat'],
+      ['backlog', [], 'heartbeat'],
+    ]);
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/project/update_task.ts
+++ b/pkg/rancher-desktop/agent/tools/project/update_task.ts
@@ -31,12 +31,25 @@ export class UpdateTaskWorker extends BaseTool {
       const current = await WorkItemsModel.getTask(id);
       if (!current) return { successBoolean: false, responseString: `No task found with id: ${ id }` };
       if (input.status !== undefined || input.assignee !== undefined) {
-        const protectedStatus = typeof input.status === 'string' ? input.status : current.status;
+        // A move must be authorized by the owner of the stage being left, not
+        // only by the destination owner. Otherwise Heartbeat could bypass a
+        // healthy protected routine by moving its task to an unprotected
+        // status (for example in_review -> done).
         await LifecycleCapabilityModel.assertActorCanManageTask(
-          protectedStatus,
+          current.status,
           current.labels,
           actor,
         );
+
+        const destinationStatus = typeof input.status === 'string' ? input.status : current.status;
+        const destinationLabels = labels ?? current.labels;
+        if (destinationStatus !== current.status || destinationLabels !== current.labels) {
+          await LifecycleCapabilityModel.assertActorCanManageTask(
+            destinationStatus,
+            destinationLabels,
+            actor,
+          );
+        }
       }
       const updated = await WorkItemsModel.updateTask(id, {
         epic_id:      typeof input.epic_id === 'string' && input.epic_id.trim() ? input.epic_id.trim() : undefined,

--- a/pkg/rancher-desktop/agent/tools/project/update_task.ts
+++ b/pkg/rancher-desktop/agent/tools/project/update_task.ts
@@ -1,3 +1,4 @@
+import { LifecycleCapabilityModel } from '../../database/models/LifecycleCapabilityModel';
 import { WorkItemsModel } from '../../database/models/WorkItemsModel';
 import { BaseTool, ToolResponse } from '../base';
 
@@ -17,7 +18,8 @@ export class UpdateTaskWorker extends BaseTool {
     if (!id) return { successBoolean: false, responseString: 'id is required to update a task.' };
 
     const parentRaw = input.parent_id;
-    const parentId = parentRaw === '' ? null
+    const parentId = parentRaw === ''
+      ? null
       : (typeof parentRaw === 'string' ? parentRaw.trim() : undefined);
     const labels = Array.isArray(input.labels)
       ? input.labels.map((l: any) => String(l)).filter(Boolean)
@@ -25,6 +27,17 @@ export class UpdateTaskWorker extends BaseTool {
 
     try {
       await WorkItemsModel.ensureTables();
+      const actor = input.actor || 'sulla';
+      const current = await WorkItemsModel.getTask(id);
+      if (!current) return { successBoolean: false, responseString: `No task found with id: ${ id }` };
+      if (input.status !== undefined || input.assignee !== undefined) {
+        const protectedStatus = typeof input.status === 'string' ? input.status : current.status;
+        await LifecycleCapabilityModel.assertActorCanManageTask(
+          protectedStatus,
+          current.labels,
+          actor,
+        );
+      }
       const updated = await WorkItemsModel.updateTask(id, {
         epic_id:      typeof input.epic_id === 'string' && input.epic_id.trim() ? input.epic_id.trim() : undefined,
         parent_id:    parentId,
@@ -38,7 +51,7 @@ export class UpdateTaskWorker extends BaseTool {
         github_issue: input.github_issue === '' ? null : input.github_issue,
         position:     typeof input.position === 'number' ? input.position : undefined,
         source:       input.source,
-        actor:        input.actor || 'sulla',
+        actor,
       });
       if (!updated) return { successBoolean: false, responseString: `No task found with id: ${ id }` };
 


### PR DESCRIPTION
Closes #674.

Adds the runtime control plane required before protected lifecycle routines and the executive Heartbeat prompt can be enabled.

What changed:
- seeds versioned capability state for planning, todo execution/artifact custody, in-review verification, durable waits, and stale recovery
- enforces one live owner claim per task stage in Postgres
- atomically acquires todo-execution ownership, creates the dispatch, and moves todo → in_progress in one transaction
- denies or racing claims without creating a dispatch or mutating the task
- recovers stale dispatches and their active stage claims atomically so tasks remain reclaimable
- preserves healthy long-running leases; restart recovery uses runtime identity, never age
- supports explicit Heartbeat fallback for unavailable capabilities and manual hold for user-disabled capabilities
- filters healthy protected stages from Heartbeat work context and enforces both protected source and destination ownership at the Projects mutation boundary
- injects the compact capability/exception digest through the replace-only assistant context carrier
- deduplicates degraded capabilities into one deterministic critical Projects recovery task
- wires the existing dispatcher into capability reporting and stage claims

Rollout:
1. merge this control-plane pivot
2. rebase protected planning/todo/review/wait/recovery branches onto landed main
3. renumber colliding migrations monotonically above the actual landed migration tip
4. regenerate the registry once, replay from an empty database, and rerun the combined conveyor acceptance
5. rebuild/restart only after the rebased stack is accepted

Final exact-head verification at d7e4a04f9e8efdec9f56de16b02b1cd20c2b5532:
- independent disposition: PASS
- 7 focused Jest suites / 45 tests passed
- focused ESLint passed
- git diff --check passed
- open against main and mergeable-clean
- no hosted check runs are registered
- full repository TypeScript remains unverified because the VM exhausted memory before diagnostics

No merge, deploy, migration execution, rebuild, restart, settings change, or runtime enablement was performed.