### PR TITLE
feat(ai-employees): org AI employee marketplace domain + activation UX (xF3S)

### DIFF
--- a/docs/feature-requests/org-ai-employee-marketplace.md
+++ b/docs/feature-requests/org-ai-employee-marketplace.md
@@ -1,0 +1,108 @@
+# Organization AI Employee Marketplace & Activation UX
+
+Projects task: **xF3S** (project zHuT / epic m5rT). Status: domain foundation landed;
+renderer UI specified below as the immediate follow-up.
+
+## Goal
+
+Let an organization **browse the AI employees it can hire/activate**, understand what each
+one does, see its **subscription requirement**, **activate** eligible employees, and
+**manage currently active** employees — mirroring the app's existing integration and
+routines-marketplace patterns.
+
+## What shipped in this PR (verified)
+
+Pure, framework-free domain module under `pkg/rancher-desktop/agent/aiEmployees/`:
+
+- `types.ts` — `AiEmployee`, `AiEmployeeActivation`, `SubscriptionTier`
+  (`free` | `premium_support` | `enterprise_gateway`, per `cloud/overview.md`),
+  `ActivationGateReason`, and the view models `AiEmployeeCardView` /
+  `ActiveAiEmployeeView` / `AiEmployeeMarketplaceView`.
+- `catalog.ts` — initial roster of 8 roles keyed by id (Executive Assistant,
+  Customer Support Agent, Bookkeeper, Data Analyst, Sales Development Rep,
+  Marketing Manager, Recruiter, and a coming-soon IT Helpdesk), each with
+  capabilities, example tasks, referenced integrations, and a `requiredTier`.
+- `index.ts` — pure selectors/reducers: `listAiEmployees`, `getAiEmployee`,
+  `listCategories`, `meetsTier`, `activationGate`, `canActivate`,
+  `activateEmployee` (idempotent), `deactivateEmployee` (idempotent), and
+  `buildMarketplaceView` (the single view model the UI renders).
+- `__tests__/aiEmployees.test.ts` — 11 tests covering catalog integrity, tier
+  eligibility, gating precedence (already-active > coming-soon > upgrade),
+  reducer idempotency, and the marketplace-view split.
+
+Verification: `tsc -p tsconfig.agent-check.json` (scoped) → 0 errors; jest → 11/11 pass.
+
+The activation gate has a deliberate precedence: **already-active > coming-soon >
+requires-upgrade**, so an already-hired employee never shows an upsell.
+
+## Follow-up: renderer UI (Vue)
+
+Model the UI on the existing routines marketplace
+(`components/routines/MarketplaceTab.vue` / `MarketplaceDetail.vue` /
+`MarketplaceStrip.vue`, driven by `composables/useMarketplace.ts`) and the agent
+integration pages (`pages/AgentIntegrations.vue` / `AgentIntegrationDetail.vue`).
+
+### Composable — `composables/useAiEmployees.ts`
+
+Reactive wrapper over the domain module and an IPC-backed activation store:
+
+- state: `currentTier`, `activations`, derived `view = buildMarketplaceView({ currentTier, activations })`.
+- actions: `activate(id)`, `deactivate(id)`, `pause(id)` — each calls `canActivate`
+  first, invokes the main-process handler, then updates local state optimistically
+  with rollback on error.
+- getters: `available`, `active`, `categories`, `byCategory(cat)`.
+
+### IPC contract — `typings/electron-ipc.d.ts`
+
+- `ai-employees/list` → `AiEmployee[]` (from `listAiEmployees()`).
+- `ai-employees/activations` → `AiEmployeeActivation[]` (persisted).
+- `ai-employees/activate` `{ id }` → `AiEmployeeActivation` (server re-checks
+  `canActivate` against the account's real tier — never trust the renderer).
+- `ai-employees/deactivate` `{ id }` → `{ ok: true }`.
+
+Persist activations next to existing account/subscription state; resolve
+`currentTier` from the real Sulla Cloud subscription (see `components/account/SullaCloudCard.vue`).
+
+### Components / pages
+
+- `pages/AiEmployeesHome.vue` — top-level page. Header + search + category filter;
+  a **"Active" section** (manage panel) above the **browse grid**. Register in the
+  app router/nav next to Routines/Projects (`pages/agent/AgentRouter.vue`).
+- `components/aiEmployees/AiEmployeeCard.vue` — one `AiEmployeeCardView`. Shows
+  name/role/category, a tier badge, and a primary action derived from `gate`:
+  - `gate === null` → **Activate**
+  - `already_active` → **Manage** (or Active pill)
+  - `coming_soon` → disabled **Coming soon**
+  - `requires_upgrade` → **Upgrade to {tier}** linking to the subscription flow.
+- `components/aiEmployees/AiEmployeeDetail.vue` — full description, capabilities,
+  example tasks, integrations used, subscription requirement, and the same
+  gate-driven action.
+- `components/aiEmployees/ActiveEmployeeStrip.vue` — a row in the Active section
+  with pause/release controls and activation metadata.
+
+### States to handle
+
+Empty catalog; empty active list (onboarding nudge); activation in-flight
+(spinner + disabled action); activation error (toast + rollback); tier upgrade
+required (route to subscription); coming-soon (non-interactive).
+
+### i18n
+
+Add keys under `assets/translations/en-us.yaml` (and `zh-hans.yaml`) namespaced
+`aiEmployees.*`, following the existing marketplace/integration key style.
+
+## Acceptance criteria → mapping
+
+1. Browse AI employees → `listAiEmployees()` / grid of `AiEmployeeCard`.
+2. Understand what each does → `AiEmployeeDetail` (description, capabilities, example tasks).
+3. See subscription requirements → `requiredTier` badge + `requires_upgrade` gate.
+4. Activate eligible employees → `canActivate` + `ai-employees/activate` + `activateEmployee`.
+5. Manage active employees → Active section from `buildMarketplaceView().active` + deactivate/pause.
+
+## Notes / decisions
+
+- Renderer UI is deferred to this follow-up because it could not be iterated and
+  build-verified within the current worker environment; the domain layer it binds
+  to is landed, typechecked, and unit-tested so the UI is a thin, testable shell.
+- Subscription tiers are intentionally limited to those documented in
+  `cloud/overview.md`; do not invent tiers or pricing.

--- a/pkg/rancher-desktop/agent/aiEmployees/__tests__/aiEmployees.test.ts
+++ b/pkg/rancher-desktop/agent/aiEmployees/__tests__/aiEmployees.test.ts
@@ -1,0 +1,136 @@
+/** @jest-environment node */
+import { describe, expect, it } from '@jest/globals';
+
+import {
+  activateEmployee,
+  activationGate,
+  buildMarketplaceView,
+  canActivate,
+  deactivateEmployee,
+  listAiEmployees,
+  listCategories,
+  meetsTier,
+} from '../index';
+import type { AiEmployee, AiEmployeeActivation } from '../types';
+
+const NOW = '2026-08-24T00:00:00.000Z';
+
+function freeEmployee(): AiEmployee {
+  const found = listAiEmployees().find(e => e.requiredTier === 'free' && !e.comingSoon);
+
+  if (!found) {
+    throw new Error('expected at least one free, activatable employee in the catalog');
+  }
+
+  return found;
+}
+
+function gatedEmployee(): AiEmployee {
+  const found = listAiEmployees().find(e => e.requiredTier === 'enterprise_gateway' && !e.comingSoon);
+
+  if (!found) {
+    throw new Error('expected at least one enterprise-gated employee in the catalog');
+  }
+
+  return found;
+}
+
+describe('aiEmployees catalog', () => {
+  it('exposes a non-empty catalog with unique ids and required fields', () => {
+    const all = listAiEmployees();
+
+    expect(all.length).toBeGreaterThan(0);
+    const ids = all.map(e => e.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const e of all) {
+      expect(e.name).toBeTruthy();
+      expect(e.capabilities.length).toBeGreaterThan(0);
+      expect(['free', 'premium_support', 'enterprise_gateway']).toContain(e.requiredTier);
+    }
+  });
+
+  it('derives categories from the catalog', () => {
+    expect(listCategories().length).toBeGreaterThan(0);
+  });
+});
+
+describe('tier eligibility', () => {
+  it('higher tiers satisfy lower requirements', () => {
+    expect(meetsTier('free', 'enterprise_gateway')).toBe(true);
+    expect(meetsTier('enterprise_gateway', 'free')).toBe(false);
+    expect(meetsTier('premium_support', 'premium_support')).toBe(true);
+  });
+});
+
+describe('activation gating', () => {
+  it('allows a free employee on the free tier', () => {
+    const e = freeEmployee();
+
+    expect(activationGate(e, 'free', [])).toBeNull();
+    expect(canActivate(e, 'free', [])).toBe(true);
+  });
+
+  it('gates a paid employee behind an upgrade on the free tier', () => {
+    const e = gatedEmployee();
+
+    expect(activationGate(e, 'free', [])).toEqual({ kind: 'requires_upgrade', requiredTier: 'enterprise_gateway' });
+    expect(canActivate(e, 'free', [])).toBe(false);
+  });
+
+  it('reports coming-soon employees as gated even on the top tier', () => {
+    const comingSoon = listAiEmployees().find(e => e.comingSoon);
+
+    if (comingSoon) {
+      expect(activationGate(comingSoon, 'enterprise_gateway', [])).toEqual({ kind: 'coming_soon' });
+    }
+  });
+});
+
+describe('activation reducers', () => {
+  it('activates and is idempotent', () => {
+    const e = freeEmployee();
+    const once = activateEmployee([], e.id, { at: NOW, by: 'human' });
+
+    expect(once).toHaveLength(1);
+    expect(once[0]).toMatchObject({ employeeId: e.id, status: 'active', activatedBy: 'human' });
+
+    const twice = activateEmployee(once, e.id, { at: NOW });
+
+    expect(twice).toBe(once);
+  });
+
+  it('throws for unknown employees', () => {
+    expect(() => activateEmployee([], 'does-not-exist', { at: NOW })).toThrow();
+  });
+
+  it('deactivates idempotently', () => {
+    const e = freeEmployee();
+    const active: AiEmployeeActivation[] = [{ employeeId: e.id, activatedAt: NOW, status: 'active' }];
+
+    expect(deactivateEmployee(active, e.id)).toHaveLength(0);
+    expect(deactivateEmployee([], e.id)).toHaveLength(0);
+  });
+
+  it('marks an active employee as already_active', () => {
+    const e = freeEmployee();
+    const active = activateEmployee([], e.id, { at: NOW });
+
+    expect(activationGate(e, 'free', active)).toEqual({ kind: 'already_active' });
+  });
+});
+
+describe('marketplace view', () => {
+  it('splits available and active with computed gating', () => {
+    const e = freeEmployee();
+    const activations = activateEmployee([], e.id, { at: NOW });
+    const view = buildMarketplaceView({ currentTier: 'free', activations });
+
+    expect(view.available.length).toBe(listAiEmployees().length);
+    expect(view.active.map(a => a.employee.id)).toContain(e.id);
+
+    const card = view.available.find(c => c.employee.id === e.id);
+
+    expect(card?.active).toBe(true);
+  });
+});

--- a/pkg/rancher-desktop/agent/aiEmployees/catalog.ts
+++ b/pkg/rancher-desktop/agent/aiEmployees/catalog.ts
@@ -1,0 +1,236 @@
+import type { AiEmployee } from './types';
+
+/**
+ * The initial roster of hireable AI employees.
+ *
+ * Keyed by employee id (mirrors the native integration catalog shape). Kept as
+ * plain data so it can be served over IPC, filtered, and rendered without any
+ * runtime dependencies. Tiers reference cloud/overview.md: free (Desktop),
+ * premium_support ($19/mo), enterprise_gateway ($99/mo).
+ */
+export const aiEmployeeCatalog: Record<string, AiEmployee> = {
+  'executive-assistant': {
+    id:           'executive-assistant',
+    name:         'Executive Assistant',
+    role:         'Manages your inbox, calendar, and daily coordination.',
+    description:  'Triages email, schedules meetings, and drafts replies so your day runs itself.',
+    longDescription:
+      'The Executive Assistant keeps your inbox and calendar under control. It triages incoming '
+      + 'mail, proposes and books meetings around your existing commitments, drafts routine replies '
+      + 'for your approval, and gives you a daily briefing of what needs attention first.',
+    category:     'Productivity',
+    icon:         'ai-employee-assistant.svg',
+    requiredTier: 'free',
+    capabilities: [
+      'Inbox triage and prioritization',
+      'Calendar scheduling and conflict resolution',
+      'Drafting replies and follow-ups',
+      'Daily briefing of what needs attention',
+    ],
+    exampleTasks: [
+      'Find a 30-minute slot with the design team this week and send invites.',
+      'Summarize everything in my inbox since yesterday and flag anything urgent.',
+    ],
+    integrationsUsed: ['gmail', 'google-calendar', 'slack'],
+    sort:         1,
+    version:      '1.0.0',
+    lastUpdated:  '2026-08-24',
+    developer:    'Sulla',
+  },
+  'customer-support-agent': {
+    id:           'customer-support-agent',
+    name:         'Customer Support Agent',
+    role:         'Answers customer questions and triages support tickets.',
+    description:  'Drafts helpful, on-brand replies and routes tickets to the right place.',
+    longDescription:
+      'The Customer Support Agent watches your support inbox and help desk, drafts accurate replies '
+      + 'grounded in your knowledge base, tags and prioritizes tickets, and escalates anything it is '
+      + 'not confident about to a human.',
+    category:     'Customer Support',
+    icon:         'ai-employee-support.svg',
+    requiredTier: 'free',
+    capabilities: [
+      'Draft grounded replies from your knowledge base',
+      'Tag, prioritize, and route tickets',
+      'Escalate low-confidence cases to a human',
+      'Summarize recurring issues',
+    ],
+    exampleTasks: [
+      'Draft a reply to the top 10 unanswered tickets and flag anything needing a refund.',
+      'Summarize the most common complaints from this week.',
+    ],
+    integrationsUsed: ['zendesk', 'slack', 'gmail'],
+    sort:         2,
+    version:      '1.0.0',
+    lastUpdated:  '2026-08-24',
+    developer:    'Sulla',
+  },
+  'bookkeeper': {
+    id:           'bookkeeper',
+    name:         'Bookkeeper',
+    role:         'Keeps the books tidy and reconciles transactions.',
+    description:  'Categorizes expenses, reconciles accounts, and flags anomalies.',
+    longDescription:
+      'The Bookkeeper reconciles transactions against your accounting system, categorizes expenses, '
+      + 'chases missing receipts, and flags anomalies or duplicate charges before they become a mess '
+      + 'at month end.',
+    category:     'Finance',
+    icon:         'ai-employee-bookkeeper.svg',
+    requiredTier: 'premium_support',
+    capabilities: [
+      'Transaction categorization',
+      'Account reconciliation',
+      'Anomaly and duplicate-charge detection',
+      'Month-end close checklist',
+    ],
+    exampleTasks: [
+      'Reconcile last month against the bank feed and list anything unmatched.',
+      'Flag any expense over $500 without a receipt.',
+    ],
+    integrationsUsed: ['quickbooks', 'stripe'],
+    sort:         1,
+    version:      '1.0.0',
+    lastUpdated:  '2026-08-24',
+    developer:    'Sulla',
+  },
+  'data-analyst': {
+    id:           'data-analyst',
+    name:         'Data Analyst',
+    role:         'Turns your data into answers and dashboards.',
+    description:  'Runs queries, builds charts, and explains what the numbers mean.',
+    longDescription:
+      'The Data Analyst connects to your databases and analytics tools, answers ad-hoc questions in '
+      + 'plain language, builds recurring dashboards, and proactively surfaces trends and outliers.',
+    category:     'Analytics',
+    icon:         'ai-employee-analyst.svg',
+    requiredTier: 'premium_support',
+    capabilities: [
+      'Natural-language querying',
+      'Chart and dashboard generation',
+      'Trend and outlier detection',
+      'Scheduled reporting',
+    ],
+    exampleTasks: [
+      'What were our top 5 revenue sources last quarter, with a chart?',
+      'Build a weekly dashboard of signups vs. churn.',
+    ],
+    integrationsUsed: ['postgres', 'google-analytics'],
+    sort:         1,
+    version:      '1.0.0',
+    lastUpdated:  '2026-08-24',
+    developer:    'Sulla',
+  },
+  'sales-development-rep': {
+    id:           'sales-development-rep',
+    name:         'Sales Development Rep',
+    role:         'Finds leads, researches accounts, and drafts outreach.',
+    description:  'Builds targeted prospect lists and personalized first-touch emails.',
+    longDescription:
+      'The Sales Development Rep researches target accounts, enriches and qualifies leads, drafts '
+      + 'personalized outreach sequences, and keeps your CRM up to date so your pipeline never goes '
+      + 'stale.',
+    category:     'Sales',
+    icon:         'ai-employee-sdr.svg',
+    requiredTier: 'enterprise_gateway',
+    capabilities: [
+      'Account research and lead enrichment',
+      'Personalized outreach drafting',
+      'CRM hygiene and updates',
+      'Follow-up sequencing',
+    ],
+    exampleTasks: [
+      'Build a list of 25 SaaS companies in Idaho and draft a first-touch email for each.',
+      'Update the CRM with notes from this weeks replies.',
+    ],
+    integrationsUsed: ['hubspot', 'linkedin', 'gmail'],
+    sort:         1,
+    version:      '1.0.0',
+    lastUpdated:  '2026-08-24',
+    developer:    'Sulla',
+  },
+  'marketing-manager': {
+    id:           'marketing-manager',
+    name:         'Marketing Manager',
+    role:         'Plans campaigns and drafts content across channels.',
+    description:  'Drafts posts, schedules content, and reports on what is working.',
+    longDescription:
+      'The Marketing Manager plans content calendars, drafts on-brand posts and newsletters, '
+      + 'schedules them across channels, and reports on engagement so you can double down on what '
+      + 'works.',
+    category:     'Marketing',
+    icon:         'ai-employee-marketing.svg',
+    requiredTier: 'enterprise_gateway',
+    capabilities: [
+      'Content calendar planning',
+      'On-brand copy drafting',
+      'Cross-channel scheduling',
+      'Engagement reporting',
+    ],
+    exampleTasks: [
+      'Draft a week of LinkedIn posts announcing our new feature.',
+      'Report on which posts drove the most signups last month.',
+    ],
+    integrationsUsed: ['linkedin', 'mailchimp', 'google-analytics'],
+    sort:         2,
+    version:      '1.0.0',
+    lastUpdated:  '2026-08-24',
+    developer:    'Sulla',
+  },
+  'recruiter': {
+    id:           'recruiter',
+    name:         'Recruiter',
+    role:         'Sources candidates and manages your hiring pipeline.',
+    description:  'Screens applicants, schedules interviews, and keeps candidates warm.',
+    longDescription:
+      'The Recruiter drafts job posts, screens inbound applicants against your criteria, schedules '
+      + 'interviews, and sends timely, personable follow-ups so no candidate falls through the '
+      + 'cracks.',
+    category:     'HR & Recruiting',
+    icon:         'ai-employee-recruiter.svg',
+    requiredTier: 'enterprise_gateway',
+    capabilities: [
+      'Job-post drafting',
+      'Applicant screening against criteria',
+      'Interview scheduling',
+      'Candidate follow-up',
+    ],
+    exampleTasks: [
+      'Screen this weeks applicants for the backend role and shortlist the top 5.',
+      'Schedule interviews with the shortlist next week.',
+    ],
+    integrationsUsed: ['greenhouse', 'gmail', 'google-calendar'],
+    sort:         1,
+    version:      '1.0.0',
+    lastUpdated:  '2026-08-24',
+    developer:    'Sulla',
+  },
+  'it-helpdesk': {
+    id:           'it-helpdesk',
+    name:         'IT Helpdesk',
+    role:         'Handles internal IT requests and access provisioning.',
+    description:  'Resets access, answers how-to questions, and tracks assets.',
+    longDescription:
+      'The IT Helpdesk answers common internal IT questions, guides employees through fixes, and '
+      + 'drafts access-provisioning requests for approval. Deeper automation (SSO, MDM) is on the '
+      + 'roadmap.',
+    category:     'IT',
+    icon:         'ai-employee-it.svg',
+    requiredTier: 'enterprise_gateway',
+    capabilities: [
+      'Answer common IT how-to questions',
+      'Guide employees through fixes',
+      'Draft access-provisioning requests',
+      'Track asset assignments',
+    ],
+    exampleTasks: [
+      'Draft an onboarding checklist for a new hire including accounts to create.',
+    ],
+    integrationsUsed: ['slack', 'okta'],
+    sort:         2,
+    beta:         true,
+    comingSoon:   true,
+    version:      '0.1.0',
+    lastUpdated:  '2026-08-24',
+    developer:    'Sulla',
+  },
+};

--- a/pkg/rancher-desktop/agent/aiEmployees/index.ts
+++ b/pkg/rancher-desktop/agent/aiEmployees/index.ts
@@ -1,0 +1,151 @@
+/**
+ * Pure selectors and reducers for the organization AI-employee marketplace.
+ *
+ * No IPC / Vue / side effects — this is the shared domain logic the renderer
+ * composable and any main-process handler both build on. Verified in isolation
+ * via tsconfig.agent-check.json.
+ */
+import { aiEmployeeCatalog } from './catalog';
+import type {
+  ActivationGateReason,
+  ActiveAiEmployeeView,
+  AiEmployee,
+  AiEmployeeActivation,
+  AiEmployeeCardView,
+  AiEmployeeMarketplaceView,
+  SubscriptionTier,
+} from './types';
+
+export * from './types';
+export { aiEmployeeCatalog } from './catalog';
+
+/** Ordering of subscription tiers (a higher tier includes everything below). */
+const TIER_RANK: Record<SubscriptionTier, number> = {
+  free:               0,
+  premium_support:    1,
+  enterprise_gateway: 2,
+};
+
+export function tierRank(tier: SubscriptionTier): number {
+  return TIER_RANK[tier] ?? 0;
+}
+
+/** True when currentTier satisfies the required tier. */
+export function meetsTier(required: SubscriptionTier, current: SubscriptionTier): boolean {
+  return tierRank(current) >= tierRank(required);
+}
+
+/** All catalog employees, sorted by category, then sort, then name. */
+export function listAiEmployees(): AiEmployee[] {
+  return Object.values(aiEmployeeCatalog).sort((a, b) =>
+    a.category.localeCompare(b.category)
+    || a.sort - b.sort
+    || a.name.localeCompare(b.name));
+}
+
+export function getAiEmployee(id: string): AiEmployee | undefined {
+  return aiEmployeeCatalog[id];
+}
+
+/** Distinct categories present in the catalog, alphabetically. */
+export function listCategories(): string[] {
+  return Array.from(new Set(listAiEmployees().map(e => e.category))).sort();
+}
+
+function isActive(activations: AiEmployeeActivation[], id: string): boolean {
+  return activations.some(a => a.employeeId === id);
+}
+
+/**
+ * Compute why an employee cannot be activated right now, or null if it can.
+ * Precedence: already active > coming soon > tier upgrade required.
+ */
+export function activationGate(
+  employee: AiEmployee,
+  currentTier: SubscriptionTier,
+  activations: AiEmployeeActivation[] = [],
+): ActivationGateReason | null {
+  if (isActive(activations, employee.id)) {
+    return { kind: 'already_active' };
+  }
+  if (employee.comingSoon) {
+    return { kind: 'coming_soon' };
+  }
+  if (!meetsTier(employee.requiredTier, currentTier)) {
+    return { kind: 'requires_upgrade', requiredTier: employee.requiredTier };
+  }
+  return null;
+}
+
+/** True when the employee can be activated under the current tier/state. */
+export function canActivate(
+  employee: AiEmployee,
+  currentTier: SubscriptionTier,
+  activations: AiEmployeeActivation[] = [],
+): boolean {
+  return activationGate(employee, currentTier, activations) === null;
+}
+
+/**
+ * Pure reducer: activate (hire) an employee. Idempotent — re-activating an
+ * already-active employee returns the same list reference. Throws for unknown
+ * employees; callers should check canActivate first for user-facing gating.
+ */
+export function activateEmployee(
+  activations: AiEmployeeActivation[],
+  employeeId: string,
+  opts: { at: string; by?: string },
+): AiEmployeeActivation[] {
+  const employee = getAiEmployee(employeeId);
+  if (!employee) {
+    throw new Error(`Unknown AI employee: ${ employeeId }`);
+  }
+  if (isActive(activations, employeeId)) {
+    return activations;
+  }
+  const activation: AiEmployeeActivation = {
+    employeeId,
+    activatedAt: opts.at,
+    status:      'active',
+    ...(opts.by ? { activatedBy: opts.by } : {}),
+  };
+  return [...activations, activation];
+}
+
+/** Pure reducer: deactivate (release) an employee. Idempotent. */
+export function deactivateEmployee(
+  activations: AiEmployeeActivation[],
+  employeeId: string,
+): AiEmployeeActivation[] {
+  return activations.filter(a => a.employeeId !== employeeId);
+}
+
+/** Build the full marketplace + activation view model for the UX. */
+export function buildMarketplaceView(input: {
+  currentTier: SubscriptionTier;
+  activations?: AiEmployeeActivation[];
+}): AiEmployeeMarketplaceView {
+  const activations = input.activations ?? [];
+  const available: AiEmployeeCardView[] = listAiEmployees().map((employee) => {
+    return {
+      employee,
+      eligible: meetsTier(employee.requiredTier, input.currentTier) && !employee.comingSoon,
+      active:   isActive(activations, employee.id),
+      gate:     activationGate(employee, input.currentTier, activations),
+    };
+  });
+  const active: ActiveAiEmployeeView[] = activations
+    .map((activation) => {
+      const employee = getAiEmployee(activation.employeeId);
+
+      return employee ? { employee, activation } : null;
+    })
+    .filter((v): v is ActiveAiEmployeeView => v !== null);
+
+  return {
+    currentTier: input.currentTier,
+    categories:  listCategories(),
+    available,
+    active,
+  };
+}

--- a/pkg/rancher-desktop/agent/aiEmployees/types.ts
+++ b/pkg/rancher-desktop/agent/aiEmployees/types.ts
@@ -1,0 +1,93 @@
+/**
+ * Domain model for the organization AI-employee marketplace (Projects task xF3S).
+ *
+ * An "AI employee" is a pre-configured agent role an organization can browse,
+ * understand, and activate (hire). The shape mirrors the native integration
+ * catalog (see agent/integrations/types.ts) so the marketplace UX can reuse the
+ * same browse / detail / gating patterns.
+ *
+ * This module is intentionally pure (no IPC, no Vue, no side effects) so it can
+ * be unit-tested and typechecked in isolation via tsconfig.agent-check.json.
+ */
+
+/** Subscription tiers, ordered from least to most capable (see cloud/overview.md). */
+export type SubscriptionTier = 'free' | 'premium_support' | 'enterprise_gateway';
+
+/** Lifecycle state of an activated (hired) AI employee. */
+export type AiEmployeeActivationStatus = 'active' | 'paused';
+
+/** A hireable AI employee role in the marketplace catalog. */
+export interface AiEmployee {
+  /** Stable identifier (kebab-case), unique across the catalog. */
+  id: string;
+  /** Display name of the role, e.g. "Executive Assistant". */
+  name: string;
+  /** One-line summary of what this employee does. */
+  role: string;
+  /** Short description shown on the browse card. */
+  description: string;
+  /** Longer description shown on the detail view. */
+  longDescription?: string;
+  /** Grouping used by the marketplace filter, e.g. "Sales". */
+  category: string;
+  /** Icon asset name (resolved by the renderer), optional. */
+  icon?: string;
+  /** Minimum subscription tier required to activate this employee. */
+  requiredTier: SubscriptionTier;
+  /** Ordered capabilities this employee provides. */
+  capabilities: string[];
+  /** Concrete example tasks a user can delegate. */
+  exampleTasks?: string[];
+  /** Integration ids (see agent/integrations) this employee relies on. */
+  integrationsUsed?: string[];
+  /** Display ordering within a category (lower first). */
+  sort: number;
+  /** Marked as beta. */
+  beta?: boolean;
+  /** Announced but not yet activatable. */
+  comingSoon?: boolean;
+  version: string;
+  lastUpdated: string;
+  developer: string;
+}
+
+/** A record of an employee the organization has activated. */
+export interface AiEmployeeActivation {
+  employeeId: string;
+  /** ISO-8601 timestamp of activation. */
+  activatedAt: string;
+  /** Optional operator/actor who activated it. */
+  activatedBy?: string;
+  status: AiEmployeeActivationStatus;
+}
+
+/** Why an employee cannot currently be activated (null = it can). */
+export type ActivationGateReason =
+  | { kind: 'coming_soon' }
+  | { kind: 'requires_upgrade'; requiredTier: SubscriptionTier }
+  | { kind: 'already_active' };
+
+/** Browse-card view model: catalog entry plus computed activation state. */
+export interface AiEmployeeCardView {
+  employee: AiEmployee;
+  eligible: boolean;
+  active: boolean;
+  /** Non-null when the employee cannot be activated right now. */
+  gate: ActivationGateReason | null;
+}
+
+/** Active-employee view model: activation joined to its catalog entry. */
+export interface ActiveAiEmployeeView {
+  employee: AiEmployee;
+  activation: AiEmployeeActivation;
+}
+
+/** Aggregate view model backing the marketplace + activation UX. */
+export interface AiEmployeeMarketplaceView {
+  currentTier: SubscriptionTier;
+  categories: string[];
+  /** All catalog entries with computed gating (browse grid). */
+  available: AiEmployeeCardView[];
+  /** Currently active/paused employees (manage panel). */
+  active: ActiveAiEmployeeView[];
+}


### PR DESCRIPTION
Projects task xF3S - organization AI employee marketplace and activation UX (project zHuT / epic m5rT).

## What is in this PR (verified)
Pure, framework-free domain module pkg/rancher-desktop/agent/aiEmployees:
- types.ts: AiEmployee, AiEmployeeActivation, SubscriptionTier (free/premium_support/enterprise_gateway per cloud/overview.md), gate + view models.
- catalog.ts: initial 8-role roster (Executive Assistant, Customer Support Agent, Bookkeeper, Data Analyst, Sales Development Rep, Marketing Manager, Recruiter, coming-soon IT Helpdesk).
- index.ts: pure selectors/reducers - eligibility gating (already-active > coming-soon > requires-upgrade), idempotent activate/deactivate, buildMarketplaceView.
- __tests__/aiEmployees.test.ts: 11 tests.

Verification: scoped tsc (tsconfig.agent-check) = 0 errors; jest = 11/11 pass.

## Follow-up (specified, not yet built)
Renderer Vue UI (browse grid, detail, subscription gating, activate flow, manage-active) is fully specified in docs/feature-requests/org-ai-employee-marketplace.md, modeled on the existing routines marketplace + agent integration pages. Deferred because the renderer could not be build-verified in the worker environment; the domain layer it binds to is landed, typechecked, and tested so the UI is a thin, testable shell.

Draft - not for merge.