### PR TITLE
P0: forbid in_review without structured artifact custody (#712)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0065_create_work_task_waits.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0065_create_work_task_waits.ts
@@ -50,7 +50,7 @@ export const up = `
        WHERE task_id = NEW.task_id
          AND status = 'active';
       UPDATE work_tasks
-         SET status = 'in_review', assignee = 'heartbeat', updated_at = now(),
+         SET status = 'planning', assignee = 'dispatcher', updated_at = now(),
              last_moved_at = now(), last_activity_at = now(),
              last_moved_by = 'external-wait-monitor'
        WHERE id = NEW.task_id AND status = 'blocked';
@@ -77,7 +77,7 @@ export const up = `
        WHERE task_id = NEW.id
          AND status = 'active';
       UPDATE work_tasks
-         SET status = 'in_review', assignee = 'heartbeat', updated_at = now(),
+         SET status = 'planning', assignee = 'dispatcher', updated_at = now(),
              last_moved_at = now(), last_activity_at = now(),
              last_moved_by = 'external-wait-monitor'
        WHERE id = NEW.id AND status = 'blocked';

--- a/pkg/rancher-desktop/agent/database/migrations/0074_semantic_lane_runtime_helpers.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0074_semantic_lane_runtime_helpers.ts
@@ -151,7 +151,7 @@ export const down = `
              updated_at = now(), completed_at = now()
        WHERE task_id = NEW.task_id AND status = 'active';
       UPDATE work_tasks
-         SET status = 'in_review', assignee = 'heartbeat', updated_at = now(),
+         SET status = 'planning', assignee = 'dispatcher', updated_at = now(),
              last_moved_at = now(), last_activity_at = now(),
              last_moved_by = 'external-wait-monitor'
        WHERE id = NEW.task_id AND status = 'blocked';
@@ -170,7 +170,7 @@ export const down = `
              updated_at = now(), completed_at = now()
        WHERE task_id = NEW.id AND status = 'active';
       UPDATE work_tasks
-         SET status = 'in_review', assignee = 'heartbeat', updated_at = now(),
+         SET status = 'planning', assignee = 'dispatcher', updated_at = now(),
              last_moved_at = now(), last_activity_at = now(),
              last_moved_by = 'external-wait-monitor'
        WHERE id = NEW.id AND status = 'blocked';

--- a/pkg/rancher-desktop/agent/database/migrations/0078_add_in_review_artifact_custody.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0078_add_in_review_artifact_custody.ts
@@ -1,0 +1,32 @@
+/** Structured, independently resolvable custody receipts for review entry. */
+export const up = `
+  CREATE TABLE IF NOT EXISTS work_task_artifact_custody (
+    id            TEXT PRIMARY KEY,
+    task_id       TEXT NOT NULL REFERENCES work_tasks(id),
+    dispatch_id   TEXT REFERENCES work_task_dispatches(id),
+    custody_status TEXT NOT NULL CHECK (custody_status IN ('validated', 'legacy')),
+    receipt       JSONB NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_work_task_artifact_custody_task
+    ON work_task_artifact_custody (task_id, created_at DESC);
+
+  INSERT INTO work_task_artifact_custody (id, task_id, dispatch_id, custody_status, receipt)
+  SELECT 'legacy-custody-' || t.id, t.id, d.id, 'legacy',
+         jsonb_build_object('legacy', true, 'reason', 'pre-0078 in_review record')
+    FROM work_tasks t
+    LEFT JOIN LATERAL (
+      SELECT id FROM work_task_dispatches
+       WHERE task_id = t.id
+       ORDER BY started_at DESC NULLS LAST
+       LIMIT 1
+    ) d ON true
+   WHERE t.status = 'in_review'
+  ON CONFLICT (id) DO NOTHING;
+`;
+
+export const down = `
+  DROP INDEX IF EXISTS idx_work_task_artifact_custody_task;
+  DROP TABLE IF EXISTS work_task_artifact_custody;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0078_add_in_review_artifact_custody.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0078_add_in_review_artifact_custody.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@jest/globals';
+import { down, up } from '../0078_add_in_review_artifact_custody';
+
+describe('0078_add_in_review_artifact_custody', () => {
+  it('creates structured receipts and marks historical review rows legacy', () => {
+    expect(up).toContain('work_task_artifact_custody');
+    expect(up).toContain("custody_status IN ('validated', 'legacy')");
+    expect(up).toContain("'legacy'");
+    expect(up).toContain('ON CONFLICT (id) DO NOTHING');
+  });
+  it('is reversible', () => {
+    expect(down).toContain('DROP TABLE IF EXISTS work_task_artifact_custody');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -64,6 +64,7 @@ import { up as up_0074, down as down_0074 } from './0074_semantic_lane_runtime_h
 import { up as up_0075, down as down_0075 } from './0075_add_project_views_and_scheduling';
 import { up as up_0076, down as down_0076 } from './0076_extend_work_task_dispatch_custody';
 import { up as up_0077, down as down_0077 } from './0077_create_work_item_knowledge_links';
+import { up as up_0078, down as down_0078 } from './0078_add_in_review_artifact_custody';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -129,4 +130,5 @@ export const migrationsRegistry = [
   { name: '0075_add_project_views_and_scheduling',                 up: up_0075, down: down_0075 },
   { name: '0076_extend_work_task_dispatch_custody',                up: up_0076, down: down_0076 },
   { name: '0077_create_work_item_knowledge_links',                 up: up_0077, down: down_0077 },
+  { name: '0078_add_in_review_artifact_custody',                   up: up_0078, down: down_0078 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -18,6 +18,7 @@ import { normalizeAutonomousTaskOwnership } from './TaskOwnership';
 import { WorkLaneDefinitionModel, type WorkLaneSemanticRole } from './WorkLaneDefinitionModel';
 
 import type { PoolClient } from 'pg';
+import type { ProposedCustody, ProposedDisposition } from '../../services/CanonicalArtifactCustodyService';
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -254,6 +255,8 @@ export interface UpdateTaskInput {
   source?:       string | null;
   source_ref?:   string | null;
   actor?:        string;
+  custody?:      ProposedCustody;
+  custodyDisposition?: ProposedDisposition;
 }
 
 export interface AddCommentInput {
@@ -989,6 +992,9 @@ export class WorkItemsModel {
 
   static async insertTask(input: UpsertTaskInput): Promise<WorkTaskRecord> {
     if (!input.epic_id) throw new Error('epic_id is required to create a task.');
+    if (input.status === 'in_review') {
+      throw new Error('new tasks cannot enter in_review without an originating dispatch and custody receipt');
+    }
     const epic = await WorkItemsModel.requireEpic(input.epic_id);
     const projectId = input.project_id || epic.project_id;
     const slug = input.slug ? input.slug.slice(0, 80) : null;
@@ -1172,6 +1178,27 @@ export class WorkItemsModel {
         const current = await client.query<WorkTaskRecord>(
           `SELECT * FROM ${ WorkItemsModel.TASKS } WHERE id = $1 AND archived = false FOR UPDATE`, [id]);
         if (!current.rows[0]) return null;
+        const enteringReview = changes.status === 'in_review' && current.rows[0].status !== 'in_review';
+        if (enteringReview) {
+          if (!changes.custody || !changes.custodyDisposition) {
+            throw new Error('in_review requires a structured artifact custody envelope');
+          }
+          const { CanonicalArtifactCustodyService } = await import('../../services/CanonicalArtifactCustodyService');
+          const verified = await CanonicalArtifactCustodyService.verify(
+            current.rows[0], changes.custody, changes.custodyDisposition,
+          );
+          if (!verified.valid) throw new Error(`artifact custody rejected: ${ verified.error }`);
+          await client.query(`
+            INSERT INTO work_task_artifact_custody
+              (id, task_id, dispatch_id, custody_status, receipt, created_at)
+            VALUES ($1, $2, $3, 'validated', $4::jsonb, now())
+          `, [
+            `custody-${ current.rows[0].id }-${ String(changes.custody.dispatchId) }`,
+            current.rows[0].id,
+            String(changes.custody.dispatchId),
+            JSON.stringify({ ...verified, custody: changes.custody }),
+          ]);
+        }
         const rows = await client.query<WorkTaskRecord>(updateSql, values);
         const committed = rows.rows[0] ?? null;
         if (committed && committed.status !== current.rows[0].status) {

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -6,6 +6,7 @@ import { AUTONOMOUS_TASK_ASSIGNEES, NON_AUTONOMOUS_TASK_LABELS, TASK_ASSIGNEES }
 
 import type { WorkTaskRecord } from './WorkItemsModel';
 import type { PoolClient } from 'pg';
+import type { ProposedCustody, ProposedDisposition } from '../../services/CanonicalArtifactCustodyService';
 
 export type WorkTaskDispatchStatus = 'running' | 'completed' | 'blocked' | 'failed' | 'stale';
 export type WorkTaskDispatchKind = 'execution' | 'verification';
@@ -117,6 +118,8 @@ export interface WorkTaskDispatchEvidence {
   reviewerVerdict?:     string;
   reviewEvidence?:      unknown;
   terminalReason?:      string;
+  custody?:             ProposedCustody;
+  custodyDisposition?:   ProposedDisposition;
 }
 
 export interface ClaimedDispatch {
@@ -722,6 +725,29 @@ export class WorkTaskDispatchModel {
       );
       if (locked.rows[0]?.status !== 'running') {
         throw new Error(`Dispatch ${ id } is not running and cannot be finalized`);
+      }
+
+      if (finalization.taskStatus === 'in_review') {
+        const custody = evidence.custody;
+        const disposition = evidence.custodyDisposition ?? {
+          taskId,
+          dispatchId: id,
+          nextState: 'in_review',
+          proposedComment: finalization.comment,
+        };
+        if (!custody) throw new Error(`Dispatch ${ id } completed without structured artifact custody`);
+        const task = await client.query<WorkTaskRecord>('SELECT * FROM work_tasks WHERE id = $1 FOR UPDATE', [taskId]);
+        const { CanonicalArtifactCustodyService } = await import('../../services/CanonicalArtifactCustodyService');
+        const verified = await CanonicalArtifactCustodyService.verify(task.rows[0], custody, disposition);
+        if (!verified.valid) throw new Error(`artifact custody rejected: ${ verified.error }`);
+        await client.query(`
+          INSERT INTO work_task_artifact_custody
+            (id, task_id, dispatch_id, custody_status, receipt, created_at)
+          VALUES ($1, $2, $3, 'validated', $4::jsonb, now())
+        `, [
+          `custody-${ taskId }-${ id }`, taskId, id,
+          JSON.stringify({ ...verified, custody }),
+        ]);
       }
 
       await client.query(`

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskWaitModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskWaitModel.ts
@@ -205,7 +205,7 @@ export class WorkTaskWaitModel {
                  last_moved_at = now(), last_activity_at = now(),
                  last_moved_by = 'external-wait-monitor'
            WHERE id = $1 AND status = 'blocked'
-        `, [current.task_id, nextStatus === 'failed' ? 'planning' : 'in_review', nextStatus === 'failed' ? 'dispatcher' : 'heartbeat']);
+        `, [current.task_id, 'planning', 'dispatcher']);
       }
       return { changed: changed || terminal, wait: updated.rows[0] ?? null };
     });

