### PR TITLE
feat(projects): activate protected review and reclaim backlog (#710)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0084_activate_protected_review.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0084_activate_protected_review.ts
@@ -1,0 +1,23 @@
+/** Promote protected review from dark rollout while preserving explicit overrides. */
+export const up = `
+  ALTER TABLE lifecycle_capabilities
+    ADD COLUMN IF NOT EXISTS details JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+  INSERT INTO sulla_settings (property, value, cast) VALUES
+    ('taskVerifierEnabled', 'true', 'boolean'),
+    ('taskVerifierOwner', 'core-routine', 'string'),
+    ('taskReviewCoreRoutineEnabled', 'true', 'boolean')
+  ON CONFLICT (property) DO UPDATE
+    SET value = EXCLUDED.value, cast = EXCLUDED.cast
+    WHERE (sulla_settings.property = 'taskVerifierEnabled' AND sulla_settings.value = 'false')
+       OR (sulla_settings.property = 'taskVerifierOwner' AND sulla_settings.value = 'legacy')
+       OR (sulla_settings.property = 'taskReviewCoreRoutineEnabled' AND sulla_settings.value = 'false');
+`;
+
+export const down = `
+  DELETE FROM sulla_settings
+   WHERE (property = 'taskVerifierEnabled' AND value = 'true')
+      OR (property = 'taskVerifierOwner' AND value = 'core-routine')
+      OR (property = 'taskReviewCoreRoutineEnabled' AND value = 'true');
+  ALTER TABLE lifecycle_capabilities DROP COLUMN IF EXISTS details;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0084_activate_protected_review.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0084_activate_protected_review.test.ts
@@ -1,0 +1,13 @@
+import { down, up } from '../0084_activate_protected_review';
+
+describe('0084_activate_protected_review', () => {
+  it('adds capability telemetry and promotes only known dark-rollout defaults', () => {
+    expect(up).toContain('ADD COLUMN IF NOT EXISTS details JSONB');
+    expect(up).toContain("('taskVerifierEnabled', 'true', 'boolean')");
+    expect(up).toContain("('taskVerifierOwner', 'core-routine', 'string')");
+    expect(up).toContain("('taskReviewCoreRoutineEnabled', 'true', 'boolean')");
+    expect(up).toContain("sulla_settings.value = 'legacy'");
+    expect(up).toContain("sulla_settings.value = 'false'");
+    expect(down).toContain('DROP COLUMN IF EXISTS details');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -70,6 +70,7 @@ import { up as up_0080, down as down_0080 } from './0080_settle_work_task_waits_
 import { up as up_0081, down as down_0081 } from './0081_add_workflow_execution_leases';
 import { up as up_0082, down as down_0082 } from './0082_create_artifact_receipts';
 import { up as up_0083, down as down_0083 } from './0083_create_work_task_dependencies';
+import { up as up_0084, down as down_0084 } from './0084_activate_protected_review';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -141,4 +142,5 @@ export const migrationsRegistry = [
   { name: '0081_add_workflow_execution_leases',                    up: up_0081, down: down_0081 },
   { name: '0082_create_artifact_receipts',                         up: up_0082, down: down_0082 },
   { name: '0083_create_work_task_dependencies',                    up: up_0083, down: down_0083 },
+  { name: '0084_activate_protected_review',                        up: up_0084, down: down_0084 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
@@ -29,6 +29,7 @@ export interface LifecycleCapabilityRecord {
   fallback_active:     boolean;
   last_error:          string | null;
   recovery_task_id:    string | null;
+  details:             Record<string, unknown>;
   updated_at:          string;
 }
 
@@ -54,6 +55,7 @@ export interface CapabilityReport {
   runtimeInstanceId?: string | null;
   fallbackMode:       LifecycleFallback;
   error?:             string | null;
+  details?:           Record<string, unknown>;
 }
 
 export interface ClaimResult {
@@ -104,12 +106,12 @@ export class LifecycleCapabilityModel {
       INSERT INTO lifecycle_capabilities (
         capability_key, version, enabled, health, active_owner,
         runtime_instance_id, last_success_at, exception_count,
-        fallback_mode, fallback_active, last_error, updated_at
+        fallback_mode, fallback_active, last_error, details, updated_at
       ) VALUES (
         $1, $2, $3, $4, $5, $6,
         CASE WHEN $4 = 'healthy' THEN now() ELSE NULL END,
         CASE WHEN $4 = 'healthy' THEN 0 ELSE 1 END,
-        $7, $8, $9, now()
+        $7, $8, $9, $10::jsonb, now()
       )
       ON CONFLICT (capability_key) DO UPDATE SET
         version = EXCLUDED.version,
@@ -129,6 +131,7 @@ export class LifecycleCapabilityModel {
         fallback_mode = EXCLUDED.fallback_mode,
         fallback_active = EXCLUDED.fallback_active,
         last_error = EXCLUDED.last_error,
+        details = EXCLUDED.details,
         updated_at = now()
       RETURNING *
     `, [
@@ -141,6 +144,7 @@ export class LifecycleCapabilityModel {
       report.fallbackMode,
       fallbackActive,
       report.error ?? null,
+      JSON.stringify(report.details ?? {}),
     ]);
     if (!row) throw new Error(`Failed to report lifecycle capability ${ report.key }`);
 
@@ -323,7 +327,10 @@ export class LifecycleCapabilityModel {
     const compact = rows.map(row => {
       const last = row.last_success_at ? new Date(row.last_success_at).toISOString() : 'never';
       const owner = effectiveOwner(row) ?? 'hold';
-      return `${ row.capability_key }@${ row.version }=${ row.enabled ? row.health : 'disabled' } owner:${ owner } ok:${ last } ex:${ row.exception_count } fallback:${ row.fallback_mode }${ row.fallback_active ? '*' : '' }`;
+      const review = row.capability_key === 'in-review-verification' && row.details
+        ? ` backlog:${ Number(row.details.backlog ?? 0) } active:${ Number(row.details.active ?? 0) } reclaimed:${ Number(row.details.reclaimed ?? 0) } suppressed:${ Number(row.details.suppressedDuplicates ?? 0) } failures:${ Number(row.details.failures ?? 0) }`
+        : '';
+      return `${ row.capability_key }@${ row.version }=${ row.enabled ? row.health : 'disabled' } owner:${ owner } ok:${ last } ex:${ row.exception_count } fallback:${ row.fallback_mode }${ row.fallback_active ? '*' : '' }${ review }`;
     });
     return ['LIFECYCLE:', ...compact.map(line => `  • ${ line }`)].join('\n');
   }

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -1020,6 +1020,77 @@ export class WorkTaskDispatchModel {
     });
   }
 
