### PR TITLE
P0: expose in-app Browser controller to scheduled agent graphs

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -7,6 +7,7 @@ import { BaseLanguageModel, type ChatMessage, type NormalizedResponse, type Stre
 import { bindCodexMcpSession, buildCodexMcpOverrides, CODEX_MCP_TOKEN_ENV } from './codexMcpConfig';
 import { redisClient } from '../database/RedisClient';
 import { ensureCodexAuthFile, codexAuthPath, codexHomeDir } from '../util/codexAuthFile';
+import { graphBrowserControllerContext } from '../utils/graphBrowserController';
 
 import type { BaseThreadState } from '@pkg/agent/nodes/Graph';
 import { getMCPServerHost, type RegisteredSession } from '@pkg/main/MCPServerHost';
@@ -568,6 +569,9 @@ Every time, in this order:
 
 This is a hard rule, not a suggestion: catalog and docs first, improvise last.
 </environment>`);
+
+    const browserController = graphBrowserControllerContext(state);
+    if (browserController) stableParts.push(browserController);
 
     const parts: string[] = [];
 

--- a/pkg/rancher-desktop/agent/nodes/Graph.ts
+++ b/pkg/rancher-desktop/agent/nodes/Graph.ts
@@ -164,6 +164,8 @@ export interface BaseThreadState {
     isTrustedUser?:      'trusted' | 'untrusted' | 'verify';
     /** Whether the user can see browser panels in the UI */
     userVisibleBrowser?: boolean;
+    /** Opt a scheduled graph into Sulla's graph-bound in-app browser controller. */
+    graphNativeBrowserController?: boolean;
 
     /** Active workflow playbook — when set, the agent orchestrates this workflow */
     activeWorkflow?: WorkflowPlaybookState;

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -738,6 +738,7 @@ const HEARTBEAT_TOOLS: string[] = [
   'exec',
   'read_file',
   'write_file',
+  'browser_controller',
 ];
 
 const SUBCONSCIOUS_ENVIRONMENT_ANCHOR = `## Sulla Desktop environment
@@ -1725,6 +1726,12 @@ async function buildHeartbeatState(wsChannel: string, prompt: string): Promise<A
 
       agent:          agentConfig,
       agentLoopCount: 0,
+
+      // Heartbeat is an autonomous scheduled graph, but its browser tabs are
+      // still scoped to this fresh graph thread. The MCP bridge uses that same
+      // identity when exposing the supported in-app Browser delegation.
+      userVisibleBrowser:            true,
+      graphNativeBrowserController: true,
     },
   };
 

