### PR TITLE
[HOLD] feat(projects-ui): customize lanes and assign workflows by scope

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts
@@ -96,6 +96,12 @@ export interface ArchiveWorkLaneResult {
   movedTasks: number;
 }
 
+export interface ArchiveWorkLanePreview {
+  taskCount:    number;
+  protected:    boolean;
+  destinations: EffectiveWorkLane[];
+}
+
 export const DEFAULT_WORK_LANES: readonly CreateWorkLaneInput[] = [
   { lane_key: 'backlog', display_name: 'Backlog', position: 0, semantic_role: 'backlog', system_required: true },
   { lane_key: 'todo', display_name: 'To Do', position: 1, semantic_role: 'execution', system_required: true },
@@ -465,6 +471,34 @@ export class WorkLaneDefinitionModel {
       `, [id, actor]);
       return { lane: updated.rows[0], movedTasks: count };
     });
+  }
+
+  static async previewArchive(id: string): Promise<ArchiveWorkLanePreview> {
+    const lane = await WorkLaneDefinitionModel.get(id);
+    if (!lane || lane.reset_at) throw new Error(`No active lane definition found with id: ${ id }`);
+    const projectFilter = lane.scope === 'project'
+      ? 'AND project_id = $2'
+      : `AND NOT EXISTS (
+           SELECT 1 FROM work_lane_definitions project_lane
+            WHERE project_lane.scope = 'project'
+              AND project_lane.project_id = work_tasks.project_id
+              AND project_lane.lane_key = $1
+              AND project_lane.reset_at IS NULL
+         )`;
+    const params = lane.scope === 'project' ? [lane.lane_key, lane.project_id] : [lane.lane_key];
+    const occupied = await postgresClient.queryOne<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM work_tasks WHERE archived = false AND status = $1 ${ projectFilter }`,
+      params,
+    );
+    const destinations = lane.scope === 'project'
+      ? await WorkLaneDefinitionModel.resolveEffective(lane.project_id!)
+      : (await WorkLaneDefinitionModel.list({ scope: 'global_default' }))
+        .map(item => ({ ...item, provenance: 'global' as const, inherited_definition_id: null }));
+    return {
+      taskCount:    Number(occupied?.count ?? 0),
+      protected:    lane.system_required,
+      destinations: destinations.filter(item => item.lane_key !== lane.lane_key && item.enabled && !item.archived),
+    };
   }
 
   static async restore(id: string, actor = 'sulla'): Promise<WorkLaneDefinitionRecord | null> {

--- a/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
@@ -93,11 +93,28 @@ export interface RecoverableLaneEntryRecord extends LaneEntryAutomationRecord {
 }
 
 interface WorkflowRow {
-  id:         string;
-  definition: Record<string, any>;
-  enabled:    boolean;
-  status:     string;
-  system:     boolean;
+  id:           string;
+  name?:        string;
+  description?: string | null;
+  definition:   Record<string, any>;
+  enabled:      boolean;
+  status:       string;
+  system:       boolean;
+}
+
+export interface CompatibleLaneWorkflow {
+  id:           string;
+  name:         string;
+  description:  string | null;
+  system:       boolean;
+  laneContract: LaneContract;
+}
+
+export interface ResolveLaneBindingContextInput {
+  projectId:  string;
+  epicId?:    string;
+  laneKey:    string;
+  profileId?: string;
 }
 
 function cleanOptional(value?: string): string | null {
@@ -120,6 +137,27 @@ function compatible(contract: LaneContract, laneKey: string, semanticRole: strin
 }
 
 export class WorkLaneWorkflowBindingModel {
+  static async listCompatibleWorkflows(projectId: string, laneKey: string): Promise<CompatibleLaneWorkflow[]> {
+    const lane = await WorkLaneWorkflowBindingModel.requireLane('project', laneKey, null, null, projectId);
+    const workflows = await postgresClient.query<WorkflowRow>(`
+      SELECT id, name, description, definition, enabled, status, system
+        FROM workflows
+       WHERE enabled = true AND status <> 'archive'
+       ORDER BY system DESC, name ASC, id ASC
+    `);
+    return workflows.flatMap((workflow) => {
+      const contract = workflowLaneContract(workflow);
+      if (!compatible(contract, lane.lane_key, lane.semantic_role)) return [];
+      return [{
+        id:           workflow.id,
+        name:         workflow.name?.trim() || workflow.id,
+        description:  workflow.description ?? null,
+        system:       workflow.system,
+        laneContract: contract,
+      }];
+    });
+  }
+
   static async list(input: ListLaneBindingsInput = {}): Promise<LaneWorkflowBindingRecord[]> {
     const conditions = ['profile_id = $1'];
     const values: unknown[] = [input.profileId?.trim() || 'default'];
@@ -185,10 +223,6 @@ export class WorkLaneWorkflowBindingModel {
 
   static async resolve(taskId: string, laneKey: string, profileId = 'default', client?: PoolClient):
   Promise<LaneBindingResolution> {
-    const query = async<T>(text: string, params: unknown[]): Promise<T[]> => {
-      if (client) return (await client.query(text, params)).rows as T[];
-      return postgresClient.query<T>(text, params);
-    };
     const queryOne = async<T>(text: string, params: unknown[]): Promise<T | null> => {
       if (client) return ((await client.query(text, params)).rows[0] as T | undefined) ?? null;
       return postgresClient.queryOne<T>(text, params);
@@ -208,6 +242,51 @@ export class WorkLaneWorkflowBindingModel {
     `, [taskId, laneKey]);
     if (!context) throw new Error(`No active task/lane context found for ${ taskId } in ${ laneKey }.`);
 
+    return WorkLaneWorkflowBindingModel.resolveContext({
+      projectId:      context.project_id,
+      epicId:         context.epic_id,
+      laneKey,
+      semanticRole:   context.semantic_role,
+      systemRequired: context.system_required,
+      profileId,
+    }, client);
+  }
+
+  static async resolveForContext(input: ResolveLaneBindingContextInput): Promise<LaneBindingResolution> {
+    const project = await postgresClient.queryOne<{ id: string }>(
+      'SELECT id FROM work_projects WHERE id = $1 AND archived = false', [input.projectId],
+    );
+    if (!project) throw new Error(`Project not found: ${ input.projectId }`);
+    if (input.epicId) {
+      const epic = await postgresClient.queryOne<{ id: string }>(
+        'SELECT id FROM work_epics WHERE id = $1 AND project_id = $2 AND archived = false',
+        [input.epicId, input.projectId],
+      );
+      if (!epic) throw new Error(`Epic not found in project ${ input.projectId }: ${ input.epicId }`);
+    }
+    const lane = await WorkLaneWorkflowBindingModel.requireLane('project', input.laneKey, null, null, input.projectId);
+    return WorkLaneWorkflowBindingModel.resolveContext({
+      projectId:      input.projectId,
+      epicId:         input.epicId ?? null,
+      laneKey:        input.laneKey,
+      semanticRole:   lane.semantic_role,
+      systemRequired: lane.system_required,
+      profileId:      input.profileId?.trim() || 'default',
+    });
+  }
+
+  private static async resolveContext(context: {
+    projectId:      string;
+    epicId:         string | null;
+    laneKey:        string;
+    semanticRole:   string;
+    systemRequired: boolean;
+    profileId:      string;
+  }, client?: PoolClient): Promise<LaneBindingResolution> {
+    const query = async<T>(text: string, params: unknown[]): Promise<T[]> => {
+      if (client) return (await client.query(text, params)).rows as T[];
+      return postgresClient.query<T>(text, params);
+    };
     const candidates = await query<LaneWorkflowBindingRecord>(`
       SELECT * FROM work_lane_workflow_bindings
        WHERE profile_id = $1 AND active = true AND archived = false
@@ -219,7 +298,7 @@ export class WorkLaneWorkflowBindingModel {
          )
        ORDER BY CASE scope WHEN 'epic' THEN 0 WHEN 'project' THEN 1 WHEN 'global' THEN 2 ELSE 3 END,
          CASE WHEN lane_key = $4 THEN 0 ELSE 1 END, created_at DESC
-    `, [profileId, context.epic_id, context.project_id, laneKey, context.semantic_role]);
+    `, [context.profileId, context.epicId, context.projectId, context.laneKey, context.semanticRole]);
 
     let fallbackReason: string | null = null;
     for (const binding of candidates) {
@@ -229,7 +308,7 @@ export class WorkLaneWorkflowBindingModel {
         continue;
       }
       const contract = workflowLaneContract(workflow);
-      if (!compatible(contract, laneKey, context.semantic_role)) {
+      if (!compatible(contract, context.laneKey, context.semanticRole)) {
         fallbackReason ??= `Binding ${ binding.id } is no longer compatible with this lane.`;
         continue;
       }
@@ -242,7 +321,7 @@ export class WorkLaneWorkflowBindingModel {
         workflowSnapshot: workflow.definition,
       };
     }
-    const manual = context.semantic_role === 'manual' && !context.system_required;
+    const manual = context.semanticRole === 'manual' && !context.systemRequired;
     return {
       binding:          null,
       workflowId:       null,
@@ -397,7 +476,7 @@ export class WorkLaneWorkflowBindingModel {
   }
 
   private static async requireLane(scope: LaneBindingScope, laneKey: string | null, semanticRole: string | null,
-    epicId: string | null, projectId: string | null): Promise<{ lane_key: string; semantic_role: string }> {
+    epicId: string | null, projectId: string | null): Promise<{ lane_key: string; semantic_role: string; system_required: boolean }> {
     let resolvedProjectId = projectId;
     if (scope === 'epic') {
       const epic = await postgresClient.queryOne<{ project_id: string }>('SELECT project_id FROM work_epics WHERE id = $1 AND archived = false', [epicId]);
@@ -409,8 +488,8 @@ export class WorkLaneWorkflowBindingModel {
       if (!project) throw new Error(`Project not found: ${ projectId }`);
     }
     if (laneKey) {
-      const lane = await postgresClient.queryOne<{ lane_key: string; semantic_role: string }>(`
-        SELECT lane_key, semantic_role FROM work_lane_definitions
+      const lane = await postgresClient.queryOne<{ lane_key: string; semantic_role: string; system_required: boolean }>(`
+        SELECT lane_key, semantic_role, system_required FROM work_lane_definitions
          WHERE lane_key = $1 AND reset_at IS NULL AND archived = false AND enabled = true
            AND (scope = 'global_default' OR (scope = 'project' AND project_id = $2))
          ORDER BY CASE WHEN scope = 'project' THEN 0 ELSE 1 END LIMIT 1
@@ -418,6 +497,6 @@ export class WorkLaneWorkflowBindingModel {
       if (!lane) throw new Error(`Active lane not found: ${ laneKey }`);
       return lane;
     }
-    return { lane_key: `role:${ semanticRole }`, semantic_role: semanticRole! };
+    return { lane_key: `role:${ semanticRole }`, semantic_role: semanticRole!, system_required: true };
   }
 }

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneDefinitionModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneDefinitionModel.test.ts
@@ -121,6 +121,21 @@ describe('WorkLaneDefinitionModel', () => {
     expect(client.query.mock.calls[5][0]).toContain('SET archived = true');
   });
 
+  it('previews the exact move count and safe destinations before archive', async() => {
+    (postgresClient as any).queryOne = (jest.fn() as any)
+      .mockResolvedValueOnce(lane({ lane_key: 'parked', scope: 'project', project_id: 'p1' }))
+      .mockResolvedValueOnce({ count: '3' });
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([
+      lane({ lane_key: 'parked', scope: 'project', project_id: 'p1' }),
+      lane({ id: 'done', lane_key: 'done', display_name: 'Done', semantic_role: 'terminal' }),
+    ]));
+
+    const preview = await WorkLaneDefinitionModel.previewArchive('lane-1');
+
+    expect(preview.taskCount).toBe(3);
+    expect(preview.destinations.map(item => item.lane_key)).toEqual(['done']);
+  });
+
   it.each([
     ' Awaiting Vendor ',
     '   ',

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts
@@ -54,6 +54,39 @@ describe('WorkLaneWorkflowBindingModel', () => {
       .rejects.toThrow('incompatible');
   });
 
+  it('lists only enabled workflows compatible with the authoritative lane contract', async() => {
+    (postgresClient as any).queryOne = jest.fn(() => Promise.resolve({
+      lane_key: 'in_review', semantic_role: 'review', system_required: true,
+    }));
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([
+      { id: 'reviewer', name: 'Reviewer', description: null, definition: { laneContract: contract }, enabled: true, status: 'production', system: true },
+      { id: 'planner', name: 'Planner', description: null, definition: { laneContract: { ...contract, semanticRoles: ['planning'] } }, enabled: true, status: 'production', system: false },
+    ]));
+
+    await expect(WorkLaneWorkflowBindingModel.listCompatibleWorkflows('project-1', 'in_review')).resolves.toEqual([
+      expect.objectContaining({ id: 'reviewer', name: 'Reviewer', system: true }),
+    ]);
+  });
+
+  it('previews effective provenance for an epic without duplicating resolution in the renderer', async() => {
+    (postgresClient as any).queryOne = (jest.fn() as any)
+      .mockResolvedValueOnce({ id: 'project-1' })
+      .mockResolvedValueOnce({ id: 'epic-1' })
+      .mockResolvedValueOnce({ id: 'project-1' })
+      .mockResolvedValueOnce({ lane_key: 'in_review', semantic_role: 'review', system_required: true })
+      .mockResolvedValueOnce({ id: 'reviewer', definition: { laneContract: contract }, enabled: true, status: 'production', system: true });
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([
+      { id: 'epic-binding', scope: 'epic', epic_id: 'epic-1', lane_key: 'in_review', workflow_id: 'reviewer' },
+    ]));
+
+    const result = await WorkLaneWorkflowBindingModel.resolveForContext({
+      projectId: 'project-1', epicId: 'epic-1', laneKey: 'in_review',
+    });
+
+    expect(result).toEqual(expect.objectContaining({ source: 'epic', workflowId: 'reviewer' }));
+    expect((postgresClient.query as any).mock.calls[0][1]).toEqual(['default', 'epic-1', 'project-1', 'in_review', 'review']);
+  });
+
   it('never removes a protected core binding', async() => {
     (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
     (postgresClient as any).queryOne = jest.fn(() => Promise.resolve({ id: 'core', scope: 'core' }));

--- a/pkg/rancher-desktop/components/projects/LaneSettings.vue
+++ b/pkg/rancher-desktop/components/projects/LaneSettings.vue
@@ -1,0 +1,692 @@
+<template>
+  <section
+    class="lane-settings"
+    aria-labelledby="lane-settings-title"
+  >
+    <header class="ls-head">
+      <div>
+        <h2 id="lane-settings-title">
+          Lane settings
+        </h2>
+        <p>Customize presentation without changing stable task status keys.</p>
+      </div>
+      <div
+        class="ls-scope"
+        role="group"
+        aria-label="Lane settings scope"
+      >
+        <button
+          :class="{ on: scope === 'project' }"
+          type="button"
+          @click="setScope('project')"
+        >
+          This project
+        </button>
+        <button
+          :class="{ on: scope === 'global_default' }"
+          type="button"
+          @click="setScope('global_default')"
+        >
+          Global defaults
+        </button>
+      </div>
+    </header>
+
+    <div
+      v-if="message"
+      class="ls-message"
+      role="status"
+    >
+      {{ message }}
+    </div>
+    <div
+      v-if="failure"
+      class="ls-error"
+      role="alert"
+    >
+      {{ failure }}
+    </div>
+    <div
+      v-if="loading"
+      class="ls-empty"
+    >
+      Loading lanes…
+    </div>
+    <div
+      v-else
+      class="ls-list"
+    >
+      <article
+        v-for="(lane, index) in lanes"
+        :key="lane.id"
+        class="ls-row"
+        :class="{ archived: lane.archived }"
+      >
+        <span
+          class="ls-color"
+          :style="{ background: lane.color || 'var(--pacc)' }"
+        />
+        <div class="ls-copy">
+          <div class="ls-title">
+            {{ lane.display_name }}
+            <code>{{ lane.lane_key }}</code>
+          </div>
+          <p>{{ lane.description || 'No description' }}</p>
+          <div class="ls-badges">
+            <span>{{ provenanceLabel(lane) }}</span>
+            <span>{{ lane.semantic_role }}</span>
+            <span v-if="lane.system_required">protected required</span>
+            <span v-if="lane.archived">archived</span>
+            <span v-else>{{ lane.semantic_role === 'manual' ? 'manual' : 'automated-capable' }}</span>
+          </div>
+        </div>
+        <div class="ls-actions">
+          <button
+            type="button"
+            :disabled="busy || index === 0 || lane.archived"
+            aria-label="Move lane left"
+            @click="move(index, -1)"
+          >
+            ←
+          </button>
+          <button
+            type="button"
+            :disabled="busy || index === lanes.length - 1 || lane.archived"
+            aria-label="Move lane right"
+            @click="move(index, 1)"
+          >
+            →
+          </button>
+          <button
+            type="button"
+            :disabled="busy || lane.archived"
+            @click="openEdit(lane)"
+          >
+            Customize
+          </button>
+          <button
+            type="button"
+            :disabled="busy || lane.archived"
+            @click="openAssignment(lane)"
+          >
+            Assign workflow
+          </button>
+          <button
+            v-if="lane.provenance === 'project_override'"
+            type="button"
+            :disabled="busy"
+            @click="resetOverride(lane)"
+          >
+            Reset override
+          </button>
+          <button
+            v-if="lane.archived"
+            type="button"
+            :disabled="busy"
+            @click="restore(lane)"
+          >
+            Restore
+          </button>
+          <button
+            v-else
+            type="button"
+            class="danger"
+            :disabled="busy || lane.system_required"
+            @click="openArchive(lane)"
+          >
+            Archive
+          </button>
+        </div>
+      </article>
+    </div>
+    <button
+      type="button"
+      class="ls-add"
+      :disabled="busy"
+      @click="openCreate"
+    >
+      ＋ Add {{ scope === 'project' ? 'project-only' : 'default' }} lane
+    </button>
+    <button
+      v-if="scope === 'project' && lanes.some(lane => lane.provenance === 'project_override')"
+      type="button"
+      class="ls-add"
+      :disabled="busy"
+      @click="resetAllOverrides"
+    >
+      Reset all project overrides
+    </button>
+
+    <div
+      v-if="editor.open"
+      class="ls-scrim"
+      @click="editor.open = false"
+    >
+      <form
+        class="ls-modal"
+        @submit.prevent="saveLane"
+        @click.stop
+      >
+        <h3>{{ editor.create ? 'Add lane' : 'Customize lane' }}</h3>
+        <label>Stable key <input
+          v-model="editor.laneKey"
+          :disabled="!editor.create"
+          required
+          pattern="[a-z0-9_-]+"
+        ></label>
+        <small>The key is permanent; renaming only changes the display name.</small>
+        <label>Display name <input
+          v-model="editor.displayName"
+          required
+        ></label>
+        <label>Description <textarea
+          v-model="editor.description"
+          rows="3"
+        /></label>
+        <div class="ls-grid">
+          <label>Color <input
+            v-model="editor.color"
+            type="color"
+          ></label>
+          <label>Semantic role
+            <select v-model="editor.semanticRole">
+              <option
+                v-for="role in ROLES"
+                :key="role"
+                :value="role"
+              >{{ role }}</option>
+            </select>
+          </label>
+        </div>
+        <div class="ls-footer">
+          <button
+            type="submit"
+            :disabled="busy"
+          >
+            {{ busy ? 'Saving…' : 'Save' }}
+          </button>
+          <button
+            type="button"
+            @click="editor.open = false"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <div
+      v-if="archiveDialog.open"
+      class="ls-scrim"
+      @click="archiveDialog.open = false"
+    >
+      <form
+        class="ls-modal"
+        @submit.prevent="archiveSelected"
+        @click.stop
+      >
+        <h3>Archive {{ archiveDialog.lane?.display_name }}</h3>
+        <p v-if="archiveDialog.preview?.protected">
+          This lane is required by the task lifecycle and can’t be archived.
+        </p>
+        <template v-else>
+          <p>This will archive the lane. {{ archiveDialog.preview?.taskCount || 0 }} task(s) currently use it.</p>
+          <label v-if="(archiveDialog.preview?.taskCount || 0) > 0">Move tasks to
+            <select
+              v-model="archiveDialog.destination"
+              required
+            >
+              <option
+                value=""
+                disabled
+              >Select a destination</option>
+              <option
+                v-for="destination in archiveDialog.preview?.destinations"
+                :key="destination.lane_key"
+                :value="destination.lane_key"
+              >
+                {{ destination.display_name }}
+              </option>
+            </select>
+          </label>
+        </template>
+        <div class="ls-footer">
+          <button
+            type="submit"
+            class="danger"
+            :disabled="busy || archiveDialog.preview?.protected"
+          >
+            Archive and move
+          </button>
+          <button
+            type="button"
+            @click="archiveDialog.open = false"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <div
+      v-if="assignment.open"
+      class="ls-scrim"
+      @click="assignment.open = false"
+    >
+      <form
+        class="ls-modal wide"
+        @submit.prevent="saveAssignment"
+        @click.stop
+      >
+        <h3>Assign workflow · {{ assignment.lane?.display_name }}</h3>
+        <fieldset>
+          <legend>Apply to</legend>
+          <label><input
+            v-model="assignment.scope"
+            type="radio"
+            value="epic"
+          > This epic</label>
+          <label><input
+            v-model="assignment.scope"
+            type="radio"
+            value="project"
+          > This project</label>
+          <label><input
+            v-model="assignment.scope"
+            type="radio"
+            value="global"
+          > Every project using this lane type</label>
+        </fieldset>
+        <p class="ls-target">
+          Affected target: <strong>{{ affectedTarget }}</strong>
+        </p>
+        <label v-if="assignment.scope === 'epic'">Epic
+          <select
+            v-model="assignment.epicId"
+            required
+            @change="refreshResolution"
+          >
+            <option
+              v-for="epic in project.epics"
+              :key="epic.id"
+              :value="epic.id"
+            >{{ epic.title }}</option>
+          </select>
+        </label>
+        <label>Compatible workflow
+          <select
+            v-model="assignment.workflowId"
+            required
+          >
+            <option
+              value=""
+              disabled
+            >Select an enabled compatible workflow</option>
+            <option
+              v-for="workflow in assignment.workflows"
+              :key="workflow.id"
+              :value="workflow.id"
+            >
+              {{ workflow.name }}{{ workflow.system ? ' · protected core' : '' }}
+            </option>
+          </select>
+        </label>
+        <p
+          v-if="!assignment.loading && !assignment.workflows.length"
+          class="ls-error"
+        >
+          No enabled workflow declares a compatible lane contract.
+        </p>
+        <div class="ls-provenance">
+          <b>Current precedence</b>
+          <ol>
+            <li
+              v-for="step in precedence"
+              :key="step.scope"
+              :class="{ effective: step.effective }"
+            >
+              {{ step.label }} — {{ step.workflow }}
+            </li>
+          </ol>
+          <p>Effective now: <strong>{{ effectiveWorkflowLabel }}</strong> <span class="ls-badge">{{ provenanceBadge }}</span></p>
+          <p v-if="assignment.resolution?.fallbackReason">
+            Fallback: {{ assignment.resolution.fallbackReason }}
+          </p>
+        </div>
+        <div class="ls-footer">
+          <button
+            type="submit"
+            :disabled="busy || !assignment.workflowId || !assignment.workflows.length"
+          >
+            Save assignment
+          </button>
+          <button
+            v-if="assignment.exactBinding"
+            type="button"
+            :disabled="busy"
+            @click="removeAssignment"
+          >
+            Use inherited fallback
+          </button>
+          <button
+            type="button"
+            @click="assignment.open = false"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+
+import type {
+  ArchiveWorkLanePreview, EffectiveWorkLane, WorkLaneSemanticRole,
+} from '@pkg/agent/database/models/WorkLaneDefinitionModel';
+import type {
+  CompatibleLaneWorkflow, LaneBindingResolution, LaneWorkflowBindingRecord, LaneBindingScope,
+} from '@pkg/agent/database/models/WorkLaneWorkflowBindingModel';
+import { useProjects, type ProjectView } from '@pkg/composables/useProjects';
+
+const props = defineProps<{ project: ProjectView }>();
+const emit = defineEmits<{ refresh: [] }>();
+const {
+  listLanes, resolveLanes, createLane, updateLane, archiveLane, previewArchiveLane, restoreLane,
+  reorderLanes, resetLaneOverride, listLaneWorkflowBindings, setLaneWorkflowBinding,
+  removeLaneWorkflowBinding, resolveLaneWorkflowContext, listCompatibleLaneWorkflows,
+} = useProjects();
+
+const ROLES: WorkLaneSemanticRole[] = ['backlog', 'planning', 'execution', 'review', 'blocked', 'terminal', 'manual'];
+const scope = ref<'project' | 'global_default'>('project');
+const lanes = ref<EffectiveWorkLane[]>([]);
+const loading = ref(false);
+const busy = ref(false);
+const failure = ref('');
+const message = ref('');
+
+const editor = reactive({
+  open:         false,
+  create:       false,
+  lane:         null as EffectiveWorkLane | null,
+  laneKey:      '',
+  displayName:  '',
+  description:  '',
+  color:        '#5096b3',
+  semanticRole: 'manual' as WorkLaneSemanticRole,
+});
+const archiveDialog = reactive({
+  open: false, lane: null as EffectiveWorkLane | null, preview: null as ArchiveWorkLanePreview | null, destination: '',
+});
+const assignment = reactive({
+  open:         false,
+  loading:      false,
+  lane:         null as EffectiveWorkLane | null,
+  scope:        'project' as Exclude<LaneBindingScope, 'core'>,
+  epicId:       '',
+  workflowId:   '',
+  workflows:    [] as CompatibleLaneWorkflow[],
+  bindings:     [] as LaneWorkflowBindingRecord[],
+  resolution:   null as LaneBindingResolution | null,
+  exactBinding: null as LaneWorkflowBindingRecord | null,
+});
+
+async function run(action: () => Promise<void>): Promise<void> {
+  busy.value = true; failure.value = ''; message.value = '';
+  try { await action() } catch (error) { failure.value = error instanceof Error ? error.message : String(error) } finally { busy.value = false }
+}
+
+async function reload(): Promise<void> {
+  loading.value = true; failure.value = '';
+  try {
+    if (scope.value === 'project') lanes.value = await resolveLanes(props.project.id, true);
+    else {
+      lanes.value = (await listLanes({ scope: 'global_default', includeArchived: true }))
+        .map(lane => ({ ...lane, provenance: 'global' as const, inherited_definition_id: null }));
+    }
+  } catch (error) { failure.value = error instanceof Error ? error.message : String(error) } finally { loading.value = false }
+}
+
+function setScope(next: 'project' | 'global_default'): void { scope.value = next }
+watch(() => [props.project.id, scope.value], () => { reload().catch(() => undefined) }, { immediate: true });
+
+function provenanceLabel(lane: EffectiveWorkLane): string {
+  if (lane.provenance === 'global') return scope.value === 'project' ? 'inherited default' : 'global default';
+  return lane.provenance === 'project_override' ? 'project override' : 'project-only';
+}
+
+function openCreate(): void {
+  Object.assign(editor, { open: true, create: true, lane: null, laneKey: '', displayName: '', description: '', color: '#5096b3', semanticRole: 'manual' });
+}
+function openEdit(lane: EffectiveWorkLane): void {
+  Object.assign(editor, { open: true, create: false, lane, laneKey: lane.lane_key, displayName: lane.display_name, description: lane.description, color: lane.color || '#5096b3', semanticRole: lane.semantic_role });
+}
+async function saveLane(): Promise<void> {
+  await run(async() => {
+    if (editor.create) {
+      await createLane({
+        lane_key:      editor.laneKey,
+        scope:         scope.value,
+        project_id:    scope.value === 'project' ? props.project.id : null,
+        display_name:  editor.displayName,
+        description:   editor.description,
+        color:         editor.color,
+        semantic_role: editor.semanticRole,
+        position:      lanes.value.length,
+      });
+    } else if (editor.lane) {
+      if (scope.value === 'project' && editor.lane.provenance === 'global') {
+        await createLane({
+          lane_key:      editor.lane.lane_key,
+          scope:         'project',
+          project_id:    props.project.id,
+          base_lane_key: editor.lane.lane_key,
+          display_name:  editor.displayName,
+          description:   editor.description,
+          color:         editor.color,
+          icon:          editor.lane.icon,
+          position:      editor.lane.position,
+          semantic_role: editor.semanticRole,
+        });
+      } else {
+        await updateLane(editor.lane.id, { display_name: editor.displayName, description: editor.description, color: editor.color, semantic_role: editor.semanticRole });
+      }
+    }
+    editor.open = false; message.value = 'Lane saved.'; await reload(); emit('refresh');
+  });
+}
+
+async function move(index: number, delta: number): Promise<void> {
+  const reordered = [...lanes.value];
+  const target = index + delta;
+  if (target < 0 || target >= reordered.length) return;
+  [reordered[index], reordered[target]] = [reordered[target], reordered[index]];
+  await run(async() => {
+    await reorderLanes(scope.value, reordered.filter(lane => !lane.archived).map(lane => lane.lane_key), scope.value === 'project' ? props.project.id : undefined);
+    await reload(); emit('refresh');
+  });
+}
+
+async function resetOverride(lane: EffectiveWorkLane): Promise<void> {
+  await run(async() => { await resetLaneOverride(props.project.id, lane.lane_key); message.value = 'Inherited defaults restored.'; await reload(); emit('refresh') });
+}
+async function resetAllOverrides(): Promise<void> {
+  await run(async() => {
+    const overrides = lanes.value.filter(lane => lane.provenance === 'project_override');
+    await Promise.all(overrides.map(lane => resetLaneOverride(props.project.id, lane.lane_key)));
+    message.value = `${ overrides.length } project override(s) reset to inherited defaults.`;
+    await reload();
+    emit('refresh');
+  });
+}
+async function restore(lane: EffectiveWorkLane): Promise<void> {
+  await run(async() => { await restoreLane(lane.id); message.value = 'Lane restored.'; await reload(); emit('refresh') });
+}
+async function openArchive(lane: EffectiveWorkLane): Promise<void> {
+  archiveDialog.open = true; archiveDialog.lane = lane; archiveDialog.preview = null; archiveDialog.destination = '';
+  await run(async() => {
+    if (scope.value === 'project' && lane.provenance === 'global') {
+      archiveDialog.preview = {
+        taskCount:    props.project.epics.flatMap(epic => epic.tasks).filter(task => task.status === lane.lane_key).length,
+        protected:    lane.system_required,
+        destinations: lanes.value.filter(item => item.lane_key !== lane.lane_key && item.enabled && !item.archived),
+      };
+    } else {
+      archiveDialog.preview = await previewArchiveLane(lane.id);
+    }
+  });
+}
+async function archiveSelected(): Promise<void> {
+  if (!archiveDialog.lane) return;
+  await run(async() => {
+    let archiveId = archiveDialog.lane!.id;
+    if (scope.value === 'project' && archiveDialog.lane!.provenance === 'global') {
+      const inherited = archiveDialog.lane!;
+      const override = await createLane({
+        lane_key:      inherited.lane_key,
+        scope:         'project',
+        project_id:    props.project.id,
+        base_lane_key: inherited.lane_key,
+        display_name:  inherited.display_name,
+        description:   inherited.description,
+        color:         inherited.color,
+        icon:          inherited.icon,
+        position:      inherited.position,
+        semantic_role: inherited.semantic_role,
+      });
+      archiveId = override.id;
+    }
+    const result = await archiveLane(archiveId, archiveDialog.destination || undefined);
+    archiveDialog.open = false; message.value = `Lane archived; ${ result.movedTasks } task(s) moved.`; await reload(); emit('refresh');
+  });
+}
+
+function bindingFor(scopeName: LaneBindingScope): LaneWorkflowBindingRecord | null {
+  if (!assignment.lane) return null;
+  return assignment.bindings.find((binding) => {
+    if (binding.scope !== scopeName) return false;
+    if (scopeName === 'epic') return binding.epic_id === assignment.epicId && binding.lane_key === assignment.lane!.lane_key;
+    if (scopeName === 'project') return binding.project_id === props.project.id && binding.lane_key === assignment.lane!.lane_key;
+    return binding.lane_key === assignment.lane!.lane_key ||
+      (!binding.lane_key && binding.semantic_role === assignment.lane!.semantic_role);
+  }) ?? null;
+}
+function exactBindingForScope(): LaneWorkflowBindingRecord | null {
+  if (!assignment.lane) return null;
+  return assignment.bindings.find(binding => binding.scope === assignment.scope &&
+    binding.lane_key === assignment.lane!.lane_key &&
+    (assignment.scope !== 'epic' || binding.epic_id === assignment.epicId) &&
+    (assignment.scope !== 'project' || binding.project_id === props.project.id)) ?? null;
+}
+async function refreshResolution(): Promise<void> {
+  if (!assignment.lane) return;
+  assignment.bindings = await listLaneWorkflowBindings();
+  assignment.resolution = await resolveLaneWorkflowContext({
+    projectId: props.project.id, epicId: assignment.epicId || undefined, laneKey: assignment.lane.lane_key,
+  });
+  assignment.exactBinding = exactBindingForScope();
+}
+async function openAssignment(lane: EffectiveWorkLane, epicId?: string): Promise<void> {
+  Object.assign(assignment, {
+    open:         true,
+    loading:      true,
+    lane,
+    scope:        epicId ? 'epic' : 'project',
+    epicId:       epicId || props.project.epics[0]?.id || '',
+    workflowId:   '',
+    workflows:    [],
+    bindings:     [],
+    resolution:   null,
+    exactBinding: null,
+  });
+  try {
+    [assignment.workflows] = await Promise.all([
+      listCompatibleLaneWorkflows(props.project.id, lane.lane_key), refreshResolution(),
+    ]);
+    assignment.exactBinding = exactBindingForScope();
+    assignment.workflowId = assignment.exactBinding?.workflow_id ?? assignment.resolution?.workflowId ?? '';
+  } catch (error) { failure.value = error instanceof Error ? error.message : String(error) } finally { assignment.loading = false }
+}
+watch(() => assignment.scope, () => {
+  if (!assignment.open) return;
+  assignment.exactBinding = exactBindingForScope();
+  assignment.workflowId = assignment.exactBinding?.workflow_id ?? assignment.resolution?.workflowId ?? '';
+});
+
+async function saveAssignment(): Promise<void> {
+  if (!assignment.lane || !assignment.workflowId) return;
+  await run(async() => {
+    await setLaneWorkflowBinding({
+      scope:      assignment.scope,
+      workflowId: assignment.workflowId,
+      laneKey:    assignment.lane!.lane_key,
+      epicId:     assignment.scope === 'epic' ? assignment.epicId : undefined,
+      projectId:  assignment.scope === 'project' ? props.project.id : undefined,
+    });
+    await refreshResolution(); message.value = `Workflow assigned. Effective source: ${ assignment.resolution?.source ?? 'none' }.`;
+  });
+}
+async function removeAssignment(): Promise<void> {
+  if (!assignment.exactBinding) return;
+  await run(async() => { await removeLaneWorkflowBinding(assignment.exactBinding!.id); await refreshResolution(); message.value = 'Override removed; inherited fallback restored.' });
+}
+
+const precedence = computed(() => ['epic', 'project', 'global', 'core'].map((item) => {
+  const binding = bindingFor(item as LaneBindingScope);
+  return {
+    scope:     item,
+    label:     item === 'core' ? 'Protected core' : `${ item[0].toUpperCase() }${ item.slice(1) } override`,
+    workflow:  binding?.workflow_id ?? 'not assigned',
+    effective: assignment.resolution?.source === item,
+  };
+}));
+const effectiveWorkflowLabel = computed(() => assignment.resolution?.workflowId ?? (assignment.resolution?.source === 'manual' ? 'Manual lane' : 'No automation'));
+const affectedTarget = computed(() => {
+  if (assignment.scope === 'global') return `all projects using lane key ${ assignment.lane?.lane_key ?? '' }`;
+  if (assignment.scope === 'project') return props.project.title;
+  return props.project.epics.find(epic => epic.id === assignment.epicId)?.title ?? 'Select an epic';
+});
+const provenanceBadge = computed(() => {
+  const source = assignment.resolution?.source;
+  return source === 'epic' ? 'epic override' : source === 'project' ? 'project override' : source === 'global' ? 'global default' : source === 'core' ? 'protected core' : source || 'none';
+});
+
+defineExpose({ openEdit, openAssignment });
+</script>
+
+<style scoped>
+.lane-settings { max-width: 1100px; color: var(--ptext); }
+.ls-head { display: flex; justify-content: space-between; gap: 24px; align-items: flex-start; margin-bottom: 20px; }
+.ls-head h2, .ls-modal h3 { font-family: var(--pserif); font-weight: 500; margin: 0 0 6px; }
+.ls-head p, .ls-copy p, .ls-modal p, .ls-modal small { color: var(--ptext2); margin: 0; line-height: 1.5; }
+.ls-scope { display: flex; border: 1px solid var(--pborder); border-radius: 8px; overflow: hidden; }
+.ls-scope button, .ls-actions button, .ls-add, .ls-footer button { background: transparent; border: 0; color: var(--ptext2); padding: 8px 10px; cursor: pointer; }
+.ls-scope button.on, .ls-footer button:first-child { color: var(--ptext); background: var(--pacc-soft); }
+.ls-list { display: grid; gap: 8px; }
+.ls-row { display: flex; align-items: center; gap: 14px; padding: 14px; border: 1px solid var(--pborder); border-radius: 10px; background: var(--psurface); }
+.ls-row.archived { opacity: .58; }
+.ls-color { width: 10px; height: 38px; border-radius: 5px; flex: 0 0 auto; }
+.ls-copy { min-width: 180px; flex: 1; }
+.ls-title { font-weight: 600; display: flex; gap: 9px; align-items: baseline; }
+.ls-title code { color: var(--ptext3); font-size: 10px; }
+.ls-copy p { font-size: 12px; margin-top: 3px; }
+.ls-badges { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 7px; }
+.ls-badges span, .ls-badge { font: 9px var(--pmono); text-transform: uppercase; letter-spacing: .06em; border: 1px solid var(--pborder); border-radius: 4px; padding: 2px 5px; color: var(--ptext3); }
+.ls-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 3px; }
+.ls-actions button { border: 1px solid var(--pborder); border-radius: 6px; font-size: 11px; padding: 5px 7px; }
+.ls-actions button:disabled, .ls-footer button:disabled { opacity: .4; cursor: default; }
+.danger { color: var(--pred) !important; }
+.ls-add { border: 1px dashed var(--pacc-line); border-radius: 8px; margin-top: 12px; color: var(--pacc); }
+.ls-message, .ls-error, .ls-empty { padding: 10px 12px; border-radius: 8px; margin-bottom: 12px; font-size: 12px; }
+.ls-message { background: var(--pacc-soft); color: var(--pacc); }.ls-error { background: rgba(201,115,111,.1); color: var(--pred); }.ls-empty { color: var(--ptext2); }
+.ls-scrim { position: fixed; inset: 0; background: rgba(4,7,12,.72); z-index: 50; display: grid; place-items: center; }
+.ls-modal { width: 480px; max-width: calc(100vw - 40px); max-height: calc(100vh - 50px); overflow: auto; background: var(--psurface); border: 1px solid var(--pborder); border-radius: 14px; padding: 22px; box-shadow: 0 30px 80px rgba(0,0,0,.5); }
+.ls-modal.wide { width: 620px; }
+.ls-modal label { display: grid; gap: 5px; margin-top: 14px; color: var(--ptext2); font-size: 12px; }
+.ls-modal input:not([type=radio]), .ls-modal textarea, .ls-modal select { width: 100%; background: var(--psurface2); border: 1px solid var(--pborder); border-radius: 7px; color: var(--ptext); padding: 8px; }
+.ls-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }.ls-modal fieldset { margin-top: 14px; border: 1px solid var(--pborder); border-radius: 8px; }.ls-modal fieldset label { display: flex; align-items: center; }
+.ls-provenance { margin-top: 15px; padding: 12px; background: var(--psurface2); border-radius: 8px; font-size: 12px; }.ls-provenance ol { padding-left: 20px; color: var(--ptext3); }.ls-provenance li.effective { color: var(--pacc); font-weight: 600; }
+.ls-footer { display: flex; gap: 8px; margin-top: 20px; }.ls-footer button { border: 1px solid var(--pborder); border-radius: 7px; }
+</style>

--- a/pkg/rancher-desktop/components/projects/__tests__/LaneSettings.contract.test.ts
+++ b/pkg/rancher-desktop/components/projects/__tests__/LaneSettings.contract.test.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from '@jest/globals';
+
+describe('LaneSettings UI contract', () => {
+  const source = fs.readFileSync(path.resolve(process.cwd(), 'pkg/rancher-desktop/components/projects/LaneSettings.vue'), 'utf8');
+
+  it('exposes global/project customization, safe archive, and all assignment scopes', () => {
+    for (const phrase of [
+      'Global defaults', 'This project', 'project-only', 'Reset override', 'Move tasks to',
+      'This epic', 'Every project using this lane type', 'Effective now:', 'Protected core',
+    ]) expect(source).toContain(phrase);
+    expect(source).toContain('previewArchiveLane');
+    expect(source).toContain('listCompatibleLaneWorkflows');
+    expect(source).toContain('resolveLaneWorkflowContext');
+  });
+
+  it('keeps stable identity immutable and uses backend mutations for reversible changes', () => {
+    expect(source).toContain(':disabled="!editor.create"');
+    expect(source).toContain('resetLaneOverride');
+    expect(source).toContain('removeLaneWorkflowBinding');
+    expect(source).not.toContain('postgresClient');
+  });
+});

--- a/pkg/rancher-desktop/composables/useProjects.ts
+++ b/pkg/rancher-desktop/composables/useProjects.ts
@@ -25,11 +25,11 @@ import type {
 } from '@pkg/agent/database/models/WorkItemsModel';
 import type {
   CreateWorkLaneInput, EffectiveWorkLane, ListWorkLaneOpts, UpdateWorkLaneInput,
-  WorkLaneDefinitionRecord, WorkLaneRuntimeCapability, WorkLaneScope,
+  ArchiveWorkLanePreview, WorkLaneDefinitionRecord, WorkLaneRuntimeCapability, WorkLaneScope,
 } from '@pkg/agent/database/models/WorkLaneDefinitionModel';
 import type {
-  LaneBindingResolution, LaneEntryAutomationRecord, LaneWorkflowBindingRecord,
-  ListLaneBindingsInput, SetLaneBindingInput,
+  CompatibleLaneWorkflow, LaneBindingResolution, LaneEntryAutomationRecord, LaneWorkflowBindingRecord,
+  ListLaneBindingsInput, ResolveLaneBindingContextInput, SetLaneBindingInput,
 } from '@pkg/agent/database/models/WorkLaneWorkflowBindingModel';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
@@ -261,6 +261,10 @@ export function useProjects() {
     return result;
   }
 
+  async function previewArchiveLane(id: string): Promise<ArchiveWorkLanePreview> {
+    return ipcRenderer.invoke('work-items:lane-archive-preview', id);
+  }
+
   async function restoreLane(id: string): Promise<WorkLaneDefinitionRecord | null> {
     return ipcRenderer.invoke('work-items:lane-restore', id);
   }
@@ -287,6 +291,14 @@ export function useProjects() {
 
   async function resolveLaneWorkflow(taskId: string, laneKey: string, profileId = 'default'): Promise<LaneBindingResolution> {
     return ipcRenderer.invoke('work-items:lane-workflow-resolve', taskId, laneKey, profileId);
+  }
+
+  async function resolveLaneWorkflowContext(input: ResolveLaneBindingContextInput): Promise<LaneBindingResolution> {
+    return ipcRenderer.invoke('work-items:lane-workflow-resolve-context', input);
+  }
+
+  async function listCompatibleLaneWorkflows(projectId: string, laneKey: string): Promise<CompatibleLaneWorkflow[]> {
+    return ipcRenderer.invoke('work-items:lane-compatible-workflows', projectId, laneKey);
   }
 
   async function inspectLaneEntryAutomation(taskId: string): Promise<LaneEntryAutomationRecord[]> {
@@ -322,6 +334,7 @@ export function useProjects() {
     createLane,
     updateLane,
     archiveLane,
+    previewArchiveLane,
     restoreLane,
     reorderLanes,
     resetLaneOverride,
@@ -329,6 +342,8 @@ export function useProjects() {
     setLaneWorkflowBinding,
     removeLaneWorkflowBinding,
     resolveLaneWorkflow,
+    resolveLaneWorkflowContext,
+    listCompatibleLaneWorkflows,
     inspectLaneEntryAutomation,
   };
 }

--- a/pkg/rancher-desktop/main/__tests__/workItemsEvents.lanes.test.ts
+++ b/pkg/rancher-desktop/main/__tests__/workItemsEvents.lanes.test.ts
@@ -9,9 +9,11 @@ describe('work-items lane IPC contract', () => {
     for (const channel of [
       'work-items:lanes-list', 'work-items:lanes-resolve', 'work-items:lane-create',
       'work-items:lane-update', 'work-items:lane-archive', 'work-items:lane-restore',
+      'work-items:lane-archive-preview',
       'work-items:lanes-reorder', 'work-items:lane-reset-override',
       'work-items:lane-bindings-list', 'work-items:lane-binding-set',
       'work-items:lane-binding-remove', 'work-items:lane-workflow-resolve',
+      'work-items:lane-workflow-resolve-context', 'work-items:lane-compatible-workflows',
       'work-items:lane-entry-automations',
     ]) expect(source).toContain(`handle('${ channel }'`);
     expect(source).toContain("import('@pkg/agent/database/models/WorkLaneDefinitionModel')");

--- a/pkg/rancher-desktop/main/workItemsEvents.ts
+++ b/pkg/rancher-desktop/main/workItemsEvents.ts
@@ -32,7 +32,9 @@ import type {
 import type {
   CreateWorkLaneInput, UpdateWorkLaneInput, WorkLaneScope,
 } from '@pkg/agent/database/models/WorkLaneDefinitionModel';
-import type { ListLaneBindingsInput, SetLaneBindingInput } from '@pkg/agent/database/models/WorkLaneWorkflowBindingModel';
+import type {
+  ListLaneBindingsInput, ResolveLaneBindingContextInput, SetLaneBindingInput,
+} from '@pkg/agent/database/models/WorkLaneWorkflowBindingModel';
 import { getIpcMainProxy } from '@pkg/main/ipcMain';
 import Logging from '@pkg/utils/logging';
 
@@ -130,6 +132,11 @@ export function initWorkItemsEvents(): void {
     return Model.archive(id, destinationLaneKey, 'human');
   });
 
+  ipcMainProxy.handle('work-items:lane-archive-preview', async(_event: unknown, id: string) => {
+    const Model = await importWorkLaneDefinitionModel();
+    return Model.previewArchive(id);
+  });
+
   ipcMainProxy.handle('work-items:lane-restore', async(_event: unknown, id: string) => {
     const Model = await importWorkLaneDefinitionModel();
     return Model.restore(id, 'human');
@@ -165,6 +172,16 @@ export function initWorkItemsEvents(): void {
   ipcMainProxy.handle('work-items:lane-workflow-resolve', async(_event: unknown, taskId: string, laneKey: string, profileId = 'default') => {
     const Model = await importWorkLaneWorkflowBindingModel();
     return Model.resolve(taskId, laneKey, profileId);
+  });
+
+  ipcMainProxy.handle('work-items:lane-workflow-resolve-context', async(_event: unknown, input: ResolveLaneBindingContextInput) => {
+    const Model = await importWorkLaneWorkflowBindingModel();
+    return Model.resolveForContext(input);
+  });
+
+  ipcMainProxy.handle('work-items:lane-compatible-workflows', async(_event: unknown, projectId: string, laneKey: string) => {
+    const Model = await importWorkLaneWorkflowBindingModel();
+    return Model.listCompatibleWorkflows(projectId, laneKey);
   });
 
   ipcMainProxy.handle('work-items:lane-entry-automations', async(_event: unknown, taskId: string) => {
@@ -284,10 +301,10 @@ export function initWorkItemsEvents(): void {
 }
 
 interface ReorderUpdate {
-  kind:     'epic' | 'task';
-  id:       string;
+  kind:      'epic' | 'task';
+  id:        string;
   position?: number;
-  status?:  string;
-  epic_id?: string;
-  actor?:   string;
+  status?:   string;
+  epic_id?:  string;
+  actor?:    string;
 }

--- a/pkg/rancher-desktop/pages/ProjectsHome.vue
+++ b/pkg/rancher-desktop/pages/ProjectsHome.vue
@@ -48,6 +48,7 @@
             <button type="button" class="ph-tab" :class="{ on: tab === 'board' }" @click="tab = 'board'">Board</button>
             <button type="button" class="ph-tab" :class="{ on: tab === 'activity' }" @click="tab = 'activity'">Activity</button>
             <button type="button" class="ph-tab" :class="{ on: tab === 'projects' }" @click="tab = 'projects'">Projects</button>
+            <button type="button" class="ph-tab" :class="{ on: tab === 'lanes' }" @click="tab = 'lanes'">Lanes</button>
           </div>
           <div class="ph-sp" />
           <button type="button" class="ph-btn ghost" @click="refresh" :disabled="isLoading">
@@ -158,7 +159,12 @@
                   @dragleave="dragOverCol = ''"
                   @drop="onColumnDrop(col.key)"
                 >
-                  <div class="ph-colh"><span class="ph-cd" :style="{ background: col.color }" />{{ col.label }} <span class="ph-n">{{ col.items.length }}</span></div>
+                  <div class="ph-colh">
+                    <span class="ph-cd" :style="{ background: col.color }" />{{ col.label }} <span class="ph-n">{{ col.items.length }}</span>
+                    <span class="ph-sp" />
+                    <button type="button" class="ph-lane-action" :aria-label="`Customize ${col.label}`" @click="openLaneEditor(col.key)">Customize</button>
+                    <button type="button" class="ph-lane-action" :aria-label="`Assign workflow to ${col.label}`" @click="openLaneAssignment(col.key)">Automate</button>
+                  </div>
                   <div v-if="!col.items.length" class="ph-card ghost"><div class="ph-ct">Drop here</div></div>
                   <div
                     v-for="t in col.items"
@@ -232,6 +238,9 @@
                 </div>
               </div>
             </div>
+
+            <!-- LANE SETTINGS -->
+            <LaneSettings v-if="sel" v-show="tab === 'lanes'" ref="laneSettings" :project="sel" @refresh="refresh" />
           </template>
         </div>
       </section>
@@ -398,6 +407,7 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from 'vue';
 
+import LaneSettings from '@pkg/components/projects/LaneSettings.vue';
 import {
   useProjects,
   type ProjectView, type EpicWithTasks, type TaskView, type WorkTaskRecord, type WorkCommentRecord, type WorkActivityRecord,
@@ -412,10 +422,11 @@ const {
   lanesByProject, laneCapability,
 } = useProjects();
 
-const tab = ref<'today' | 'board' | 'activity' | 'projects'>('today');
+const tab = ref<'today' | 'board' | 'activity' | 'projects' | 'lanes'>('today');
 const saving = ref(false);
 const activity = ref<WorkActivityRecord[]>([]);
 const activityLoading = ref(false);
+const laneSettings = ref<InstanceType<typeof LaneSettings> | null>(null);
 
 const selectedLanes = computed(() => selectedId.value ? (lanesByProject.value[selectedId.value] ?? []) : []);
 const COMPATIBILITY_LANE_KEYS = ['backlog', 'todo', 'planning', 'in_progress', 'in_review', 'blocked', 'done', 'cancelled', 'parked'];
@@ -590,6 +601,19 @@ const boardColumns = computed(() => {
   }
   return columns;
 });
+
+function openLaneEditor(laneKey: string): void {
+  const lane = selectedLanes.value.find(item => item.lane_key === laneKey);
+  if (!lane) return;
+  tab.value = 'lanes';
+  laneSettings.value?.openEdit(lane);
+}
+
+function openLaneAssignment(laneKey: string): void {
+  const lane = selectedLanes.value.find(item => item.lane_key === laneKey);
+  if (!lane) return;
+  laneSettings.value?.openAssignment(lane);
+}
 
 // ══════════ DRAG TO REORDER ══════════
 // Native HTML5 DnD. A drag carries { kind, id, fromEpicId }; on drop we rebuild
@@ -1076,6 +1100,8 @@ async function confirmArchiveEpic(e: EpicWithTasks): Promise<void> {
 .ph-card[draggable="true"] { cursor: grab; }
 .ph-card[draggable="true"]:active { cursor: grabbing; }
 .ph-colh { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; font-size: 12px; font-weight: 600; color: var(--ptext2); }
+.ph-lane-action { border: 0; background: transparent; color: var(--ptext3); font: 9px var(--pmono); cursor: pointer; padding: 2px; text-transform: uppercase; }
+.ph-lane-action:hover, .ph-lane-action:focus-visible { color: var(--pacc); outline: none; }
 .ph-cd { width: 7px; height: 7px; border-radius: 50%; }
 .ph-n { font-family: var(--pmono); font-size: 11px; color: var(--ptext3); }
 .ph-card { background: var(--psurface); border: 1px solid var(--pborder-soft); border-radius: 10px; padding: 12px 13px; margin-bottom: 9px; cursor: pointer; }

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -451,6 +451,7 @@ export interface IpcMainInvokeEvents {
   'work-items:lane-create':     (input: import('@pkg/agent/database/models/WorkLaneDefinitionModel').CreateWorkLaneInput) => import('@pkg/agent/database/models/WorkLaneDefinitionModel').WorkLaneDefinitionRecord;
   'work-items:lane-update':     (id: string, changes: import('@pkg/agent/database/models/WorkLaneDefinitionModel').UpdateWorkLaneInput) => import('@pkg/agent/database/models/WorkLaneDefinitionModel').WorkLaneDefinitionRecord | null;
   'work-items:lane-archive':    (id: string, destinationLaneKey?: string) => import('@pkg/agent/database/models/WorkLaneDefinitionModel').ArchiveWorkLaneResult;
+  'work-items:lane-archive-preview': (id: string) => import('@pkg/agent/database/models/WorkLaneDefinitionModel').ArchiveWorkLanePreview;
   'work-items:lane-restore':    (id: string) => import('@pkg/agent/database/models/WorkLaneDefinitionModel').WorkLaneDefinitionRecord | null;
   'work-items:lanes-reorder':   (scope: import('@pkg/agent/database/models/WorkLaneDefinitionModel').WorkLaneScope, orderedKeys: string[], projectId?: string) => number;
   'work-items:lane-reset-override': (projectId: string, laneKey: string) => boolean;
@@ -458,6 +459,8 @@ export interface IpcMainInvokeEvents {
   'work-items:lane-binding-set': (input: import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel').SetLaneBindingInput) => import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel').LaneWorkflowBindingRecord;
   'work-items:lane-binding-remove': (id: string) => import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel').LaneWorkflowBindingRecord | null;
   'work-items:lane-workflow-resolve': (taskId: string, laneKey: string, profileId?: string) => import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel').LaneBindingResolution;
+  'work-items:lane-workflow-resolve-context': (input: import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel').ResolveLaneBindingContextInput) => import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel').LaneBindingResolution;
+  'work-items:lane-compatible-workflows': (projectId: string, laneKey: string) => import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel').CompatibleLaneWorkflow[];
   'work-items:lane-entry-automations': (taskId: string) => import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel').LaneEntryAutomationRecord[];
 
   // User-defined project catalog (scanned from ~/sulla/projects/ + DB)


### PR DESCRIPTION
HOLD — dependency gate not satisfied. Do not review or merge.

This draft preserves reversible implementation custody for #685, but it was cut from #690 before a superseding Projects comment was observed. #692 is actively repairing the same ProjectsHome/useProjects/workItemsEvents surfaces and remains in_progress at 7995856bb after a REPAIRABLE review.

Required before this PR can return to review:
1. #692 repair reaches a pushed clean head.
2. Independent exact-head acceptance returns PASS and x2Dd has no active repair lease.
3. Rebase/retarget this branch onto that accepted #692 head, reconcile overlap into its multi-view UI, and rerun the combined #686/#688/#690/#692/#685 regression and rendered accessibility/theme coverage.

Current preserved artifact:
- commit a42c8e29d on hb/Fvnz-lane-customization-ui
- base hb/axtD-semantic-lane-runtime (#690)
- 4 focused Jest suites / 20 tests passed
- changed-boundary ESLint, esbuild, Vue compile, and diff-check passed
- full tsc hit the known 4 GB OOM ceiling

No merge, rebuild, restart, migration execution, deployment, or live runtime mutation occurred.