--- a/pkg/rancher-desktop/agent/services/CanonicalArtifactCustodyService.ts
+++ b/pkg/rancher-desktop/agent/services/CanonicalArtifactCustodyService.ts
@@ -10,11 +10,21 @@ export interface ProposedCustody {
   artifactRef?:          unknown;
   contentHash?:          unknown;
   headSha?:              unknown;
+  repository?:           unknown;
+  branch?:               unknown;
+  base?:                 unknown;
+  pullRequestRef?:       unknown;
+  pullRequestUrl?:       unknown;
+  taskId?:               unknown;
+  dispatchId?:           unknown;
+  validationEvidence?:   unknown;
+  workerProvenance?:     unknown;
   verificationEvidence?: unknown;
 }
 
 export interface ProposedDisposition {
   taskId?:          unknown;
+  dispatchId?:      unknown;
   nextState?:       unknown;
   proposedComment?: unknown;
 }
@@ -24,6 +34,7 @@ interface PullRequestArtifact {
   state:   string;
   draft:   boolean;
   headRef: string;
+  baseRef?: string;
   headSha: string;
   body:    string;
 }
@@ -78,6 +89,7 @@ class VaultGitHubArtifactReader implements CanonicalArtifactReader {
       state:   data.state,
       draft:   data.draft === true,
       headRef: data.head.ref,
+      baseRef: data.base.ref,
       headSha: data.head.sha,
       body:    data.body || '',
     };
