### PR TITLE
feat(projects): first-class atomic task-dependency claim gates (#714)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0083_create_work_task_dependencies.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0083_create_work_task_dependencies.ts
@@ -1,50 +1,68 @@
+import type { Client } from 'pg';
+
 /**
- * Migration 0083 — first-class task dependencies that mechanically gate
- * planning, execution, review, and lane-entry claims.
- *
- * A row means `dependent_task_id` depends on `depends_on_task_id`. Rows are
- * soft-archived (archived_at) so attribution and removal history survive.
- * Self-links and cycles are rejected transactionally in the model
- * (WorkTaskDependencyModel.create) via a recursive reachability check; the
- * partial unique index below enforces one active relation per pair+type. The
- * CHECK constraints below are DB-level belt-and-suspenders for the same rules.
- * This migration depends on work_tasks (migration 0044).
+ * Upgrade the dependency table introduced by migration 0075 into the richer
+ * first-class claim-gate schema without discarding existing links.
  */
+export async function up(client: Client): Promise<void> {
+  await client.query(`
+    ALTER TABLE work_task_dependencies
+      RENAME COLUMN task_id TO dependent_task_id;
 
-export const up = `
-  DO $$
-  BEGIN
-    IF to_regclass('work_tasks') IS NULL THEN
-      RAISE EXCEPTION 'migration 0083 requires work_tasks from migration 0044';
-    END IF;
-  END $$;
+    ALTER TABLE work_task_dependencies
+      ADD COLUMN id TEXT,
+      ADD COLUMN relation_type TEXT NOT NULL DEFAULT 'requires',
+      ADD COLUMN acceptance_condition TEXT,
+      ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      ADD COLUMN archived_at TIMESTAMPTZ;
 
-  CREATE TABLE IF NOT EXISTS work_task_dependencies (
-    id                   TEXT        PRIMARY KEY,
-    dependent_task_id    TEXT        NOT NULL REFERENCES work_tasks(id),
-    depends_on_task_id   TEXT        NOT NULL REFERENCES work_tasks(id),
-    relation_type        TEXT        NOT NULL DEFAULT 'requires',
-    acceptance_condition TEXT,
-    created_by           TEXT,
-    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
-    archived_at          TIMESTAMPTZ,
-    CONSTRAINT work_task_dependencies_no_self
-      CHECK (dependent_task_id <> depends_on_task_id),
-    CONSTRAINT work_task_dependencies_relation_type
-      CHECK (relation_type IN ('blocks', 'requires', 'ordered-after'))
-  );
+    UPDATE work_task_dependencies
+       SET id = 'dep-' || md5(dependent_task_id || ':' || depends_on_task_id),
+           archived_at = CASE WHEN archived THEN now() ELSE NULL END;
 
-  CREATE UNIQUE INDEX IF NOT EXISTS idx_wtd_active_unique
-    ON work_task_dependencies (dependent_task_id, depends_on_task_id, relation_type)
-    WHERE archived_at IS NULL;
+    ALTER TABLE work_task_dependencies ALTER COLUMN id SET NOT NULL;
+    ALTER TABLE work_task_dependencies DROP CONSTRAINT work_task_dependencies_pkey;
+    ALTER TABLE work_task_dependencies ADD PRIMARY KEY (id);
+    ALTER TABLE work_task_dependencies DROP COLUMN archived;
 
-  CREATE INDEX IF NOT EXISTS idx_wtd_dependent_lookup
-    ON work_task_dependencies (dependent_task_id, archived_at);
-  CREATE INDEX IF NOT EXISTS idx_wtd_depends_on_lookup
-    ON work_task_dependencies (depends_on_task_id, archived_at);
-`;
+    ALTER TABLE work_task_dependencies
+      ADD CONSTRAINT work_task_dependencies_relation_type
+      CHECK (relation_type IN ('blocks', 'requires', 'ordered-after'));
 
-export const down = `
-  DROP TABLE IF EXISTS work_task_dependencies CASCADE;
-`;
+    DROP INDEX IF EXISTS idx_work_task_dependencies_reverse;
+    CREATE UNIQUE INDEX idx_wtd_active_unique
+      ON work_task_dependencies (dependent_task_id, depends_on_task_id, relation_type)
+      WHERE archived_at IS NULL;
+    CREATE INDEX idx_wtd_dependent_lookup
+      ON work_task_dependencies (dependent_task_id, archived_at);
+    CREATE INDEX idx_wtd_depends_on_lookup
+      ON work_task_dependencies (depends_on_task_id, archived_at);
+  `);
+}
+
+export async function down(client: Client): Promise<void> {
+  await client.query(`
+    DELETE FROM work_task_dependencies newer
+     USING work_task_dependencies older
+     WHERE newer.id > older.id
+       AND newer.dependent_task_id = older.dependent_task_id
+       AND newer.depends_on_task_id = older.depends_on_task_id;
+
+    DROP INDEX IF EXISTS idx_wtd_active_unique;
+    DROP INDEX IF EXISTS idx_wtd_dependent_lookup;
+    DROP INDEX IF EXISTS idx_wtd_depends_on_lookup;
+    ALTER TABLE work_task_dependencies DROP CONSTRAINT IF EXISTS work_task_dependencies_relation_type;
+    ALTER TABLE work_task_dependencies DROP CONSTRAINT work_task_dependencies_pkey;
+    ALTER TABLE work_task_dependencies ADD COLUMN archived BOOLEAN NOT NULL DEFAULT false;
+    UPDATE work_task_dependencies SET archived = archived_at IS NOT NULL;
+    ALTER TABLE work_task_dependencies DROP COLUMN id;
+    ALTER TABLE work_task_dependencies DROP COLUMN relation_type;
+    ALTER TABLE work_task_dependencies DROP COLUMN acceptance_condition;
+    ALTER TABLE work_task_dependencies DROP COLUMN updated_at;
+    ALTER TABLE work_task_dependencies DROP COLUMN archived_at;
+    ALTER TABLE work_task_dependencies RENAME COLUMN dependent_task_id TO task_id;
+    ALTER TABLE work_task_dependencies ADD PRIMARY KEY (task_id, depends_on_task_id);
+    CREATE INDEX idx_work_task_dependencies_reverse
+      ON work_task_dependencies(depends_on_task_id) WHERE archived = false;
+  `);
+}

--- a/pkg/rancher-desktop/agent/database/migrations/0083_create_work_task_dependencies.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0083_create_work_task_dependencies.ts
@@ -1,0 +1,50 @@
+/**
+ * Migration 0083 — first-class task dependencies that mechanically gate
+ * planning, execution, review, and lane-entry claims.
+ *
+ * A row means `dependent_task_id` depends on `depends_on_task_id`. Rows are
+ * soft-archived (archived_at) so attribution and removal history survive.
+ * Self-links and cycles are rejected transactionally in the model
+ * (WorkTaskDependencyModel.create) via a recursive reachability check; the
+ * partial unique index below enforces one active relation per pair+type. The
+ * CHECK constraints below are DB-level belt-and-suspenders for the same rules.
+ * This migration depends on work_tasks (migration 0044).
+ */
+
+export const up = `
+  DO $$
+  BEGIN
+    IF to_regclass('work_tasks') IS NULL THEN
+      RAISE EXCEPTION 'migration 0083 requires work_tasks from migration 0044';
+    END IF;
+  END $$;
+
+  CREATE TABLE IF NOT EXISTS work_task_dependencies (
+    id                   TEXT        PRIMARY KEY,
+    dependent_task_id    TEXT        NOT NULL REFERENCES work_tasks(id),
+    depends_on_task_id   TEXT        NOT NULL REFERENCES work_tasks(id),
+    relation_type        TEXT        NOT NULL DEFAULT 'requires',
+    acceptance_condition TEXT,
+    created_by           TEXT,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    archived_at          TIMESTAMPTZ,
+    CONSTRAINT work_task_dependencies_no_self
+      CHECK (dependent_task_id <> depends_on_task_id),
+    CONSTRAINT work_task_dependencies_relation_type
+      CHECK (relation_type IN ('blocks', 'requires', 'ordered-after'))
+  );
+
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_wtd_active_unique
+    ON work_task_dependencies (dependent_task_id, depends_on_task_id, relation_type)
+    WHERE archived_at IS NULL;
+
+  CREATE INDEX IF NOT EXISTS idx_wtd_dependent_lookup
+    ON work_task_dependencies (dependent_task_id, archived_at);
+  CREATE INDEX IF NOT EXISTS idx_wtd_depends_on_lookup
+    ON work_task_dependencies (depends_on_task_id, archived_at);
+`;
+
+export const down = `
+  DROP TABLE IF EXISTS work_task_dependencies CASCADE;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -69,6 +69,7 @@ import { up as up_0079, down as down_0079 } from './0079_create_work_task_artifa
 import { up as up_0080, down as down_0080 } from './0080_settle_work_task_waits_on_replan';
 import { up as up_0081, down as down_0081 } from './0081_add_workflow_execution_leases';
 import { up as up_0082, down as down_0082 } from './0082_create_artifact_receipts';
+import { up as up_0083, down as down_0083 } from './0083_create_work_task_dependencies';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -139,4 +140,5 @@ export const migrationsRegistry = [
   { name: '0080_settle_work_task_waits_on_replan',                 up: up_0080, down: down_0080 },
   { name: '0081_add_workflow_execution_leases',                    up: up_0081, down: down_0081 },
   { name: '0082_create_artifact_receipts',                         up: up_0082, down: down_0082 },
+  { name: '0083_create_work_task_dependencies',                    up: up_0083, down: down_0083 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -16,6 +16,7 @@
 import { postgresClient } from '../PostgresClient';
 import { normalizeAutonomousTaskOwnership } from './TaskOwnership';
 import { WorkLaneDefinitionModel, type WorkLaneSemanticRole } from './WorkLaneDefinitionModel';
+import { WorkTaskDependencyModel } from './WorkTaskDependencyModel';
 import { ArtifactCustodyPolicy, type ArtifactCustody } from '../../services/ArtifactCustodyPolicy';
 
 import type { PoolClient } from 'pg';
@@ -95,8 +96,10 @@ export interface WorkTaskRecord {
 export interface WorkTaskDependencyRecord {
   task_id:            string;
   depends_on_task_id: string;
+  relation_type:      string;
+  acceptance_condition: string | null;
   created_at:         string;
-  created_by:         string;
+  created_by:         string | null;
   archived:           boolean;
 }
 
@@ -939,54 +942,46 @@ export class WorkItemsModel {
 
   static async listTaskDependencies(projectId: string): Promise<WorkTaskDependencyRecord[]> {
     return postgresClient.query<WorkTaskDependencyRecord>(`
-      SELECT dependency.*
+      SELECT dependency.dependent_task_id AS task_id,
+             dependency.depends_on_task_id,
+             dependency.relation_type,
+             dependency.acceptance_condition,
+             dependency.created_at,
+             dependency.created_by,
+             (dependency.archived_at IS NOT NULL) AS archived
       FROM work_task_dependencies dependency
-      JOIN ${ WorkItemsModel.TASKS } task ON task.id = dependency.task_id
+      JOIN ${ WorkItemsModel.TASKS } task ON task.id = dependency.dependent_task_id
       JOIN ${ WorkItemsModel.TASKS } prerequisite ON prerequisite.id = dependency.depends_on_task_id
-      WHERE dependency.archived = false
+      WHERE dependency.archived_at IS NULL
         AND task.archived = false AND prerequisite.archived = false
         AND task.project_id = $1 AND prerequisite.project_id = $1
       ORDER BY dependency.created_at ASC`, [projectId]);
   }
 
   static async setTaskDependency(taskId: string, dependsOnTaskId: string, actor = 'human'): Promise<WorkTaskDependencyRecord> {
-    if (taskId === dependsOnTaskId) throw new Error('A task cannot depend on itself.');
-    return postgresClient.transaction(async(client) => {
-      const tasks = await client.query<WorkTaskRecord>(`
-        SELECT * FROM ${ WorkItemsModel.TASKS }
-        WHERE id = ANY($1::text[]) AND archived = false
-        FOR UPDATE`, [[taskId, dependsOnTaskId]]);
-      if (tasks.rows.length !== 2) throw new Error('Both dependency tasks must be active.');
-      if (new Set(tasks.rows.map(task => task.project_id)).size !== 1) {
-        throw new Error('Task dependencies must stay within one project.');
-      }
-      const cycle = await client.query<{ found: boolean }>(`
-        WITH RECURSIVE prerequisites(id) AS (
-          SELECT $2::text
-          UNION
-          SELECT dependency.depends_on_task_id
-          FROM work_task_dependencies dependency
-          JOIN prerequisites current ON dependency.task_id = current.id
-          WHERE dependency.archived = false
-        )
-        SELECT EXISTS(SELECT 1 FROM prerequisites WHERE id = $1) AS found`, [taskId, dependsOnTaskId]);
-      if (cycle.rows[0]?.found) throw new Error('This dependency would create a cycle.');
-      const rows = await client.query<WorkTaskDependencyRecord>(`
-        INSERT INTO work_task_dependencies (task_id, depends_on_task_id, created_by, archived)
-        VALUES ($1, $2, $3, false)
-        ON CONFLICT (task_id, depends_on_task_id) DO UPDATE
-          SET archived = false, created_by = EXCLUDED.created_by, created_at = now()
-        RETURNING *`, [taskId, dependsOnTaskId, actor]);
-      return rows.rows[0];
+    const dependency = await WorkTaskDependencyModel.create({
+      dependentTaskId: taskId,
+      dependsOnTaskId,
+      relationType: 'requires',
+      actor,
     });
+    return {
+      task_id: dependency.dependent_task_id,
+      depends_on_task_id: dependency.depends_on_task_id,
+      relation_type: dependency.relation_type,
+      acceptance_condition: dependency.acceptance_condition,
+      created_at: dependency.created_at,
+      created_by: dependency.created_by,
+      archived: dependency.archived_at !== null,
+    };
   }
 
   static async removeTaskDependency(taskId: string, dependsOnTaskId: string): Promise<boolean> {
-    const rows = await postgresClient.query<{ task_id: string }>(`
-      UPDATE work_task_dependencies SET archived = true
-      WHERE task_id = $1 AND depends_on_task_id = $2 AND archived = false
-      RETURNING task_id`, [taskId, dependsOnTaskId]);
-    return rows.length > 0;
+    return WorkTaskDependencyModel.remove({
+      dependentTaskId: taskId,
+      dependsOnTaskId,
+      relationType: 'requires',
+    });
   }
 
   static async insertTask(input: UpsertTaskInput): Promise<WorkTaskRecord> {

--- a/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { WorkTaskDependencyModel } from './WorkTaskDependencyModel';
 
 import { postgresClient } from '../PostgresClient';
 
@@ -435,6 +436,7 @@ export class WorkLaneWorkflowBindingModel {
     actor = 'sulla', profileId = 'default'):
     Promise<{ created: boolean; entry: LaneEntryAutomationRecord }> {
     await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`lane-entry:${ taskId }`]);
+    await WorkTaskDependencyModel.assertClaimable(taskId, client);
     const prior = await client.query<LaneEntryAutomationRecord>(`
         SELECT * FROM work_lane_entry_automations WHERE task_id = $1 ORDER BY generation DESC LIMIT 1
       `, [taskId]);

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDependencyBackfill.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDependencyBackfill.ts
@@ -1,0 +1,124 @@
+import { postgresClient } from '../PostgresClient';
+import { WorkTaskDependencyModel, type DependencyRelationType } from './WorkTaskDependencyModel';
+
+/**
+ * Conservative, dry-run-first backfill of first-class task dependencies from
+ * two recognizable legacy conventions:
+ *
+ *   1. parent/child tasks (work_tasks.parent_id) — the parent depends_on each
+ *      active child ('requires'), matching the existing dispatcher rule that a
+ *      parent is not claimable while any child is incomplete.
+ *   2. HOLD comments (work_task_comments.body ILIKE 'HOLD%') — proposed ONLY
+ *      when the comment body names an EXISTING task id. HOLD comments that name
+ *      no resolvable task are reported for manual review; no link is guessed.
+ *
+ * planTaskDependencyBackfill() is read-only and emits an audit report.
+ * applyTaskDependencyBackfill() writes via WorkTaskDependencyModel.create(),
+ * which is idempotent and rejects cycles/self-links, so re-runs are safe.
+ */
+
+export interface BackfillProposal {
+  dependentTaskId: string;
+  dependsOnTaskId: string;
+  relationType: DependencyRelationType;
+  source: 'parent_child' | 'hold_comment';
+  evidence: string;
+}
+
+export interface UnresolvedHold {
+  taskId: string;
+  commentId: string;
+  body: string;
+}
+
+export interface BackfillSkip {
+  proposal: BackfillProposal;
+  reason: string;
+}
+
+export interface BackfillAudit {
+  dryRun: boolean;
+  proposals: BackfillProposal[];
+  unresolvedHolds: UnresolvedHold[];
+  created: BackfillProposal[];
+  skipped: BackfillSkip[];
+  summary: string;
+}
+
+async function collectProposals(): Promise<{ proposals: BackfillProposal[]; unresolvedHolds: UnresolvedHold[] }> {
+  const proposals: BackfillProposal[] = [];
+  const unresolvedHolds: UnresolvedHold[] = [];
+
+  const parentChild = await postgresClient.query<{ parent_id: string; child_id: string }>(
+    `SELECT c.parent_id AS parent_id, c.id AS child_id
+       FROM work_tasks c
+       JOIN work_tasks p ON p.id = c.parent_id AND p.archived = false
+      WHERE c.parent_id IS NOT NULL AND c.archived = false`);
+  for (const row of parentChild) {
+    proposals.push({
+      dependentTaskId: row.parent_id,
+      dependsOnTaskId:  row.child_id,
+      relationType:    'requires',
+      source:          'parent_child',
+      evidence:        'work_tasks.parent_id',
+    });
+  }
+
+  const ids = new Set(
+    (await postgresClient.query<{ id: string }>(`SELECT id FROM work_tasks WHERE archived = false`)).map(r => r.id));
+  const holds = await postgresClient.query<{ id: string; task_id: string; body: string }>(
+    `SELECT id, task_id, body FROM work_task_comments WHERE archived = false AND body ILIKE 'HOLD%'`);
+  for (const h of holds) {
+    const target = (h.body.match(/[A-Za-z0-9_-]{2,}/g) ?? []).find(t => t !== h.task_id && ids.has(t));
+    if (target) {
+      proposals.push({
+        dependentTaskId: h.task_id,
+        dependsOnTaskId:  target,
+        relationType:    'blocks',
+        source:          'hold_comment',
+        evidence:        h.body.slice(0, 240),
+      });
+    } else {
+      unresolvedHolds.push({ taskId: h.task_id, commentId: h.id, body: h.body.slice(0, 240) });
+    }
+  }
+  return { proposals, unresolvedHolds };
+}
+
+/** Read-only audit of what a backfill WOULD create. Writes nothing. */
+export async function planTaskDependencyBackfill(): Promise<BackfillAudit> {
+  const { proposals, unresolvedHolds } = await collectProposals();
+  const pc = proposals.filter(p => p.source === 'parent_child').length;
+  const hc = proposals.filter(p => p.source === 'hold_comment').length;
+  return {
+    dryRun: true, proposals, unresolvedHolds, created: [], skipped: [],
+    summary: `DRY RUN — ${ proposals.length } proposed link(s) (${ pc } parent-child, ${ hc } HOLD-comment); `
+      + `${ unresolvedHolds.length } HOLD comment(s) need manual review. No links written.`,
+  };
+}
+
+/** Apply the backfill. Idempotent; cycles/self-links/invalid targets are skipped. */
+export async function applyTaskDependencyBackfill(opts: { actor?: string } = {}): Promise<BackfillAudit> {
+  const { proposals, unresolvedHolds } = await collectProposals();
+  const created: BackfillProposal[] = [];
+  const skipped: BackfillSkip[] = [];
+  for (const p of proposals) {
+    try {
+      await WorkTaskDependencyModel.create({
+        dependentTaskId:     p.dependentTaskId,
+        dependsOnTaskId:     p.dependsOnTaskId,
+        relationType:        p.relationType,
+        acceptanceCondition: null,
+        actor:               opts.actor ?? 'backfill-0078',
+      });
+      created.push(p);
+    } catch (err: any) {
+      skipped.push({ proposal: p, reason: err?.message ?? String(err) });
+    }
+  }
+  return {
+    dryRun: false, proposals, unresolvedHolds, created, skipped,
+    summary: `APPLIED — ${ created.length } link(s) created, ${ skipped.length } skipped (existing/cycle/invalid), `
+      + `${ unresolvedHolds.length } HOLD comment(s) need manual review.`,
+  };
+}

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDependencyModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDependencyModel.ts
@@ -1,0 +1,340 @@
+import { randomUUID } from 'node:crypto';
+import type { PoolClient } from 'pg';
+
+import { postgresClient } from '../PostgresClient';
+
+/**
+ * WorkTaskDependencyModel — FK-backed dependencies between Projects tasks that
+ * mechanically gate planning, execution, review, and lane-entry claims. A row
+ * means `dependent_task_id` depends on `depends_on_task_id`; the dependent
+ * cannot be claimed on any autonomous path until the prerequisite reaches a
+ * qualifying terminal state ('done').
+ *
+ * Design: there is NO cached "resolved" flag. The gate
+ * (listUnresolvedDependencies / assertClaimable) always joins the LIVE
+ * work_tasks.status, and callers run it INSIDE their own claim transaction
+ * (passing their PoolClient) after locking the task row FOR UPDATE. A
+ * dependency resolved between queue-scan and claim is therefore observed
+ * atomically, and a prerequisite that reaches a failed/cancelled terminal state
+ * (status <> 'done') stays blocking — we never silently unblock. Auto-release
+ * is a consequence of reading live status, not a separate write path.
+ *
+ * Rows are soft-archived (archived_at) so attribution and removal history
+ * survive. Cycles and self-links are rejected transactionally in create().
+ */
+
+export type DependencyRelationType = 'blocks' | 'requires' | 'ordered-after';
+
+const RELATION_TYPES: ReadonlySet<DependencyRelationType> = new Set<DependencyRelationType>([
+  'blocks', 'requires', 'ordered-after',
+]);
+
+/** A prerequisite in one of these states satisfies (auto-releases) a dependency. */
+export const RESOLVING_STATES: readonly string[] = ['done'];
+
+/**
+ * Terminal prerequisite states that did NOT satisfy the dependency. Policy: the
+ * dependent stays blocked pending an EXPLICIT override (remove the dependency).
+ * We never silently unblock on cancellation/parking/failure.
+ */
+export const FAILED_TERMINAL_STATES: readonly string[] = ['cancelled', 'parked'];
+
+export interface DependencyRecord {
+  id: string;
+  dependent_task_id: string;
+  depends_on_task_id: string;
+  relation_type: DependencyRelationType;
+  acceptance_condition: string | null;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string | null;
+  archived_at: string | null;
+}
+
+export interface CreateDependencyInput {
+  dependentTaskId: string;
+  dependsOnTaskId: string;
+  relationType?: DependencyRelationType | string | null;
+  acceptanceCondition?: string | null;
+  actor?: string | null;
+}
+
+export interface RemoveDependencyInput {
+  id?: string;
+  dependentTaskId?: string;
+  dependsOnTaskId?: string;
+  relationType?: DependencyRelationType | string | null;
+}
+
+export type UnresolvedPolicy = 'pending' | 'failed_terminal' | 'missing';
+
+export interface UnresolvedDependency {
+  dependency: DependencyRecord;
+  dependsOnTaskId: string;
+  dependsOnStatus: string | null;
+  dependsOnTitle: string | null;
+  policy: UnresolvedPolicy;
+  reason: string;
+}
+
+export interface DependencyChainEntry {
+  taskId: string;
+  status: string | null;
+  title: string | null;
+  relationType: DependencyRelationType;
+  depth: number;
+  resolved: boolean;
+}
+
+export interface ClaimabilityExplanation {
+  taskId: string;
+  claimable: boolean;
+  reason: string;
+  unresolved: UnresolvedDependency[];
+  chain: DependencyChainEntry[];
+}
+
+function normalizeRelation(value?: DependencyRelationType | string | null): DependencyRelationType {
+  const v = (value ?? 'requires').toString().trim() as DependencyRelationType;
+  if (!RELATION_TYPES.has(v)) {
+    throw new Error(`Invalid relation_type '${ value }'. Expected one of: blocks, requires, ordered-after.`);
+  }
+  return v;
+}
+
+export class WorkTaskDependencyModel {
+  private static readonly TABLE = 'work_task_dependencies';
+
+  /**
+   * A correlated `AND NOT EXISTS (...)` SQL fragment for queue-scan claim
+   * SELECTs. Interpolate into a candidate query INSIDE the same FOR UPDATE
+   * transaction so any task with an unresolved dependency is never selected —
+   * fail-closed, non-starving, and free of a scan->claim gap. `taskIdExpr` is a
+   * trusted column reference (e.g. 't.id'), never user input.
+   */
+  static claimExclusionSql(taskIdExpr: string): string {
+    return `AND NOT EXISTS (
+          SELECT 1 FROM ${ this.TABLE } wtd
+          LEFT JOIN work_tasks dep_t ON dep_t.id = wtd.depends_on_task_id
+          WHERE wtd.dependent_task_id = ${ taskIdExpr }
+            AND wtd.archived_at IS NULL
+            AND (dep_t.id IS NULL OR dep_t.status IS DISTINCT FROM 'done')
+        )`;
+  }
+
+
+  private static mapRow(row: any): DependencyRecord {
+    return {
+      id:                   row.id,
+      dependent_task_id:    row.dependent_task_id,
+      depends_on_task_id:   row.depends_on_task_id,
+      relation_type:        row.relation_type as DependencyRelationType,
+      acceptance_condition: row.acceptance_condition ?? null,
+      created_by:           row.created_by ?? null,
+      created_at:           row.created_at,
+      updated_at:           row.updated_at ?? null,
+      archived_at:          row.archived_at ?? null,
+    };
+  }
+
+  /**
+   * Create (or reactivate) one dependency. Rejects self-links and cycles
+   * transactionally: both task rows are locked FOR UPDATE, a pair advisory lock
+   * serialises concurrent edits, and a recursive reachability check ensures the
+   * prerequisite cannot already reach the dependent before we insert.
+   */
+  static async create(input: CreateDependencyInput): Promise<DependencyRecord> {
+    const relation = normalizeRelation(input.relationType);
+    const dependentId = (input.dependentTaskId ?? '').toString().trim();
+    const dependsOnId = (input.dependsOnTaskId ?? '').toString().trim();
+    if (!dependentId || !dependsOnId) throw new Error('dependent_task_id and depends_on_task_id are required.');
+    if (dependentId === dependsOnId) throw new Error('A task cannot depend on itself.');
+
+    return postgresClient.transaction(async(client) => {
+      const [lo, hi] = [dependentId, dependsOnId].sort();
+      const locked = await client.query<{ id: string; archived: boolean }>(
+        `SELECT id, archived FROM work_tasks WHERE id = ANY($1::text[]) ORDER BY id FOR UPDATE`,
+        [[lo, hi]],
+      );
+      const byId = new Map(locked.rows.map(r => [r.id, r]));
+      if (!byId.has(dependentId)) throw new Error(`Dependent task not found: ${ dependentId }`);
+      if (!byId.has(dependsOnId)) throw new Error(`Depended-on task not found: ${ dependsOnId }`);
+      if (byId.get(dependentId)!.archived) throw new Error(`Dependent task is archived: ${ dependentId }`);
+      if (byId.get(dependsOnId)!.archived) throw new Error(`Depended-on task is archived: ${ dependsOnId }`);
+
+      await client.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [`wtd:${ lo }:${ hi }`]);
+
+      const cycle = await client.query(
+        `WITH RECURSIVE reach AS (
+           SELECT $1::text AS node
+           UNION
+           SELECT d.depends_on_task_id
+             FROM ${ this.TABLE } d
+             JOIN reach r ON d.dependent_task_id = r.node
+            WHERE d.archived_at IS NULL
+         )
+         SELECT 1 FROM reach WHERE node = $2 LIMIT 1`,
+        [dependsOnId, dependentId],
+      );
+      if (cycle.rows[0]) {
+        throw new Error(`Dependency rejected: would create a cycle (${ dependsOnId } already depends on ${ dependentId }).`);
+      }
+
+      const existing = await client.query<DependencyRecord>(
+        `SELECT * FROM ${ this.TABLE }
+          WHERE dependent_task_id = $1 AND depends_on_task_id = $2 AND relation_type = $3
+          ORDER BY archived_at NULLS FIRST, updated_at DESC NULLS LAST LIMIT 1 FOR UPDATE`,
+        [dependentId, dependsOnId, relation],
+      );
+      if (existing.rows[0]) {
+        const reactivated = await client.query<DependencyRecord>(
+          `UPDATE ${ this.TABLE }
+              SET archived_at = NULL,
+                  acceptance_condition = $2,
+                  created_by = COALESCE(created_by, $3),
+                  updated_at = now()
+            WHERE id = $1 RETURNING *`,
+          [existing.rows[0].id, input.acceptanceCondition ?? existing.rows[0].acceptance_condition ?? null, input.actor ?? null],
+        );
+        return this.mapRow(reactivated.rows[0]);
+      }
+
+      const inserted = await client.query<DependencyRecord>(
+        `INSERT INTO ${ this.TABLE }
+           (id, dependent_task_id, depends_on_task_id, relation_type, acceptance_condition, created_by, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, now()) RETURNING *`,
+        [`dep-${ randomUUID() }`, dependentId, dependsOnId, relation, input.acceptanceCondition ?? null, input.actor ?? null],
+      );
+      return this.mapRow(inserted.rows[0]);
+    });
+  }
+
+  /** Soft-archive one dependency by id, or by (dependent, depends_on, relation). */
+  static async remove(input: RemoveDependencyInput): Promise<boolean> {
+    return postgresClient.transaction(async(client) => {
+      if (input.id) {
+        const res = await client.query(
+          `UPDATE ${ this.TABLE } SET archived_at = now(), updated_at = now()
+            WHERE id = $1 AND archived_at IS NULL`, [input.id]);
+        return (res.rowCount ?? 0) > 0;
+      }
+      const dependentId = (input.dependentTaskId ?? '').toString().trim();
+      const dependsOnId = (input.dependsOnTaskId ?? '').toString().trim();
+      if (!dependentId || !dependsOnId) throw new Error('Provide id, or both dependent_task_id and depends_on_task_id.');
+      const relation = normalizeRelation(input.relationType);
+      const res = await client.query(
+        `UPDATE ${ this.TABLE } SET archived_at = now(), updated_at = now()
+          WHERE dependent_task_id = $1 AND depends_on_task_id = $2 AND relation_type = $3 AND archived_at IS NULL`,
+        [dependentId, dependsOnId, relation]);
+      return (res.rowCount ?? 0) > 0;
+    });
+  }
+
+  /** Active dependencies where `taskId` is the dependent (its prerequisites). */
+  static async listDependencies(taskId: string, opts: { includeArchived?: boolean } = {}): Promise<DependencyRecord[]> {
+    const rows = await postgresClient.query<any>(
+      `SELECT * FROM ${ this.TABLE }
+        WHERE dependent_task_id = $1 ${ opts.includeArchived ? '' : 'AND archived_at IS NULL' }
+        ORDER BY created_at ASC`, [taskId]);
+    return rows.map(r => this.mapRow(r));
+  }
+
+  /** Active dependencies where `taskId` is the prerequisite (its dependents). */
+  static async listDependents(taskId: string, opts: { includeArchived?: boolean } = {}): Promise<DependencyRecord[]> {
+    const rows = await postgresClient.query<any>(
+      `SELECT * FROM ${ this.TABLE }
+        WHERE depends_on_task_id = $1 ${ opts.includeArchived ? '' : 'AND archived_at IS NULL' }
+        ORDER BY created_at ASC`, [taskId]);
+    return rows.map(r => this.mapRow(r));
+  }
+
+  /**
+   * The fail-closed gate's data: active prerequisites of `taskId` whose task is
+   * not 'done'. Pass a PoolClient to run inside the caller's claim transaction
+   * so a resolution committed between queue-scan and claim is seen atomically.
+   */
+  static async listUnresolvedDependencies(taskId: string, client?: PoolClient): Promise<UnresolvedDependency[]> {
+    const sql = `
+      SELECT d.*, t.id AS dep_exists, t.status AS dep_status, t.title AS dep_title
+        FROM ${ this.TABLE } d
+        LEFT JOIN work_tasks t ON t.id = d.depends_on_task_id
+       WHERE d.dependent_task_id = $1
+         AND d.archived_at IS NULL
+         AND (t.id IS NULL OR t.status IS DISTINCT FROM 'done')
+       ORDER BY d.created_at ASC`;
+    const rows = client ? (await client.query(sql, [taskId])).rows : await postgresClient.query<any>(sql, [taskId]);
+    return rows.map((r: any) => {
+      const status: string | null = r.dep_status ?? null;
+      const missing = !r.dep_exists;
+      const failed = !!status && FAILED_TERMINAL_STATES.includes(status);
+      const policy: UnresolvedPolicy = missing ? 'missing' : failed ? 'failed_terminal' : 'pending';
+      const reason = missing
+        ? `prerequisite ${ r.depends_on_task_id } is missing or archived; stays blocked pending explicit override`
+        : failed
+          ? `prerequisite ${ r.depends_on_task_id } reached terminal state '${ status }' without completing; stays blocked pending explicit override`
+          : `prerequisite ${ r.depends_on_task_id } is '${ status ?? 'unknown' }', not yet done`;
+      return {
+        dependency:      this.mapRow(r),
+        dependsOnTaskId: r.depends_on_task_id,
+        dependsOnStatus: status,
+        dependsOnTitle:  r.dep_title ?? null,
+        policy,
+        reason,
+      };
+    });
+  }
+
+  /**
+   * Fail-closed claim gate. MUST be called inside the caller's claim
+   * transaction (pass its PoolClient) after the task row is locked FOR UPDATE.
+   * Throws (code TASK_DEPENDENCY_UNRESOLVED) when any prerequisite is
+   * unresolved, which rolls the claim back.
+   */
+  static async assertClaimable(taskId: string, client: PoolClient): Promise<void> {
+    const unresolved = await this.listUnresolvedDependencies(taskId, client);
+    if (unresolved.length > 0) {
+      const summary = unresolved.map(u => `${ u.dependsOnTaskId }(${ u.dependsOnStatus ?? 'missing' })`).join(', ');
+      const err = new Error(`Task ${ taskId } blocked by ${ unresolved.length } unresolved dependency(ies): ${ summary }`) as Error & {
+        code?: string; unresolved?: UnresolvedDependency[];
+      };
+      err.code = 'TASK_DEPENDENCY_UNRESOLVED';
+      err.unresolved = unresolved;
+      throw err;
+    }
+  }
+
+  /** Human/agent-facing claimability explanation with the transitive chain. */
+  static async explainClaimability(taskId: string, maxDepth = 25): Promise<ClaimabilityExplanation> {
+    const unresolved = await this.listUnresolvedDependencies(taskId);
+    const chainRows = await postgresClient.query<any>(
+      `WITH RECURSIVE chain AS (
+         SELECT d.depends_on_task_id AS task_id, d.relation_type, 1 AS depth
+           FROM ${ this.TABLE } d
+          WHERE d.dependent_task_id = $1 AND d.archived_at IS NULL
+         UNION ALL
+         SELECT d.depends_on_task_id, d.relation_type, c.depth + 1
+           FROM ${ this.TABLE } d
+           JOIN chain c ON d.dependent_task_id = c.task_id
+          WHERE d.archived_at IS NULL AND c.depth < $2
+       )
+       SELECT DISTINCT ON (task_id) task_id, relation_type, depth,
+              t.status AS status, t.title AS title
+         FROM chain
+         LEFT JOIN work_tasks t ON t.id = chain.task_id
+        ORDER BY task_id, depth ASC`,
+      [taskId, maxDepth]);
+    const chain: DependencyChainEntry[] = chainRows.map(r => ({
+      taskId:       r.task_id,
+      status:       r.status ?? null,
+      title:        r.title ?? null,
+      relationType: r.relation_type as DependencyRelationType,
+      depth:        r.depth,
+      resolved:     r.status === 'done',
+    }));
+    const claimable = unresolved.length === 0;
+    const reason = claimable
+      ? `Task ${ taskId } is claimable: no unresolved dependencies.`
+      : `Task ${ taskId } is NOT claimable — ${ unresolved.map(u => u.reason).join('; ') }`;
+    return { taskId, claimable, reason, unresolved, chain };
+  }
+}

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDependencyModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDependencyModel.ts
@@ -77,6 +77,10 @@ export interface UnresolvedDependency {
   reason: string;
 }
 
+export interface TaskDependencyHold extends UnresolvedDependency {
+  taskId: string;
+}
+
 export interface DependencyChainEntry {
   taskId: string;
   status: string | null;
@@ -163,6 +167,7 @@ export class WorkTaskDependencyModel {
       if (byId.get(dependsOnId)!.archived) throw new Error(`Depended-on task is archived: ${ dependsOnId }`);
 
       await client.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [`wtd:${ lo }:${ hi }`]);
+      await client.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', ['work-task-dependency-graph']);
 
       const cycle = await client.query(
         `WITH RECURSIVE reach AS (
@@ -278,6 +283,39 @@ export class WorkTaskDependencyModel {
         dependsOnTaskId: r.depends_on_task_id,
         dependsOnStatus: status,
         dependsOnTitle:  r.dep_title ?? null,
+        policy,
+        reason,
+      };
+    });
+  }
+
+  /** One bounded query for report/UI separation of dependency-held work. */
+  static async listUnresolvedForTasks(taskIds: string[]): Promise<TaskDependencyHold[]> {
+    if (taskIds.length === 0) return [];
+    const rows = await postgresClient.query<any>(`
+      SELECT d.*, t.id AS dep_exists, t.status AS dep_status, t.title AS dep_title
+        FROM ${ this.TABLE } d
+        LEFT JOIN work_tasks t ON t.id = d.depends_on_task_id
+       WHERE d.dependent_task_id = ANY($1::text[])
+         AND d.archived_at IS NULL
+         AND (t.id IS NULL OR t.status IS DISTINCT FROM 'done')
+       ORDER BY d.dependent_task_id, d.created_at ASC`, [taskIds]);
+    return rows.map((r: any) => {
+      const status: string | null = r.dep_status ?? null;
+      const missing = !r.dep_exists;
+      const failed = !!status && FAILED_TERMINAL_STATES.includes(status);
+      const policy: UnresolvedPolicy = missing ? 'missing' : failed ? 'failed_terminal' : 'pending';
+      const reason = missing
+        ? `prerequisite ${ r.depends_on_task_id } is missing or archived; stays blocked pending explicit override`
+        : failed
+          ? `prerequisite ${ r.depends_on_task_id } reached terminal state '${ status }' without completing; stays blocked pending explicit override`
+          : `prerequisite ${ r.depends_on_task_id } is '${ status ?? 'unknown' }', not yet done`;
+      return {
+        taskId: r.dependent_task_id,
+        dependency: this.mapRow(r),
+        dependsOnTaskId: r.depends_on_task_id,
+        dependsOnStatus: status,
+        dependsOnTitle: r.dep_title ?? null,
         policy,
         reason,
       };

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import { WorkTaskDependencyModel } from './WorkTaskDependencyModel';
 
 import { postgresClient } from '../PostgresClient';
 import { ArtifactCustodyPolicy, type ArtifactCustody } from '../../services/ArtifactCustodyPolicy';
@@ -291,6 +292,7 @@ export class WorkTaskDispatchModel {
                 AND child.archived = false
                 AND child.status NOT IN ('done', 'cancelled', 'parked')
            )
+         ${WorkTaskDependencyModel.claimExclusionSql('t.id')}
          ORDER BY
            CASE e.priority
              WHEN 'critical' THEN 0 WHEN 'p0' THEN 0 WHEN 'P0' THEN 0 WHEN '🔴' THEN 0
@@ -388,6 +390,7 @@ export class WorkTaskDispatchModel {
                 AND d.status IN ('failed', 'stale')
                 AND d.finished_at > now() - interval '5 minutes'
            )
+         ${WorkTaskDependencyModel.claimExclusionSql('t.id')}
          ORDER BY
            CASE p.priority
              WHEN 'critical' THEN 0 WHEN 'p0' THEN 0 WHEN 'P0' THEN 0 WHEN '🔴' THEN 0

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { WorkTaskDependencyModel } from './WorkTaskDependencyModel';
 
 import { postgresClient } from '../PostgresClient';
 import { LifecycleCapabilityModel } from './LifecycleCapabilityModel';
@@ -73,6 +74,7 @@ export class WorkTaskPlanningRunModel {
       `, [taskId]);
       const task = taskResult.rows[0];
       if (!task || !planningKeys.includes(task.status)) return null;
+      if ((await WorkTaskDependencyModel.listUnresolvedDependencies(taskId, client)).length > 0) return null;
 
       const active = await client.query<{ id: string }>(`
         SELECT id FROM work_task_planning_runs

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDependencyBackfill.database.integration.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDependencyBackfill.database.integration.test.ts
@@ -4,7 +4,8 @@ import { Pool } from 'pg';
 
 import { postgresClient } from '../../PostgresClient';
 import { up as workItemsMigration } from '../../migrations/0044_create_work_items_tables';
-import { up as dependencyMigration } from '../../migrations/0078_create_work_task_dependencies';
+import { up as schedulingMigration } from '../../migrations/0075_add_project_views_and_scheduling';
+import { up as dependencyMigration } from '../../migrations/0083_create_work_task_dependencies';
 import { applyTaskDependencyBackfill, planTaskDependencyBackfill } from '../WorkTaskDependencyBackfill';
 
 import mockModules from '@pkg/utils/testUtils/mockModules';
@@ -46,7 +47,8 @@ describeDatabase('WorkTaskDependencyBackfill on a migrated PostgreSQL database',
     pool = new Pool({ connectionString: databaseUrl, max: 8 });
     await pool.query('DROP SCHEMA public CASCADE; CREATE SCHEMA public');
     await pool.query(workItemsMigration);
-    await pool.query(dependencyMigration);
+    await schedulingMigration(pool as any);
+    await dependencyMigration(pool as any);
     routeModelToTestDatabase();
   });
 

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDependencyBackfill.database.integration.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDependencyBackfill.database.integration.test.ts
@@ -1,0 +1,90 @@
+/** @jest-environment node */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Pool } from 'pg';
+
+import { postgresClient } from '../../PostgresClient';
+import { up as workItemsMigration } from '../../migrations/0044_create_work_items_tables';
+import { up as dependencyMigration } from '../../migrations/0078_create_work_task_dependencies';
+import { applyTaskDependencyBackfill, planTaskDependencyBackfill } from '../WorkTaskDependencyBackfill';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+mockModules({
+  electron:            undefined,
+  '@pkg/main/ipcMain': { getIpcMainProxy: () => ({ handle: jest.fn() }) },
+});
+
+const databaseUrl = process.env.SULLA_INTEGRATION_POSTGRES_URL
+  || process.env.SULLA_ASSOCIATION_TEST_DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+
+describeDatabase('WorkTaskDependencyBackfill on a migrated PostgreSQL database', () => {
+  let pool: Pool;
+
+  function routeModelToTestDatabase() {
+    jest.spyOn(postgresClient, 'query').mockImplementation(async(text: string, params: any[] = []) => {
+      const result = await pool.query(text, params);
+      return result.rows as any;
+    });
+    jest.spyOn(postgresClient, 'transaction').mockImplementation(async(callback: any) => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        const result = await callback(client);
+        await client.query('COMMIT');
+        return result;
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+      }
+    });
+  }
+
+  beforeAll(async() => {
+    pool = new Pool({ connectionString: databaseUrl, max: 8 });
+    await pool.query('DROP SCHEMA public CASCADE; CREATE SCHEMA public');
+    await pool.query(workItemsMigration);
+    await pool.query(dependencyMigration);
+    routeModelToTestDatabase();
+  });
+
+  afterAll(async() => {
+    jest.restoreAllMocks();
+    await pool.end();
+  });
+
+  beforeEach(async() => {
+    await pool.query('TRUNCATE work_task_dependencies, work_task_comments, work_tasks, work_epics, work_projects RESTART IDENTITY CASCADE');
+    await pool.query("INSERT INTO work_projects (id, slug, title) VALUES ('p1', 'p1', 'P1')");
+    await pool.query("INSERT INTO work_epics (id, project_id, slug, title) VALUES ('e1', 'p1', 'e1', 'E1')");
+    await pool.query("INSERT INTO work_tasks (id, project_id, epic_id, title, status) VALUES ('t1', 'p1', 'e1', 't1', 'todo'), ('t3', 'p1', 'e1', 't3', 'todo')");
+    await pool.query("INSERT INTO work_tasks (id, project_id, epic_id, parent_id, title, status) VALUES ('t2', 'p1', 'e1', 't1', 't2', 'todo')");
+    await pool.query("INSERT INTO work_task_comments (id, task_id, body, author) VALUES ('c1', 't1', 'HOLD: blocked until t3 lands', 'a')");
+    await pool.query("INSERT INTO work_task_comments (id, task_id, body, author) VALUES ('c2', 't2', 'HOLD external vendor signoff', 'a')");
+  });
+
+  it('dry run proposes recognizable links, reports unresolved HOLDs, and writes nothing', async() => {
+    const audit = await planTaskDependencyBackfill();
+    expect(audit.dryRun).toBe(true);
+    expect(audit.proposals).toHaveLength(2);
+    expect(audit.proposals.some(p => p.source === 'parent_child' && p.dependentTaskId === 't1' && p.dependsOnTaskId === 't2')).toBe(true);
+    expect(audit.proposals.some(p => p.source === 'hold_comment' && p.dependentTaskId === 't1' && p.dependsOnTaskId === 't3')).toBe(true);
+    expect(audit.unresolvedHolds).toHaveLength(1);
+    expect(audit.unresolvedHolds[0].taskId).toBe('t2');
+    const rows = await pool.query('SELECT count(*)::int AS n FROM work_task_dependencies');
+    expect(rows.rows[0].n).toBe(0);
+  });
+
+  it('apply creates the proposed links and is idempotent', async() => {
+    const applied = await applyTaskDependencyBackfill({ actor: 'test' });
+    expect(applied.dryRun).toBe(false);
+    expect(applied.created).toHaveLength(2);
+    let n = (await pool.query('SELECT count(*)::int AS n FROM work_task_dependencies WHERE archived_at IS NULL')).rows[0].n;
+    expect(n).toBe(2);
+    await applyTaskDependencyBackfill({ actor: 'test' });
+    n = (await pool.query('SELECT count(*)::int AS n FROM work_task_dependencies WHERE archived_at IS NULL')).rows[0].n;
+    expect(n).toBe(2);
+  });
+});

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDependencyModel.database.integration.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDependencyModel.database.integration.test.ts
@@ -4,7 +4,8 @@ import { Pool } from 'pg';
 
 import { postgresClient } from '../../PostgresClient';
 import { up as workItemsMigration } from '../../migrations/0044_create_work_items_tables';
