### PR TITLE
fix: pin protected core routines to sulla-desktop

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -326,12 +326,6 @@ export class WorkTaskDispatchModel {
                 AND d.status IN ('failed', 'stale')
                 AND d.finished_at > now() - interval '5 minutes'
            )
-           AND COALESCE((
-             SELECT d.agent_id
-               FROM work_task_dispatches d
-              WHERE d.task_id = t.id AND d.kind = 'execution'
-              ORDER BY d.started_at DESC LIMIT 1
-           ), '') <> $3
          ORDER BY
            CASE p.priority
              WHEN 'critical' THEN 0 WHEN 'p0' THEN 0 WHEN 'P0' THEN 0 WHEN '🔴' THEN 0
@@ -359,7 +353,7 @@ export class WorkTaskDispatchModel {
            t.position ASC
          FOR UPDATE OF t SKIP LOCKED
          LIMIT 1
-      `, [CLOSED_EPIC_STATUSES, NON_AUTONOMOUS_TASK_LABELS, agentId]);
+      `, [CLOSED_EPIC_STATUSES, NON_AUTONOMOUS_TASK_LABELS]);
 
       const task = candidate.rows[0];
       if (!task) return null;

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
@@ -232,7 +232,7 @@ describe('WorkTaskDispatchModel', () => {
     expect(clientQuery.mock.calls[5][1]).toEqual(['task-new', 'dispatcher']);
   });
 