@@ -108,11 +120,17 @@ export class CanonicalArtifactCustodyService {
     if (String(disposition.taskId || '') !== origin.id) {
       return invalid('proposed disposition is not bound to the originating task');
     }
+    if (!String(custody.taskId || '') || String(custody.taskId) !== origin.id) {
+      return invalid('custody is not bound to the originating task');
+    }
+    if (!String(custody.dispatchId || '') || String(disposition.dispatchId || '') !== String(custody.dispatchId)) {
+      return invalid('custody is not bound to the originating dispatch');
+    }
     if (disposition.nextState !== 'in_review') {
       return invalid('successful custody must propose in_review');
     }
-    if (!String(disposition.proposedComment || '').trim()) {
-      return invalid('successful custody requires proposed comment evidence');
+    if (!String(custody.validationEvidence || '').trim() || !String(custody.workerProvenance || '').trim()) {
+      return invalid('structured validation evidence and worker provenance are required');
     }
 
     const live = await WorkItemsModel.getTask(origin.id);
@@ -136,23 +154,37 @@ export class CanonicalArtifactCustodyService {
     reader: CanonicalArtifactReader,
   ): Promise<CanonicalCustodyResult> {
     const artifactUrl = String(custody.artifactUrl || '');
-    const requested = parsePullRequestUrl(artifactUrl);
+    const pullRequestUrl = String(custody.pullRequestUrl || artifactUrl);
+    const repository = String(custody.repository || '');
+    const branch = String(custody.branch || custody.artifactRef || '');
+    const base = String(custody.base || '');
+    const pullRequestRef = String(custody.pullRequestRef || '');
+    const requested = parsePullRequestUrl(pullRequestUrl);
     const expectedIssue = parseTaskIssue(origin.github_issue);
-    if (!requested) return invalid('code custody requires a canonical GitHub pull-request URL');
+    if (!requested || !repository || !branch || !base || !pullRequestRef) {
+      return invalid('code custody requires repository, branch, base, PR reference, and canonical URL');
+    }
+    if (pullRequestRef !== `${ requested.owner }/${ requested.repo }#${ requested.number }` ||
+        repository !== `${ requested.owner }/${ requested.repo }`) {
+      return invalid('code custody repository or pull request reference does not match the canonical URL');
+    }
     if (expectedIssue && (requested.owner !== expectedIssue.owner || requested.repo !== expectedIssue.repo)) {
       return invalid('pull request repository does not match the originating task');
     }
 
     const pull = await reader.getPullRequest(requested.owner, requested.repo, requested.number);
     const assertedHead = String(custody.headSha || '');
-    if (pull.htmlUrl !== artifactUrl || pull.state !== 'open' || !pull.draft) {
+    if (pull.htmlUrl !== pullRequestUrl || pull.state !== 'open' || !pull.draft) {
       return invalid('canonical pull request is missing, closed, or not draft');
     }
     if (!/^[0-9a-f]{40}$/i.test(assertedHead) || pull.headSha !== assertedHead) {
       return invalid('asserted head SHA does not match the canonical pull request head');
     }
-    if (String(custody.artifactRef || '') !== pull.headRef) {
+    if (branch !== pull.headRef || String(custody.artifactRef || branch) !== pull.headRef) {
       return invalid('asserted branch does not match the canonical pull request head ref');
+    }
+    if (base !== String(pull.baseRef || '')) {
+      return invalid('asserted base does not match the canonical pull request base');
     }
     if (String(custody.contentHash || '') !== pull.headSha) {
       return invalid('content hash does not match the canonical pull request head');
@@ -175,6 +207,11 @@ export class CanonicalArtifactCustodyService {
     custody: ProposedCustody,
     reader: CanonicalArtifactReader,
   ): Promise<CanonicalCustodyResult> {
+    if (!String(custody.artifactType || '').trim() || !String(custody.artifactLocation || '').trim() ||
+        !String(custody.artifactRef || '').trim() || !String(custody.contentHash || '').trim() ||
+        (!String(custody.artifactUrl || '').trim() && !String(custody.artifactLocation || '').trim())) {
+      return invalid('non-code custody requires type, authoritative system, stable reference, immutable hash, and URL or path');
+    }
     const issue = parseTaskIssue(liveTask.github_issue);
     if (issue) {
       const live = await reader.getIssue(issue.owner, issue.repo, issue.number);

--- a/pkg/rancher-desktop/agent/services/LaneEntryAutomationService.ts
+++ b/pkg/rancher-desktop/agent/services/LaneEntryAutomationService.ts
@@ -2,6 +2,7 @@ import { WorkLaneWorkflowBindingModel, type LaneEntryAutomationRecord } from '..
 
 import type { RoutineExecutionOptions, RoutineExecutionResult } from '@pkg/main/sullaRoutineTemplateEvents';
 import type { WorkflowDefinition } from '@pkg/pages/editor/workflow/types';
+import type { ProposedCustody, ProposedDisposition } from './CanonicalArtifactCustodyService';
 
 export interface LaneEntryTransitionResult {
   created: boolean;
@@ -10,8 +11,17 @@ export interface LaneEntryTransitionResult {
 
 /** Claims and dispatches the immutable automation snapshot for one real lane transition. */
 export class LaneEntryAutomationService {
-  static async handleTransition(taskId: string, laneKey: string, actor = 'sulla'):
+  static async handleTransition(taskId: string, laneKey: string, actor = 'sulla', custody?: ProposedCustody, disposition?: ProposedDisposition):
   Promise<LaneEntryTransitionResult> {
+    if (laneKey === 'in_review') {
+      if (!custody || !disposition) throw new Error('lane entry in_review requires structured artifact custody');
+      const { WorkItemsModel } = await import('../database/models/WorkItemsModel');
+      const task = await WorkItemsModel.getTask(taskId);
+      if (!task) throw new Error(`Task not found for in_review lane entry: ${ taskId }`);
+      const { CanonicalArtifactCustodyService } = await import('./CanonicalArtifactCustodyService');
+      const verified = await CanonicalArtifactCustodyService.verify(task, custody, disposition);
+      if (!verified.valid) throw new Error(`artifact custody rejected: ${ verified.error }`);
+    }
     const claimed = await WorkLaneWorkflowBindingModel.claimLaneEntry(taskId, laneKey, actor);
     if (claimed.created && claimed.entry.workflow_id) {
       return { created: true, entry: await LaneEntryAutomationService.dispatchEntry(claimed.entry.id) };

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -27,6 +27,7 @@ import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../routines/core/defaultCoreAgent
 import { extractAgentTurnOutcome } from '../tools/agents/agentTurnOutcome';
 import { toolRegistry } from '../tools/registry';
 import { createPlaybookState } from '../workflow/WorkflowPlaybook';
+import type { ProposedCustody } from './CanonicalArtifactCustodyService';
 
 const CHECK_INTERVAL_MS = 60_000;
 const LEASE_HEARTBEAT_MS = 120_000;
@@ -577,34 +578,44 @@ export class TaskDispatcherService {
     summary: string,
   ): Promise<void> {
     const { dispatch, task } = claim;
-    const taskStatus = status === 'completed' ? 'in_review' : 'blocked';
-    const result = status === 'failed' ? undefined : summary;
-    const error = status === 'failed' ? summary : undefined;
-    const comment = status === 'failed'
+    const custody = status === 'completed' ? this.parseArtifactCustody(summary) : null;
+    const evidenceGap = status === 'completed' && !custody;
+    const finalStatus = evidenceGap ? 'failed' : status;
+    const taskStatus = status === 'completed' && custody ? 'in_review' : evidenceGap ? 'planning' : 'blocked';
+    const result = finalStatus === 'failed' ? undefined : summary;
+    const error = finalStatus === 'failed' ? (evidenceGap ? 'structured artifact custody missing' : summary) : undefined;
+    const comment = finalStatus === 'failed'
       ? `Dispatch ${ dispatch.id } failed: ${ summary }`
+      : evidenceGap
+        ? `Dispatch ${ dispatch.id } completed without structured artifact custody; routed to planning.`
       : `Dispatch ${ dispatch.id } ${ status } via ${ dispatch.agent_id }.\n\n${ summary }`;
+    await WorkTaskDispatchModel.finalize(dispatch.id, task.id, {
+      dispatchStatus: finalStatus,
+      taskStatus,
+      taskAssignee: taskStatus === 'planning' ? 'dispatcher' : taskStatus === 'blocked' ? 'heartbeat' : 'heartbeat',
+      comment,
+      result,
+      error,
+      evidence: custody ? {
+        artifactType: custody.artifactType as string,
+        artifactLocation: custody.artifactLocation as string,
+        artifactUrl: custody.artifactUrl as string,
+        artifactRef: custody.artifactRef as string,
+        contentHash: custody.contentHash as string,
+        custody,
+        custodyDisposition: { taskId: task.id, dispatchId: dispatch.id, nextState: 'in_review', proposedComment: comment },
+      } : undefined,
+    });
+  }
 
-    // Persist the worker's blocker/result before the status transition. A
-    // blocked transition immediately snapshots the task for the planning
-    // council, so racing the comment and update could omit the original
-    // blocker from every planner's input.
-    const settled = await Promise.allSettled([
-      WorkTaskDispatchModel.settle(dispatch.id, status, result, error),
-      WorkItemsModel.addComment({ task_id: task.id, author: 'dispatcher', body: comment }),
-    ]);
-
-    for (const outcome of settled) {
-      if (outcome.status === 'rejected') {
-        console.error(`[TaskDispatcher] Could not finalize ${ dispatch.id }:`, outcome.reason);
-      }
-    }
-
+  private parseArtifactCustody(summary: string): ProposedCustody | null {
+    const matches = [...summary.matchAll(/<ARTIFACT_CUSTODY>([\s\S]*?)<\/ARTIFACT_CUSTODY>/g)];
+    if (matches.length !== 1) return null;
     try {
-      await WorkItemsModel.updateTask(task.id, {
-        status: taskStatus, assignee: 'heartbeat', actor: 'dispatcher',
-      });
-    } catch (err) {
-      console.error(`[TaskDispatcher] Could not move task ${ task.id } after ${ dispatch.id }:`, err);
+      const parsed = JSON.parse(matches[0][1].trim());
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as ProposedCustody : null;
+    } catch {
+      return null;
     }
   }
 
@@ -620,7 +631,7 @@ Dispatch: ${ dispatchId }
 Description:
 ${ task.description || '(no description)' }
 
-Execute the task autonomously to the reversible edge. Inspect the real state first. For code work, use an isolated worktree/feature branch, verify the change, commit it, push it through the Sulla GitHub tools, and open a draft PR when possible. Do not merge, deploy, spend money, send external communications, or perform destructive shared-system actions. End with a concise artifact-and-verification summary. If a truly irreversible dependency remains, return BLOCKED with the exact requirement; reversible uncertainty is yours to decide.`;
+Execute the task autonomously to the reversible edge. Inspect the real state first. For code work, use an isolated worktree/feature branch, verify the change, commit it, push it through the Sulla GitHub tools, and open a draft PR when possible. Do not merge, deploy, spend money, send external communications, or perform destructive shared-system actions. A completed result may enter review only when the final response includes exactly one <ARTIFACT_CUSTODY>{JSON}</ARTIFACT_CUSTODY> block with taskId, dispatchId, repository, branch, base, pullRequestRef, pullRequestUrl, full headSha, validationEvidence, and workerProvenance for code, or the complete non-code custody envelope. Free-form narration never satisfies custody. If the envelope is missing or unverifiable, return BLOCKED with the exact gap; reversible evidence gaps are routed to planning.`;
   }
 
   private buildVerifierPrompt(task: WorkTaskRecord, dispatchId: string, comments: { author: string | null; body: string }[]): string {

--- a/pkg/rancher-desktop/agent/services/__tests__/CanonicalArtifactCustodyService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/CanonicalArtifactCustodyService.test.ts
@@ -1,120 +1,41 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
-
 import { WorkItemsModel } from '../../database/models/WorkItemsModel';
-import {
-  CanonicalArtifactCustodyService,
-  type CanonicalArtifactReader,
-} from '../CanonicalArtifactCustodyService';
+import { CanonicalArtifactCustodyService, type CanonicalArtifactReader } from '../CanonicalArtifactCustodyService';
 
-const origin = {
-  id:           'task-1',
-  project_id:   'project-1',
-  epic_id:      'epic-1',
-  title:        'Implement issue 668',
-  status:       'in_progress',
-  priority:     'critical',
-  assignee:     'dispatcher',
-  github_issue: 'merchantprotocol/sulla-desktop#668',
-} as any;
+const sha = '1234567890123456789012345678901234567890';
+const origin = { id: 'task-1', project_id: 'project-1', epic_id: 'epic-1', title: 'Implement issue 668', status: 'in_progress', priority: 'critical', assignee: 'dispatcher', github_issue: 'merchantprotocol/sulla-desktop#668' } as any;
+const disposition = { taskId: 'task-1', dispatchId: 'dispatch-1', nextState: 'in_review', proposedComment: 'receipt' };
+const code = { artifactType: 'code', artifactUrl: 'https://github.com/merchantprotocol/sulla-desktop/pull/670', artifactRef: 'hb/5tEH-core-todo-routine', headSha: sha, contentHash: sha, repository: 'merchantprotocol/sulla-desktop', branch: 'hb/5tEH-core-todo-routine', base: 'main', pullRequestRef: 'merchantprotocol/sulla-desktop#670', pullRequestUrl: 'https://github.com/merchantprotocol/sulla-desktop/pull/670', taskId: 'task-1', dispatchId: 'dispatch-1', validationEvidence: 'jest: 2 suites passed', workerProvenance: 'worker-1' };
+
+function reader(headSha = sha): CanonicalArtifactReader {
+  return { getPullRequest: jest.fn(() => Promise.resolve({ htmlUrl: code.pullRequestUrl as string, state: 'open', draft: true, headRef: code.branch as string, baseRef: 'main', headSha, body: 'Closes #668' })), getIssue: jest.fn() as any };
+}
 
 describe('CanonicalArtifactCustodyService', () => {
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('binds code custody to the originating task and the live draft PR head', async() => {
+  afterEach(() => { jest.restoreAllMocks(); });
+  it('accepts a task- and dispatch-bound code receipt against the live draft PR', async() => {
     jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue(origin);
-    const reader: CanonicalArtifactReader = {
-      getPullRequest: jest.fn(() => Promise.resolve({
-        htmlUrl: 'https://github.com/merchantprotocol/sulla-desktop/pull/670',
-        state:   'open',
-        draft:   true,
-        headRef: 'hb/5tEH-core-todo-routine',
-        headSha: '1234567890123456789012345678901234567890',
-        body:    'Closes #668',
-      })),
-      getIssue: jest.fn() as any,
-    };
-
-    await expect(CanonicalArtifactCustodyService.verify(origin, {
-      artifactType:     'code',
-      artifactUrl:      'https://github.com/merchantprotocol/sulla-desktop/pull/670',
-      artifactRef:      'hb/5tEH-core-todo-routine',
-      headSha:          '1234567890123456789012345678901234567890',
-      contentHash:      '1234567890123456789012345678901234567890',
-    }, {
-      taskId:          'task-1',
-      nextState:       'in_review',
-      proposedComment: 'Remote PR and validation verified.',
-    }, reader)).resolves.toEqual(expect.objectContaining({
-      valid:       true,
-      artifactRef: 'hb/5tEH-core-todo-routine',
-      contentHash: '1234567890123456789012345678901234567890',
-    }));
+    await expect(CanonicalArtifactCustodyService.verify(origin, code, disposition, reader())).resolves.toEqual(expect.objectContaining({ valid: true, contentHash: sha }));
   });
-
-  it('rejects an asserted PR head that differs from the live canonical head', async() => {
+  it('rejects every missing structured code field', async() => {
     jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue(origin);
-    const reader: CanonicalArtifactReader = {
-      getPullRequest: jest.fn(() => Promise.resolve({
-        htmlUrl: 'https://github.com/merchantprotocol/sulla-desktop/pull/670',
-        state:   'open',
-        draft:   true,
-        headRef: 'hb/5tEH-core-todo-routine',
-        headSha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        body:    'Closes #668',
-      })),
-      getIssue: jest.fn() as any,
-    };
-
-    await expect(CanonicalArtifactCustodyService.verify(origin, {
-      artifactType: 'code',
-      artifactUrl:  'https://github.com/merchantprotocol/sulla-desktop/pull/670',
-      artifactRef:  'hb/5tEH-core-todo-routine',
-      headSha:      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-      contentHash:  'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-    }, {
-      taskId: 'task-1', nextState: 'in_review', proposedComment: 'Verified.',
-    }, reader)).resolves.toEqual(expect.objectContaining({
-      valid: false,
-      error: 'asserted head SHA does not match the canonical pull request head',
-    }));
+    for (const field of ['repository', 'branch', 'base', 'headSha', 'pullRequestRef', 'pullRequestUrl', 'validationEvidence', 'workerProvenance', 'taskId', 'dispatchId']) {
+      await expect(CanonicalArtifactCustodyService.verify(origin, { ...code, [field]: '' }, disposition, reader())).resolves.toEqual(expect.objectContaining({ valid: false }));
+    }
   });
-
-  it('rejects a disposition for any task other than the originating claim', async() => {
-    const reader = { getPullRequest: jest.fn(), getIssue: jest.fn() } as any;
-    await expect(CanonicalArtifactCustodyService.verify(origin, {}, {
-      taskId: 'task-other', nextState: 'in_review', proposedComment: 'Wrong task.',
-    }, reader)).resolves.toEqual(expect.objectContaining({
-      valid: false,
-      error: 'proposed disposition is not bound to the originating task',
-    }));
-    expect(reader.getPullRequest).not.toHaveBeenCalled();
+  it('rejects stale remote heads and comment-only proof', async() => {
+    jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue(origin);
+    await expect(CanonicalArtifactCustodyService.verify(origin, code, disposition, reader('a'.repeat(40)))).resolves.toEqual(expect.objectContaining({ valid: false, error: 'asserted head SHA does not match the canonical pull request head' }));
+    await expect(CanonicalArtifactCustodyService.verify(origin, { ...code, validationEvidence: '' }, disposition, reader())).resolves.toEqual(expect.objectContaining({ valid: false }));
   });
-
-  it('binds non-code custody to the live originating Projects row', async() => {
-    const projectOnlyTask = {
-      ...origin,
-      github_issue: null,
-      updated_at:   '2026-08-23T20:30:00.000Z',
-    };
-    jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue(projectOnlyTask);
-    const reader = { getPullRequest: jest.fn(), getIssue: jest.fn() } as any;
-
-    await expect(CanonicalArtifactCustodyService.verify(projectOnlyTask, {
-      artifactType:     'research',
-      artifactLocation: 'projects:task-1',
-      artifactRef:      'task-1',
-    }, {
-      taskId:          'task-1',
-      nextState:       'in_review',
-      proposedComment: 'Research evidence and disposition are ready.',
-    }, reader)).resolves.toEqual(expect.objectContaining({
-      valid:             true,
-      artifactLocation: 'projects:task-1',
-      artifactRef:      'task-1',
-      contentHash:      '2026-08-23T20:30:00.000Z',
-    }));
-    expect(reader.getIssue).not.toHaveBeenCalled();
+  it('requires complete non-code custody and binds it to task and dispatch', async() => {
+    const projectTask = { ...origin, github_issue: null, updated_at: '2026-08-23T20:30:00.000Z' };
+    jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue(projectTask);
+    const custody = { artifactType: 'research', artifactLocation: 'projects:task-1', artifactRef: 'task-1', artifactUrl: 'projects://task-1', contentHash: 'hash-project-1', taskId: 'task-1', dispatchId: 'dispatch-1', validationEvidence: 'research checked', workerProvenance: 'worker-1' };
+    await expect(CanonicalArtifactCustodyService.verify(projectTask, custody, disposition, reader())).resolves.toEqual(expect.objectContaining({ valid: true, artifactRef: 'task-1' }));
+    await expect(CanonicalArtifactCustodyService.verify(projectTask, { ...custody, artifactRef: 'wrong' }, disposition, reader())).resolves.toEqual(expect.objectContaining({ valid: false }));
+    for (const field of ['artifactType', 'artifactLocation', 'artifactRef', 'artifactUrl', 'contentHash', 'taskId', 'dispatchId', 'validationEvidence', 'workerProvenance']) {
+      await expect(CanonicalArtifactCustodyService.verify(projectTask, { ...custody, [field]: '' }, disposition, reader())).resolves.toEqual(expect.objectContaining({ valid: false }));
+    }
   });
 });

--- a/pkg/rancher-desktop/agent/tools/project/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/project/manifests.ts
@@ -292,6 +292,8 @@ export const projectToolManifests: ToolManifest[] = [
       github_issue: { type: 'string', optional: true, description: 'owner/repo#n or URL, or empty string to clear.' },
       position:     { type: 'number', optional: true, description: 'Manual sort order inside the epic.' },
       actor:        { type: 'string', optional: true, description: 'Acting source/agent for attribution: "heartbeat" (autonomous), "sulla" (chat), "workbench", or "human". Defaults to "sulla".' },
+      custody:      { type: 'object', optional: true, description: 'Typed artifact custody envelope required when entering in_review; free-form narration is not accepted.' },
+      custodyDisposition: { type: 'object', optional: true, description: 'Typed task/dispatch disposition paired with custody.' },
     },
     operationTypes: ['update'],
     loader:         () => import('./update_task'),

--- a/pkg/rancher-desktop/agent/tools/project/update_task.ts
+++ b/pkg/rancher-desktop/agent/tools/project/update_task.ts
@@ -64,6 +64,10 @@ export class UpdateTaskWorker extends BaseTool {
         github_issue: input.github_issue === '' ? null : input.github_issue,
         position:     typeof input.position === 'number' ? input.position : undefined,
         source:       input.source,
+        custody:      input.custody && typeof input.custody === 'object' ? input.custody : undefined,
+        custodyDisposition: input.custodyDisposition && typeof input.custodyDisposition === 'object'
+          ? input.custodyDisposition
+          : undefined,
         actor,
       });
       if (!updated) return { successBoolean: false, responseString: `No task found with id: ${ id }` };


### PR DESCRIPTION
Closes #712.

Design:
- Extends the existing CanonicalArtifactCustodyService.verify() envelope with task/dispatch binding, repository, branch, base, canonical PR ref/url, full head SHA, validation evidence, and worker provenance.
- Gates WorkItemsModel, dispatcher finalization, lane automation, project update_task, and IPC pass-through; free-form narration cannot enter in_review.
- Adds migration 0078 with atomic validated receipts and legacy markers for historical in_review rows.
- Dispatcher settlement, custody receipt, comment, and in_review transition share one transaction.
- External-wait completion routes to planning until new custody exists.

Coverage:
- Code and non-code missing-field negatives, task/dispatch mismatch, stale remote head, comment-only proof, migration legacy markers, and migration registry ordering.
- git diff --check passes.
- Migration registry suite passed 1/1. Runtime custody/tool/Postgres suites are blocked on the mandated origin/main baseline: node_modules target is deleted and origin/main has pre-existing WorkLaneDefinitionModel/TaskOwnership type errors. No Postgres runtime result is claimed.