-import { down as dependencyMigrationDown, up as dependencyMigration } from '../../migrations/0078_create_work_task_dependencies';
+import { up as schedulingMigration } from '../../migrations/0075_add_project_views_and_scheduling';
+import { down as dependencyMigrationDown, up as dependencyMigration } from '../../migrations/0083_create_work_task_dependencies';
 import { WorkTaskDependencyModel } from '../WorkTaskDependencyModel';
 
 import mockModules from '@pkg/utils/testUtils/mockModules';
@@ -60,7 +61,8 @@ describeDatabase('WorkTaskDependencyModel on a migrated PostgreSQL database', ()
     pool = new Pool({ connectionString: databaseUrl, max: 8 });
     await pool.query('DROP SCHEMA public CASCADE; CREATE SCHEMA public');
     await pool.query(workItemsMigration);
-    await pool.query(dependencyMigration);
+    await schedulingMigration(pool as any);
+    await dependencyMigration(pool as any);
     routeModelToTestDatabase();
   });
 
@@ -74,18 +76,20 @@ describeDatabase('WorkTaskDependencyModel on a migrated PostgreSQL database', ()
     await seedTasks();
   });
 
-  it('migration up creates the table (idempotent) and down drops it', async() => {
+  it('migration upgrades the 0075 table and down restores its legacy shape', async() => {
     const cols = await pool.query(
       `SELECT column_name FROM information_schema.columns WHERE table_name = 'work_task_dependencies'`);
     expect(cols.rows.map(r => r.column_name)).toEqual(expect.arrayContaining([
       'id', 'dependent_task_id', 'depends_on_task_id', 'relation_type',
       'acceptance_condition', 'created_by', 'created_at', 'updated_at', 'archived_at',
     ]));
-    await pool.query(dependencyMigration); // idempotent
-    await pool.query(dependencyMigrationDown);
-    const gone = await pool.query(`SELECT to_regclass('work_task_dependencies') AS t`);
-    expect(gone.rows[0].t).toBeNull();
-    await pool.query(dependencyMigration); // restore for later tests
+    await dependencyMigrationDown(pool as any);
+    const legacy = await pool.query(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'work_task_dependencies'`);
+    expect(legacy.rows.map(r => r.column_name)).toEqual(expect.arrayContaining([
+      'task_id', 'depends_on_task_id', 'archived',
+    ]));
+    await dependencyMigration(pool as any); // restore for later tests
   });
 
   it('creates a dependency with each relation type', async() => {

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDependencyModel.database.integration.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDependencyModel.database.integration.test.ts
@@ -1,0 +1,201 @@
+/** @jest-environment node */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { Pool } from 'pg';
+
+import { postgresClient } from '../../PostgresClient';
+import { up as workItemsMigration } from '../../migrations/0044_create_work_items_tables';
+import { down as dependencyMigrationDown, up as dependencyMigration } from '../../migrations/0078_create_work_task_dependencies';
+import { WorkTaskDependencyModel } from '../WorkTaskDependencyModel';
+
+import mockModules from '@pkg/utils/testUtils/mockModules';
+
+mockModules({
+  electron:            undefined,
+  '@pkg/main/ipcMain': { getIpcMainProxy: () => ({ handle: jest.fn() }) },
+});
+
+const databaseUrl = process.env.SULLA_INTEGRATION_POSTGRES_URL
+  || process.env.SULLA_ASSOCIATION_TEST_DATABASE_URL;
+const describeDatabase = databaseUrl ? describe : describe.skip;
+
+describeDatabase('WorkTaskDependencyModel on a migrated PostgreSQL database', () => {
+  let pool: Pool;
+
+  function routeModelToTestDatabase() {
+    jest.spyOn(postgresClient, 'query').mockImplementation(async(text: string, params: any[] = []) => {
+      const result = await pool.query(text, params);
+      return result.rows as any;
+    });
+    jest.spyOn(postgresClient, 'transaction').mockImplementation(async(callback: any) => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        const result = await callback(client);
+        await client.query('COMMIT');
+        return result;
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+      }
+    });
+  }
+
+  async function seedTasks() {
+    await pool.query(`
+      INSERT INTO work_projects (id, slug, title) VALUES ('p1', 'p1', 'Project One') ON CONFLICT (id) DO NOTHING;
+      INSERT INTO work_epics (id, project_id, slug, title) VALUES ('e1', 'p1', 'e1', 'Epic One') ON CONFLICT (id) DO NOTHING;
+    `);
+    const rows: Array<[string, string]> = [['t1', 'todo'], ['t2', 'todo'], ['t3', 'todo'], ['t4', 'done'], ['t5', 'cancelled']];
+    for (const [id, status] of rows) {
+      await pool.query(
+        `INSERT INTO work_tasks (id, project_id, epic_id, title, status) VALUES ($1, 'p1', 'e1', $1, $2)
+         ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status`,
+        [id, status]);
+    }
+  }
+
+  beforeAll(async() => {
+    pool = new Pool({ connectionString: databaseUrl, max: 8 });
+    await pool.query('DROP SCHEMA public CASCADE; CREATE SCHEMA public');
+    await pool.query(workItemsMigration);
+    await pool.query(dependencyMigration);
+    routeModelToTestDatabase();
+  });
+
+  afterAll(async() => {
+    jest.restoreAllMocks();
+    await pool.end();
+  });
+
+  beforeEach(async() => {
+    await pool.query('TRUNCATE work_task_dependencies, work_tasks, work_epics, work_projects RESTART IDENTITY CASCADE');
+    await seedTasks();
+  });
+
+  it('migration up creates the table (idempotent) and down drops it', async() => {
+    const cols = await pool.query(
+      `SELECT column_name FROM information_schema.columns WHERE table_name = 'work_task_dependencies'`);
+    expect(cols.rows.map(r => r.column_name)).toEqual(expect.arrayContaining([
+      'id', 'dependent_task_id', 'depends_on_task_id', 'relation_type',
+      'acceptance_condition', 'created_by', 'created_at', 'updated_at', 'archived_at',
+    ]));
+    await pool.query(dependencyMigration); // idempotent
+    await pool.query(dependencyMigrationDown);
+    const gone = await pool.query(`SELECT to_regclass('work_task_dependencies') AS t`);
+    expect(gone.rows[0].t).toBeNull();
+    await pool.query(dependencyMigration); // restore for later tests
+  });
+
+  it('creates a dependency with each relation type', async() => {
+    for (const rel of ['blocks', 'requires', 'ordered-after'] as const) {
+      const dep = await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2', relationType: rel });
+      expect(dep.relation_type).toBe(rel);
+      await WorkTaskDependencyModel.remove({ id: dep.id });
+    }
+  });
+
+  it('rejects an unknown relation type', async() => {
+    await expect(WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2', relationType: 'bogus' }))
+      .rejects.toThrow(/Invalid relation_type/i);
+  });
+
+  it('rejects a self-link', async() => {
+    await expect(WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't1' }))
+      .rejects.toThrow(/cannot depend on itself/i);
+  });
+
+  it('rejects a direct cycle', async() => {
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' });
+    await expect(WorkTaskDependencyModel.create({ dependentTaskId: 't2', dependsOnTaskId: 't1' }))
+      .rejects.toThrow(/cycle/i);
+  });
+
+  it('rejects a transitive cycle', async() => {
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' });
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't2', dependsOnTaskId: 't3' });
+    await expect(WorkTaskDependencyModel.create({ dependentTaskId: 't3', dependsOnTaskId: 't1' }))
+      .rejects.toThrow(/cycle/i);
+  });
+
+  it('soft-archives on remove and reactivates the same row on re-create', async() => {
+    const dep = await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' });
+    expect(await WorkTaskDependencyModel.remove({ id: dep.id })).toBe(true);
+    expect(await WorkTaskDependencyModel.listDependencies('t1')).toHaveLength(0);
+    const archived = await WorkTaskDependencyModel.listDependencies('t1', { includeArchived: true });
+    expect(archived).toHaveLength(1);
+    expect(archived[0].archived_at).not.toBeNull();
+    const again = await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' });
+    expect(again.id).toBe(dep.id);
+    expect(again.archived_at).toBeNull();
+  });
+
+  it('keeps at most one active row per (dependent, depends_on, relation)', async() => {
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' });
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' });
+    const n = await pool.query(
+      `SELECT count(*)::int AS n FROM work_task_dependencies
+        WHERE dependent_task_id = 't1' AND depends_on_task_id = 't2' AND relation_type = 'requires' AND archived_at IS NULL`);
+    expect(n.rows[0].n).toBe(1);
+  });
+
+  it('lists unresolved deps: done resolves, cancelled stays blocking (failed_terminal)', async() => {
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' });
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't4' });
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't5' });
+    const unresolved = await WorkTaskDependencyModel.listUnresolvedDependencies('t1');
+    expect(unresolved.map(u => u.dependsOnTaskId).sort()).toEqual(['t2', 't5']);
+    expect(unresolved.find(u => u.dependsOnTaskId === 't5')?.policy).toBe('failed_terminal');
+  });
+
+  it('assertClaimable fails closed when unresolved and passes once resolved', async() => {
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' });
+    await postgresClient.transaction(async(client: any) => {
+      await expect(WorkTaskDependencyModel.assertClaimable('t1', client)).rejects.toMatchObject({ code: 'TASK_DEPENDENCY_UNRESOLVED' });
+    });
+    await pool.query(`UPDATE work_tasks SET status = 'done' WHERE id = 't2'`);
+    await postgresClient.transaction(async(client: any) => {
+      await expect(WorkTaskDependencyModel.assertClaimable('t1', client)).resolves.toBeUndefined();
+    });
+  });
+
+  it('no scan->claim gap: a resolution committed before the claim check is observed', async() => {
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' });
+    await pool.query(`UPDATE work_tasks SET status = 'done' WHERE id = 't2'`);
+    await postgresClient.transaction(async(client: any) => {
+      await expect(WorkTaskDependencyModel.assertClaimable('t1', client)).resolves.toBeUndefined();
+    });
+  });
+
+  it('claimExclusionSql excludes dependency-blocked tasks and keeps free/resolved ones', async() => {
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' }); // t1 blocked (t2 todo)
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't3', dependsOnTaskId: 't4' }); // t3 free (t4 done)
+    const sql = `SELECT t.id FROM work_tasks t WHERE t.status = 'todo' ${ WorkTaskDependencyModel.claimExclusionSql('t.id') } ORDER BY t.id`;
+    const ids = (await pool.query(sql)).rows.map(r => r.id);
+    expect(ids).toContain('t3');
+    expect(ids).not.toContain('t1');
+  });
+
+  it('explainClaimability returns the transitive chain and blocking reason', async() => {
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' });
+    await WorkTaskDependencyModel.create({ dependentTaskId: 't2', dependsOnTaskId: 't3' });
+    const ex = await WorkTaskDependencyModel.explainClaimability('t1');
+    expect(ex.claimable).toBe(false);
+    expect(ex.chain.map(c => c.taskId).sort()).toEqual(['t2', 't3']);
+    expect(ex.reason).toMatch(/not claimable/i);
+  });
+
+  it('concurrent opposing edges: exactly one succeeds, the other is rejected as a cycle', async() => {
+    const results = await Promise.allSettled([
+      WorkTaskDependencyModel.create({ dependentTaskId: 't1', dependsOnTaskId: 't2' }),
+      WorkTaskDependencyModel.create({ dependentTaskId: 't2', dependsOnTaskId: 't1' }),
+    ]);
+    expect(results.filter(r => r.status === 'fulfilled')).toHaveLength(1);
+    const rejected = results.filter(r => r.status === 'rejected') as PromiseRejectedResult[];
+    expect(rejected).toHaveLength(1);
+    expect(String(rejected[0].reason?.message)).toMatch(/cycle/i);
+    const active = await pool.query(`SELECT count(*)::int AS n FROM work_task_dependencies WHERE archived_at IS NULL`);
+    expect(active.rows[0].n).toBe(1);
+  });
+});

--- a/pkg/rancher-desktop/agent/prompts/projectReport.ts
+++ b/pkg/rancher-desktop/agent/prompts/projectReport.ts
@@ -12,6 +12,7 @@
 import { LifecycleCapabilityModel } from '../database/models/LifecycleCapabilityModel';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { WorkItemsModel } from '../database/models/WorkItemsModel';
+import { WorkTaskDependencyModel } from '../database/models/WorkTaskDependencyModel';
 import { WorkTaskWaitModel } from '../database/models/WorkTaskWaitModel';
 
 export interface ProjectReportOpts {
@@ -79,17 +80,20 @@ export async function buildProjectReport(opts: ProjectReportOpts = {}): Promise<
   const lifecycleOwnedRows = lifecycleAccess
     ? listedOpenRows.filter(task => !['heartbeat_fallback', 'unmanaged'].includes(lifecycleAccess.get(task.id)?.mode ?? 'manual_hold'))
     : [];
-  const [activeWaitIds, activeWaits, suppressionConfigured, monitorEnabled] = await Promise.all([
+  const [activeWaitIds, activeWaits, suppressionConfigured, monitorEnabled, dependencyHolds] = await Promise.all([
     WorkTaskWaitModel.activeTaskIds(),
     WorkTaskWaitModel.list({ status: 'active', limit: 500 }),
     SullaSettingsModel.get('externalWaitCommentSuppressionEnabled', false),
     SullaSettingsModel.get('externalWaitMonitorEnabled', true),
+    WorkTaskDependencyModel.listUnresolvedForTasks(openRows.map(task => task.id)),
   ]);
   const suppressionEnabled = monitorEnabled && suppressionConfigured;
   const scopedTaskIds = new Set(openRows.map(task => task.id));
   const scopedActiveWaits = activeWaits.filter(wait => scopedTaskIds.has(wait.task_id));
+  const dependencyHeldIds = new Set(dependencyHolds.map(hold => hold.taskId));
   const actionableRows = openRows.filter(t =>
-    t.status !== 'blocked' && t.status !== 'planning' && (!suppressionEnabled || !activeWaitIds.has(t.id)),
+    t.status !== 'blocked' && t.status !== 'planning' && !dependencyHeldIds.has(t.id)
+      && (!suppressionEnabled || !activeWaitIds.has(t.id)),
   );
   const blockedRows = openRows.filter(t => t.status === 'blocked');
   const planningRows = openRows.filter(t => t.status === 'planning');
@@ -129,6 +133,16 @@ export async function buildProjectReport(opts: ProjectReportOpts = {}): Promise<
       const who = t.assignee ? ` · ${ t.assignee }` : '';
       lines.push(`- [${ t.priority }] **${ t.title }** — ${ context(t) } · ${ t.status }${ due }${ who } (id ${ t.id })`);
     }
+  }
+
+  lines.push('');
+  lines.push(`## 🔗 Dependency-held work (${ dependencyHeldIds.size })`);
+  lines.push('_These tasks are mechanically excluded from planning, execution, review, and lane-entry claims. They are separate from external waits and human gates._');
+  for (const taskId of [...dependencyHeldIds].slice(0, nextLimit)) {
+    const task = openRows.find(row => row.id === taskId);
+    const reasons = dependencyHolds.filter(hold => hold.taskId === taskId)
+      .map(hold => `${ hold.dependsOnTaskId } (${ hold.dependsOnStatus ?? hold.policy })`).join(', ');
+    lines.push(`- **${ task?.title ?? taskId }** · blocked by ${ reasons } (id ${ taskId })`);
   }
 
   lines.push('');

--- a/pkg/rancher-desktop/agent/tools/project/__tests__/taskDependencyTools.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/taskDependencyTools.test.ts
@@ -1,0 +1,74 @@
+/** @jest-environment node */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('../../../database/models/WorkTaskDependencyModel', () => ({
+  WorkTaskDependencyModel: {
+    create:              jest.fn(),
+    remove:              jest.fn(),
+    listDependencies:    jest.fn(),
+    listDependents:      jest.fn(),
+    explainClaimability: jest.fn(),
+  },
+}));
+
+import { WorkTaskDependencyModel } from '../../../database/models/WorkTaskDependencyModel';
+import { CreateTaskDependencyWorker } from '../create_task_dependency';
+import { ExplainTaskClaimabilityWorker } from '../explain_task_claimability';
+import { ListTaskDependenciesWorker } from '../list_task_dependencies';
+import { RemoveTaskDependencyWorker } from '../remove_task_dependency';
+
+const call = (tool: any, input: any) => tool._validatedCall(input);
+
+describe('task dependency tools', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('create_task_dependency requires both task ids', async() => {
+    const res = await call(new CreateTaskDependencyWorker(), { depends_on_task_id: 'b' });
+    expect(res.successBoolean).toBe(false);
+    expect(WorkTaskDependencyModel.create).not.toHaveBeenCalled();
+  });
+
+  it('create_task_dependency rejects an invalid relation type', async() => {
+    const res = await call(new CreateTaskDependencyWorker(), { dependent_task_id: 'a', depends_on_task_id: 'b', relation_type: 'nope' });
+    expect(res.successBoolean).toBe(false);
+    expect(WorkTaskDependencyModel.create).not.toHaveBeenCalled();
+  });
+
+  it('create_task_dependency maps args and reports success', async() => {
+    (WorkTaskDependencyModel.create as any).mockResolvedValue({ id: 'dep-1', dependent_task_id: 'a', depends_on_task_id: 'b', relation_type: 'requires' });
+    const res = await call(new CreateTaskDependencyWorker(), { dependent_task_id: 'a', depends_on_task_id: 'b' });
+    expect(res.successBoolean).toBe(true);
+    expect(WorkTaskDependencyModel.create).toHaveBeenCalledWith(expect.objectContaining({ dependentTaskId: 'a', dependsOnTaskId: 'b', relationType: 'requires' }));
+  });
+
+  it('create_task_dependency surfaces a cycle error from the model', async() => {
+    (WorkTaskDependencyModel.create as any).mockRejectedValue(new Error('would create a cycle'));
+    const res = await call(new CreateTaskDependencyWorker(), { dependent_task_id: 'a', depends_on_task_id: 'b' });
+    expect(res.successBoolean).toBe(false);
+    expect(res.responseString).toMatch(/cycle/i);
+  });
+
+  it('remove_task_dependency requires id or both task ids', async() => {
+    expect((await call(new RemoveTaskDependencyWorker(), {})).successBoolean).toBe(false);
+    (WorkTaskDependencyModel.remove as any).mockResolvedValue(true);
+    const res = await call(new RemoveTaskDependencyWorker(), { id: 'dep-1' });
+    expect(res.successBoolean).toBe(true);
+    expect(WorkTaskDependencyModel.remove).toHaveBeenCalledWith(expect.objectContaining({ id: 'dep-1' }));
+  });
+
+  it('list_task_dependencies requires task_id and returns both directions', async() => {
+    expect((await call(new ListTaskDependenciesWorker(), {})).successBoolean).toBe(false);
+    (WorkTaskDependencyModel.listDependencies as any).mockResolvedValue([{ id: 'd1' }]);
+    (WorkTaskDependencyModel.listDependents as any).mockResolvedValue([]);
+    const res = await call(new ListTaskDependenciesWorker(), { task_id: 't1' });
+    expect(res.successBoolean).toBe(true);
+    expect(res.responseString).toContain('dependencies');
+  });
+
+  it('explain_task_claimability returns the explanation payload', async() => {
+    (WorkTaskDependencyModel.explainClaimability as any).mockResolvedValue({ taskId: 't1', claimable: false, reason: 'x', unresolved: [], chain: [] });
+    const res = await call(new ExplainTaskClaimabilityWorker(), { task_id: 't1' });
+    expect(res.successBoolean).toBe(true);
+    expect(res.responseString).toContain('claimable');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/project/create_task_dependency.ts
+++ b/pkg/rancher-desktop/agent/tools/project/create_task_dependency.ts
@@ -1,0 +1,36 @@
+import { WorkTaskDependencyModel, type DependencyRelationType } from '../../database/models/WorkTaskDependencyModel';
+import { BaseTool, ToolResponse } from '../base';
+
+const RELATIONS = new Set<DependencyRelationType>(['blocks', 'requires', 'ordered-after']);
+
+/** Create one first-class task dependency. Rejects self-links and cycles transactionally. */
+export class CreateTaskDependencyWorker extends BaseTool {
+  name = '';
+  description = '';
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const dependentTaskId = typeof input.dependent_task_id === 'string' ? input.dependent_task_id.trim() : '';
+    const dependsOnTaskId = typeof input.depends_on_task_id === 'string' ? input.depends_on_task_id.trim() : '';
+    const relationRaw = typeof input.relation_type === 'string' && input.relation_type.trim() ? input.relation_type.trim() : 'requires';
+    if (!dependentTaskId || !dependsOnTaskId) {
+      return { successBoolean: false, responseString: 'dependent_task_id and depends_on_task_id are required.' };
+    }
+    if (!RELATIONS.has(relationRaw as DependencyRelationType)) {
+      return { successBoolean: false, responseString: 'relation_type must be one of blocks, requires, ordered-after.' };
+    }
+    try {
+      const dep = await WorkTaskDependencyModel.create({
+        dependentTaskId,
+        dependsOnTaskId,
+        relationType:         relationRaw as DependencyRelationType,
+        acceptanceCondition:  typeof input.acceptance_condition === 'string' && input.acceptance_condition.trim() ? input.acceptance_condition.trim() : null,
+        actor:                typeof input.actor === 'string' && input.actor.trim() ? input.actor.trim() : undefined,
+      });
+      return {
+        successBoolean: true,
+        responseString: `Dependency ${ dep.id }: task ${ dep.dependent_task_id } ${ dep.relation_type } ${ dep.depends_on_task_id }. The dependent cannot be claimed until the prerequisite is done.`,
+      };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to create task dependency: ${ err?.message ?? String(err) }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/project/explain_task_claimability.ts
+++ b/pkg/rancher-desktop/agent/tools/project/explain_task_claimability.ts
@@ -1,0 +1,18 @@
+import { WorkTaskDependencyModel } from '../../database/models/WorkTaskDependencyModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/** Explain whether a task is claimable: dependency chain + exact blocking reason. */
+export class ExplainTaskClaimabilityWorker extends BaseTool {
+  name = '';
+  description = '';
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const taskId = typeof input.task_id === 'string' ? input.task_id.trim() : '';
+    if (!taskId) return { successBoolean: false, responseString: 'task_id is required.' };
+    try {
+      const explanation = await WorkTaskDependencyModel.explainClaimability(taskId);
+      return { successBoolean: true, responseString: JSON.stringify(explanation, null, 2) };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to explain task claimability: ${ err?.message ?? String(err) }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/project/list_task_dependencies.ts
+++ b/pkg/rancher-desktop/agent/tools/project/list_task_dependencies.ts
@@ -1,0 +1,22 @@
+import { WorkTaskDependencyModel } from '../../database/models/WorkTaskDependencyModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/** List a task's dependencies (its prerequisites) and its dependents. Read-only. */
+export class ListTaskDependenciesWorker extends BaseTool {
+  name = '';
+  description = '';
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const taskId = typeof input.task_id === 'string' ? input.task_id.trim() : '';
+    if (!taskId) return { successBoolean: false, responseString: 'task_id is required.' };
+    try {
+      const includeArchived = input.include_archived === true;
+      const [dependencies, dependents] = await Promise.all([
+        WorkTaskDependencyModel.listDependencies(taskId, { includeArchived }),
+        WorkTaskDependencyModel.listDependents(taskId, { includeArchived }),
+      ]);
+      return { successBoolean: true, responseString: JSON.stringify({ taskId, dependencies, dependents }, null, 2) };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to list task dependencies: ${ err?.message ?? String(err) }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/project/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/project/manifests.ts
@@ -176,6 +176,54 @@ export const projectToolManifests: ToolManifest[] = [
     loader:         () => import('./unlink_knowledge_item'),
   },
 
+  {
+    name:        'create_task_dependency',
+    description: 'Create one first-class task dependency (dependent depends on a prerequisite). Rejects self-links and cycles transactionally. The dependent cannot be claimed for planning, execution, review, or lane entry until the prerequisite task is done.',
+    category:    'project',
+    schemaDef:   {
+      dependent_task_id:    { type: 'string', description: 'The task that is blocked (the dependent).' },
+      depends_on_task_id:   { type: 'string', description: 'The prerequisite task that must reach done first.' },
+      relation_type:        { type: 'string', optional: true, description: 'blocks | requires | ordered-after. Default requires.' },
+      acceptance_condition: { type: 'string', optional: true, description: 'Optional human-readable release condition, surfaced in explain_task_claimability.' },
+      actor:                { type: 'string', optional: true, description: 'Attribution for the created dependency.' },
+    },
+    operationTypes: ['create'],
+    loader:         () => import('./create_task_dependency'),
+  },
+  {
+    name:        'remove_task_dependency',
+    description: 'Remove (soft-archive) one task dependency by id, or by dependent_task_id + depends_on_task_id (+ relation_type). Use to explicitly override a failed/cancelled prerequisite; dependencies are never silently unblocked.',
+    category:    'project',
+    schemaDef:   {
+      id:                 { type: 'string', optional: true, description: 'Dependency id from list_task_dependencies.' },
+      dependent_task_id:  { type: 'string', optional: true, description: 'The dependent task (with depends_on_task_id).' },
+      depends_on_task_id: { type: 'string', optional: true, description: 'The prerequisite task (with dependent_task_id).' },
+      relation_type:      { type: 'string', optional: true, description: 'blocks | requires | ordered-after. Default requires.' },
+    },
+    operationTypes: ['update'],
+    loader:         () => import('./remove_task_dependency'),
+  },
+  {
+    name:        'list_task_dependencies',
+    description: 'List a task dependencies (its prerequisites) and its dependents. Read-only.',
+    category:    'project',
+    schemaDef:   {
+      task_id:          { type: 'string', description: 'Projects task id.' },
+      include_archived: { type: 'boolean', optional: true, description: 'Include soft-archived dependencies.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./list_task_dependencies'),
+  },
+  {
+    name:        'explain_task_claimability',
+    description: 'Explain whether a task is claimable: returns the transitive dependency chain and the exact reason a task is or is not claimable (unresolved prerequisites and their live status).',
+    category:    'project',
+    schemaDef:   {
+      task_id: { type: 'string', description: 'Projects task id.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./explain_task_claimability'),
+  },
   // ── projects ─────────────────────────────────────────────────────────
   {
     name:        'create_project',

--- a/pkg/rancher-desktop/agent/tools/project/remove_task_dependency.ts
+++ b/pkg/rancher-desktop/agent/tools/project/remove_task_dependency.ts
@@ -1,0 +1,27 @@
+import { WorkTaskDependencyModel } from '../../database/models/WorkTaskDependencyModel';
+import { BaseTool, ToolResponse } from '../base';
+
+/** Soft-archive one task dependency by id, or by dependent+depends_on(+relation). */
+export class RemoveTaskDependencyWorker extends BaseTool {
+  name = '';
+  description = '';
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const id = typeof input.id === 'string' && input.id.trim() ? input.id.trim() : undefined;
+    const dependentTaskId = typeof input.dependent_task_id === 'string' && input.dependent_task_id.trim() ? input.dependent_task_id.trim() : undefined;
+    const dependsOnTaskId = typeof input.depends_on_task_id === 'string' && input.depends_on_task_id.trim() ? input.depends_on_task_id.trim() : undefined;
+    if (!id && (!dependentTaskId || !dependsOnTaskId)) {
+      return { successBoolean: false, responseString: 'Provide id, or both dependent_task_id and depends_on_task_id.' };
+    }
+    try {
+      const removed = await WorkTaskDependencyModel.remove({
+        id,
+        dependentTaskId,
+        dependsOnTaskId,
+        relationType: typeof input.relation_type === 'string' && input.relation_type.trim() ? input.relation_type.trim() : undefined,
+      });
+      return { successBoolean: true, responseString: removed ? 'Dependency removed (soft-archived).' : 'No matching active dependency found.' };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to remove task dependency: ${ err?.message ?? String(err) }` };
+    }
+  }
+}


### PR DESCRIPTION
Closes #714. Projects task: 3wqs.

Replaces HOLD-comment conventions with FK-backed task dependencies that mechanically gate every autonomous claim path.

## Delivered
- Migration 0083 upgrades the existing 0075 dependency table in place without losing links.
- Relation types: blocks, requires, ordered-after; acceptance condition, actor, timestamps, and soft archive.
- Transactional self-link and cycle rejection, including a graph-wide advisory lock for concurrent transitive edits.
- Live-status claim gates in execution, protected review, planning, and lane-entry transactions.
- A done prerequisite releases eligibility automatically; cancelled/parked prerequisites remain blocked pending explicit removal.
- Create/remove/list/explain tools with transitive claimability reasoning.
- Existing Projects UI dependency controls are preserved through a compatibility adapter.
- Project reports separate dependency-held work from external waits and human gates.
- Conservative dry-run-first backfill for explicit parent/child and recognizable HOLD references, with unresolved entries reported rather than guessed.
- Real-Postgres integration suites and tool tests included.

## Verification
- Rebased on main at 24363dd8ceb96a55cb097a8494e102bf2882c8e9.
- git diff --check clean.
- TypeScript transpile of all 16 changed TS files: 0 errors.
- Worker’s earlier isolated PostgreSQL source harness reported 22 core/gate/concurrency assertions and 9 backfill assertions passing before the migration was corrected for current main.
- No hosted checks. Repository Jest/full typecheck and migrated-Postgres rerun remain unavailable because the checkout dependency tree is broken and SULLA_INTEGRATION_POSTGRES_URL is not configured.

Source merge only; rebuild/restart and runtime acceptance remain required.