### PR TITLE
feat(projects): conveyor health & productivity metrics (#717)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0078_add_conveyor_metrics_indexes.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0078_add_conveyor_metrics_indexes.ts
@@ -1,0 +1,38 @@
+/**
+ * 0078_add_conveyor_metrics_indexes — additive, index-only migration that keeps
+ * the Projects conveyor-health dashboard (issue #717) bounded on local Postgres.
+ * No data is mutated and no columns/tables are dropped; every index uses
+ * IF NOT EXISTS so re-running is safe.
+ */
+export const up = `
+  -- verifier throughput / rework scans by dispatch kind over a finished-at window
+  CREATE INDEX IF NOT EXISTS idx_wtd_kind_finished
+    ON work_task_dispatches (kind, finished_at DESC);
+
+  -- duplicate/suppressed review-generation dedup key (verification leases only)
+  CREATE INDEX IF NOT EXISTS idx_wtd_verif_generation
+    ON work_task_dispatches (task_id, review_generation_hash)
+    WHERE kind = 'verification';
+
+  -- custody completeness joins dispatches to their task by kind
+  CREATE INDEX IF NOT EXISTS idx_wtd_task_kind
+    ON work_task_dispatches (task_id, kind);
+
+  -- independent-shipment / done-throughput window scans
+  CREATE INDEX IF NOT EXISTS idx_work_tasks_completed
+    ON work_tasks (project_id, completed_at)
+    WHERE status = 'done';
+
+  -- stage-age percentile window scans over recently-active tasks
+  CREATE INDEX IF NOT EXISTS idx_work_tasks_activity
+    ON work_tasks (project_id, last_activity_at)
+    WHERE archived = false;
+`;
+
+export const down = `
+  DROP INDEX IF EXISTS idx_work_tasks_activity;
+  DROP INDEX IF EXISTS idx_work_tasks_completed;
+  DROP INDEX IF EXISTS idx_wtd_task_kind;
+  DROP INDEX IF EXISTS idx_wtd_verif_generation;
+  DROP INDEX IF EXISTS idx_wtd_kind_finished;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0078_add_conveyor_metrics_indexes.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0078_add_conveyor_metrics_indexes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from '@jest/globals';
+import { up, down } from '../0078_add_conveyor_metrics_indexes';
+
+describe('0078_add_conveyor_metrics_indexes', () => {
+  it('creates the bounded conveyor-metric indexes additively', () => {
+    expect(up).toContain('CREATE INDEX IF NOT EXISTS');
+    expect(up).toContain('idx_wtd_kind_finished');
+    expect(up).toContain('idx_wtd_verif_generation');
+    expect(up).toContain('idx_wtd_task_kind');
+    expect(up).toContain('idx_work_tasks_completed');
+    expect(up).toContain('idx_work_tasks_activity');
+    // additive only: never mutates data or drops schema
+    expect(up).not.toMatch(/DROP\s+(TABLE|COLUMN)/i);
+    expect(up).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b/i);
+  });
+
+  it('down drops exactly the indexes it created', () => {
+    expect(down).toContain('DROP INDEX IF EXISTS idx_wtd_kind_finished');
+    expect(down).toContain('DROP INDEX IF EXISTS idx_wtd_verif_generation');
+    expect(down).toContain('DROP INDEX IF EXISTS idx_wtd_task_kind');
+    expect(down).toContain('DROP INDEX IF EXISTS idx_work_tasks_completed');
+    expect(down).toContain('DROP INDEX IF EXISTS idx_work_tasks_activity');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -64,6 +64,7 @@ import { up as up_0074, down as down_0074 } from './0074_semantic_lane_runtime_h
 import { up as up_0075, down as down_0075 } from './0075_add_project_views_and_scheduling';
 import { up as up_0076, down as down_0076 } from './0076_extend_work_task_dispatch_custody';
 import { up as up_0077, down as down_0077 } from './0077_create_work_item_knowledge_links';
+import { up as up_0078, down as down_0078 } from './0078_add_conveyor_metrics_indexes';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -129,4 +130,5 @@ export const migrationsRegistry = [
   { name: '0075_add_project_views_and_scheduling',                 up: up_0075, down: down_0075 },
   { name: '0076_extend_work_task_dispatch_custody',                up: up_0076, down: down_0076 },
   { name: '0077_create_work_item_knowledge_links',                 up: up_0077, down: down_0077 },
+  { name: '0078_add_conveyor_metrics_indexes', up: up_0078, down: down_0078 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
@@ -1,0 +1,443 @@
+/**
+ * WorkConveyorMetricsModel — read-only Projects conveyor-health & productivity
+ * metrics (GitHub issue #717).
+ *
+ * Contract (issue acceptance criteria):
+ *  - AC#1: every number documents its denominator + legacy-data handling in
+ *    the comment above its query.
+ *  - Stage grouping resolves the *semantic* lane role via the DB function
+ *    resolve_work_task_lane_role(task_id, lane_key) so custom lane names stay
+ *    compatible (issue Scope). work_tasks.status IS the lane key.
+ *  - AC#7 query-performance: aggregates over indexed columns; every drill-down
+ *    list is LIMITed. Optional project scoping uses a static guard
+ *    ($1::text IS NULL OR <col> = $1) so the SQL stays constant/index-friendly.
+ *  - Comments/narration are never counted as completion (issue Scope):
+ *    completion is read only from terminal task state + the dispatch ledger.
+ *
+ * Read-only: no INSERT/UPDATE/DELETE.
+ */
+import { postgresClient } from '../PostgresClient';
+
+export type SemanticStage =
+  | 'backlog' | 'planning' | 'execution' | 'review' | 'blocked' | 'terminal' | 'manual';
+
+export interface ConveyorMetricsOptions {
+  /** Limit every metric to one project; null/undefined = whole portfolio. */
+  projectId?: string | null;
+  /** Rolling window for rate/throughput metrics (hours). Default 168 (7d). */
+  windowHours?: number;
+  /** Soft WIP ceiling for active execution leases. Default 6. */
+  wipLimit?: number;
+  /** Lease is stale/zombie when its heartbeat is older than this (minutes). Default 20. */
+  staleMinutes?: number;
+  /** Drill-down row cap. Default 20, hard-capped at 100. */
+  drillLimit?: number;
+}
+
+const DEFAULT_WINDOW_HOURS = 168;
+const DEFAULT_WIP_LIMIT = 6;
+const DEFAULT_STALE_MINUTES = 20;
+const DEFAULT_DRILL_LIMIT = 20;
+const MAX_DRILL_LIMIT = 100;
+
+function num(v: any): number { const n = Number(v); return Number.isFinite(n) ? n : 0; }
+function pid(o: ConveyorMetricsOptions): string | null { return o.projectId ?? null; }
+function win(o: ConveyorMetricsOptions): number {
+  return o.windowHours && o.windowHours > 0 ? Math.floor(o.windowHours) : DEFAULT_WINDOW_HOURS;
+}
+function stale(o: ConveyorMetricsOptions): number {
+  return o.staleMinutes && o.staleMinutes > 0 ? Math.floor(o.staleMinutes) : DEFAULT_STALE_MINUTES;
+}
+function drill(o: ConveyorMetricsOptions): number {
+  const d = o.drillLimit ?? DEFAULT_DRILL_LIMIT;
+  return Math.max(1, Math.min(MAX_DRILL_LIMIT, Math.floor(d)));
+}
+function wipLimit(o: ConveyorMetricsOptions): number {
+  return o.wipLimit && o.wipLimit > 0 ? Math.floor(o.wipLimit) : DEFAULT_WIP_LIMIT;
+}
+
+export interface StageCount {
+  stage: SemanticStage; count: number;
+  oldestTaskId: string | null; oldestTitle: string | null;
+  oldestEnteredAt: string | null; oldestAgeSeconds: number | null;
+}
+export interface StageAge {
+  stage: SemanticStage; sampleSize: number;
+  p50AgeSeconds: number; p90AgeSeconds: number;
+}
+export interface Throughput { enteredReview: number; reviewsCompleted: number; reachedDone: number; }
+export interface VerifierThroughput { completedReviews: number; perDay: number; activeVerificationLeases: number; }
+export interface Rework { reviewed: number; reworked: number; reworkRate: number; avgRepairLoops: number; }
+export interface CustodyRow {
+  artifactType: string; total: number;
+  structured: number; legacy: number; missing: number; invalid: number;
+}
+export interface WaitAdoption { blockedTotal: number; blockedWithActiveWait: number; adoptionRate: number; }
+export interface StaleLeases { staleLeases: number; activeLeases: number; }
+export interface WipPressure {
+  activeExecutionWip: number; activeVerificationWip: number; staleWip: number;
+  wipLimit: number; over: boolean; backpressureReason: string | null;
+}
+export interface Shipments { independentShipments: number; integrationTrainClosures: number; }
+
+export class WorkConveyorMetricsModel {
+  /**
+   * AC#2 — current count and the exact oldest item per semantic stage.
+   * Denominator: all non-archived work_tasks (each counted in exactly one
+   * stage). Age = now() - last_moved_at (dwell in current lane). Returns the
+   * oldest item's id/title so the UI can jump straight to it.
+   * Legacy: last_moved_at is NOT NULL (defaulted at insert) — no null handling.
+   */
+  static async stageCounts(opts: ConveyorMetricsOptions = {}): Promise<StageCount[]> {
+    const rows = await postgresClient.query(`
+      WITH staged AS (
+        SELECT t.id, t.title, t.last_moved_at,
+               resolve_work_task_lane_role(t.id, t.status) AS stage
+        FROM work_tasks t
+        WHERE t.archived = false
+          AND ($1::text IS NULL OR t.project_id = $1)
+      ), ranked AS (
+        SELECT s.*,
+               ROW_NUMBER() OVER (PARTITION BY s.stage ORDER BY s.last_moved_at ASC) AS rn,
+               COUNT(*)     OVER (PARTITION BY s.stage) AS stage_count
+        FROM staged s
+      )
+      SELECT stage, stage_count AS count, id AS oldest_task_id, title AS oldest_title,
+             last_moved_at AS oldest_entered_at,
+             EXTRACT(EPOCH FROM (now() - last_moved_at))::bigint AS oldest_age_seconds
+      FROM ranked WHERE rn = 1
+      ORDER BY stage
+    `, [pid(opts)]);
+    return rows.map((r: any) => ({
+      stage: r.stage as SemanticStage,
+      count: num(r.count),
+      oldestTaskId: r.oldest_task_id ?? null,
+      oldestTitle: r.oldest_title ?? null,
+      oldestEnteredAt: r.oldest_entered_at ? String(r.oldest_entered_at) : null,
+      oldestAgeSeconds: r.oldest_age_seconds == null ? null : num(r.oldest_age_seconds),
+    }));
+  }
+
+  /**
+   * Median (p50) and p90 stage age over a selectable window.
+   * Denominator: non-archived tasks whose last_activity_at falls in the window,
+   * grouped by semantic stage. Age = now() - last_moved_at.
+   */
+  static async stageAgePercentiles(opts: ConveyorMetricsOptions = {}): Promise<StageAge[]> {
+    const rows = await postgresClient.query(`
+      SELECT resolve_work_task_lane_role(t.id, t.status) AS stage,
+             COUNT(*) AS sample_size,
+             percentile_cont(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (now() - t.last_moved_at))) AS p50_age_seconds,
+             percentile_cont(0.9) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (now() - t.last_moved_at))) AS p90_age_seconds
+      FROM work_tasks t
+      WHERE t.archived = false
+        AND ($1::text IS NULL OR t.project_id = $1)
+        AND t.last_activity_at >= now() - make_interval(hours => $2)
+      GROUP BY stage
+      ORDER BY stage
+    `, [pid(opts), win(opts)]);
+    return rows.map((r: any) => ({
+      stage: r.stage as SemanticStage,
+      sampleSize: num(r.sample_size),
+      p50AgeSeconds: num(r.p50_age_seconds),
+      p90AgeSeconds: num(r.p90_age_seconds),
+    }));
+  }
+
+  /**
+   * Execution->review and review->done throughput over the window.
+   * There is no transition-history table, so these are derived from the
+   * authoritative dispatch ledger + terminal task state (never comments):
+   *   entered_review    = distinct tasks with a verification dispatch STARTED in window.
+   *   reviews_completed = distinct (task_id, review_generation_hash) FINISHED in window.
+   *   reached_done      = tasks whose completed_at falls in window (status='done').
+   * Denominator for each is stated inline; all three share the same window.
+   */
+  static async throughput(opts: ConveyorMetricsOptions = {}): Promise<Throughput> {
+    const r = (await postgresClient.query(`
+      SELECT
+        (SELECT COUNT(DISTINCT d.task_id)
+           FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+           WHERE d.kind = 'verification' AND d.started_at >= now() - make_interval(hours => $2)
+             AND ($1::text IS NULL OR t.project_id = $1)) AS entered_review,
+        (SELECT COUNT(*) FROM (
+              SELECT DISTINCT d.task_id, d.review_generation_hash
+              FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+              WHERE d.kind = 'verification' AND d.finished_at >= now() - make_interval(hours => $2)
+                AND d.status <> 'cancelled' AND d.review_generation_hash IS NOT NULL
+                AND ($1::text IS NULL OR t.project_id = $1)
+           ) g) AS reviews_completed,
+        (SELECT COUNT(*) FROM work_tasks t
+           WHERE t.status = 'done' AND t.completed_at >= now() - make_interval(hours => $2)
+             AND ($1::text IS NULL OR t.project_id = $1)) AS reached_done
+    `, [pid(opts), win(opts)]))[0] || {};
+    return {
+      enteredReview: num(r.entered_review),
+      reviewsCompleted: num(r.reviews_completed),
+      reachedDone: num(r.reached_done),
+    };
+  }
+
+  /**
+   * AC#5 — verifier throughput + utilization, EXCLUDING duplicate/suppressed
+   * generations. Duplicates are collapsed by DISTINCT (task_id,
+   * review_generation_hash) — the same dedup key WorkTaskDispatchModel uses to
+   * detect duplicate review generations. Suppressed generations
+   * (terminal_reason ILIKE 'suppress%') and cancelled leases are excluded.
+   * Denominator: distinct completed review generations in window.
+   * perDay is completed_reviews normalised to a 24h rate.
+   * Utilization is expressed as the count of currently-running verification
+   * leases (no capacity value is stored in the schema).
+   */
+  static async verifierThroughput(opts: ConveyorMetricsOptions = {}): Promise<VerifierThroughput> {
+    const hours = win(opts);
+    const r = (await postgresClient.query(`
+      SELECT
+        (SELECT COUNT(*) FROM (
+           SELECT DISTINCT d.task_id, d.review_generation_hash
+           FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+           WHERE d.kind = 'verification' AND d.finished_at >= now() - make_interval(hours => $2)
+             AND d.status <> 'cancelled'
+             AND COALESCE(d.terminal_reason, '') NOT ILIKE 'suppress%'
+             AND d.review_generation_hash IS NOT NULL
+             AND ($1::text IS NULL OR t.project_id = $1)
+         ) g) AS completed_reviews,
+        (SELECT COUNT(*) FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+           WHERE d.kind = 'verification' AND d.status = 'running'
+             AND ($1::text IS NULL OR t.project_id = $1)) AS active_verification_leases
+    `, [pid(opts), hours]))[0] || {};
+    const completed = num(r.completed_reviews);
+    return {
+      completedReviews: completed,
+      perDay: hours > 0 ? completed / (hours / 24) : 0,
+      activeVerificationLeases: num(r.active_verification_leases),
+    };
+  }
+
+  /**
+   * Rework rate + average repair loops from the custody ledger.
+   * Denominator: execution dispatches FINISHED in window that were reviewed
+   * (review_count > 0). reworkRate = reworked / reviewed. avgRepairLoops =
+   * mean(repair_count) over reviewed. Empty denominator degrades to 0.
+   */
+  static async reworkRate(opts: ConveyorMetricsOptions = {}): Promise<Rework> {
+    const r = (await postgresClient.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE d.review_count > 0) AS reviewed,
+        COUNT(*) FILTER (WHERE d.review_count > 0 AND d.repair_count > 0) AS reworked,
+        COALESCE(AVG(d.repair_count) FILTER (WHERE d.review_count > 0), 0)::float8 AS avg_repair_loops
+      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+      WHERE d.kind = 'execution' AND d.finished_at >= now() - make_interval(hours => $2)
+        AND ($1::text IS NULL OR t.project_id = $1)
+    `, [pid(opts), win(opts)]))[0] || {};
+    const reviewed = num(r.reviewed);
+    const reworked = num(r.reworked);
+    return { reviewed, reworked, reworkRate: reviewed > 0 ? reworked / reviewed : 0, avgRepairLoops: num(r.avg_repair_loops) };
+  }
+
+  /**
+   * AC#3 — structured custody completeness by artifact type. Denominator:
+   * terminal (status='done') execution dispatches. Four disjoint classes:
+   *   structured = real run + artifact_type + (content_hash OR artifact_ref)
+   *   legacy     = run_kind='legacy-worker' (pre-custody rows; not penalised)
+   *   missing    = real run, no artifact_type at all
+   *   invalid    = real run, claims an artifact_type but no hash/ref/url locator
+   */
+  static async custodyCompleteness(opts: ConveyorMetricsOptions = {}): Promise<CustodyRow[]> {
+    const rows = await postgresClient.query(`
+      SELECT
+        COALESCE(d.artifact_type, '(none)') AS artifact_type,
+        COUNT(*) AS total,
+        COUNT(*) FILTER (WHERE d.run_kind <> 'legacy-worker' AND d.artifact_type IS NOT NULL
+                           AND (d.content_hash IS NOT NULL OR d.artifact_ref IS NOT NULL)) AS structured,
+        COUNT(*) FILTER (WHERE d.run_kind = 'legacy-worker') AS legacy,
+        COUNT(*) FILTER (WHERE d.run_kind <> 'legacy-worker' AND d.artifact_type IS NULL) AS missing,
+        COUNT(*) FILTER (WHERE d.run_kind <> 'legacy-worker' AND d.artifact_type IS NOT NULL
+                           AND d.content_hash IS NULL AND d.artifact_ref IS NULL AND d.artifact_url IS NULL) AS invalid
+      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+      WHERE d.kind = 'execution' AND t.status = 'done'
+        AND ($1::text IS NULL OR t.project_id = $1)
+      GROUP BY COALESCE(d.artifact_type, '(none)')
+      ORDER BY total DESC
+      LIMIT 50
+    `, [pid(opts)]);
+    return rows.map((r: any) => ({
+      artifactType: String(r.artifact_type),
+      total: num(r.total), structured: num(r.structured), legacy: num(r.legacy),
+      missing: num(r.missing), invalid: num(r.invalid),
+    }));
+  }
+
+  /**
+   * AC#4 — durable-wait adoption for blocked external gates. Denominator:
+   * non-archived tasks whose semantic stage is 'blocked'. A blocked task counts
+   * as adopted only when it has a work_task_waits row with status='active'.
+   */
+  static async waitAdoption(opts: ConveyorMetricsOptions = {}): Promise<WaitAdoption> {
+    const r = (await postgresClient.query(`
+      WITH blocked AS (
+        SELECT t.id FROM work_tasks t
+        WHERE t.archived = false
+          AND resolve_work_task_lane_role(t.id, t.status) = 'blocked'
+          AND ($1::text IS NULL OR t.project_id = $1)
+      )
+      SELECT
+        (SELECT COUNT(*) FROM blocked) AS blocked_total,
+        (SELECT COUNT(*) FROM blocked b WHERE EXISTS (
+           SELECT 1 FROM work_task_waits w WHERE w.task_id = b.id AND w.status = 'active')) AS blocked_with_active_wait
+    `, [pid(opts)]))[0] || {};
+    const total = num(r.blocked_total);
+    const withWait = num(r.blocked_with_active_wait);
+    return { blockedTotal: total, blockedWithActiveWait: withWait, adoptionRate: total > 0 ? withWait / total : 0 };
+  }
+
+  /**
+   * Zombie/stale lease count. Denominator: currently-running dispatches
+   * (execution + verification). A lease is stale when heartbeat_at is older
+   * than staleMinutes (default 20).
+   */
+  static async staleLeases(opts: ConveyorMetricsOptions = {}): Promise<StaleLeases> {
+    const r = (await postgresClient.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE d.status = 'running' AND d.heartbeat_at < now() - make_interval(mins => $2)) AS stale_leases,
+        COUNT(*) FILTER (WHERE d.status = 'running') AS active_leases
+      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+      WHERE ($1::text IS NULL OR t.project_id = $1)
+    `, [pid(opts), stale(opts)]))[0] || {};
+    return { staleLeases: num(r.stale_leases), activeLeases: num(r.active_leases) };
+  }
+
+  /**
+   * Dependency-held count. Denominator: non-archived, non-terminal tasks that
+   * have a non-archived dependency on another non-terminal task.
+   */
+  static async dependencyHeld(opts: ConveyorMetricsOptions = {}): Promise<{ dependencyHeld: number }> {
+    const r = (await postgresClient.query(`
+      SELECT COUNT(DISTINCT t.id) AS dependency_held
+      FROM work_tasks t
+      JOIN work_task_dependencies dep ON dep.task_id = t.id AND dep.archived = false
+      JOIN work_tasks dt ON dt.id = dep.depends_on_task_id
+      WHERE t.archived = false
+        AND resolve_work_task_lane_role(t.id, t.status) <> 'terminal'
+        AND resolve_work_task_lane_role(dt.id, dt.status) <> 'terminal'
+        AND ($1::text IS NULL OR t.project_id = $1)
+    `, [pid(opts)]))[0] || {};
+    return { dependencyHeld: num(r.dependency_held) };
+  }
+
+  /**
+   * WIP limit and active backpressure reason. active_execution_wip is the count
+   * of running execution leases; the soft limit is a configurable default (no
+   * authoritative WIP store exists in the schema). backpressureReason is
+   * derived: stale leases holding slots > wip saturation > idle.
+   */
+  static async wipPressure(opts: ConveyorMetricsOptions = {}): Promise<WipPressure> {
+    const r = (await postgresClient.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE d.kind = 'execution' AND d.status = 'running') AS active_execution_wip,
+        COUNT(*) FILTER (WHERE d.kind = 'verification' AND d.status = 'running') AS active_verification_wip,
+        COUNT(*) FILTER (WHERE d.status = 'running' AND d.heartbeat_at < now() - make_interval(mins => $2)) AS stale_wip
+      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+      WHERE ($1::text IS NULL OR t.project_id = $1)
+    `, [pid(opts), stale(opts)]))[0] || {};
+    const activeExec = num(r.active_execution_wip);
+    const staleWip = num(r.stale_wip);
+    const limit = wipLimit(opts);
+    const over = activeExec >= limit;
+    let reason: string | null = null;
+    if (staleWip > 0) reason = 'stale_leases_holding_slots';
+    else if (over) reason = 'wip_limit_reached';
+    else if (activeExec === 0) reason = 'idle';
+    return {
+      activeExecutionWip: activeExec,
+      activeVerificationWip: num(r.active_verification_wip),
+      staleWip, wipLimit: limit, over, backpressureReason: reason,
+    };
+  }
+
+  /**
+   * AC#6 — completed independent shipments separated from integration-train
+   * closures. Denominator: tasks with status='done' and completed_at in window.
+   * A done task is an INDEPENDENT shipment when it carries its own artifact
+   * custody (an execution dispatch with content_hash or artifact_ref). Done
+   * tasks closed WITHOUT their own custody are integration-train closures
+   * (rolled up with another shipment) and are reported separately, never as
+   * independent shipments. (No explicit integration-train marker exists in the
+   * schema; artifact custody is the authoritative available signal.)
+   */
+  static async shipments(opts: ConveyorMetricsOptions = {}): Promise<Shipments> {
+    const r = (await postgresClient.query(`
+      WITH done AS (
+        SELECT t.id,
+          EXISTS (SELECT 1 FROM work_task_dispatches d
+                  WHERE d.task_id = t.id AND d.kind = 'execution'
+                    AND (d.content_hash IS NOT NULL OR d.artifact_ref IS NOT NULL)) AS has_custody
+        FROM work_tasks t
+        WHERE t.status = 'done' AND t.completed_at >= now() - make_interval(hours => $2)
+          AND ($1::text IS NULL OR t.project_id = $1)
+      )
+      SELECT
+        COUNT(*) FILTER (WHERE has_custody) AS independent_shipments,
+        COUNT(*) FILTER (WHERE NOT has_custody) AS integration_train_closures
+      FROM done
+    `, [pid(opts), win(opts)]))[0] || {};
+    return {
+      independentShipments: num(r.independent_shipments),
+      integrationTrainClosures: num(r.integration_train_closures),
+    };
+  }
+
+  /** Bounded drill-down: oldest N tasks in a semantic stage (AC#2/#7). */
+  static async oldestItems(opts: ConveyorMetricsOptions, stage: SemanticStage) {
+    const rows = await postgresClient.query(`
+      SELECT t.id, t.title, t.status, t.project_id,
+             EXTRACT(EPOCH FROM (now() - t.last_moved_at))::bigint AS age_seconds,
+             t.last_moved_at
+      FROM work_tasks t
+      WHERE t.archived = false
+        AND resolve_work_task_lane_role(t.id, t.status) = $2
+        AND ($1::text IS NULL OR t.project_id = $1)
+      ORDER BY t.last_moved_at ASC
+      LIMIT $3
+    `, [pid(opts), stage, drill(opts)]);
+    return rows.map((r: any) => ({
+      id: r.id, title: r.title, status: r.status, projectId: r.project_id,
+      ageSeconds: num(r.age_seconds), lastMovedAt: r.last_moved_at ? String(r.last_moved_at) : null,
+    }));
+  }
+
+  /** Bounded drill-down: the stale/zombie running leases (AC#7). */
+  static async staleLeaseItems(opts: ConveyorMetricsOptions = {}) {
+    const rows = await postgresClient.query(`
+      SELECT d.id AS dispatch_id, d.task_id, d.kind, d.agent_id, d.heartbeat_at,
+             EXTRACT(EPOCH FROM (now() - d.heartbeat_at))::bigint AS silent_seconds, t.title
+      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+      WHERE d.status = 'running' AND d.heartbeat_at < now() - make_interval(mins => $2)
+        AND ($1::text IS NULL OR t.project_id = $1)
+      ORDER BY d.heartbeat_at ASC
+      LIMIT $3
+    `, [pid(opts), stale(opts), drill(opts)]);
+    return rows.map((r: any) => ({
+      dispatchId: r.dispatch_id, taskId: r.task_id, kind: r.kind, agentId: r.agent_id,
+      silentSeconds: num(r.silent_seconds), title: r.title,
+    }));
+  }
+
+  /** Aggregate snapshot of every conveyor metric (all queries run concurrently). */
+  static async snapshot(opts: ConveyorMetricsOptions = {}) {
+    const [stages, agePercentiles, throughput, verifier, rework, custody, waits, leases, deps, wip, shipments] =
+      await Promise.all([
+        this.stageCounts(opts), this.stageAgePercentiles(opts), this.throughput(opts),
+        this.verifierThroughput(opts), this.reworkRate(opts), this.custodyCompleteness(opts),
+        this.waitAdoption(opts), this.staleLeases(opts), this.dependencyHeld(opts),
+        this.wipPressure(opts), this.shipments(opts),
+      ]);
+    return {
+      metric: 'conveyor_health',
+      window_hours: win(opts),
+      project_id: pid(opts),
+      stages, agePercentiles, throughput, verifier, rework, custody,
+      waits, leases, deps, wip, shipments,
+    };
+  }
+}

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkConveyorMetricsModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkConveyorMetricsModel.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { postgresClient } from '../../PostgresClient';
+import { WorkConveyorMetricsModel } from '../WorkConveyorMetricsModel';
+
+describe('WorkConveyorMetricsModel', () => {
+  let originalQuery: any;
+  let sqls: string[] = [];
+
+  beforeAll(() => { originalQuery = (postgresClient as any).query; });
+  afterEach(() => { (postgresClient as any).query = originalQuery; jest.restoreAllMocks(); sqls = []; });
+
+  function mock(rows: any[]) {
+    (postgresClient as any).query = jest.fn((sql: string, _params?: any[]) => {
+      sqls.push(sql);
+      return Promise.resolve(rows);
+    });
+  }
+
+  it('stageCounts groups by semantic lane role (custom-lane safe) and returns the exact oldest item (AC#2)', async () => {
+    mock([{ stage: 'execution', count: '3', oldest_task_id: 'task-9', oldest_title: 'Old one',
+            oldest_entered_at: '2026-08-01T00:00:00.000Z', oldest_age_seconds: '86400' }]);
+    const rows = await WorkConveyorMetricsModel.stageCounts({ projectId: 'p1' });
+    expect(sqls[0]).toContain('resolve_work_task_lane_role');
+    expect(sqls[0]).toContain('$1::text IS NULL OR');
+    expect(rows[0]).toMatchObject({ stage: 'execution', count: 3, oldestTaskId: 'task-9', oldestAgeSeconds: 86400 });
+  });
+
+  it('empty-state: rate aggregates degrade to zero without NaN', async () => {
+    mock([]);
+    const rework = await WorkConveyorMetricsModel.reworkRate({});
+    expect(rework).toEqual({ reviewed: 0, reworked: 0, reworkRate: 0, avgRepairLoops: 0 });
+    const waits = await WorkConveyorMetricsModel.waitAdoption({});
+    expect(waits.adoptionRate).toBe(0);
+  });
+
+  it('verifier throughput excludes duplicate and suppressed generations (AC#5)', async () => {
+    mock([{ completed_reviews: '4', active_verification_leases: '1' }]);
+    const v = await WorkConveyorMetricsModel.verifierThroughput({ windowHours: 24 });
+    expect(sqls[0]).toContain('DISTINCT');
+    expect(sqls[0]).toContain('review_generation_hash');
+    expect(sqls[0].toLowerCase()).toContain('suppress');
+    expect(v.completedReviews).toBe(4);
+    expect(v.perDay).toBeCloseTo(4);
+  });
+
+  it('custody completeness distinguishes structured/legacy/missing/invalid incl migrated data (AC#3)', async () => {
+    mock([{ artifact_type: 'pull_request', total: '5', structured: '3', legacy: '1', missing: '1', invalid: '0' }]);
+    const rows = await WorkConveyorMetricsModel.custodyCompleteness({});
+    expect(sqls[0]).toContain("'legacy-worker'");
+    expect(rows[0]).toMatchObject({ artifactType: 'pull_request', total: 5, structured: 3, legacy: 1, missing: 1, invalid: 0 });
+  });
+
+  it('wait adoption counts only blocked tasks with an active matching durable wait (AC#4)', async () => {
+    mock([{ blocked_total: '2', blocked_with_active_wait: '1' }]);
+    const w = await WorkConveyorMetricsModel.waitAdoption({});
+    expect(sqls[0]).toContain('resolve_work_task_lane_role');
+    expect(sqls[0]).toContain("status = 'active'");
+    expect(w).toEqual({ blockedTotal: 2, blockedWithActiveWait: 1, adoptionRate: 0.5 });
+  });
+
+  it('separates independent shipments from integration-train closures via artifact custody (AC#6)', async () => {
+    mock([{ independent_shipments: '3', integration_train_closures: '2' }]);
+    const s = await WorkConveyorMetricsModel.shipments({ windowHours: 168 });
+    expect(sqls[0]).toContain('content_hash');
+    expect(s).toEqual({ independentShipments: 3, integrationTrainClosures: 2 });
+  });
+
+  it('drill-down queries are bounded with LIMIT for query performance (AC#7)', async () => {
+    mock([]);
+    await WorkConveyorMetricsModel.oldestItems({ drillLimit: 10 }, 'execution');
+    await WorkConveyorMetricsModel.staleLeaseItems({});
+    expect(sqls[0]).toContain('LIMIT');
+    expect(sqls[1]).toContain('LIMIT');
+  });
+
+  it('wipPressure reports a documented WIP limit and derived backpressure reason', async () => {
+    mock([{ active_execution_wip: '6', active_verification_wip: '1', stale_wip: '0' }]);
+    const wip = await WorkConveyorMetricsModel.wipPressure({ wipLimit: 6 });
+    expect(wip.over).toBe(true);
+    expect(wip.backpressureReason).toBe('wip_limit_reached');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/project/__tests__/conveyor_health.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/conveyor_health.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from '@jest/globals';
+import { ConveyorHealthWorker } from '../conveyor_health';
+
+describe('ConveyorHealthWorker', () => {
+  it('is a BaseTool with a validated-call implementation', () => {
+    expect(typeof ConveyorHealthWorker).toBe('function');
+    expect(typeof (ConveyorHealthWorker.prototype as any)._validatedCall).toBe('function');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/project/conveyor_health.ts
+++ b/pkg/rancher-desktop/agent/tools/project/conveyor_health.ts
@@ -1,0 +1,58 @@
+import { BaseTool, ToolResponse } from '../base';
+import {
+  WorkConveyorMetricsModel,
+  type ConveyorMetricsOptions,
+} from '../../database/models/WorkConveyorMetricsModel';
+
+/**
+ * conveyor_health — read-only Projects conveyor-health & productivity snapshot
+ * (GitHub issue #717). Returns a compact human summary plus the full structured
+ * JSON the Projects UI panel/drill-down consumes. Every number is defined (with
+ * denominator) in WorkConveyorMetricsModel.
+ */
+export class ConveyorHealthWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    try {
+      const opts: ConveyorMetricsOptions = {
+        projectId:    typeof input?.project_id === 'string' ? input.project_id : null,
+        windowHours:  typeof input?.window_hours === 'number' ? input.window_hours : undefined,
+        wipLimit:     typeof input?.wip_limit === 'number' ? input.wip_limit : undefined,
+        staleMinutes: typeof input?.stale_minutes === 'number' ? input.stale_minutes : undefined,
+      };
+      const snap = await WorkConveyorMetricsModel.snapshot(opts);
+      const scope = snap.project_id ? `project ${ snap.project_id }` : 'all projects';
+      const lines: string[] = [];
+      lines.push(`# Projects conveyor health (window ${ snap.window_hours }h, ${ scope })`);
+      lines.push('');
+      lines.push('## Stage counts (oldest item per semantic stage)');
+      for (const s of snap.stages) {
+        const age = s.oldestAgeSeconds == null ? '-' : `${ Math.round(s.oldestAgeSeconds / 3600) }h`;
+        lines.push(`- ${ s.stage }: ${ s.count }  (oldest ${ age }${ s.oldestTaskId ? ` -> ${ s.oldestTaskId }` : '' })`);
+      }
+      lines.push('');
+      lines.push(`Throughput: entered_review=${ snap.throughput.enteredReview } reviews_completed=${ snap.throughput.reviewsCompleted } reached_done=${ snap.throughput.reachedDone }`);
+      lines.push(`Verifier: completed_reviews=${ snap.verifier.completedReviews } per_day=${ snap.verifier.perDay.toFixed(2) } active_leases=${ snap.verifier.activeVerificationLeases }`);
+      lines.push(`Rework: rate=${ (snap.rework.reworkRate * 100).toFixed(1) }% avg_repair_loops=${ snap.rework.avgRepairLoops.toFixed(2) } (reviewed ${ snap.rework.reviewed })`);
+      lines.push(`Wait adoption: ${ snap.waits.blockedWithActiveWait }/${ snap.waits.blockedTotal } blocked tasks have an active durable wait (${ (snap.waits.adoptionRate * 100).toFixed(0) }%)`);
+      lines.push(`Stale leases: ${ snap.leases.staleLeases }/${ snap.leases.activeLeases } running leases stale`);
+      lines.push(`Dependency-held: ${ snap.deps.dependencyHeld }`);
+      lines.push(`WIP: execution=${ snap.wip.activeExecutionWip }/${ snap.wip.wipLimit } verification=${ snap.wip.activeVerificationWip } backpressure=${ snap.wip.backpressureReason ?? 'none' }`);
+      lines.push(`Shipments: independent=${ snap.shipments.independentShipments } integration_train_closures=${ snap.shipments.integrationTrainClosures }`);
+      lines.push('');
+      lines.push('## Custody completeness by artifact type (structured/legacy/missing/invalid)');
+      for (const c of snap.custody) {
+        lines.push(`- ${ c.artifactType }: total=${ c.total } structured=${ c.structured } legacy=${ c.legacy } missing=${ c.missing } invalid=${ c.invalid }`);
+      }
+      lines.push('');
+      lines.push('```json');
+      lines.push(JSON.stringify(snap, null, 2));
+      lines.push('```');
+      return { successBoolean: true, responseString: lines.join('\n') };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to compute conveyor health: ${ err?.message }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/project/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/project/manifests.ts
@@ -503,4 +503,16 @@ export const projectToolManifests: ToolManifest[] = [
     operationTypes: ['read'],
     loader: () => import('./inspect_lane_entry_automation'),
   },
+  {
+    name:        'conveyor_health',
+    description: 'Read-only Projects conveyor-health & productivity snapshot (issue #717): count/oldest-age by semantic stage, stage-age percentiles, execution->review->done throughput, verifier throughput (dedup/suppression excluded), rework rate & repair loops, custody completeness, durable-wait adoption, stale leases, dependency-held, WIP pressure, and independent shipments vs integration-train closures. Optional project scope and time window.',
+    category:    'project',
+    schemaDef:   {
+      project_id:    { type: 'string', optional: true, description: 'Limit metrics to one project id (default: whole portfolio).' },
+      window_hours:  { type: 'number', optional: true, description: 'Rolling window for rate/throughput metrics in hours (default 168 = 7d).' },
+      wip_limit:     { type: 'number', optional: true, description: 'Soft WIP ceiling for active execution leases (default 6).' },
+      stale_minutes: { type: 'number', optional: true, description: 'Lease is stale when its heartbeat is older than this many minutes (default 20).' },
+    },
+    loader:      () => import('./conveyor_health'),
+  },
 ];


### PR DESCRIPTION
Implements #717 — expose Projects conveyor-health & productivity metrics.

## What this adds (backend + tool)
`WorkConveyorMetricsModel` (agent/database/models) — read-only metric queries, each with its **denominator and legacy-data handling documented in-code** (AC#1):
- Count + **exact oldest item** per semantic stage (AC#2)
- Stage-age p50/p90 over a selectable window
- execution→review→done throughput (from the dispatch ledger + terminal state; no transition-history table exists, documented)
- Verifier throughput = **distinct (task_id, review_generation_hash)**, excluding cancelled + suppressed generations (AC#5)
- Rework rate + avg repair loops (custody `repair_count`/`review_count`)
- Custody completeness by artifact type — **structured / legacy / missing / invalid** (AC#3)
- Durable-wait adoption = blocked tasks with an **active** matching `work_task_waits` row (AC#4)
- Stale/zombie lease count, dependency-held count, WIP pressure + derived backpressure reason
- Independent shipments vs **integration-train closures**, split by artifact custody (AC#6)
- Bounded drill-downs (oldest items per stage, stale leases) — all `LIMIT`ed (AC#7 perf)

Semantic-stage grouping uses `resolve_work_task_lane_role(task_id, status)` so **custom lane names stay compatible**. Optional `project_id` scope + `window_hours` via a static `($1::text IS NULL OR …)` guard. Completion is read only from terminal task state + the dispatch ledger — comments/narration are never counted.

`0078_add_conveyor_metrics_indexes` — **additive `CREATE INDEX IF NOT EXISTS` only** (no data mutation) so the dashboard queries stay bounded on local Postgres.

New `conveyor_health` project tool (registered in `manifests.ts`) returns a compact human summary **plus the full structured JSON** the Projects UI panel/drill-down will consume.

## Tests (AC#7)
Contract tests in the repo's `postgresClient`-mocking style — model (custom-lane/semantic-role, empty-state no-NaN, verifier dedup+suppression, custody 4-way incl. migrated/legacy, wait-adoption, shipment split, bounded-LIMIT drill-down, WIP backpressure), migration (additive-only up / matching down), tool (compiles + shape).

**Verification status:** tests are authored but were **not executed in the worker sandbox** — dependencies are not installed there (no jest/ts-jest). They are written for the existing `test:unit:jest` and should run in CI. Please run CI before merge.

## Follow-up (not in this PR)
Renderer wiring: a compact conveyor-health panel + drill-down tables in `pages/ProjectsHome.vue` consuming the `conveyor_health` tool output. The data contract + drill-down payload it needs are complete here.