-  it('claims review work under the same cross-kind lease and excludes the execution agent', async() => {
+  it('claims review work under the same cross-kind lease even when the default profile executed the work', async() => {
     const task = { id: 'task-2', status: 'in_review', labels: [] } as any;
     const capability = {
       capability_key: 'in-review-verification', enabled: true, health: 'healthy',
@@ -270,8 +270,9 @@ describe('WorkTaskDispatchModel', () => {
     expect(query.mock.calls[0][0]).toContain("d.status = 'running'");
     expect(query.mock.calls[0][0]).toContain("d.status IN ('failed', 'stale')");
     expect(query.mock.calls[0][0]).toContain("interval '5 minutes'");
-    expect(query.mock.calls[0][0]).toContain("d.kind = 'execution'");
-    expect(query.mock.calls[0][0]).toContain("<> $3");
+    expect(query.mock.calls[0][0]).not.toContain("<> $3");
+    expect(query.mock.calls[0][1]).toEqual(expect.any(Array));
+    expect(query.mock.calls[0][1]).not.toContain('codex-test');
     expect(query.mock.calls[1][0]).toContain('lifecycle_capabilities');
     expect(query.mock.calls[3][0]).toContain('INSERT INTO work_task_stage_claims');
     expect(query.mock.calls[4][0]).toContain("'verification'");

--- a/pkg/rancher-desktop/agent/routines/core/__tests__/executeProjectTodo.test.ts
+++ b/pkg/rancher-desktop/agent/routines/core/__tests__/executeProjectTodo.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 
 import { createPlaybookState } from '../../../workflow/WorkflowPlaybook';
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../defaultCoreAgent';
 import { EXECUTE_PROJECT_TODO_DEFINITION, EXECUTE_PROJECT_TODO_ID } from '../executeProjectTodo';
+import { CORE_ROUTINES } from '../index';
 
 describe('Execute Projects Todo core routine', () => {
   it('is a connected locked-core-compatible graph with the complete custody lifecycle', () => {
@@ -27,7 +29,8 @@ describe('Execute Projects Todo core routine', () => {
   it('requires capability selection, independent inspection, #667 replan, and durable remote evidence', () => {
     const text = JSON.stringify(EXECUTE_PROJECT_TODO_DEFINITION);
 
-    expect(text).toContain('Choose 1-10 existing agent IDs based on their real capabilities');
+    expect(text).toContain(`every assignment must use agentId ${ DEFAULT_CORE_ROUTINE_AGENT_ID }`);
+    expect(text).toContain('Never select or name a custom agent profile');
     expect(text).toContain('You did not execute the work');
     expect(text).toContain('core-routine-plan-project-task');
     expect(text).toContain('remote draft PR');
@@ -37,5 +40,15 @@ describe('Execute Projects Todo core routine', () => {
     expect(text).toContain('Do not call any project write tool');
     expect(text).toContain('dispatcher controller will validate the originating task and live canonical artifact');
     expect(text).not.toContain('recorded=true');
+  });
+
+  it('pins every baked-in core routine agent node to the default Sulla Desktop profile', () => {
+    for (const routine of CORE_ROUTINES) {
+      const agentNodes = routine.nodes.filter((node: any) => node.data?.subtype === 'agent');
+      expect(agentNodes.length).toBeGreaterThan(0);
+      expect(agentNodes.every((node: any) =>
+        node.data.config.agentId === DEFAULT_CORE_ROUTINE_AGENT_ID,
+      )).toBe(true);
+    }
   });
 });

--- a/pkg/rancher-desktop/agent/routines/core/__tests__/planProjectTask.test.ts
+++ b/pkg/rancher-desktop/agent/routines/core/__tests__/planProjectTask.test.ts
@@ -6,6 +6,7 @@ import {
   createPlaybookState,
   processNextStep,
 } from '../../../workflow/WorkflowPlaybook';
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../defaultCoreAgent';
 import { PLAN_PROJECT_TASK_DEFINITION, PLAN_PROJECT_TASK_ID } from '../planProjectTask';
 
 import type { WorkflowDefinition } from '@pkg/pages/editor/workflow/types';
@@ -29,7 +30,9 @@ describe('locked Projects planning routine', () => {
     expect(nodes.get('node-plan-synthesis')?.data.subtype).toBe('agent');
     expect(nodes.get('node-plan-persist')?.data.subtype).toBe('agent');
     expect(nodes.get('node-plan-done')?.data.subtype).toBe('response');
-    expect(planners.every(id => nodes.get(id)?.data.config.agentId === 'opus-worker')).toBe(true);
+    expect(planners.every(id => nodes.get(id)?.data.config.agentId === DEFAULT_CORE_ROUTINE_AGENT_ID)).toBe(true);
+    expect(nodes.get('node-plan-synthesis')?.data.config.agentId).toBe(DEFAULT_CORE_ROUTINE_AGENT_ID);
+    expect(nodes.get('node-plan-persist')?.data.config.agentId).toBe(DEFAULT_CORE_ROUTINE_AGENT_ID);
 
     for (const plannerId of planners) {
       const prompt = String(nodes.get(plannerId)?.data.config.orchestratorInstructions);

--- a/pkg/rancher-desktop/agent/routines/core/__tests__/reviewProjectArtifact.test.ts
+++ b/pkg/rancher-desktop/agent/routines/core/__tests__/reviewProjectArtifact.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from '@jest/globals';
 
 import { validateWorkflowDefinition } from '../../../tools/workflow/validate_sulla_workflow';
 import { CORE_ROUTINES } from '../index';
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../defaultCoreAgent';
 import {
   REVIEW_PROJECT_ARTIFACT_DEFINITION,
   REVIEW_PROJECT_ARTIFACT_ID,
   ARTIFACT_VERIFICATION_ADAPTERS,
-  REVIEWER_AGENT_IDS,
   REVIEWER_NODE_IDS,
 } from '../reviewProjectArtifact';
 
@@ -17,12 +17,12 @@ describe('protected review core routine', () => {
     expect(REVIEW_PROJECT_ARTIFACT_DEFINITION.enabled).toBe(true);
     const nodes = REVIEW_PROJECT_ARTIFACT_DEFINITION.nodes;
     const reviewers = nodes.filter((node: any) => (REVIEWER_NODE_IDS as readonly string[]).includes(node.id));
-    expect(reviewers.map((node: any) => node.data.config.agentId)).toEqual(REVIEWER_AGENT_IDS);
-    expect(new Set(REVIEWER_AGENT_IDS).size).toBe(REVIEWER_AGENT_IDS.length);
+    expect(reviewers.every((node: any) => node.data.config.agentId === DEFAULT_CORE_ROUTINE_AGENT_ID)).toBe(true);
     expect(reviewers.every((node: any) => node.data.config.inheritParentToolPolicy === true)).toBe(true);
     expect(nodes.filter((node: any) => node.data.subtype === 'agent')
       .every((node: any) => node.data.config.inheritParentToolPolicy === true)).toBe(true);
-    expect(nodes.find((node: any) => node.id === 'node-review-synthesize')?.data.config.agentId).toBe('codex-test');
+    expect(nodes.find((node: any) => node.id === 'node-review-synthesize')?.data.config.agentId)
+      .toBe(DEFAULT_CORE_ROUTINE_AGENT_ID);
     expect(REVIEW_PROJECT_ARTIFACT_DEFINITION.edges.filter((edge: any) => edge.target === 'node-review-merge')).toHaveLength(3);
   });
 

--- a/pkg/rancher-desktop/agent/routines/core/defaultCoreAgent.ts
+++ b/pkg/rancher-desktop/agent/routines/core/defaultCoreAgent.ts
@@ -1,0 +1,7 @@
+/**
+ * Locked core routines always execute with the product's default Sulla Desktop
+ * profile. Role-specific behavior belongs in the workflow node's task prompt,
+ * never in a custom agent directory that can replace prompts or tool policy.
+ */
+export const DEFAULT_CORE_ROUTINE_AGENT_ID = 'sulla-desktop' as const;
+

--- a/pkg/rancher-desktop/agent/routines/core/dreamAboutHuman.ts
+++ b/pkg/rancher-desktop/agent/routines/core/dreamAboutHuman.ts
@@ -16,6 +16,8 @@
  * Runs nightly at 00:00 local (staggered ahead of the other per-domain dreamers).
  */
 
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from './defaultCoreAgent';
+
 export const DREAM_ABOUT_HUMAN_ID = 'core-routine-dream-about-human';
 
 /**
@@ -39,10 +41,10 @@ export const DREAM_ABOUT_HUMAN_DEFINITION: Record<string, any> = {
     'observations, synthesizes goals-over-time and personality/communication style, ' +
     'prunes what is stale or contradicted, and writes the consolidated profile into ' +
     'the `user` system-prompt section. Locked core routine — DB-only, no filesystem.',
-  version:   2,
+  version:   3,
   enabled:   true,
   createdAt: '2026-08-19T00:00:00.000Z',
-  updatedAt: '2026-08-19T00:00:00.000Z',
+  updatedAt: '2026-08-24T20:32:00.000Z',
 
   edges: [
     { id: 'e-dah-trigger-load',      source: 'node-dah-trigger',     target: 'node-dah-load',        animated: true },
@@ -112,7 +114,7 @@ export const DREAM_ABOUT_HUMAN_DEFINITION: Record<string, any> = {
         category: 'agent',
         subtype:  'agent',
         config: {
-          agentId:                  'thinker-worker',
+          agentId:                  DEFAULT_CORE_ROUTINE_AGENT_ID,
           agentName:                'Human Goals Horizon',
           additionalPrompt:         OBSERVE_ONLY,
           successCriteria:          'A concise goals-over-time snapshot for the human.',
@@ -136,7 +138,7 @@ export const DREAM_ABOUT_HUMAN_DEFINITION: Record<string, any> = {
         category: 'agent',
         subtype:  'agent',
         config: {
-          agentId:                  'thinker-worker',
+          agentId:                  DEFAULT_CORE_ROUTINE_AGENT_ID,
           agentName:                'Human Personality Reader',
           additionalPrompt:         OBSERVE_ONLY,
           successCriteria:          'A personality + how-to-work-with-them snapshot for the human.',
@@ -170,7 +172,7 @@ export const DREAM_ABOUT_HUMAN_DEFINITION: Record<string, any> = {
         category: 'agent',
         subtype:  'agent',
         config: {
-          agentId:                  'thinker-worker',
+          agentId:                  DEFAULT_CORE_ROUTINE_AGENT_ID,
           agentName:                'Human Observation Pruner',
           additionalPrompt:         OBSERVE_ONLY,
           successCriteria:          'Stale, duplicate, or contradicted human observations archived.',
@@ -194,7 +196,7 @@ export const DREAM_ABOUT_HUMAN_DEFINITION: Record<string, any> = {
         category: 'agent',
         subtype:  'agent',
         config: {
-          agentId:                  'thinker-worker',
+          agentId:                  DEFAULT_CORE_ROUTINE_AGENT_ID,
           agentName:                'Human Profile Synthesizer',
           additionalPrompt:         OBSERVE_ONLY,
           successCriteria:          'The `user` system-prompt section holds a fresh consolidated human profile.',

--- a/pkg/rancher-desktop/agent/routines/core/executeProjectTodo.ts
+++ b/pkg/rancher-desktop/agent/routines/core/executeProjectTodo.ts
@@ -9,6 +9,8 @@
  * the human's name.
  */
 
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from './defaultCoreAgent';
+
 export const EXECUTE_PROJECT_TODO_ID = 'core-routine-execute-project-todo';
 
 const SAFETY = [
@@ -29,7 +31,7 @@ const AGENT_NODE = (id: string, label: string, y: number, instructions: string, 
     category: 'agent',
     subtype:  'agent',
     config:   {
-      agentId:                  'opus-worker',
+      agentId:                  DEFAULT_CORE_ROUTINE_AGENT_ID,
       agentName:                label,
       additionalPrompt:         SAFETY,
       successCriteria:          success,
@@ -43,12 +45,12 @@ export const EXECUTE_PROJECT_TODO_DEFINITION: Record<string, any> = {
   id:          EXECUTE_PROJECT_TODO_ID,
   name:        'Execute Projects Todo',
   description: 'Locked core routine for atomic todo execution, capability-based worker fan-out, independent acceptance review, repair/replan routing, and durable artifact custody.',
-  version:     1,
+  version:     2,
   // Ship dark. The human enables the protected routine only after shadow and
   // low-risk acceptance passes; the legacy owner remains the default meanwhile.
   enabled:     false,
   createdAt:   '2026-08-23T19:00:00.000Z',
-  updatedAt:   '2026-08-23T19:00:00.000Z',
+  updatedAt:   '2026-08-24T20:32:00.000Z',
   nodes:       [
     {
       id:       'node-todo-trigger',
@@ -68,14 +70,14 @@ export const EXECUTE_PROJECT_TODO_DEFINITION: Record<string, any> = {
       'node-todo-classify',
       'Classify Work',
       140,
-      `${ SAFETY } Inspect the bounded Projects task snapshot and available configured agents. Classify it as coding/repository, research/analysis, marketing/content, operations/administration, design/media, data/spreadsheet, or mixed/decomposable. Choose 1-10 existing agent IDs based on their real capabilities. Split only independent work; record dependencies where ordering is required. Return JSON only with keys workType, selectedAgents (array of {agentId,reason,assignment,dependsOn}), expectedArtifacts, validation, forbiddenActions, and authoritativeDestination.`,
-      'A valid dispatch strategy names capability-matched agents, dependencies, artifacts, validation, gates, and destination.',
+      `${ SAFETY } Inspect the bounded Projects task snapshot. Classify it as coding/repository, research/analysis, marketing/content, operations/administration, design/media, data/spreadsheet, or mixed/decomposable. Choose 1-10 independent worker assignments based on the work itself; every assignment must use agentId ${ DEFAULT_CORE_ROUTINE_AGENT_ID } so role instructions cannot replace the default Sulla Desktop prompt or tools. Split only independent work; record dependencies where ordering is required. Return JSON only with keys workType, selectedAgents (array of {agentId,reason,assignment,dependsOn}), expectedArtifacts, validation, forbiddenActions, and authoritativeDestination.`,
+      'A valid dispatch strategy uses only the default Sulla Desktop agent profile and names dependencies, artifacts, validation, gates, and destination.',
     ),
     AGENT_NODE(
       'node-todo-workers',
       'Dynamic Worker Fan-out',
       300,
-      `${ SAFETY } Original claimed task: {{trigger}} Classifier decision: {{Classify Work}}. Use the Sulla agent catalog to launch every selected worker, up to 10, in parallel only when assignments are independent and sequentially when dependencies require it. Give each worker the original acceptance criteria, its exact assignment, validation evidence required, forbidden actions, and artifact destination. Wait for every worker, reconcile their results without hiding failures, and return JSON only with keys childIds, workers, combinedOutcome, artifacts, verification, and unresolved. Coding workers must use isolated worktrees and may stop only after commit + Sulla GitHub push + remote draft PR. Non-code workers may update the named non-Projects authoritative tracker and return its durable ID or URL. Neither this node nor its child workers may mutate the originating Projects task before controller finalization.`,
+      `${ SAFETY } Original claimed task: {{trigger}} Classifier decision: {{Classify Work}}. Launch every selected assignment as a separate ${ DEFAULT_CORE_ROUTINE_AGENT_ID } worker instance, up to 10, in parallel only when assignments are independent and sequentially when dependencies require it. Never select or name a custom agent profile. Give each worker the original acceptance criteria, its exact assignment, validation evidence required, forbidden actions, and artifact destination. Wait for every worker, reconcile their results without hiding failures, and return JSON only with keys childIds, workers, combinedOutcome, artifacts, verification, and unresolved. Coding workers must use isolated worktrees and may stop only after commit + Sulla GitHub push + remote draft PR. Non-code workers may update the named non-Projects authoritative tracker and return its durable ID or URL. Neither this node nor its child workers may mutate the originating Projects task before controller finalization.`,
       'All selected workers finish or report a concrete failure, with child IDs and durable artifact evidence retained.',
     ),
     AGENT_NODE(

--- a/pkg/rancher-desktop/agent/routines/core/index.ts
+++ b/pkg/rancher-desktop/agent/routines/core/index.ts
@@ -15,6 +15,7 @@ import { DREAM_ABOUT_HUMAN_DEFINITION } from './dreamAboutHuman';
 import { REVIEW_PROJECT_ARTIFACT_DEFINITION } from './reviewProjectArtifact';
 import { PLAN_PROJECT_TASK_DEFINITION } from './planProjectTask';
 import { EXECUTE_PROJECT_TODO_DEFINITION } from './executeProjectTodo';
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from './defaultCoreAgent';
 
 export const CORE_ROUTINES: readonly Record<string, any>[] = [
   DREAM_ABOUT_HUMAN_DEFINITION,
@@ -22,3 +23,14 @@ export const CORE_ROUTINES: readonly Record<string, any>[] = [
   PLAN_PROJECT_TASK_DEFINITION,
   EXECUTE_PROJECT_TODO_DEFINITION,
 ];
+
+for (const routine of CORE_ROUTINES) {
+  const customAgentNode = routine.nodes?.find((node: any) =>
+    node.data?.subtype === 'agent' && node.data?.config?.agentId !== DEFAULT_CORE_ROUTINE_AGENT_ID,
+  );
+  if (customAgentNode) {
+    throw new Error(
+      `Locked core routine ${ routine.id } node ${ customAgentNode.id } must use ${ DEFAULT_CORE_ROUTINE_AGENT_ID }`,
+    );
+  }
+}

--- a/pkg/rancher-desktop/agent/routines/core/planProjectTask.ts
+++ b/pkg/rancher-desktop/agent/routines/core/planProjectTask.ts
@@ -8,6 +8,7 @@
  */
 
 import { PROJECT_TASK_PLANNING_WORKFLOW_ID } from '../../database/models/WorkTaskPlanningRunModel';
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from './defaultCoreAgent';
 
 export const PLAN_PROJECT_TASK_ID = PROJECT_TASK_PLANNING_WORKFLOW_ID;
 
@@ -32,7 +33,7 @@ function plannerNode(
       category: 'agent',
       subtype:  'agent',
       config:   {
-        agentId:            'opus-worker',
+        agentId:            DEFAULT_CORE_ROUTINE_AGENT_ID,
         agentName:          label,
         additionalPrompt:   SAFETY,
         successCriteria:    'A grounded, executable planning recommendation with evidence, risks, verification, and exact gates.',
@@ -56,10 +57,10 @@ export const PLAN_PROJECT_TASK_DEFINITION: Record<string, any> = {
     'Automatically runs an independent three-planner council for a Projects task in blocked/planning, ' +
     'synthesizes one executable plan, persists it, and returns reversible work to the dispatcher. ' +
     'Locked core routine; visible and disable-able, but not editable, archivable, or deletable.',
-  version:   1,
+  version:   2,
   enabled:   true,
   createdAt: '2026-08-23T00:00:00.000Z',
-  updatedAt: '2026-08-23T00:00:00.000Z',
+  updatedAt: '2026-08-24T20:32:00.000Z',
 
   edges: [
     { id: 'e-plan-trigger-fanout', source: 'node-plan-trigger', target: 'node-plan-fanout', animated: true },
@@ -138,7 +139,7 @@ export const PLAN_PROJECT_TASK_DEFINITION: Record<string, any> = {
         category: 'agent',
         subtype:  'agent',
         config:   {
-          agentId:            'opus-worker',
+          agentId:            DEFAULT_CORE_ROUTINE_AGENT_ID,
           agentName:          'Independent Planning Synthesizer',
           additionalPrompt:   SAFETY,
           successCriteria:    'One evidence-grounded final plan with an explicit TODO or BLOCKED disposition.',
@@ -162,7 +163,7 @@ export const PLAN_PROJECT_TASK_DEFINITION: Record<string, any> = {
         category: 'agent',
         subtype:  'agent',
         config:   {
-          agentId:            'opus-worker',
+          agentId:            DEFAULT_CORE_ROUTINE_AGENT_ID,
           agentName:          'Planning Council Recordkeeper',
           additionalPrompt:   SAFETY,
           successCriteria:    'The final plan is appended once and the task is moved to the correct Projects lane.',

--- a/pkg/rancher-desktop/agent/routines/core/reviewProjectArtifact.ts
+++ b/pkg/rancher-desktop/agent/routines/core/reviewProjectArtifact.ts
@@ -7,18 +7,14 @@
  * evidence and state transition in one transaction.
  */
 
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from './defaultCoreAgent';
+
 export const REVIEW_PROJECT_ARTIFACT_ID = 'core-routine-review-project-artifact';
 
 export const REVIEWER_NODE_IDS = [
   'node-review-code',
   'node-review-deliverable',
   'node-review-risk',
-] as const;
-
-export const REVIEWER_AGENT_IDS = [
-  'code-researcher',
-  'thinking-worker',
-  'technical-architect',
 ] as const;
 
 export const ARTIFACT_VERIFICATION_ADAPTERS = {
@@ -41,7 +37,6 @@ const READ_ONLY = [
 const reviewerNode = (
   id: string,
   label: string,
-  agentId: string,
   x: number,
   instructions: string,
 ) => ({
@@ -53,7 +48,7 @@ const reviewerNode = (
     category: 'agent',
     subtype:  'agent',
     config:   {
-      agentId,
+      agentId:                  DEFAULT_CORE_ROUTINE_AGENT_ID,
       agentName:                label,
       additionalPrompt:         READ_ONLY,
       inheritParentToolPolicy:  true,
@@ -68,10 +63,10 @@ export const REVIEW_PROJECT_ARTIFACT_DEFINITION: Record<string, any> = {
   id:          REVIEW_PROJECT_ARTIFACT_ID,
   name:        'Review Projects Artifact',
   description: 'Locked core routine that owns in_review: generation-safe claims, independent artifact-aware review, one synthesized verdict, durable evidence, and deterministic disposition.',
-  version:     1,
+  version:     2,
   enabled:     true,
   createdAt:   '2026-08-23T19:30:00.000Z',
-  updatedAt:   '2026-08-23T19:30:00.000Z',
+  updatedAt:   '2026-08-24T20:32:00.000Z',
   nodes:       [
     {
       id:       'node-review-trigger',
@@ -96,7 +91,7 @@ export const REVIEW_PROJECT_ARTIFACT_DEFINITION: Record<string, any> = {
         category: 'agent',
         subtype:  'agent',
         config:   {
-          agentId:                  'codex-test',
+          agentId:                  DEFAULT_CORE_ROUTINE_AGENT_ID,
           agentName:                'Review Classifier',
           additionalPrompt:         READ_ONLY,
           inheritParentToolPolicy:  true,
@@ -120,21 +115,18 @@ export const REVIEW_PROJECT_ARTIFACT_DEFINITION: Record<string, any> = {
     reviewerNode(
       'node-review-code',
       'Code and PR Reviewer',
-      'code-researcher',
       160,
       'For code or mixed work, inspect the remote PR state, draft flag, base, exact head SHA, diff, commits, callers and consumers, focused test/typecheck/lint/build evidence, migrations, backward compatibility, unrelated changes, and tenant/security boundaries. Re-resolve the remote head before returning. For non-code work, mark this lens not applicable.',
     ),
     reviewerNode(
       'node-review-deliverable',
       'Authoritative Deliverable Reviewer',
-      'thinking-worker',
       500,
       'For documentation, research, marketing, data, design, operations, or mixed work, open the authoritative artifact and verify readability, completeness, stable identity, provenance, and every acceptance criterion. Never treat unpublished outbound work as sent. For pure code work, still verify PR description and Projects custody, then limit findings to that lens.',
     ),
     reviewerNode(
       'node-review-risk',
       'Regression and Authority Reviewer',
-      'technical-architect',
       840,
       'Independently challenge the plan and artifact for missed consumers, hidden coupling, security/privacy/tenant boundaries, destructive behavior, authority violations, rollout/rollback gaps, and tests that do not prove the claim. Distinguish reversible defects, wrong-plan failures, genuine external waits, and irreversible human-only gates.',
     ),
@@ -158,7 +150,7 @@ export const REVIEW_PROJECT_ARTIFACT_DEFINITION: Record<string, any> = {
         category: 'agent',
         subtype:  'agent',
         config:   {
-          agentId:                  'codex-test',
+          agentId:                  DEFAULT_CORE_ROUTINE_AGENT_ID,
           agentName:                'Review Verdict Synthesizer',
           additionalPrompt:         READ_ONLY,
           inheritParentToolPolicy:  true,

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -6,7 +6,6 @@ import { GraphRegistry } from './GraphRegistry';
 import { isInsideWindow } from './HeartbeatService';
 import { LifecycleCapabilityModel } from '../database/models/LifecycleCapabilityModel';
 import { getIntegrationService } from './IntegrationService';
-import { isKnowledgeAssociationAgentId } from './KnowledgeAssociationPolicies';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { WorkItemsModel, type WorkTaskRecord } from '../database/models/WorkItemsModel';
 import {
@@ -23,20 +22,16 @@ import {
   REVIEW_PROJECT_ARTIFACT_DEFINITION,
   REVIEW_PROJECT_ARTIFACT_ID,
   ARTIFACT_VERIFICATION_ADAPTERS,
-  REVIEWER_AGENT_IDS,
-  REVIEWER_NODE_IDS,
 } from '../routines/core/reviewProjectArtifact';
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../routines/core/defaultCoreAgent';
 import { extractAgentTurnOutcome } from '../tools/agents/agentTurnOutcome';
 import { toolRegistry } from '../tools/registry';
-import { findAgentDir } from '../utils/sullaPaths';
 import { createPlaybookState } from '../workflow/WorkflowPlaybook';
 
 const CHECK_INTERVAL_MS = 60_000;
 const LEASE_HEARTBEAT_MS = 120_000;
 const DEFAULT_CONCURRENCY = 3;
-const DEFAULT_AGENT_ID = 'opus-worker';
 const RUNTIME_INSTANCE_ID = `task-dispatcher-${ process.pid }-${ Date.now() }`;
-const DEFAULT_VERIFIER_AGENT_ID = 'codex-test';
 const DEFAULT_VERIFIER_TIMEOUT_MINUTES = 45;
 const DEFAULT_IN_PROGRESS_STALE_MINUTES = 360;
 const DEFAULT_RECOVERY_BATCH_SIZE = 1;
@@ -226,20 +221,7 @@ export class TaskDispatcherService {
   private async fillExecutionPool(): Promise<void> {
     const configured = Number(await SullaSettingsModel.get('taskDispatcherConcurrency', DEFAULT_CONCURRENCY));
     const concurrency = Math.max(1, Math.min(10, configured || DEFAULT_CONCURRENCY));
-    const agentId = String(await SullaSettingsModel.get('taskDispatcherAgentId', DEFAULT_AGENT_ID)).trim() || DEFAULT_AGENT_ID;
-    if (!findAgentDir(agentId) && !isKnowledgeAssociationAgentId(agentId)) {
-      console.error(`[TaskDispatcher] Agent config "${ agentId }" does not exist; execution paused`);
-      await LifecycleCapabilityModel.report({
-        key:               'todo-execution',
-        enabled:           true,
-        health:            'degraded',
-        owner:             'dispatcher',
-        runtimeInstanceId: RUNTIME_INSTANCE_ID,
-        fallbackMode:      'heartbeat',
-        error:             `Agent config ${ agentId } does not exist.`,
-      });
-      return;
-    }
+    const agentId = DEFAULT_CORE_ROUTINE_AGENT_ID;
 
     await LifecycleCapabilityModel.report({
       key:               'todo-execution',
@@ -276,20 +258,7 @@ export class TaskDispatcherService {
     if (!owner) return;
     const configured = Number(await SullaSettingsModel.get('taskVerifierConcurrency', DEFAULT_CONCURRENCY));
     const concurrency = Math.max(1, Math.min(10, configured || DEFAULT_CONCURRENCY));
-    const agentId = String(await SullaSettingsModel.get('taskVerifierAgentId', DEFAULT_VERIFIER_AGENT_ID)).trim() || DEFAULT_VERIFIER_AGENT_ID;
-    if (!findAgentDir(agentId)) {
-      console.error(`[TaskDispatcher] Agent config "${ agentId }" does not exist; verification paused`);
-      await LifecycleCapabilityModel.report({
-        key:               'in-review-verification',
-        enabled:           true,
-        health:            'degraded',
-        owner:             'dispatcher',
-        runtimeInstanceId: RUNTIME_INSTANCE_ID,
-        fallbackMode:      'heartbeat',
-        error:             `Agent config ${ agentId } does not exist.`,
-      });
-      return;
-    }
+    const agentId = DEFAULT_CORE_ROUTINE_AGENT_ID;
 
     await LifecycleCapabilityModel.report({
       key:               'in-review-verification',
@@ -304,7 +273,7 @@ export class TaskDispatcherService {
     while (freeSlots > 0 && this.initialized) {
       const claim = await WorkTaskDispatchModel.claimNextReview(
         agentId,
-        owner === 'core-routine' ? [...REVIEWER_AGENT_IDS] : [],
+        owner === 'core-routine' ? [DEFAULT_CORE_ROUTINE_AGENT_ID] : [],
         RUNTIME_INSTANCE_ID,
       );
       if (!claim) break;
@@ -358,11 +327,10 @@ export class TaskDispatcherService {
         const binding = await WorkTaskDispatchModel.bindReviewGeneration(dispatch.id, claimedArtifacts);
         if (binding.suppressed) return;
         excludedAgentIds = binding.excludedAgentIds;
-        selectedReviewerAgentIds = REVIEWER_AGENT_IDS.filter(id => !excludedAgentIds.includes(id));
-        if (selectedReviewerAgentIds.length === 0) {
-          await WorkTaskDispatchModel.failVerification(dispatch.id, 'no_independent_reviewer_available');
-          return;
-        }
+        // Review independence comes from separate workflow-node executions and
+        // threads. Agent profile identity is deliberately the same default
+        // Sulla Desktop profile for workers, reviewers, and synthesizers.
+        selectedReviewerAgentIds = [DEFAULT_CORE_ROUTINE_AGENT_ID];
         generationHash = binding.generationHash;
       }
 
@@ -383,8 +351,7 @@ export class TaskDispatcherService {
         state.metadata.allowedToolNames = verifierTools;
         state.metadata.verifierReadOnly = true;
         if (verificationOwner === 'core-routine') {
-          const definition = this.buildReviewDefinition(excludedAgentIds);
-          const playbook = createPlaybookState(definition as any, reviewPrompt);
+          const playbook = createPlaybookState(REVIEW_PROJECT_ARTIFACT_DEFINITION as any, reviewPrompt);
           state.metadata.activeWorkflow = playbook;
           state.metadata.verificationAdapters = ARTIFACT_VERIFICATION_ADAPTERS;
           await WorkTaskDispatchModel.recordReviewLaunch(dispatch.id, playbook.executionId, selectedReviewerAgentIds);
@@ -604,20 +571,6 @@ export class TaskDispatcherService {
     };
   }
 
-  private buildReviewDefinition(excludedAgentIds: string[]): Record<string, any> {
-    const definition = JSON.parse(JSON.stringify(REVIEW_PROJECT_ARTIFACT_DEFINITION));
-    if (excludedAgentIds.length === 0) return definition;
-    const excluded = new Set(
-      definition.nodes
-        .filter((node: any) => (REVIEWER_NODE_IDS as readonly string[]).includes(node.id) && excludedAgentIds.includes(node.data?.config?.agentId))
-        .map((node: any) => node.id),
-    );
-    if (excluded.size === 0) return definition;
-    definition.nodes = definition.nodes.filter((node: any) => !excluded.has(node.id));
-    definition.edges = definition.edges.filter((edge: any) => !excluded.has(edge.source) && !excluded.has(edge.target));
-    return definition;
-  }
-
   private async finalizeClaim(
     claim: ClaimedDispatch,
     status: 'completed' | 'blocked' | 'failed',
@@ -746,7 +699,7 @@ ${ JSON.stringify(dispatch.origin_evidence ?? {}) }
 Artifact hint: ${ task.github_issue ?? '(resolve from custody evidence)' }
 Bound review generation: ${ generationHash }
 Structured artifact components: ${ JSON.stringify(artifacts) }
-Durably excluded worker/custodian identities: ${ JSON.stringify(excludedAgentIds) }
+Producer/custodian profile identities (audit only; reviewer independence is enforced by separate workflow node executions): ${ JSON.stringify(excludedAgentIds) }
 Read-only adapter catalog: ${ JSON.stringify(ARTIFACT_VERIFICATION_ADAPTERS) }
 
 Acceptance contract:

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -29,7 +29,6 @@ const resolvePullRequestHeadsMock: any = jest.fn();
 const bindReviewGenerationMock: any = jest.fn();
 const generationHashMock: any = jest.fn(() => 'f'.repeat(64));
 const workflowFindByIdMock: any = jest.fn(() => Promise.resolve({ attributesSnapshot: { enabled: true } }));
-const findAgentDirMock: any = jest.fn(() => '/agents/opus-worker');
 
 jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
   SullaSettingsModel: { get: settingsGetMock },
@@ -86,9 +85,6 @@ jest.unstable_mockModule('../GitHubPullRequestHeadService', () => ({
   resolvePullRequestHead:  resolvePullRequestHeadMock,
   resolvePullRequestHeads: resolvePullRequestHeadsMock,
 }));
-jest.unstable_mockModule('../../utils/sullaPaths', () => ({
-  findAgentDir: findAgentDirMock,
-}));
 jest.unstable_mockModule('../../tools/registry', () => ({
   toolRegistry: {
     convertToolToLLM: jest.fn((name: string) => Promise.resolve({
@@ -116,7 +112,6 @@ describe('TaskDispatcherService', () => {
     bindReviewGenerationMock.mockResolvedValue({
       generationHash: 'f'.repeat(64), excludedAgentIds: ['technical-architect'], suppressed: false,
     });
-    findAgentDirMock.mockReturnValue('/agents/opus-worker');
     settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
       if (key === 'heartbeatEnabled') return Promise.resolve(true);
       if (key === 'taskVerifierOwner') return Promise.resolve('legacy');
@@ -225,8 +220,7 @@ describe('TaskDispatcherService', () => {
       .toBeLessThan(countRunningMock.mock.invocationCallOrder[0]);
   });
 
-  it('dispatches canonical Knowledge/Projects role actors without a filesystem persona', async() => {
-    findAgentDirMock.mockReturnValue(null);
+  it('ignores custom dispatcher profile settings and pins work to sulla-desktop', async() => {
     settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
       if (key === 'heartbeatEnabled') return Promise.resolve(true);
       if (key === 'taskDispatcherAgentId') return Promise.resolve('project-reader');
@@ -238,7 +232,7 @@ describe('TaskDispatcherService', () => {
     await service.initialize();
     service.destroy();
 
-    expect(claimNextMock).toHaveBeenCalledWith('project-reader');
+    expect(claimNextMock).toHaveBeenCalledWith('sulla-desktop', expect.stringContaining('task-dispatcher-'));
   });
 
   it('claims mechanically, executes the assigned worker, and returns completed work for review', async() => {
@@ -252,7 +246,7 @@ describe('TaskDispatcherService', () => {
         priority:    'high',
       },
       dispatch: {
-        id: 'dispatch-1', task_id: 'task-1', agent_id: 'opus-worker', thread_id: 'thread-1',
+        id: 'dispatch-1', task_id: 'task-1', agent_id: 'sulla-desktop', thread_id: 'thread-1',
       },
       stage_claim: { id: 'stage-claim-1' },
     };
@@ -271,7 +265,7 @@ describe('TaskDispatcherService', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
     service.destroy();
 
-    expect(claimNextMock).toHaveBeenCalledWith('opus-worker', expect.stringContaining('task-dispatcher-'));
+    expect(claimNextMock).toHaveBeenCalledWith('sulla-desktop', expect.stringContaining('task-dispatcher-'));
     expect(executeMock).toHaveBeenCalled();
     expect(settleMock).toHaveBeenCalledWith(
       'dispatch-1', 'completed', 'Draft PR opened and tests passed.', undefined,
@@ -315,7 +309,7 @@ describe('TaskDispatcherService', () => {
       dispatch: {
         id:        `verify-${ i }`,
         task_id:   `task-${ i }`,
-        agent_id:  'codex-test',
+        agent_id:  'sulla-desktop',
         thread_id: `verify-thread-${ i }`,
         kind:      'verification',
         attempt:   1,
@@ -347,7 +341,7 @@ describe('TaskDispatcherService', () => {
     service.destroy();
 
     expect(claimNextReviewMock).toHaveBeenCalledTimes(4);
-    expect(claimNextReviewMock).toHaveBeenCalledWith('codex-test', [], expect.stringContaining('task-dispatcher-'));
+    expect(claimNextReviewMock).toHaveBeenCalledWith('sulla-desktop', [], expect.stringContaining('task-dispatcher-'));
     expect(executeMock).toHaveBeenCalledTimes(3);
     expect(finalizeVerificationMock).toHaveBeenCalledTimes(3);
     expect(finalizeVerificationMock).toHaveBeenCalledWith(
@@ -380,7 +374,7 @@ describe('TaskDispatcherService', () => {
         dispatch: {
           id:        'verify-5',
           task_id:   'task-5',
-          agent_id:  'codex-test',
+          agent_id:  'sulla-desktop',
           thread_id: 'v5',
           kind:      'verification',
           attempt:   1,
@@ -416,7 +410,7 @@ describe('TaskDispatcherService', () => {
     expect(finalizeVerificationMock).not.toHaveBeenCalled();
   });
 
-  it('runs the locked review council, excludes the execution worker, and settles one synthesized verdict', async() => {
+  it('runs separate default-profile reviewer executions and settles one synthesized verdict', async() => {
     const hash = 'd'.repeat(40);
     claimNextReviewMock
       .mockResolvedValueOnce({
@@ -432,11 +426,11 @@ describe('TaskDispatcherService', () => {
         dispatch: {
           id:              'verify-core',
           task_id:         'task-core',
-          agent_id:        'codex-test',
+          agent_id:        'sulla-desktop',
           thread_id:       'core-thread',
           kind:            'verification',
           attempt:         1,
-          origin_agent_id: 'technical-architect',
+          origin_agent_id: 'sulla-desktop',
         },
         stage_claim: { id: 'review-stage-core' },
       })
@@ -492,17 +486,17 @@ describe('TaskDispatcherService', () => {
     service.destroy();
 
     expect(recordReviewLaunchMock).toHaveBeenCalledWith(
-      'verify-core', expect.stringMatching(/^wfp-/), ['code-researcher', 'thinking-worker'],
+      'verify-core', expect.stringMatching(/^wfp-/), ['sulla-desktop'],
     );
     const state = executeMock.mock.calls[0][0];
-    expect(state.metadata.activeWorkflow.definition.nodes.some(
-      (node: any) => node.data?.config?.agentId === 'technical-architect',
-    )).toBe(false);
+    expect(state.metadata.activeWorkflow.definition.nodes
+      .filter((node: any) => node.data?.subtype === 'agent')
+      .every((node: any) => node.data?.config?.agentId === 'sulla-desktop')).toBe(true);
     expect(state.metadata.verifierReadOnly).toBe(true);
     expect(finalizeProtectedReviewMock).toHaveBeenCalledWith(
       'verify-core', 'PASS', expect.objectContaining({
         workflowExecutionId: 'wfp-review-1',
-        reviewerAgentIds:    ['code-researcher', 'thinking-worker'],
+        reviewerAgentIds:    ['sulla-desktop'],
         artifactHash:        hash,
       }), expect.any(Array),
     );
@@ -555,7 +549,7 @@ describe('TaskDispatcherService', () => {
     claimNextReviewMock
       .mockResolvedValueOnce({
         task:     { id: 'task-4', title: 'Review', description: '', project_id: 'p', epic_id: 'e', priority: 'p0' },
-        dispatch: { id: 'verify-4', task_id: 'task-4', agent_id: 'codex-test', thread_id: 'v4', kind: 'verification', attempt: 1 },
+        dispatch: { id: 'verify-4', task_id: 'task-4', agent_id: 'sulla-desktop', thread_id: 'v4', kind: 'verification', attempt: 1 },
         stage_claim: { id: 'review-stage-4' },
       })
       .mockResolvedValue(null);


### PR DESCRIPTION
## Outcome

Pins every baked-in core routine agent node and both Projects dispatcher entry points to the default `sulla-desktop` profile. Custom agents remain fully supported for user-created agents and editable workflows.

## What changed

- added one shared `DEFAULT_CORE_ROUTINE_AGENT_ID` source constant
- migrated Dreaming About My Human, planning, todo execution, and protected review definitions off hard-coded custom profiles
- forced dynamic todo fan-out assignments to launch separate `sulla-desktop` instances
- removed dispatcher/verifier setting overrides that could select custom profiles for core lifecycle work
- preserved review independence through distinct workflow-node executions/threads instead of distinct custom personas
- added a boot-time production invariant rejecting any future custom profile in `CORE_ROUTINES`
- removed the same-profile review claim exclusion that would deadlock `sulla-desktop` execution followed by `sulla-desktop` review

## Validation

- TaskDispatcherService: 17/17 passed with normal Jest type diagnostics
- core routine suites: passed under the existing ts-jest transpile path
- same-profile WorkTaskDispatch review claim regression: passed
- TypeScript transpile syntax check: 13 changed source/test files clean
- `git diff --check`: clean
- source scan: no banned custom agent IDs remain in core routine/dispatcher production source

## Existing main blocker

The broader normal Jest run reaches unrelated merged semantic-lane consumers whose `WorkLaneDefinitionModel` methods are absent on current main (`runtimeCapability`, `resolveStatus`, `validateTaskStatus`, etc.). This branch does not modify or mask that separate main defect.

Projects task: SVUz
Commit: bc8641fee