### PR TITLE
fix(projects): restore renderer lane hydration contract

### DIFF
--- a/pkg/rancher-desktop/composables/__tests__/useProjects.spec.ts
+++ b/pkg/rancher-desktop/composables/__tests__/useProjects.spec.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+const invoke = jest.fn((_channel: string) => Promise.resolve({}));
+mockModules({ '@pkg/utils/ipcRenderer': { ipcRenderer: { invoke } } });
+
+const { useProjects } = await import('../useProjects');
+
+describe('useProjects board hydration', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+  });
+
+  it('hydrates the lane contract consumed during ProjectsHome setup', async() => {
+    const lane = {
+      id:                      'lane-done',
+      lane_key:                'finished',
+      scope:                   'project',
+      project_id:              'project-1',
+      base_lane_key:           null,
+      display_name:            'Finished',
+      description:             '',
+      color:                   null,
+      icon:                    null,
+      position:                1,
+      semantic_role:           'terminal',
+      enabled:                 true,
+      archived:                false,
+      system_required:         false,
+      created_by:              'human',
+      updated_by:              null,
+      created_at:              '2026-08-24T00:00:00.000Z',
+      updated_at:              null,
+      archived_at:             null,
+      reset_at:                null,
+      provenance:              'project_only',
+      inherited_definition_id: null,
+    };
+    const capability = { ready: true, catalogPresent: true, missingRoles: [], degradedReason: null };
+    invoke.mockResolvedValueOnce({
+      projects: [{ id: 'project-1', title: 'Project', status: 'working' }],
+      epics:    [{ id: 'epic-1', project_id: 'project-1', title: 'Epic', position: 0 }],
+      tasks:    [{
+        id:              'task-1',
+        project_id:      'project-1',
+        epic_id:         'epic-1',
+        parent_id:       null,
+        title:           'Task',
+        status:          'finished',
+        priority:        'high',
+        position:        0,
+        created_at:      '2026-08-24T00:00:00.000Z',
+        knowledge_count: 2,
+      }],
+      lanesByProject: { 'project-1': [lane] },
+      laneCapability: capability,
+    });
+
+    const state = useProjects();
+    await state.load();
+
+    expect(state.lanesByProject.value).toEqual({ 'project-1': [lane] });
+    expect(state.laneCapability.value).toEqual(capability);
+    expect(state.projects.value[0].epics[0].tasks[0]).toMatchObject({ lane, knowledge_count: 2 });
+    expect(state.projects.value[0]).toMatchObject({ openCount: 0, doneCount: 1 });
+  });
+
+  it('falls back to stable terminal keys when lane metadata is unavailable', async() => {
+    invoke.mockResolvedValueOnce({
+      projects: [{ id: 'project-1', title: 'Project', status: 'working' }],
+      epics:    [{ id: 'epic-1', project_id: 'project-1', title: 'Epic', position: 0 }],
+      tasks:    [{
+        id:         'task-1',
+        project_id: 'project-1',
+        epic_id:    'epic-1',
+        parent_id:  null,
+        title:      'Task',
+        status:     'parked',
+        priority:   'medium',
+        position:   0,
+        created_at: '2026-08-24T00:00:00.000Z',
+      }],
+    });
+
+    const state = useProjects();
+    await state.load();
+
+    expect(state.projects.value[0]).toMatchObject({ openCount: 0, doneCount: 1 });
+    expect(state.lanesByProject.value).toEqual({});
+    expect(state.laneCapability.value).toBeNull();
+  });
+});