--- a/pkg/rancher-desktop/agent/tools/browser/__tests__/controller.registry.integration.test.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/__tests__/controller.registry.integration.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+const views = new Map<string, {
+  executeJavaScript: jest.Mock<(code: string) => Promise<unknown>>;
+  loadURL:           jest.Mock<() => Promise<void>>;
+}>();
+const createView = jest.fn((assetId: string) => {
+  views.set(assetId, {
+    executeJavaScript: jest.fn((code: string) => {
+      if (code === 'document.title') return Promise.resolve('Local test');
+      if (code === 'location.href') return Promise.resolve('http://127.0.0.1:5173/settings');
+      return Promise.resolve(null);
+    }),
+    loadURL: jest.fn(() => Promise.resolve()),
+  });
+});
+const destroyView = jest.fn((assetId: string) => views.delete(assetId));
+
+jest.unstable_mockModule('@pkg/window/browserTabViewManager', () => ({
+  BrowserTabViewManager: {
+    getInstance: () => ({
+      createView,
+      destroyView,
+      getWebContents: (assetId: string) => views.get(assetId) ?? null,
+    }),
+  },
+}));
+
+let GraphBrowserControllerWorker: typeof import('../controller').GraphBrowserControllerWorker;
+let browserToolManifests: typeof import('../manifests').browserToolManifests;
+let tabRegistry: typeof import('@pkg/main/browserTabs/TabRegistry').tabRegistry;
+let toolRegistry: typeof import('../../registry').toolRegistry;
+let browserAssetId: typeof import('../../../utils/graphBrowserController').browserAssetId;
+
+function state(threadId: string) {
+  return {
+    metadata: {
+      graphNativeBrowserController: true,
+      userVisibleBrowser:           true,
+      threadId,
+      allowedToolNames:             ['browser_controller'],
+    },
+  } as any;
+}
+
+function controller(): InstanceType<typeof GraphBrowserControllerWorker> {
+  const manifest = browserToolManifests.find(item => item.name === 'browser_controller')!;
+  const worker = new GraphBrowserControllerWorker();
+  worker.name = manifest.name;
+  worker.description = manifest.description;
+  worker.schemaDef = manifest.schemaDef;
+  return worker;
+}
+
+describe('graph Browser controller ownership at the production registry boundary', () => {
+  beforeAll(async() => {
+    ({ GraphBrowserControllerWorker } = await import('../controller'));
+    ({ browserToolManifests } = await import('../manifests'));
+    ({ tabRegistry } = await import('@pkg/main/browserTabs/TabRegistry'));
+    ({ toolRegistry } = await import('../../registry'));
+    ({ browserAssetId } = await import('../../../utils/graphBrowserController'));
+    toolRegistry.registerManifests(browserToolManifests);
+  });
+
+  afterEach(() => {
+    for (const tab of tabRegistry.list()) tabRegistry.close(tab.assetId);
+    views.clear();
+    jest.clearAllMocks();
+  });
+
+  it('opens through the real controller, tool loader, tab worker, and registry, then rejects a colliding graph before navigation', async() => {
+    const sharedSuffix = '123456789012345678901234';
+    const sharedSlugPrefix = 'a'.repeat(60);
+    const first = controller();
+    const firstResult = await first.invoke({
+      tool: 'tab',
+      args: { action: 'upsert', url: `http://127.0.0.1:5173/${ sharedSlugPrefix }-first` },
+    }, state(`first-${ sharedSuffix }`));
+
+    expect(firstResult.success).toBe(true);
+    const [record] = tabRegistry.list();
+    expect(record.owner).toEqual({ kind: 'graph', sessionId: `graph:first-${ sharedSuffix }` });
+    expect(createView).toHaveBeenCalledTimes(1);
+
+    const existingView = views.get(record.assetId)!;
+    const createTool = jest.spyOn(toolRegistry, 'createTool');
+    const secondResult = await controller().invoke({
+      tool: 'tab',
+      args: { action: 'upsert', url: `http://127.0.0.1:5173/${ sharedSlugPrefix }-second` },
+    }, state(`second-${ sharedSuffix }`));
+
+    expect(secondResult.success).toBe(false);
+    expect(secondResult.error).toContain('different browser session');
+    expect(createTool).not.toHaveBeenCalled();
+    expect(existingView.loadURL).not.toHaveBeenCalled();
+    expect(tabRegistry.get(record.assetId)?.url).toBe(`http://127.0.0.1:5173/${ sharedSlugPrefix }-first`);
+  });
+
+  it('rejects an existing user tab with the deterministic graph asset ID before loading a browser worker', async() => {
+    const threadId = 'heartbeat-user-collision';
+    const targetUrl = 'http://127.0.0.1:5173/settings';
+    const assetId = browserAssetId(threadId, targetUrl);
+    tabRegistry.open({
+      assetId,
+      url:    'http://127.0.0.1:5173/user-private',
+      origin: 'user',
+    });
+    const existingView = views.get(assetId)!;
+    const createTool = jest.spyOn(toolRegistry, 'createTool');
+
+    const result = await controller().invoke({
+      tool: 'tab',
+      args: { action: 'upsert', url: targetUrl },
+    }, state(threadId));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('different browser session');
+    expect(createTool).not.toHaveBeenCalled();
+    expect(existingView.loadURL).not.toHaveBeenCalled();
+    expect(tabRegistry.get(assetId)?.url).toBe('http://127.0.0.1:5173/user-private');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/browser/__tests__/controller.test.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/__tests__/controller.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { toolRegistry } from '../../registry';
+import { GraphBrowserControllerWorker } from '../controller';
+import { browserToolManifests } from '../manifests';
+
+import type { BaseThreadState } from '../../../nodes/Graph';
+
+function state(metadata: Record<string, unknown>): BaseThreadState {
+  return { metadata } as unknown as BaseThreadState;
+}
+
+function controller(): GraphBrowserControllerWorker {
+  const manifest = browserToolManifests.find(item => item.name === 'browser_controller');
+  if (!manifest) throw new Error('browser_controller manifest missing');
+  const worker = new GraphBrowserControllerWorker();
+  worker.name = manifest.name;
+  worker.description = manifest.description;
+  worker.schemaDef = manifest.schemaDef;
+  return worker;
+}
+
+describe('GraphBrowserControllerWorker', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('fails closed before loading a browser worker when capability is disabled', async() => {
+    const createTool = jest.spyOn(toolRegistry, 'createTool');
+
+    const result = await controller().invoke(
+      { tool: 'screenshot', args: {} },
+      state({ threadId: 'ordinary-chat', allowedToolNames: ['browser_controller'] }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.result).toContain('disabled');
+    expect(createTool).not.toHaveBeenCalled();
+  });
+
+  it('delegates with the same graph state and a stable thread-scoped asset id', async() => {
+    const innerInvoke = jest.fn<(
+      input: unknown,
+      state: BaseThreadState,
+    ) => Promise<{ toolName: string; success: boolean; result: string }>>().mockResolvedValue({
+      toolName: 'tab',
+      success:  true,
+      result:   'opened',
+    });
+    jest.spyOn(toolRegistry, 'createTool').mockResolvedValue({ invoke: innerInvoke });
+    const graphState = state({
+      graphNativeBrowserController: true,
+      userVisibleBrowser:           true,
+      threadId:                     'heartbeat_123',
+      allowedToolNames:             ['exec', 'browser_controller'],
+    });
+
+    const result = await controller().invoke({
+      tool: 'tab',
+      args: { action: 'upsert', url: 'http://127.0.0.1:5173/settings' },
+    }, graphState);
+
+    expect(result.success).toBe(true);
+    expect(toolRegistry.createTool).toHaveBeenCalledWith('tab');
+    expect(innerInvoke).toHaveBeenCalledWith(expect.objectContaining({
+      assetId: 'iab_heartbeat_123_127-0-0-1-settings',
+    }), graphState);
+    expect((graphState.metadata as any).__browserControllerLastAssetId)
+      .toBe('iab_heartbeat_123_127-0-0-1-settings');
+  });
+
+  it('cannot target a tab outside the bound graph session', async() => {
+    const innerInvoke = jest.fn<(
+      input: unknown,
+      state: BaseThreadState,
+    ) => Promise<{ toolName: string; success: boolean; result: string }>>().mockResolvedValue({
+      toolName: 'screenshot', success: true, result: 'captured',
+    });
+    jest.spyOn(toolRegistry, 'createTool').mockResolvedValue({ invoke: innerInvoke });
+    const graphState = state({
+      graphNativeBrowserController:     true,
+      userVisibleBrowser:               true,
+      threadId:                         'heartbeat_123',
+      allowedToolNames:                 ['browser_controller'],
+      __browserControllerLastAssetId:   'iab_heartbeat_123_local',
+    });
+
+    const result = await controller().invoke({
+      tool: 'screenshot',
+      args: { assetId: 'user_private_tab' },
+    }, graphState);
+
+    expect(result.success).toBe(true);
+    expect(innerInvoke).toHaveBeenCalledWith({ assetId: 'iab_heartbeat_123_local' }, graphState);
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/browser/__tests__/controller.test.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/__tests__/controller.test.ts
@@ -1,16 +1,28 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
-import { toolRegistry } from '../../registry';
-import { GraphBrowserControllerWorker } from '../controller';
-import { browserToolManifests } from '../manifests';
-
 import type { BaseThreadState } from '../../../nodes/Graph';
+
+const createTool = jest.fn<(name: string) => Promise<unknown>>();
+const claimOwner = jest.fn();
+const assertOwner = jest.fn();
+const releaseOwnerReservation = jest.fn();
+
+jest.unstable_mockModule('../../registry', () => ({
+  toolRegistry: { createTool },
+}));
+
+jest.unstable_mockModule('@pkg/main/browserTabs/TabRegistry', () => ({
+  tabRegistry: { claimOwner, assertOwner, releaseOwnerReservation },
+}));
+
+const { GraphBrowserControllerWorker } = await import('../controller');
+const { browserToolManifests } = await import('../manifests');
 
 function state(metadata: Record<string, unknown>): BaseThreadState {
   return { metadata } as unknown as BaseThreadState;
 }
 
-function controller(): GraphBrowserControllerWorker {
+function controller(): InstanceType<typeof GraphBrowserControllerWorker> {
   const manifest = browserToolManifests.find(item => item.name === 'browser_controller');
   if (!manifest) throw new Error('browser_controller manifest missing');
   const worker = new GraphBrowserControllerWorker();
@@ -22,12 +34,10 @@ function controller(): GraphBrowserControllerWorker {
 
 describe('GraphBrowserControllerWorker', () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
   it('fails closed before loading a browser worker when capability is disabled', async() => {
-    const createTool = jest.spyOn(toolRegistry, 'createTool');
-
     const result = await controller().invoke(
       { tool: 'screenshot', args: {} },
       state({ threadId: 'ordinary-chat', allowedToolNames: ['browser_controller'] }),
@@ -47,7 +57,8 @@ describe('GraphBrowserControllerWorker', () => {
       success:  true,
       result:   'opened',
     });
-    jest.spyOn(toolRegistry, 'createTool').mockResolvedValue({ invoke: innerInvoke });
+    const setTabOwner = jest.fn();
+    createTool.mockResolvedValue({ invoke: innerInvoke, setTabOwner });
     const graphState = state({
       graphNativeBrowserController: true,
       userVisibleBrowser:           true,
@@ -61,7 +72,12 @@ describe('GraphBrowserControllerWorker', () => {
     }, graphState);
 
     expect(result.success).toBe(true);
-    expect(toolRegistry.createTool).toHaveBeenCalledWith('tab');
+    expect(createTool).toHaveBeenCalledWith('tab');
+    expect(claimOwner).toHaveBeenCalledWith(
+      'iab_heartbeat_123_127-0-0-1-settings',
+      { kind: 'graph', sessionId: 'graph:heartbeat_123' },
+    );
+    expect(setTabOwner).toHaveBeenCalledWith({ kind: 'graph', sessionId: 'graph:heartbeat_123' });
     expect(innerInvoke).toHaveBeenCalledWith(expect.objectContaining({
       assetId: 'iab_heartbeat_123_127-0-0-1-settings',
     }), graphState);
@@ -76,7 +92,7 @@ describe('GraphBrowserControllerWorker', () => {
     ) => Promise<{ toolName: string; success: boolean; result: string }>>().mockResolvedValue({
       toolName: 'screenshot', success: true, result: 'captured',
     });
-    jest.spyOn(toolRegistry, 'createTool').mockResolvedValue({ invoke: innerInvoke });
+    createTool.mockResolvedValue({ invoke: innerInvoke });
     const graphState = state({
       graphNativeBrowserController:     true,
       userVisibleBrowser:               true,
@@ -91,6 +107,31 @@ describe('GraphBrowserControllerWorker', () => {
     }, graphState);
 
     expect(result.success).toBe(true);
+    expect(assertOwner).toHaveBeenCalledWith(
+      'iab_heartbeat_123_local',
+      { kind: 'graph', sessionId: 'graph:heartbeat_123' },
+    );
     expect(innerInvoke).toHaveBeenCalledWith({ assetId: 'iab_heartbeat_123_local' }, graphState);
+  });
+
+  it('releases an unopened ownership reservation when delegation cannot load', async() => {
+    createTool.mockRejectedValue(new Error('worker load failed'));
+    const graphState = state({
+      graphNativeBrowserController: true,
+      userVisibleBrowser:           true,
+      threadId:                     'heartbeat_123',
+      allowedToolNames:             ['browser_controller'],
+    });
+
+    const result = await controller().invoke({
+      tool: 'tab',
+      args: { action: 'upsert', url: 'http://127.0.0.1:5173/settings' },
+    }, graphState);
+
+    expect(result.success).toBe(false);
+    expect(releaseOwnerReservation).toHaveBeenCalledWith(
+      'iab_heartbeat_123_127-0-0-1-settings',
+      { kind: 'graph', sessionId: 'graph:heartbeat_123' },
+    );
   });
 });

--- a/pkg/rancher-desktop/agent/tools/browser/controller.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/controller.ts
@@ -1,0 +1,44 @@
+import { isGraphBrowserControllerEnabled, normalizeGraphBrowserArgs, type GraphBrowserTool } from '../../utils/graphBrowserController';
+import { BaseTool, type ToolResponse } from '../base';
+import { toolRegistry } from '../registry';
+
+/** Provider-neutral scheduled-graph delegation to Sulla's in-app Browser. */
+export class GraphBrowserControllerWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: Record<string, unknown>): Promise<ToolResponse> {
+    if (!isGraphBrowserControllerEnabled(this.state)) {
+      return {
+        successBoolean: false,
+        responseString: 'Browser controller is disabled for this graph.',
+      };
+    }
+
+    const tool = input.tool as GraphBrowserTool;
+    const args = (input.args && typeof input.args === 'object' && !Array.isArray(input.args))
+      ? input.args as Record<string, unknown>
+      : {};
+    const threadId = String(this.state.metadata.threadId ?? this.state.metadata.conversationId ?? 'graph');
+    const lastAssetId = typeof this.state.metadata.__browserControllerLastAssetId === 'string'
+      ? this.state.metadata.__browserControllerLastAssetId
+      : null;
+    const normalized = normalizeGraphBrowserArgs(tool, args, threadId, lastAssetId);
+    const worker = await toolRegistry.createTool(tool);
+    const result = await worker.invoke(normalized, this.state);
+
+    const assetId = typeof normalized.assetId === 'string' ? normalized.assetId : null;
+    if (result.success && assetId) {
+      if (tool === 'tab' && normalized.action === 'remove') {
+        if (lastAssetId === assetId) delete this.state.metadata.__browserControllerLastAssetId;
+      } else {
+        this.state.metadata.__browserControllerLastAssetId = assetId;
+      }
+    }
+
+    return {
+      successBoolean: result.success,
+      responseString: JSON.stringify(result, null, 2),
+    };
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/browser/controller.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/controller.ts
@@ -1,6 +1,13 @@
-import { isGraphBrowserControllerEnabled, normalizeGraphBrowserArgs, type GraphBrowserTool } from '../../utils/graphBrowserController';
+import {
+  graphBrowserOwnerSessionId,
+  isGraphBrowserControllerEnabled,
+  normalizeGraphBrowserArgs,
+  type GraphBrowserTool,
+} from '../../utils/graphBrowserController';
 import { BaseTool, type ToolResponse } from '../base';
 import { toolRegistry } from '../registry';
+
+import { tabRegistry, type TabOwner } from '@pkg/main/browserTabs/TabRegistry';
 
 /** Provider-neutral scheduled-graph delegation to Sulla's in-app Browser. */
 export class GraphBrowserControllerWorker extends BaseTool {
@@ -24,10 +31,36 @@ export class GraphBrowserControllerWorker extends BaseTool {
       ? this.state.metadata.__browserControllerLastAssetId
       : null;
     const normalized = normalizeGraphBrowserArgs(tool, args, threadId, lastAssetId);
-    const worker = await toolRegistry.createTool(tool);
-    const result = await worker.invoke(normalized, this.state);
-
     const assetId = typeof normalized.assetId === 'string' ? normalized.assetId : null;
+    if (!assetId) throw new Error('Browser controller could not resolve its graph-owned tab.');
+
+    const owner: TabOwner = { kind: 'graph', sessionId: graphBrowserOwnerSessionId(threadId) };
+    const isOpening = tool === 'tab' && normalized.action !== 'remove';
+    if (isOpening) {
+      tabRegistry.claimOwner(assetId, owner);
+    } else {
+      tabRegistry.assertOwner(assetId, owner);
+    }
+
+    const result = await (async() => {
+      try {
+        const worker = await toolRegistry.createTool(tool);
+        if (tool === 'tab') {
+          if (typeof worker.setTabOwner !== 'function') {
+            throw new Error('Browser tab worker does not support graph ownership binding.');
+          }
+          worker.setTabOwner(owner);
+        }
+        return await worker.invoke(normalized, this.state);
+      } catch (error) {
+        if (isOpening) tabRegistry.releaseOwnerReservation(assetId, owner);
+        throw error;
+      }
+    })();
+    if (isOpening && !result.success) {
+      tabRegistry.releaseOwnerReservation(assetId, owner);
+    }
+
     if (result.success && assetId) {
       if (tool === 'tab' && normalized.action === 'remove') {
         if (lastAssetId === assetId) delete this.state.metadata.__browserControllerLastAssetId;

--- a/pkg/rancher-desktop/agent/tools/browser/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/manifests.ts
@@ -1,3 +1,5 @@
+import { GRAPH_BROWSER_TOOLS } from '../../utils/graphBrowserController';
+
 import type { ToolManifest } from '../registry';
 
 /**
@@ -11,6 +13,22 @@ import type { ToolManifest } from '../registry';
  * inline base64.
  */
 export const browserToolManifests: ToolManifest[] = [
+  {
+    name:        'browser_controller',
+    description: 'Graph-bound delegation to Sulla Desktop\'s in-app Browser for capability-enabled scheduled graphs. Read the installed Browser skill safety rules and bundled tools/browser.md first, then pass one browser operation plus its documented arguments. Tabs are automatically scoped to the calling graph thread. Fails closed outside explicitly enabled graphs.',
+    category:    'browser',
+    schemaDef:   {
+      tool: {
+        type:        'enum',
+        enum:        [...GRAPH_BROWSER_TOOLS],
+        description: 'Sulla browser operation to execute.',
+      },
+      args: { type: 'object', optional: true, default: {}, description: 'Arguments documented for the selected browser operation.' },
+    },
+    operationTypes: ['read', 'execute'],
+    loader:         () => import('./controller'),
+  },
+
   // ── Tabs & navigation ────────────────────────────────────────────
 
   {

--- a/pkg/rancher-desktop/agent/tools/browser/tab.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/tab.ts
@@ -5,13 +5,19 @@
 // state machine. After opening, reads the page state off the same
 // WebContents via GuestBridge.
 
-import { tabRegistry } from '@pkg/main/browserTabs/TabRegistry';
-
 import { BaseTool, ToolResponse } from '../base';
+
+import { tabRegistry, type TabOwner } from '@pkg/main/browserTabs/TabRegistry';
 
 export class BrowserTabWorker extends BaseTool {
   name = '';
   description = '';
+  private owner: TabOwner | undefined;
+
+  /** Internal controller-only binding; never exposed in the public tool schema. */
+  setTabOwner(owner: TabOwner): void {
+    this.owner = { ...owner };
+  }
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     const action = String(input.action || 'upsert').trim().toLowerCase();
@@ -27,6 +33,7 @@ export class BrowserTabWorker extends BaseTool {
       if (!removeId) {
         return { successBoolean: false, responseString: 'assetId is required when action is remove.' };
       }
+      if (this.owner) tabRegistry.assertOwner(removeId, this.owner);
       const closed = tabRegistry.close(removeId);
       return {
         successBoolean: true,
@@ -64,7 +71,7 @@ export class BrowserTabWorker extends BaseTool {
 
     const title = typeof input.title === 'string' && input.title.trim().length > 0 ? input.title.trim() : 'Website';
 
-    tabRegistry.open({ assetId, url, title, origin: 'agent' });
+    tabRegistry.open({ assetId, url, title, origin: 'agent', owner: this.owner });
 
     return await this.readPageState(assetId, title, url);
   }

--- a/pkg/rancher-desktop/agent/tools/registry.ts
+++ b/pkg/rancher-desktop/agent/tools/registry.ts
@@ -197,11 +197,16 @@ export class ToolRegistry {
 
   async getTool(name: string): Promise<any> {
     if (this.instances.has(name)) return this.instances.get(name)!;
-    const loader = this.loaders.get(name);
-    if (!loader) throw new Error(`Tool ${ name } not registered`);
-    const tool = await loader();
+    const tool = await this.createTool(name);
     this.instances.set(name, tool);
     return tool;
+  }
+
+  /** Create a fresh worker instance for graph-bound concurrent execution. */
+  async createTool(name: string): Promise<any> {
+    const loader = this.loaders.get(name);
+    if (!loader) throw new Error(`Tool ${ name } not registered`);
+    return await loader();
   }
 
   async getToolsByCategory(category: string): Promise<any[]> {

--- a/pkg/rancher-desktop/agent/utils/__tests__/graphBrowserController.test.ts
+++ b/pkg/rancher-desktop/agent/utils/__tests__/graphBrowserController.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 
 import {
   browserAssetId,
+  graphBrowserOwnerSessionId,
   graphBrowserControllerContext,
   isGraphBrowserControllerEnabled,
   normalizeGraphBrowserArgs,
@@ -38,6 +39,7 @@ describe('scheduled graph Browser controller policy', () => {
       .toMatchObject({ assetId: id });
     expect(normalizeGraphBrowserArgs('screenshot', {}, 'heartbeat_123', id))
       .toEqual({ assetId: id });
+    expect(graphBrowserOwnerSessionId('heartbeat_123')).toBe('graph:heartbeat_123');
   });
 
   it('overrides caller-supplied asset ids and rejects use before graph ownership exists', () => {

--- a/pkg/rancher-desktop/agent/utils/__tests__/graphBrowserController.test.ts
+++ b/pkg/rancher-desktop/agent/utils/__tests__/graphBrowserController.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  browserAssetId,
+  graphBrowserControllerContext,
+  isGraphBrowserControllerEnabled,
+  normalizeGraphBrowserArgs,
+} from '../graphBrowserController';
+
+import type { BaseThreadState } from '../../nodes/Graph';
+
+function state(metadata: Record<string, unknown>): BaseThreadState {
+  return { metadata } as unknown as BaseThreadState;
+}
+
+describe('scheduled graph Browser controller policy', () => {
+  it('enables only an explicitly capable graph with a visible browser', () => {
+    const allowedToolNames = ['exec', 'browser_controller'];
+    expect(isGraphBrowserControllerEnabled(state({ graphNativeBrowserController: true, allowedToolNames }))).toBe(true);
+    expect(isGraphBrowserControllerEnabled(state({ graphNativeBrowserController: true }))).toBe(false);
+    expect(isGraphBrowserControllerEnabled(state({ graphNativeBrowserController: true, allowedToolNames, userVisibleBrowser: false }))).toBe(false);
+    expect(isGraphBrowserControllerEnabled(state({}))).toBe(false);
+  });
+
+  it('keeps ordinary chat context unchanged and documents scheduled delegation', () => {
+    expect(graphBrowserControllerContext(state({}))).toBe('');
+    expect(graphBrowserControllerContext(state({
+      graphNativeBrowserController: true,
+      allowedToolNames:             ['browser_controller'],
+    })))
+      .toContain('mcp__sulla_native__browser_controller');
+  });
+
+  it('derives stable graph-scoped iab asset ids and reuses them', () => {
+    const id = browserAssetId('heartbeat_123', 'http://127.0.0.1:5173/settings');
+    expect(id).toBe('iab_heartbeat_123_127-0-0-1-settings');
+    expect(normalizeGraphBrowserArgs('tab', { action: 'upsert', url: 'http://127.0.0.1:5173/settings' }, 'heartbeat_123'))
+      .toMatchObject({ assetId: id });
+    expect(normalizeGraphBrowserArgs('screenshot', {}, 'heartbeat_123', id))
+      .toEqual({ assetId: id });
+  });
+
+  it('overrides caller-supplied asset ids and rejects use before graph ownership exists', () => {
+    const id = browserAssetId('heartbeat_123', 'http://127.0.0.1:5173/settings');
+
+    expect(normalizeGraphBrowserArgs(
+      'tab',
+      { action: 'upsert', url: 'http://127.0.0.1:5173/settings', assetId: 'user_private_tab' },
+      'heartbeat_123',
+    )).toMatchObject({ assetId: id });
+    expect(normalizeGraphBrowserArgs('screenshot', { assetId: 'user_private_tab' }, 'heartbeat_123', id))
+      .toEqual({ assetId: id });
+    expect(() => normalizeGraphBrowserArgs('screenshot', {}, 'heartbeat_123'))
+      .toThrow('no graph-owned tab');
+  });
+});

--- a/pkg/rancher-desktop/agent/utils/__tests__/graphBrowserControllerMcp.test.ts
+++ b/pkg/rancher-desktop/agent/utils/__tests__/graphBrowserControllerMcp.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { registerGraphBrowserControllerMcp } from '../graphBrowserControllerMcp';
+
+import type { BaseThreadState } from '../../nodes/Graph';
+
+function state(metadata: Record<string, unknown>): BaseThreadState {
+  return { metadata } as unknown as BaseThreadState;
+}
+
+describe('scheduled graph Browser MCP registration', () => {
+  it('registers for the explicitly capable Heartbeat state', () => {
+    const registerTool = jest.fn();
+
+    const registered = registerGraphBrowserControllerMcp({ registerTool }, state({
+      threadId:                     'heartbeat_1',
+      graphNativeBrowserController: true,
+      userVisibleBrowser:           true,
+      allowedToolNames:             ['exec', 'browser_controller'],
+    }));
+
+    expect(registered).toBe(true);
+    expect(registerTool).toHaveBeenCalledWith(
+      'browser_controller',
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it.each([
+    ['ordinary chat', { threadId: 'chat_1' }],
+    ['headless graph', {
+      threadId:                     'heartbeat_1',
+      graphNativeBrowserController: true,
+      userVisibleBrowser:           false,
+      allowedToolNames:             ['browser_controller'],
+    }],
+    ['missing allowlist grant', {
+      threadId:                     'heartbeat_1',
+      graphNativeBrowserController: true,
+      userVisibleBrowser:           true,
+      allowedToolNames:             ['exec'],
+    }],
+  ])('does not register for %s', (_label, metadata) => {
+    const registerTool = jest.fn();
+
+    expect(registerGraphBrowserControllerMcp({ registerTool }, state(metadata))).toBe(false);
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});

--- a/pkg/rancher-desktop/agent/utils/graphBrowserController.ts
+++ b/pkg/rancher-desktop/agent/utils/graphBrowserController.ts
@@ -8,6 +8,10 @@ export const GRAPH_BROWSER_TOOLS = [
 
 export type GraphBrowserTool = typeof GRAPH_BROWSER_TOOLS[number];
 
+export function graphBrowserOwnerSessionId(threadId: string): string {
+  return `graph:${ threadId }`;
+}
+
 export function isGraphBrowserControllerEnabled(state?: BaseThreadState): boolean {
   const metadata = state?.metadata as any;
   const allowedToolNames = metadata?.allowedToolNames;

--- a/pkg/rancher-desktop/agent/utils/graphBrowserController.ts
+++ b/pkg/rancher-desktop/agent/utils/graphBrowserController.ts
@@ -1,0 +1,67 @@
+import type { BaseThreadState } from '../nodes/Graph';
+
+export const GRAPH_BROWSER_TOOLS = [
+  'tab', 'snapshot', 'text', 'form', 'screenshot',
+  'click', 'fill', 'press_key', 'scroll', 'wait',
+  'click_at', 'type_at', 'hover', 'eval_js',
+] as const;
+
+export type GraphBrowserTool = typeof GRAPH_BROWSER_TOOLS[number];
+
+export function isGraphBrowserControllerEnabled(state?: BaseThreadState): boolean {
+  const metadata = state?.metadata as any;
+  const allowedToolNames = metadata?.allowedToolNames;
+
+  return metadata?.graphNativeBrowserController === true &&
+    metadata?.userVisibleBrowser !== false &&
+    Array.isArray(allowedToolNames) &&
+    allowedToolNames.includes('browser_controller');
+}
+
+export function graphBrowserControllerContext(state?: BaseThreadState): string {
+  if (!isGraphBrowserControllerEnabled(state)) return '';
+  return `<scheduled_browser_controller>
+This scheduled Sulla graph has a graph-bound in-app Browser delegation tool:
+\`mcp__sulla_native__browser_controller\`. The installed Codex Browser skill's
+\`node_repl\` controller is host-app-specific and is not the supported controller
+inside this Lima-launched scheduled graph. Read the installed Browser skill for
+its safety/confirmation rules and Sulla's bundled \`tools/browser.md\` for this
+controller's operations, then call \`browser_controller\` with a browser tool
+name and args. Tabs are scoped to this graph thread; reuse the returned assetId.
+Do not substitute a standalone Playwright server or bypass browser safety rules.
+</scheduled_browser_controller>`;
+}
+
+export function browserAssetId(threadId: string, url: string): string {
+  const scope = threadId.replace(/[^a-zA-Z0-9_-]/g, '-').slice(-24) || 'graph';
+  let target = 'page';
+  try {
+    const parsed = new URL(url);
+    target = `${ parsed.hostname || parsed.protocol.replace(':', '') }${ parsed.pathname }`;
+  } catch { /* retain page fallback */ }
+  const slug = target.replace(/[^a-zA-Z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 48) || 'page';
+  return `iab_${ scope }_${ slug }`;
+}
+
+export function normalizeGraphBrowserArgs(
+  tool: GraphBrowserTool,
+  args: Record<string, unknown>,
+  threadId: string,
+  lastAssetId?: string | null,
+): Record<string, unknown> {
+  const normalized = { ...args };
+
+  if (tool === 'tab' && normalized.action !== 'remove') {
+    // Never trust a caller-provided assetId. Derive ownership from the bound
+    // graph session so a scheduled turn cannot attach to a user/chat tab.
+    normalized.assetId = browserAssetId(threadId, String(normalized.url ?? ''));
+  } else {
+    if (!lastAssetId) {
+      throw new Error('Browser controller has no graph-owned tab. Open one with tab/upsert first.');
+    }
+    // All follow-up operations, including tab/remove, are forced onto the
+    // graph-owned tab. Global tab discovery is intentionally unsupported.
+    normalized.assetId = lastAssetId;
+  }
+  return normalized;
+}

--- a/pkg/rancher-desktop/agent/utils/graphBrowserControllerMcp.ts
+++ b/pkg/rancher-desktop/agent/utils/graphBrowserControllerMcp.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod';
+
+import {
+  GRAPH_BROWSER_TOOLS,
+  isGraphBrowserControllerEnabled,
+  type GraphBrowserTool,
+} from './graphBrowserController';
+import { toolRegistry } from '../tools/registry';
+
+import type { BaseThreadState } from '../nodes/Graph';
+
+interface McpToolRegistrar {
+  registerTool(
+    name: string,
+    config: Record<string, unknown>,
+    handler: (input: { tool: GraphBrowserTool; args: Record<string, unknown> }) => Promise<{
+      content: { type: 'text'; text: string }[];
+      isError: boolean;
+    }>,
+  ): unknown;
+}
+
+/** Register the scheduled-graph Browser bridge only when the bound graph owns the capability. */
+export function registerGraphBrowserControllerMcp(server: unknown, state: BaseThreadState): boolean {
+  if (!isGraphBrowserControllerEnabled(state)) return false;
+
+  // The SDK's registerTool signature recursively infers its Zod schema and
+  // exceeds TypeScript's depth limit in MCPServerHost. Keep that generic
+  // boundary here while retaining concrete request/result types internally.
+  const registrar = server as McpToolRegistrar;
+  registrar.registerTool(
+    'browser_controller',
+    {
+      description: [
+        'Graph-bound controller for Sulla Desktop\'s in-app Browser.',
+        'Use this in scheduled Sulla graphs after reading the installed Browser skill safety rules and the bundled tools/browser.md operation guide.',
+        'Pass one supported browser operation and its arguments. Every operation is forced onto the tab owned by the calling graph thread.',
+        'This is the supported scheduled-graph delegation path; do not substitute standalone Playwright or an external browser.',
+      ].join(' '),
+      inputSchema: {
+        tool: z.enum(GRAPH_BROWSER_TOOLS).describe('Browser operation to execute.'),
+        args: z.record(z.unknown()).default({}).describe('Arguments documented for the selected Sulla browser operation.'),
+      },
+    },
+    async({ tool, args }) => {
+      const worker = await toolRegistry.createTool('browser_controller');
+      const result = await worker.invoke({ tool, args }, state);
+
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+        isError: !result.success,
+      };
+    },
+  );
+
+  return true;
+}

--- a/pkg/rancher-desktop/main/MCPServerHost.ts
+++ b/pkg/rancher-desktop/main/MCPServerHost.ts
@@ -42,6 +42,7 @@ import { z } from 'zod';
 import { ApprovalService } from '@pkg/agent/services/ApprovalService';
 import { toolRegistry } from '@pkg/agent/tools/registry';
 import { activateWorkflowOnState } from '@pkg/agent/tools/workflow/execute_workflow';
+import { registerGraphBrowserControllerMcp } from '@pkg/agent/utils/graphBrowserControllerMcp';
 import {
   clampTimeout,
   emitQuestionCardViaWs,
@@ -474,6 +475,12 @@ export class MCPServerHost {
         };
       },
     );
+
+    // Scheduled providers run inside Lima and cannot launch host-app-specific
+    // controller binaries. Capability-enabled graphs receive this narrow
+    // delegation to Sulla's real in-app WebContents browser. Ordinary chat,
+    // API, Slack, and explicitly headless graphs do not see the tool at all.
+    registerGraphBrowserControllerMcp(server, session.state);
 
     return server;
   }

--- a/pkg/rancher-desktop/main/browserTabs/TabRegistry.ts
+++ b/pkg/rancher-desktop/main/browserTabs/TabRegistry.ts
@@ -16,9 +16,9 @@
 
 import { EventEmitter } from 'node:events';
 
-import { BrowserTabViewManager } from '@pkg/window/browserTabViewManager';
-
 import { GuestBridge } from './GuestBridge';
+
+import { BrowserTabViewManager } from '@pkg/window/browserTabViewManager';
 
 export interface TabRecord {
   assetId:        string;
@@ -26,9 +26,16 @@ export interface TabRecord {
   url:            string;
   isLoading:      boolean;
   origin:         'user' | 'agent';
+  /** Scheduled-graph session that exclusively owns this tab, when applicable. */
+  owner?:         TabOwner;
   /** ms since epoch — used only for sorting display. No eviction, no idle sweep. */
   createdAt:      number;
   lastAccessedAt: number;
+}
+
+export interface TabOwner {
+  kind:      'graph';
+  sessionId: string;
 }
 
 type TabsListener = (tabs: TabRecord[]) => void;
@@ -43,6 +50,8 @@ const MAX_AGENT_TABS = 10;
 
 class TabRegistryImpl {
   private readonly records = new Map<string, TabRecord>();
+  /** Includes pre-open reservations so ownership checks remain atomic across delegation. */
+  private readonly owners = new Map<string, TabOwner>();
   private readonly emitter = new EventEmitter();
   private activeAssetId: string | null = null;
 
@@ -59,10 +68,61 @@ class TabRegistryImpl {
     }
   }
 
+  private sameOwner(left?: TabOwner, right?: TabOwner): boolean {
+    return left?.kind === right?.kind && left?.sessionId === right?.sessionId;
+  }
+
+  private ownershipError(assetId: string): Error {
+    return new Error(`Browser tab "${ assetId }" is owned by a different browser session.`);
+  }
+
+  /**
+   * Atomically reserve an asset ID for a scheduled graph before its browser
+   * worker is loaded. Existing user/unowned tabs and other graph sessions fail
+   * closed, so delegation can never navigate a colliding tab.
+   */
+  claimOwner(assetId: string, owner: TabOwner): void {
+    const existing = this.records.get(assetId);
+    if (existing && !this.sameOwner(existing.owner, owner)) {
+      throw this.ownershipError(assetId);
+    }
+
+    const reserved = this.owners.get(assetId);
+    if (reserved && !this.sameOwner(reserved, owner)) {
+      throw this.ownershipError(assetId);
+    }
+
+    this.owners.set(assetId, { ...owner });
+  }
+
+  /** Verify a tab belongs to this exact graph session before any delegation. */
+  assertOwner(assetId: string, owner: TabOwner): void {
+    const existing = this.records.get(assetId);
+    const reserved = this.owners.get(assetId);
+    if (!existing || !this.sameOwner(existing.owner, owner) || !this.sameOwner(reserved, owner)) {
+      throw this.ownershipError(assetId);
+    }
+  }
+
+  /** Release a failed pre-open reservation; live tab ownership is never released here. */
+  releaseOwnerReservation(assetId: string, owner: TabOwner): void {
+    if (this.records.has(assetId)) return;
+    const reserved = this.owners.get(assetId);
+    if (this.sameOwner(reserved, owner)) this.owners.delete(assetId);
+  }
+
   /** Open or update a tab. Re-entrant: same assetId + URL is a no-op. */
-  open(input: { assetId: string; url: string; title?: string; origin?: 'user' | 'agent' }): TabRecord {
+  open(input: { assetId: string; url: string; title?: string; origin?: 'user' | 'agent'; owner?: TabOwner }): TabRecord {
+    const reserved = this.owners.get(input.assetId);
+    if (reserved && !this.sameOwner(reserved, input.owner)) {
+      throw this.ownershipError(input.assetId);
+    }
+
     const existing = this.records.get(input.assetId);
     if (existing) {
+      if (!this.sameOwner(existing.owner, input.owner)) {
+        throw this.ownershipError(input.assetId);
+      }
       const sameUrl = existing.url === input.url;
       existing.title = input.title ?? existing.title;
       existing.url = input.url;
@@ -89,9 +149,11 @@ class TabRegistryImpl {
       url:            input.url,
       isLoading:      true,
       origin:         input.origin ?? 'agent',
+      ...(input.owner ? { owner: { ...input.owner } } : {}),
       createdAt:      Date.now(),
       lastAccessedAt: Date.now(),
     };
+    if (input.owner) this.owners.set(input.assetId, { ...input.owner });
     this.records.set(input.assetId, record);
     this.activeAssetId = input.assetId;
     if (record.origin === 'agent') this.enforceCap();
@@ -103,6 +165,7 @@ class TabRegistryImpl {
     if (!this.records.has(assetId)) return false;
     BrowserTabViewManager.getInstance().destroyView(assetId);
     this.records.delete(assetId);
+    this.owners.delete(assetId);
     if (this.activeAssetId === assetId) {
       this.activeAssetId = this.records.size > 0 ? [...this.records.keys()][0] : null;
     }

--- a/resources/sulla-docs/tools/browser.md
+++ b/resources/sulla-docs/tools/browser.md
@@ -1,6 +1,6 @@
 # Browser Tools
 
-The richest tool surface in Sulla. **23 tools** for tabs, page reading, interaction, JS evaluation, cookies, history, network monitoring, and persistent agent storage. **All tools target Sulla's built-in WebContentsViews — not the user's external browser.**
+The richest tool surface in Sulla. **24 tools** for tabs, page reading, interaction, JS evaluation, cookies, history, network monitoring, persistent agent storage, and scheduled-graph delegation. **All tools target Sulla's built-in WebContentsViews — not the user's external browser.**
 
 ## Two paradigms — pick the right one
 
@@ -8,6 +8,34 @@ The richest tool surface in Sulla. **23 tools** for tabs, page reading, interact
 2. **Coordinate-based** (fallback): when handles fail (shadow DOM, iframes, custom canvas widgets), use `screenshot` to see pixel coords, then `click_at` / `type_at` / `hover` at (x, y). Trusted CDP events.
 
 Default to handle-based. Drop to coordinates only when the snapshot can't see the element.
+
+## Scheduled graph controller
+
+Heartbeat and other explicitly browser-capable scheduled graphs receive the
+graph-bound MCP tool `mcp__sulla_native__browser_controller`. This is the
+supported delegation path when the installed Codex Browser skill is present
+but its host-app-specific `node_repl` controller cannot run inside Sulla's Lima
+model process.
+
+Read the installed Browser skill first and keep its confirmation, transmission,
+CAPTCHA, credential, and untrusted-page rules. Then call the controller with a
+Sulla browser operation and the arguments documented on this page:
+
+```json
+{
+  "tool": "tab",
+  "args": { "action": "upsert", "url": "http://127.0.0.1:5173" }
+}
+```
+
+The controller derives an `iab_<graph>_<target>` assetId from the scheduled
+graph's thread and forces every later operation onto that graph-owned tab,
+ignoring caller-supplied asset IDs. Global tab listing is intentionally not
+available through this controller. This keeps concurrent Heartbeat/browser work isolated. The controller is
+not registered for ordinary chat graphs or any graph with
+`userVisibleBrowser=false`; attempting to use it there fails closed as an
+unknown MCP tool. Do not use standalone Playwright or another browser server as
+a fallback.
 
 ## Asset IDs and tab scoping
 

--- a/resources/sulla-docs/tools/inventory.md
+++ b/resources/sulla-docs/tools/inventory.md
@@ -1,6 +1,6 @@
 # Tool Inventory
 
-Master list of every tool the agent can call. **Regenerated from the source manifests (`pkg/rancher-desktop/agent/tools/<category>/manifests.ts`) on 2026-08-19 — 262 tools across 30 categories.** Each line is `sulla <category>/<tool> — purpose`.
+Master list of every tool the agent can call. **Regenerated from the source manifests (`pkg/rancher-desktop/agent/tools/<category>/manifests.ts`) on 2026-08-23 — 263 tools across 30 categories.** Each line is `sulla <category>/<tool> — purpose`.
 
 > The `rules` category (user-created guardrail rules) and its **Security Conscience** enforcement were **retired 2026-08-19** and are intentionally omitted here. Some `rules/*` tool code may still linger in a given build; treat it as vestigial and don't re-add it to this doc.
 
@@ -82,7 +82,8 @@ sulla <category> --help          # what THIS install exposes right now
 
 → See [`functions/authoring.md`](../functions/authoring.md)
 
-## browser — web automation (23 tools)
+## browser — web automation (24 tools)
+- `sulla browser/browser_controller` — Graph-bound in-app Browser delegation for explicitly capable scheduled graphs; fails closed elsewhere.
 - `sulla browser/tab` — Open / navigate / close a tab (`action: upsert | remove`).
 - `sulla browser/list` — List open tabs (assetId, URL, title, ready/loading).
 - `sulla browser/snapshot` — Dehydrated DOM with clickable handles.


### PR DESCRIPTION
## Summary

Implements Projects task `aDGi` with the acceptance-permitted supported delegation path for scheduled graphs:

- registers `mcp__sulla_native__browser_controller` only for explicitly browser-capable graph sessions
- requires all three gates: `graphNativeBrowserController=true`, `userVisibleBrowser!==false`, and an explicit `allowedToolNames` grant
- gives Heartbeat the capability while leaving ordinary chat, API/Slack, headless, and ungranted graphs unchanged
- forces every browser action onto a deterministic graph-thread-owned `iab_...` asset ID; callers cannot attach to another tab
- delegates into Sulla Desktop's real in-app WebContents browser with a fresh worker bound to the same live graph state
- documents the installed Browser skill safety/confirmation rules and the supported scheduled path

## Ownership repair

Exact repair head: `52f9f16f0645355531350d6b3d6e1f170ad76e07`.

- `TabRegistry` now records an explicit graph owner/session and atomically reserves the deterministic asset ID before any browser worker is loaded
- an existing user tab, another graph's tab, or a mismatched reservation is rejected before browser delegation or navigation
- failed pre-open delegation releases its reservation; live ownership is removed with the tab
- the controller binds the production tab worker to the exact graph session while retaining caller asset-ID override protection
- capability gates, ordinary-chat isolation, disabled fail-closed behavior, and Browser safety/confirmation documentation are unchanged

## Verification

- focused Jest: 4 suites / 14 tests passed
- production-boundary integration coverage drives the real controller → tool loader → tab worker → `TabRegistry` path and proves both user-tab and cross-graph collisions are rejected before `createTool` / `loadURL`
- touched-file ESLint: clean
- `git diff --check`: clean
- local worktree: clean
- no hosted GitHub checks exist for the repair SHA
- TypeScript: the project check could not complete in this worktree; the native dependency read first reports missing `@types/jest` / `@types/node`, and reuse of the compatible shared dependency tree exhausts the VM heap (exit 137; narrowed ownership-files attempt exits 134). The focused Jest run compiled the touched production/test paths with ts-jest.

## Live acceptance gate

Do not merge yet. Per task boundary, no rebuild/restart was performed. After Jonathon authorizes build/restart, run one real scheduled Heartbeat turn that:

1. reads the installed Browser skill and bundled `tools/browser.md`
2. discovers the graph-bound MCP controller
3. opens a harmless local/page target
4. inspects it and captures a screenshot
5. records exact graph thread, asset ID, screenshot path, and disabled-capability negative proof

Only after that live evidence should tasks `MFKb`, `yc1Y`, `mLwo`, and `4KrP` be unblocked.