+  /**
+   * Settle verification dispatches whose previous-runtime stage claims were
+   * explicitly recovered during startup. Healthy current-runtime leases are
+   * never selected, regardless of their age.
+   */
+  static async recoverOrphanedVerification(taskIds: string[]): Promise<string[]> {
+    if (taskIds.length === 0) return [];
+    return postgresClient.transaction(async(client: PoolClient) => {
+      const reclaimed = await client.query<{ id: string; task_id: string }>(`
+        UPDATE work_task_dispatches dispatch
+           SET status = 'stale', failure_reason = 'previous_runtime_recovered',
+               error = 'previous runtime ended before review settlement',
+               heartbeat_at = now(), finished_at = now()
+         WHERE dispatch.kind = 'verification'
+           AND dispatch.status = 'running'
+           AND dispatch.task_id = ANY($1::text[])
+           AND NOT EXISTS (
+             SELECT 1 FROM work_task_stage_claims claim
+              WHERE claim.task_id = dispatch.task_id
+                AND claim.capability_key = 'in-review-verification'
+                AND claim.stage = 'in_review'
+                AND claim.status = 'active'
+           )
+        RETURNING dispatch.id, dispatch.task_id
+      `, [taskIds]);
+      const reclaimedTaskIds: string[] = [
+        ...new Set<string>(reclaimed.rows.map((row: { task_id: string }) => row.task_id)),
+      ];
+      if (reclaimedTaskIds.length > 0) {
+        await client.query(`
+          UPDATE work_tasks
+             SET status = 'in_review', assignee = 'heartbeat', updated_at = now(),
+                 last_activity_at = now(), last_moved_by = 'dispatcher'
+           WHERE id = ANY($1::text[]) AND status = 'in_review' AND assignee = 'verifier'
+        `, [reclaimedTaskIds]);
+      }
+      return reclaimedTaskIds;
+    });
+  }
+
+  static async verificationPoolStats(): Promise<{
+    backlog: number;
+    active: number;
+    suppressedDuplicates: number;
+    failures: number;
+  }> {
+    const rows = await postgresClient.query<{
+      backlog: string;
+      active: string;
+      suppressed_duplicates: string;
+      failures: string;
+    }>(`
+      SELECT
+        (SELECT COUNT(*) FROM work_tasks WHERE archived = false AND status = 'in_review')::text AS backlog,
+        (SELECT COUNT(*) FROM work_task_dispatches WHERE kind = 'verification' AND status = 'running')::text AS active,
+        (SELECT COUNT(*) FROM work_task_dispatches
+          WHERE kind = 'verification' AND status = 'completed'
+            AND result LIKE 'suppressed identical terminal generation%')::text AS suppressed_duplicates,
+        (SELECT COUNT(*) FROM work_task_dispatches
+          WHERE kind = 'verification' AND status = 'failed'
+            AND finished_at >= now() - interval '24 hours')::text AS failures
+    `);
+    const row = rows[0];
+    return {
+      backlog: Number(row?.backlog ?? 0),
+      active: Number(row?.active ?? 0),
+      suppressedDuplicates: Number(row?.suppressed_duplicates ?? 0),
+      failures: Number(row?.failures ?? 0),
+    };
+  }
+
   /** Settle a parsed verifier verdict and its Projects transition atomically. */
   static async finalizeVerification(
     id: string,
@@ -1300,13 +1371,21 @@ export class WorkTaskDispatchModel {
          LIMIT 1
       `, [taskId, id, reason]);
       if (!duplicate.rows[0] || terminal) {
-        await client.query(`
-          INSERT INTO work_task_comments (id, task_id, body, author)
-          VALUES ($1, $2, $3, 'verifier')
-        `, [randomUUID().slice(0, 12), taskId,
-          terminal
-            ? `Verification ${ id } hit three equivalent infrastructure failures for generation ${ generationHash ?? 'unbound' } and was escalated to planning: ${ reason }`
-            : `Verification ${ id } failed and was released for retry: ${ reason }`]);
+        await this.persistReceiptWithClient(client, this.reviewReceipt({
+          taskId,
+          eventType:         terminal ? 'repair' : 'review',
+          actor:             'verifier',
+          dispatchId:        id,
+          disposition:       terminal ? 'REPLAN' : 'RETRY',
+          nextOwner:         terminal ? 'dispatcher' : 'protected-review',
+          validationSummary: terminal
+            ? `Three equivalent verification infrastructure failures for generation ${ generationHash ?? 'unbound' }: ${ reason }`
+            : `Verification infrastructure failure released for retry: ${ reason }`,
+          artifacts:         generationHash
+            ? [{ type: 'review_generation', canonicalRef: generationHash, hash: generationHash }]
+            : [{ type: 'verification_dispatch', canonicalRef: id }],
+          evidence:          { kind: 'dispatch', ref: id },
+        }), 'verifier');
       }
       await client.query(`
         UPDATE work_tasks

--- a/pkg/rancher-desktop/agent/database/models/__tests__/LifecycleCapabilityModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/LifecycleCapabilityModel.test.ts
@@ -153,12 +153,25 @@ describe('LifecycleCapabilityModel', () => {
         fallback_mode:   'manual_hold',
         fallback_active: true,
       },
+      {
+        capability_key:  'in-review-verification',
+        version:         1,
+        enabled:         true,
+        health:          'healthy',
+        active_owner:    'dispatcher',
+        last_success_at: '2026-08-23T20:00:00.000Z',
+        exception_count: 0,
+        fallback_mode:   'manual_hold',
+        fallback_active: false,
+        details:         { backlog: 12, active: 3, reclaimed: 2, suppressedDuplicates: 4, failures: 1 },
+      },
     ]));
 
     const digest = await LifecycleCapabilityModel.buildDigest();
     expect(digest).toContain('planning-council@2=healthy owner:planning-council');
     expect(digest).toContain('todo-execution@1=disabled owner:hold');
     expect(digest).toContain('fallback:manual_hold*');
