### PR TITLE
fix: drain Projects review before starting new work

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -224,6 +224,23 @@ export class WorkTaskDispatchModel {
               WHERE c.task_id = t.id AND c.stage = 'in_progress' AND c.status = 'active'
            )
            AND NOT EXISTS (
+             SELECT 1
+               FROM work_tasks downstream
+               JOIN work_epics downstream_epic ON downstream_epic.id = downstream.epic_id
+               JOIN work_projects downstream_project ON downstream_project.id = downstream_epic.project_id
+              WHERE downstream.archived = false
+                AND downstream.status = 'in_review'
+                AND downstream_epic.archived = false
+                AND downstream_project.archived = false
+                AND NOT (downstream_project.status = ANY($1::text[]))
+                AND NOT (downstream_epic.status = ANY($1::text[]))
+                AND (downstream.assignee IS NULL OR LOWER(downstream.assignee) IN ('heartbeat', 'dispatcher', 'verifier'))
+                AND NOT EXISTS (
+                  SELECT 1 FROM unnest(COALESCE(downstream.labels, '{}')) AS downstream_label
+                   WHERE LOWER(downstream_label) = ANY($3::text[])
+                )
+           )
+           AND NOT EXISTS (
              SELECT 1 FROM work_tasks child
               WHERE child.parent_id = t.id
                 AND child.archived = false
@@ -409,6 +426,33 @@ export class WorkTaskDispatchModel {
         WHERE status = 'running' AND ($1::text IS NULL OR kind = $1)`,
       [kind ?? null],
     );
+    return Number(row?.count || 0);
+  }
+
+  /**
+   * Count autonomous work already at the review stage, including work with an
+   * active verification lease. Any such row is farther down the conveyor than
+   * todo, so the dispatcher uses this as a hard backpressure gate before
+   * claiming fresh execution work.
+   */
+  static async countReviewBacklog(): Promise<number> {
+    const row = await postgresClient.queryOne<{ count: string }>(`
+      SELECT COUNT(*)::text AS count
+        FROM work_tasks t
+        JOIN work_epics e ON e.id = t.epic_id
+        JOIN work_projects p ON p.id = e.project_id
+       WHERE t.archived = false
+         AND t.status = 'in_review'
+         AND e.archived = false
+         AND p.archived = false
+         AND NOT (p.status = ANY($1::text[]))
+         AND NOT (e.status = ANY($1::text[]))
+         AND (t.assignee IS NULL OR LOWER(t.assignee) IN ('heartbeat', 'dispatcher', 'verifier'))
+         AND NOT EXISTS (
+           SELECT 1 FROM unnest(COALESCE(t.labels, '{}')) AS label
+            WHERE LOWER(label) = ANY($2::text[])
+         )
+    `, [CLOSED_EPIC_STATUSES, NON_AUTONOMOUS_TASK_LABELS]);
     return Number(row?.count || 0);
   }
 

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchBackpressure.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchBackpressure.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { postgresClient } from '../../PostgresClient';
+import { WorkTaskDispatchModel } from '../WorkTaskDispatchModel';
+
+describe('WorkTaskDispatchModel downstream-first backpressure', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('counts autonomous in-review work whether or not a verifier already holds it', async() => {
+    const queryOne = jest.spyOn(postgresClient, 'queryOne').mockResolvedValue({ count: '4' } as any);
+
+    await expect(WorkTaskDispatchModel.countReviewBacklog()).resolves.toBe(4);
+
+    const [sql, params] = queryOne.mock.calls[0];
+    expect(sql).toContain("t.status = 'in_review'");
+    expect(sql).toContain("LOWER(t.assignee) IN ('heartbeat', 'dispatcher', 'verifier')");
+    expect(sql).toContain("FROM unnest(COALESCE(t.labels, '{}')) AS label");
+    expect(sql).not.toContain("d.status = 'running'");
+    expect(params).toEqual([
+      ['done', 'cancelled', 'parked', 'blocked'],
+      ['gated', 'decision', 'human', 'manual', 'no-auto-dispatch'],
+    ]);
+  });
+
+  it('makes the todo claim itself reject races with downstream review work', async() => {
+    const query = jest.fn(() => Promise.resolve({ rows: [] })) as any;
+    jest.spyOn(postgresClient, 'transaction').mockImplementation((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.claimNext('sulla-desktop', 'runtime-1')).resolves.toBeNull();
+
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain("downstream.status = 'in_review'");
+    expect(sql).toContain("LOWER(downstream.assignee) IN ('heartbeat', 'dispatcher', 'verifier')");
+    expect(sql).toContain("LOWER(downstream_label) = ANY($3::text[])");
+    expect(sql.indexOf("downstream.status = 'in_review'"))
+      .toBeLessThan(sql.indexOf('FOR UPDATE OF t SKIP LOCKED'));
+  });
+});

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -134,8 +134,13 @@ export class TaskDispatcherService {
       }
 
       await this.checkInProgressRecovery();
-      await this.fillExecutionPool();
       await this.fillVerificationPool();
+      const reviewBacklog = await WorkTaskDispatchModel.countReviewBacklog();
+      if (reviewBacklog > 0) {
+        console.log(`[TaskDispatcher] Holding fresh todo work until ${ reviewBacklog } downstream review item(s) drain`);
+        return;
+      }
+      await this.fillExecutionPool();
     } catch (err) {
       console.error('[TaskDispatcher] Dispatch check failed:', err);
       await LifecycleCapabilityModel.report({

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -5,6 +5,7 @@ const recoverStaleMock: any = jest.fn(() => Promise.resolve([]));
 const findRecoverableInProgressMock: any = jest.fn(() => Promise.resolve([]));
 const recoverOrphanedInProgressMock: any = jest.fn(() => Promise.resolve([]));
 const countRunningMock: any = jest.fn(() => Promise.resolve(0));
+const countReviewBacklogMock: any = jest.fn(() => Promise.resolve(0));
 const claimNextMock: any = jest.fn(() => Promise.resolve(null));
 const claimNextReviewMock: any = jest.fn(() => Promise.resolve(null));
 const settleMock: any = jest.fn(() => Promise.resolve());
@@ -46,6 +47,7 @@ jest.unstable_mockModule('../../database/models/WorkTaskDispatchModel', () => ({
     findRecoverableInProgress: findRecoverableInProgressMock,
     recoverOrphanedInProgress: recoverOrphanedInProgressMock,
     countRunning:            countRunningMock,
+    countReviewBacklog:      countReviewBacklogMock,
     claimNext:               claimNextMock,
     claimNextReview:         claimNextReviewMock,
     settle:                  settleMock,
@@ -100,6 +102,7 @@ describe('TaskDispatcherService', () => {
     findRecoverableInProgressMock.mockResolvedValue([]);
     recoverOrphanedInProgressMock.mockResolvedValue([]);
     countRunningMock.mockResolvedValue(0);
+    countReviewBacklogMock.mockResolvedValue(0);
     claimNextMock.mockResolvedValue(null);
     claimNextReviewMock.mockResolvedValue(null);
     workflowFindByIdMock.mockResolvedValue({ attributesSnapshot: { enabled: true } });
@@ -186,6 +189,43 @@ describe('TaskDispatcherService', () => {
     expect(recoverStaleMock).toHaveBeenCalledWith(0);
     expect(recoverPreviousRuntimeMock).toHaveBeenCalledWith('todo-execution', expect.stringContaining('task-dispatcher-'));
     expect(countRunningMock).toHaveBeenCalled();
+  });
+
+  it('drains downstream review before claiming fresh todo work', async() => {
+    settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+      if (key === 'heartbeatEnabled' || key === 'taskVerifierEnabled') return Promise.resolve(true);
+      if (key === 'taskVerifierOwner') return Promise.resolve('legacy');
+      return Promise.resolve(fallback);
+    });
+    countReviewBacklogMock.mockResolvedValue(2);
+
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    service.destroy();
+
+    expect(claimNextReviewMock).toHaveBeenCalled();
+    expect(countReviewBacklogMock).toHaveBeenCalledTimes(1);
+    expect(claimNextMock).not.toHaveBeenCalled();
+    expect(claimNextReviewMock.mock.invocationCallOrder[0])
+      .toBeLessThan(countReviewBacklogMock.mock.invocationCallOrder[0]);
+  });
+
+  it('starts todo work only after the downstream review backlog is empty', async() => {
+    settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+      if (key === 'heartbeatEnabled' || key === 'taskVerifierEnabled') return Promise.resolve(true);
+      if (key === 'taskVerifierOwner') return Promise.resolve('legacy');
+      return Promise.resolve(fallback);
+    });
+    countReviewBacklogMock.mockResolvedValue(0);
+
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    service.destroy();
+
+    expect(claimNextReviewMock.mock.invocationCallOrder[0])
+      .toBeLessThan(claimNextMock.mock.invocationCallOrder[0]);
   });
 
   it('reports in-progress candidates without mutating while rollout is disabled', async() => {


### PR DESCRIPTION
## Outcome

Makes the mechanical Projects dispatcher finish work furthest down the conveyor before starting fresh todo execution.

## Changes

- recovery still runs first
- verification capacity is filled before execution capacity
- any autonomous in-review backlog hard-pauses fresh todo claims, including items already under verification or temporarily unable to claim
- the todo SQL claim repeats the downstream guard so a service-level timing window cannot bypass backpressure
- priority, due date, activity rotation, and position ordering remain unchanged inside each stage
- human/manual/gated review items do not block autonomous execution

## Validation

- focused dispatcher/model Jest: 2 suites, 21/21 tests passed
- git diff --check passed
- ESLint could not start because the existing shared oxc-resolver native binding is unavailable; no package was installed or changed

Projects task: woqG
Commit: 26ff86a91