--- a/pkg/rancher-desktop/composables/useProjects.ts
+++ b/pkg/rancher-desktop/composables/useProjects.ts
@@ -26,7 +26,7 @@ import type {
 } from '@pkg/agent/database/models/WorkItemsModel';
 import type {
   CreateWorkLaneInput, EffectiveWorkLane, ListWorkLaneOpts, UpdateWorkLaneInput,
-  ArchiveWorkLanePreview, WorkLaneDefinitionRecord, WorkLaneRuntimeCapability, WorkLaneScope,
+  ArchiveWorkLanePreview, WorkLaneDefinitionRecord, WorkLaneScope,
 } from '@pkg/agent/database/models/WorkLaneDefinitionModel';
 import type {
   CompatibleLaneWorkflow, LaneBindingResolution, LaneEntryAutomationRecord, LaneWorkflowBindingRecord,
@@ -48,9 +48,22 @@ export type {
   ProjectViewType, SaveProjectViewInput, WorkProjectViewRecord,
 };
 
+/** A task with its resolved lane attached, ready for every Projects projection. */
+export interface TaskView extends WorkTaskRecord {
+  lane?:            EffectiveWorkLane;
+  knowledge_count?: number;
+}
+
+export interface WorkLaneRuntimeCapability {
+  ready:          boolean;
+  catalogPresent: boolean;
+  missingRoles:   string[];
+  degradedReason: string | null;
+}
+
 /** An epic with its tasks attached, ready to render. */
 export interface EpicWithTasks extends WorkEpicRecord {
-  tasks:            (WorkTaskRecord & { knowledge_count?: number })[];
+  tasks:            TaskView[];
   knowledge_count?: number;
 }
 
@@ -79,6 +92,8 @@ export function useProjects() {
   const isLoading = ref(false);
   const error = ref<string | null>(null);
   const loaded = ref(false);
+  const lanesByProject = ref<Record<string, EffectiveWorkLane[]>>({});
+  const laneCapability = ref<WorkLaneRuntimeCapability | null>(null);
 
   /** currently selected project id (drives the one-project-at-a-time view) */
   const selectedId = ref<string | null>(null);
@@ -90,12 +105,16 @@ export function useProjects() {
     rawProjects: WorkProjectRecord[],
     rawEpics: WorkEpicRecord[],
     rawTasks: WorkTaskRecord[],
+    resolvedLanes: Record<string, EffectiveWorkLane[]> = {},
   ): ProjectView[] {
-    const tasksByEpic = new Map<string, WorkTaskRecord[]>();
+    const laneMaps = new Map(Object.entries(resolvedLanes).map(([projectId, lanes]) => [
+      projectId, new Map(lanes.map(lane => [lane.lane_key, lane])),
+    ]));
+    const tasksByEpic = new Map<string, TaskView[]>();
     for (const t of rawTasks) {
       const key = t.epic_id ?? '__none__';
       const arr = tasksByEpic.get(key) ?? [];
-      arr.push(t);
+      arr.push({ ...t, lane: laneMaps.get(t.project_id)?.get(t.status) });
       tasksByEpic.set(key, arr);
     }
     for (const arr of tasksByEpic.values()) {
@@ -129,8 +148,8 @@ export function useProjects() {
       let doneCount = 0;
       for (const e of epics) {
         for (const t of e.tasks) {
-          if (t.status === 'done') doneCount++;
-          else if (!CLOSED.has(t.status) || t.status === 'blocked') openCount++;
+          if (t.lane ? t.lane.semantic_role === 'terminal' : CLOSED.has(t.status)) doneCount++;
+          else openCount++;
         }
       }
 
@@ -143,7 +162,9 @@ export function useProjects() {
     error.value = null;
     try {
       const board = await ipcRenderer.invoke('work-items:board');
-      projects.value = buildTree(board.projects, board.epics, board.tasks);
+      lanesByProject.value = board.lanesByProject ?? {};
+      laneCapability.value = board.laneCapability ?? null;
+      projects.value = buildTree(board.projects, board.epics, board.tasks, lanesByProject.value);
       if (!selectedId.value && projects.value.length) {
         selectedId.value = projects.value[0].id;
       }
@@ -337,6 +358,8 @@ export function useProjects() {
     isLoading,
     error,
     loaded,
+    lanesByProject,
+    laneCapability,
     load,
     select,
     loadComments,


### PR DESCRIPTION
ProjectsHome destructures TaskView-backed lane state from useProjects, but the merged composable no longer exported TaskView, lanesByProject, or laneCapability. That makes the page fail during setup before its load/error state can render.

This restores the renderer contract, hydrates resolved lane metadata when present, preserves knowledge counts, and falls back to stable terminal keys if lane metadata is unavailable.

Validation:
- ProjectsHome + useProjects Jest: 2 suites, 11 tests passed
- touched-file ESLint: clean
- git diff --check: clean

Projects task: 6D89