+    expect(digest).toContain('backlog:12 active:3 reclaimed:2 suppressed:4 failures:1');
   });
 
   it('hides healthy protected stages and preserves explicit Heartbeat fallbacks', async() => {

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
@@ -326,6 +326,26 @@ describe('WorkTaskDispatchModel', () => {
     expect(query.mock.calls[2][0]).toContain("assignee = 'verifier'");
   });
 
+  it('reclaims only verification dispatches whose previous-runtime claims were recovered', async() => {
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [{ id: 'verify-old', task_id: 'task-old' }] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.recoverOrphanedVerification(['task-old']))
+      .resolves.toEqual(['task-old']);
+    expect(query.mock.calls[0][0]).toContain("dispatch.kind = 'verification'");
+    expect(query.mock.calls[0][0]).toContain("claim.status = 'active'");
+    expect(query.mock.calls[0][1]).toEqual([['task-old']]);
+    expect(query.mock.calls[1][0]).toContain("assignee = 'verifier'");
+  });
+
+  it('leaves healthy review leases untouched when no recovered task ids exist', async() => {
+    const transaction = jest.spyOn(postgresClient, 'transaction');
+    await expect(WorkTaskDispatchModel.recoverOrphanedVerification([])).resolves.toEqual([]);
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
   it('settles the verifier verdict, exact head, comment, and task transition in one transaction', async() => {
     const query = (jest.fn() as any)
       .mockResolvedValueOnce({ rows: [{ task_id: 'task-2' }] })
@@ -365,7 +385,7 @@ describe('WorkTaskDispatchModel', () => {
 
     await expect(WorkTaskDispatchModel.failVerification('dispatch-2', 'boom')).resolves.toBe(true);
     expect(query.mock.calls[0][0]).toContain("status = 'failed'");
-    expect(query.mock.calls[3][1][2]).toContain('released for retry');
+    expect(query.mock.calls[3][1][2]).toContain('<!-- artifact-receipt');
     expect(query.mock.calls[4][1]).toEqual(['task-2', 'in_review', 'heartbeat']);
   });
 
@@ -381,7 +401,7 @@ describe('WorkTaskDispatchModel', () => {
 
     await expect(WorkTaskDispatchModel.failVerification('dispatch-fail', 'adapter_unavailable')).resolves.toBe(true);
     expect(query.mock.calls[2][0]).toContain("'terminal:' || $2");
-    expect(query.mock.calls[4][1][2]).toContain('escalated to planning');
+    expect(query.mock.calls[4][1][2]).toContain('<!-- artifact-receipt');
     expect(query.mock.calls[5][1]).toEqual(['task-fail', 'planning', 'dispatcher']);
   });
 

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -31,6 +31,7 @@ import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../routines/core/defaultCoreAgent
 import { extractAgentTurnOutcome } from '../tools/agents/agentTurnOutcome';
 import { toolRegistry } from '../tools/registry';
 import { createPlaybookState } from '../workflow/WorkflowPlaybook';
+import { findAgentDir } from '../utils/sullaPaths';
 
 const CHECK_INTERVAL_MS = 60_000;
 const LEASE_HEARTBEAT_MS = 120_000;
@@ -80,6 +81,7 @@ export class TaskDispatcherService {
   private checking = false;
   private schedulerId: ReturnType<typeof setInterval> | null = null;
   private recoveredOnStart = false;
+  private reclaimedReviewsOnStart = 0;
   private active = new Map<string, AbortService>();
   private lastBackpressure: {
     limits:   WipLimits;
@@ -93,7 +95,12 @@ export class TaskDispatcherService {
     this.initialized = true;
 
     await LifecycleCapabilityModel.recoverPreviousRuntime('todo-execution', RUNTIME_INSTANCE_ID);
-    await LifecycleCapabilityModel.recoverPreviousRuntime('in-review-verification', RUNTIME_INSTANCE_ID);
+    const recoveredReviewClaims = await LifecycleCapabilityModel.recoverPreviousRuntime(
+      'in-review-verification', RUNTIME_INSTANCE_ID,
+    );
+    this.reclaimedReviewsOnStart = (await WorkTaskDispatchModel.recoverOrphanedVerification(
+      recoveredReviewClaims,
+    )).length;
     await this.checkAndDispatch();
     this.schedulerId = setInterval(() => {
       this.checkAndDispatch().catch(err => console.error('[TaskDispatcher] Scheduled check failed:', err));
@@ -152,13 +159,17 @@ export class TaskDispatcherService {
       if (window && !isInsideWindow(window)) return;
 
       if (!this.recoveredOnStart) {
-        const recovered = await WorkTaskDispatchModel.recoverStale(0);
+        const recovered = await WorkTaskDispatchModel.recoverStale();
         this.recoveredOnStart = true;
         if (recovered.length > 0) console.warn(`[TaskDispatcher] Recovered ${ recovered.length } orphaned dispatch(es)`);
       }
 
       await this.checkInProgressRecovery();
-      await this.fillVerificationPool();
+      const reviewReady = await this.fillVerificationPool();
+      if (!reviewReady) {
+        console.warn('[TaskDispatcher] Protected review is unavailable; holding fresh execution work');
+        return;
+      }
       // Issue #711: semantic stage-aware WIP limits + downstream-first backpressure.
       // Additive over the #709 review-drain guard below: this only ever holds MORE
       // work, never less, and never interrupts already-running work. Re-evaluated
@@ -285,7 +296,7 @@ export class TaskDispatcherService {
       health:            'healthy',
       owner:             'dispatcher',
       runtimeInstanceId: RUNTIME_INSTANCE_ID,
-      fallbackMode:      'heartbeat',
+      fallbackMode:      'manual_hold',
     });
 
         let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning('execution'));
@@ -312,8 +323,8 @@ export class TaskDispatcherService {
     }
   }
 
-  private async fillVerificationPool(): Promise<void> {
-    const enabled = await SullaSettingsModel.get('taskVerifierEnabled', false);
+  private async fillVerificationPool(): Promise<boolean> {
+    const enabled = await SullaSettingsModel.get('taskVerifierEnabled', true);
     if (!enabled) {
       await LifecycleCapabilityModel.report({
         key:               'in-review-verification',
@@ -321,12 +332,25 @@ export class TaskDispatcherService {
         health:            'unavailable',
         owner:             null,
         runtimeInstanceId: RUNTIME_INSTANCE_ID,
-        fallbackMode:      'heartbeat',
+        fallbackMode:      'manual_hold',
+        details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviewsOnStart },
       });
-      return;
+      return false;
     }
     const owner = await this.resolveVerificationOwner();
-    if (!owner) return;
+    if (!owner) {
+      await LifecycleCapabilityModel.report({
+        key:               'in-review-verification',
+        enabled:           true,
+        health:            'unavailable',
+        owner:             null,
+        runtimeInstanceId: RUNTIME_INSTANCE_ID,
+        fallbackMode:      'manual_hold',
+        error:             'Protected review routine, rollout, or default agent is unavailable.',
+        details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviewsOnStart },
+      });
+      return false;
+    }
     const configured = Number(await SullaSettingsModel.get('taskVerifierConcurrency', DEFAULT_CONCURRENCY));
     const concurrency = await RoutineConcurrencyPolicy.resolveLimit('review', configured || DEFAULT_CONCURRENCY);
     const enforceSlots = await RoutineConcurrencyPolicy.isEnabled();
@@ -340,9 +364,10 @@ export class TaskDispatcherService {
       owner:             'dispatcher',
       runtimeInstanceId: RUNTIME_INSTANCE_ID,
       fallbackMode:      'heartbeat',
+      details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviewsOnStart },
     });
 
-        let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning('verification'));
+    let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning('verification'));
     while (freeSlots > 0 && this.initialized) {
       let slot: string | null = null;
       if (enforceSlots) {
@@ -368,16 +393,28 @@ export class TaskDispatcherService {
         });
       freeSlots -= 1;
     }
+    await LifecycleCapabilityModel.report({
+      key:               'in-review-verification',
+      enabled:           true,
+      health:            'healthy',
+      owner:             'dispatcher',
+      runtimeInstanceId: RUNTIME_INSTANCE_ID,
+      fallbackMode:      'manual_hold',
+      details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviewsOnStart },
+    });
+    return true;
   }
 
   /** One service and one claim path own in_review. Disabling the core routine pauses it. */
   private async resolveVerificationOwner(): Promise<VerificationOwner | null> {
-    const configured = String(await SullaSettingsModel.get('taskVerifierOwner', 'legacy'));
+    const configured = String(await SullaSettingsModel.get('taskVerifierOwner', 'core-routine'));
     if (configured === 'legacy') return 'legacy';
-    const rolloutEnabled = await SullaSettingsModel.get('taskReviewCoreRoutineEnabled', false);
+    if (configured !== 'core-routine') return null;
+    const rolloutEnabled = await SullaSettingsModel.get('taskReviewCoreRoutineEnabled', true);
     if (!rolloutEnabled) return null;
     const routine = await WorkflowModel.findById(REVIEW_PROJECT_ARTIFACT_ID);
     if (!routine || routine.attributesSnapshot.enabled === false) return null;
+    if (!findAgentDir(DEFAULT_CORE_ROUTINE_AGENT_ID)) return null;
     return 'core-routine';
   }
 

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const settingsGetMock: any = jest.fn();
 const recoverStaleMock: any = jest.fn(() => Promise.resolve([]));
+const recoverOrphanedVerificationMock: any = jest.fn(() => Promise.resolve([]));
+const verificationPoolStatsMock: any = jest.fn(() => Promise.resolve({ backlog: 0, active: 0, suppressedDuplicates: 0, failures: 0 }));
 const findRecoverableInProgressMock: any = jest.fn(() => Promise.resolve([]));
 const recoverOrphanedInProgressMock: any = jest.fn(() => Promise.resolve([]));
 const countRunningMock: any = jest.fn(() => Promise.resolve(0));
@@ -31,6 +33,7 @@ const resolvePullRequestHeadsMock: any = jest.fn();
 const bindReviewGenerationMock: any = jest.fn();
 const generationHashMock: any = jest.fn(() => 'f'.repeat(64));
 const workflowFindByIdMock: any = jest.fn(() => Promise.resolve({ attributesSnapshot: { enabled: true } }));
+const findAgentDirMock: any = jest.fn(() => '/agents/sulla-desktop');
 
 jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
   SullaSettingsModel: { get: settingsGetMock },
@@ -45,6 +48,8 @@ jest.unstable_mockModule('../../database/models/LifecycleCapabilityModel', () =>
 jest.unstable_mockModule('../../database/models/WorkTaskDispatchModel', () => ({
   WorkTaskDispatchModel: {
     recoverStale:            recoverStaleMock,
+    recoverOrphanedVerification: recoverOrphanedVerificationMock,
+    verificationPoolStats:   verificationPoolStatsMock,
     findRecoverableInProgress: findRecoverableInProgressMock,
     recoverOrphanedInProgress: recoverOrphanedInProgressMock,
     countRunning:            countRunningMock,
@@ -96,11 +101,16 @@ jest.unstable_mockModule('../../tools/registry', () => ({
     })),
   },
 }));
+jest.unstable_mockModule('../../utils/sullaPaths', () => ({
+  findAgentDir: findAgentDirMock,
+}));
 
 describe('TaskDispatcherService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     recoverStaleMock.mockResolvedValue([]);
+    recoverOrphanedVerificationMock.mockResolvedValue([]);
+    verificationPoolStatsMock.mockResolvedValue({ backlog: 0, active: 0, suppressedDuplicates: 0, failures: 0 });
     findRecoverableInProgressMock.mockResolvedValue([]);
     recoverOrphanedInProgressMock.mockResolvedValue([]);
     countRunningMock.mockResolvedValue(0);
@@ -108,6 +118,7 @@ describe('TaskDispatcherService', () => {
     claimNextMock.mockResolvedValue(null);
     claimNextReviewMock.mockResolvedValue(null);
     workflowFindByIdMock.mockResolvedValue({ attributesSnapshot: { enabled: true } });
+    findAgentDirMock.mockReturnValue('/agents/sulla-desktop');
     resolvePullRequestHeadMock.mockResolvedValue({
       owner: 'merchantprotocol', repo: 'sulla-desktop', pullNumber: 123, sha: 'a'.repeat(40),
     });
@@ -127,13 +138,30 @@ describe('TaskDispatcherService', () => {
     releaseStageMock.mockResolvedValue(undefined);
   });
 
-  it('dark-gates verification by default', async() => {
+  it('activates verification by default', async() => {
     const { TaskDispatcherService } = await import('../TaskDispatcherService');
     const service = new TaskDispatcherService();
     await service.initialize();
     service.destroy();
 
-    expect(claimNextReviewMock).not.toHaveBeenCalled();
+    expect(claimNextReviewMock).toHaveBeenCalled();
+  });
+
+  it('reclaims only review tasks whose previous-runtime claims were recovered', async() => {
+    recoverPreviousRuntimeMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(['orphan-review']);
+    recoverOrphanedVerificationMock.mockResolvedValue(['orphan-review']);
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    service.destroy();
+    expect(recoverOrphanedVerificationMock).toHaveBeenCalledWith(['orphan-review']);
+    expect(recoverStaleMock).toHaveBeenCalledWith();
+    expect(reportCapabilityMock).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'in-review-verification',
+      details: expect.objectContaining({ reclaimed: 1 }),
+    }));
   });
 
   it('leaves in_review visible and unclaimed when the protected routine is disabled', async() => {
@@ -148,6 +176,25 @@ describe('TaskDispatcherService', () => {
     await service.initialize();
     service.destroy();
     expect(claimNextReviewMock).not.toHaveBeenCalled();
+    expect(claimNextMock).not.toHaveBeenCalled();
+    expect(reportCapabilityMock).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'in-review-verification', health: 'unavailable', fallbackMode: 'manual_hold',
+    }));
+  });
+
+  it('fails closed when the default core agent is unavailable', async() => {
+    settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+      if (key === 'heartbeatEnabled' || key === 'taskVerifierEnabled' || key === 'taskReviewCoreRoutineEnabled') return Promise.resolve(true);
+      if (key === 'taskVerifierOwner') return Promise.resolve('core-routine');
+      return Promise.resolve(fallback);
+    });
+    findAgentDirMock.mockReturnValue(null);
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    service.destroy();
+    expect(claimNextReviewMock).not.toHaveBeenCalled();
+    expect(claimNextMock).not.toHaveBeenCalled();
   });
 
   it('suppresses an identical terminal generation before graph or workflow side effects', async() => {


### PR DESCRIPTION
Closes #710. Projects task: yG4z.

Activates the protected in-review routine as the default owner and safely drains/reclaims the review backlog.

## Delivered
- Migration 0084 promotes the known dark-rollout settings to protected review while preserving later explicit configuration.
- Clean installs default taskVerifierEnabled=true, taskVerifierOwner=core-routine, and taskReviewCoreRoutineEnabled=true.
- Claims fail closed unless the protected workflow exists, is enabled, and the default sulla-desktop agent is installed.
- An unavailable/disabled review capability pauses fresh todo execution so review debt cannot grow.
- Startup recovery uses previous-runtime stage identity to reclaim only provably orphaned verification dispatches; healthy current-runtime leases are untouched.
- Generic stale recovery returned to its 45-minute lease threshold instead of reclaiming every running dispatch at startup.
- Backlog draining remains bounded by global routine and verifier concurrency limits and preserves downstream-first ordering.
- Identical terminal artifact generations are suppressed before graph/workflow execution.
- Lifecycle capability telemetry now reports backlog, active verifiers, reclaimed work, suppressed duplicates, and 24-hour failures.
- Verifier failures now write one concise artifact receipt linked to full dispatch evidence.
- Focused tests cover activation defaults, fail-closed workflow/agent checks, orphan-only restart recovery, healthy-lease preservation, telemetry, migration behavior, and receipt output.

## Verification
- Based on main at af1813858914c0e38d3ea2d38decc2d037c15f17.
- git diff --check clean.
- TypeScript transpile of all 7 changed TS files: zero errors.
- No hosted checks. Jest/full typecheck/migrated-Postgres tests could not run because the repository dependency tree is broken and SULLA_INTEGRATION_POSTGRES_URL is unavailable.

Source merge only; rebuild/restart is required before protected review becomes live and backlog drain can be accepted.