### PR TITLE
feat(projects): expose exact conveyor health metrics

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0085_add_conveyor_metrics_indexes.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0085_add_conveyor_metrics_indexes.ts
@@ -1,0 +1,38 @@
+/**
+ * 0085_add_conveyor_metrics_indexes — additive, index-only migration that keeps
+ * the Projects conveyor-health dashboard (issue #717) bounded on local Postgres.
+ * No data is mutated and no columns/tables are dropped; every index uses
+ * IF NOT EXISTS so re-running is safe.
+ */
+export const up = `
+  -- verifier throughput / rework scans by dispatch kind over a finished-at window
+  CREATE INDEX IF NOT EXISTS idx_wtd_kind_finished
+    ON work_task_dispatches (kind, finished_at DESC);
+
+  -- duplicate/suppressed review-generation dedup key (verification leases only)
+  CREATE INDEX IF NOT EXISTS idx_wtd_verif_generation
+    ON work_task_dispatches (task_id, review_generation_hash)
+    WHERE kind = 'verification';
+
+  -- custody completeness joins dispatches to their task by kind
+  CREATE INDEX IF NOT EXISTS idx_wtd_task_kind
+    ON work_task_dispatches (task_id, kind);
+
+  -- independent-shipment / done-throughput window scans
+  CREATE INDEX IF NOT EXISTS idx_work_tasks_completed
+    ON work_tasks (project_id, completed_at)
+    WHERE status = 'done';
+
+  -- stage-age percentile window scans over recently-active tasks
+  CREATE INDEX IF NOT EXISTS idx_work_tasks_activity
+    ON work_tasks (project_id, last_activity_at)
+    WHERE archived = false;
+`;
+
+export const down = `
+  DROP INDEX IF EXISTS idx_work_tasks_activity;
+  DROP INDEX IF EXISTS idx_work_tasks_completed;
+  DROP INDEX IF EXISTS idx_wtd_task_kind;
+  DROP INDEX IF EXISTS idx_wtd_verif_generation;
+  DROP INDEX IF EXISTS idx_wtd_kind_finished;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0085_add_conveyor_metrics_indexes.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0085_add_conveyor_metrics_indexes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from '@jest/globals';
+import { up, down } from '../0085_add_conveyor_metrics_indexes';
+
+describe('0085_add_conveyor_metrics_indexes', () => {
+  it('creates the bounded conveyor-metric indexes additively', () => {
+    expect(up).toContain('CREATE INDEX IF NOT EXISTS');
+    expect(up).toContain('idx_wtd_kind_finished');
+    expect(up).toContain('idx_wtd_verif_generation');
+    expect(up).toContain('idx_wtd_task_kind');
+    expect(up).toContain('idx_work_tasks_completed');
+    expect(up).toContain('idx_work_tasks_activity');
+    // additive only: never mutates data or drops schema
+    expect(up).not.toMatch(/DROP\s+(TABLE|COLUMN)/i);
+    expect(up).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b/i);
+  });
+
+  it('down drops exactly the indexes it created', () => {
+    expect(down).toContain('DROP INDEX IF EXISTS idx_wtd_kind_finished');
+    expect(down).toContain('DROP INDEX IF EXISTS idx_wtd_verif_generation');
+    expect(down).toContain('DROP INDEX IF EXISTS idx_wtd_task_kind');
+    expect(down).toContain('DROP INDEX IF EXISTS idx_work_tasks_completed');
+    expect(down).toContain('DROP INDEX IF EXISTS idx_work_tasks_activity');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -71,6 +71,7 @@ import { up as up_0081, down as down_0081 } from './0081_add_workflow_execution_
 import { up as up_0082, down as down_0082 } from './0082_create_artifact_receipts';
 import { up as up_0083, down as down_0083 } from './0083_create_work_task_dependencies';
 import { up as up_0084, down as down_0084 } from './0084_activate_protected_review';
+import { up as up_0085, down as down_0085 } from './0085_add_conveyor_metrics_indexes';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -143,4 +144,5 @@ export const migrationsRegistry = [
   { name: '0082_create_artifact_receipts',                         up: up_0082, down: down_0082 },
   { name: '0083_create_work_task_dependencies',                    up: up_0083, down: down_0083 },
   { name: '0084_activate_protected_review',                        up: up_0084, down: down_0084 },
+  { name: '0085_add_conveyor_metrics_indexes',                     up: up_0085, down: down_0085 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
@@ -1,0 +1,443 @@
+/**
+ * WorkConveyorMetricsModel — read-only Projects conveyor-health & productivity
+ * metrics (GitHub issue #717).
+ *
+ * Contract (issue acceptance criteria):
+ *  - AC#1: every number documents its denominator + legacy-data handling in
+ *    the comment above its query.
+ *  - Stage grouping resolves the *semantic* lane role via the DB function
+ *    resolve_work_task_lane_role(task_id, lane_key) so custom lane names stay
+ *    compatible (issue Scope). work_tasks.status IS the lane key.
+ *  - AC#7 query-performance: aggregates over indexed columns; every drill-down
+ *    list is LIMITed. Optional project scoping uses a static guard
+ *    ($1::text IS NULL OR <col> = $1) so the SQL stays constant/index-friendly.
+ *  - Comments/narration are never counted as completion (issue Scope):
+ *    completion is read only from terminal task state + the dispatch ledger.
+ *
+ * Read-only: no INSERT/UPDATE/DELETE.
+ */
+import { postgresClient } from '../PostgresClient';
+
+export type SemanticStage =
+  | 'backlog' | 'planning' | 'execution' | 'review' | 'blocked' | 'terminal' | 'manual';
+
+export interface ConveyorMetricsOptions {
+  /** Limit every metric to one project; null/undefined = whole portfolio. */
+  projectId?: string | null;
+  /** Rolling window for rate/throughput metrics (hours). Default 168 (7d). */
+  windowHours?: number;
+  /** Soft WIP ceiling for active execution leases. Default 6. */
+  wipLimit?: number;
+  /** Lease is stale/zombie when its heartbeat is older than this (minutes). Default 20. */
+  staleMinutes?: number;
+  /** Drill-down row cap. Default 20, hard-capped at 100. */
+  drillLimit?: number;
+}
+
+const DEFAULT_WINDOW_HOURS = 168;
+const DEFAULT_WIP_LIMIT = 6;
+const DEFAULT_STALE_MINUTES = 20;
+const DEFAULT_DRILL_LIMIT = 20;
+const MAX_DRILL_LIMIT = 100;
+
+function num(v: any): number { const n = Number(v); return Number.isFinite(n) ? n : 0; }
+function pid(o: ConveyorMetricsOptions): string | null { return o.projectId ?? null; }
+function win(o: ConveyorMetricsOptions): number {
+  return o.windowHours && o.windowHours > 0 ? Math.floor(o.windowHours) : DEFAULT_WINDOW_HOURS;
+}
+function stale(o: ConveyorMetricsOptions): number {
+  return o.staleMinutes && o.staleMinutes > 0 ? Math.floor(o.staleMinutes) : DEFAULT_STALE_MINUTES;
+}
+function drill(o: ConveyorMetricsOptions): number {
+  const d = o.drillLimit ?? DEFAULT_DRILL_LIMIT;
+  return Math.max(1, Math.min(MAX_DRILL_LIMIT, Math.floor(d)));
+}
+function wipLimit(o: ConveyorMetricsOptions): number {
+  return o.wipLimit && o.wipLimit > 0 ? Math.floor(o.wipLimit) : DEFAULT_WIP_LIMIT;
+}
+
+export interface StageCount {
+  stage: SemanticStage; count: number;
+  oldestTaskId: string | null; oldestTitle: string | null;
+  oldestEnteredAt: string | null; oldestAgeSeconds: number | null;
+}
+export interface StageAge {
+  stage: SemanticStage; sampleSize: number;
+  p50AgeSeconds: number; p90AgeSeconds: number;
+}
+export interface Throughput { enteredReview: number; reviewsCompleted: number; reachedDone: number; }
+export interface VerifierThroughput { completedReviews: number; perDay: number; activeVerificationLeases: number; }
+export interface Rework { reviewed: number; reworked: number; reworkRate: number; avgRepairLoops: number; }
+export interface CustodyRow {
+  artifactType: string; total: number;
+  structured: number; legacy: number; missing: number; invalid: number;
+}
+export interface WaitAdoption { blockedTotal: number; blockedWithActiveWait: number; adoptionRate: number; }
+export interface StaleLeases { staleLeases: number; activeLeases: number; }
+export interface WipPressure {
+  activeExecutionWip: number; activeVerificationWip: number; staleWip: number;
+  wipLimit: number; over: boolean; backpressureReason: string | null;
+}
+export interface Shipments { independentShipments: number; integrationTrainClosures: number; }
+
+export class WorkConveyorMetricsModel {
+  /**
+   * AC#2 — current count and the exact oldest item per semantic stage.
+   * Denominator: all non-archived work_tasks (each counted in exactly one
+   * stage). Age = now() - last_moved_at (dwell in current lane). Returns the
+   * oldest item's id/title so the UI can jump straight to it.
+   * Legacy: last_moved_at is NOT NULL (defaulted at insert) — no null handling.
+   */
+  static async stageCounts(opts: ConveyorMetricsOptions = {}): Promise<StageCount[]> {
+    const rows = await postgresClient.query(`
+      WITH staged AS (
+        SELECT t.id, t.title, t.last_moved_at,
+               resolve_work_task_lane_role(t.id, t.status) AS stage
+        FROM work_tasks t
+        WHERE t.archived = false
+          AND ($1::text IS NULL OR t.project_id = $1)
+      ), ranked AS (
+        SELECT s.*,
+               ROW_NUMBER() OVER (PARTITION BY s.stage ORDER BY s.last_moved_at ASC) AS rn,
+               COUNT(*)     OVER (PARTITION BY s.stage) AS stage_count
+        FROM staged s
+      )
+      SELECT stage, stage_count AS count, id AS oldest_task_id, title AS oldest_title,
+             last_moved_at AS oldest_entered_at,
+             EXTRACT(EPOCH FROM (now() - last_moved_at))::bigint AS oldest_age_seconds
+      FROM ranked WHERE rn = 1
+      ORDER BY stage
+    `, [pid(opts)]);
+    return rows.map((r: any) => ({
+      stage: r.stage as SemanticStage,
+      count: num(r.count),
+      oldestTaskId: r.oldest_task_id ?? null,
+      oldestTitle: r.oldest_title ?? null,
+      oldestEnteredAt: r.oldest_entered_at ? String(r.oldest_entered_at) : null,
+      oldestAgeSeconds: r.oldest_age_seconds == null ? null : num(r.oldest_age_seconds),
+    }));
+  }
+
+  /**
+   * Median (p50) and p90 stage age over a selectable window.
+   * Denominator: non-archived tasks whose last_activity_at falls in the window,
+   * grouped by semantic stage. Age = now() - last_moved_at.
+   */
+  static async stageAgePercentiles(opts: ConveyorMetricsOptions = {}): Promise<StageAge[]> {
+    const rows = await postgresClient.query(`
+      SELECT resolve_work_task_lane_role(t.id, t.status) AS stage,
+             COUNT(*) AS sample_size,
+             percentile_cont(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (now() - t.last_moved_at))) AS p50_age_seconds,
+             percentile_cont(0.9) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (now() - t.last_moved_at))) AS p90_age_seconds
+      FROM work_tasks t
+      WHERE t.archived = false
+        AND ($1::text IS NULL OR t.project_id = $1)
+        AND t.last_activity_at >= now() - make_interval(hours => $2)
+      GROUP BY stage
+      ORDER BY stage
+    `, [pid(opts), win(opts)]);
+    return rows.map((r: any) => ({
+      stage: r.stage as SemanticStage,
+      sampleSize: num(r.sample_size),
+      p50AgeSeconds: num(r.p50_age_seconds),
+      p90AgeSeconds: num(r.p90_age_seconds),
+    }));
+  }
+
+  /**
+   * Execution->review and review->done throughput over the window.
+   * There is no transition-history table, so these are derived from the
+   * authoritative dispatch ledger + terminal task state (never comments):
+   *   entered_review    = distinct tasks with a verification dispatch STARTED in window.
+   *   reviews_completed = distinct (task_id, review_generation_hash) FINISHED in window.
+   *   reached_done      = tasks whose completed_at falls in window (status='done').
+   * Denominator for each is stated inline; all three share the same window.
+   */
+  static async throughput(opts: ConveyorMetricsOptions = {}): Promise<Throughput> {
+    const r = (await postgresClient.query(`
+      SELECT
+        (SELECT COUNT(DISTINCT d.task_id)
+           FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+           WHERE d.kind = 'verification' AND d.started_at >= now() - make_interval(hours => $2)
+             AND ($1::text IS NULL OR t.project_id = $1)) AS entered_review,
+        (SELECT COUNT(*) FROM (
+              SELECT DISTINCT d.task_id, d.review_generation_hash
+              FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+              WHERE d.kind = 'verification' AND d.finished_at >= now() - make_interval(hours => $2)
+                AND d.status <> 'cancelled' AND d.review_generation_hash IS NOT NULL
+                AND ($1::text IS NULL OR t.project_id = $1)
+           ) g) AS reviews_completed,
+        (SELECT COUNT(*) FROM work_tasks t
+           WHERE t.status = 'done' AND t.completed_at >= now() - make_interval(hours => $2)
+             AND ($1::text IS NULL OR t.project_id = $1)) AS reached_done
+    `, [pid(opts), win(opts)]))[0] || {};
+    return {
+      enteredReview: num(r.entered_review),
+      reviewsCompleted: num(r.reviews_completed),
+      reachedDone: num(r.reached_done),
+    };
+  }
+
+  /**
+   * AC#5 — verifier throughput + utilization, EXCLUDING duplicate/suppressed
+   * generations. Duplicates are collapsed by DISTINCT (task_id,
+   * review_generation_hash) — the same dedup key WorkTaskDispatchModel uses to
+   * detect duplicate review generations. Suppressed generations
+   * (terminal_reason ILIKE 'suppress%') and cancelled leases are excluded.
+   * Denominator: distinct completed review generations in window.
+   * perDay is completed_reviews normalised to a 24h rate.
+   * Utilization is expressed as the count of currently-running verification
+   * leases (no capacity value is stored in the schema).
+   */
+  static async verifierThroughput(opts: ConveyorMetricsOptions = {}): Promise<VerifierThroughput> {
+    const hours = win(opts);
+    const r = (await postgresClient.query(`
+      SELECT
+        (SELECT COUNT(*) FROM (
+           SELECT DISTINCT d.task_id, d.review_generation_hash
+           FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+           WHERE d.kind = 'verification' AND d.finished_at >= now() - make_interval(hours => $2)
+             AND d.status <> 'cancelled'
+             AND COALESCE(d.terminal_reason, '') NOT ILIKE 'suppress%'
+             AND d.review_generation_hash IS NOT NULL
+             AND ($1::text IS NULL OR t.project_id = $1)
+         ) g) AS completed_reviews,
+        (SELECT COUNT(*) FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+           WHERE d.kind = 'verification' AND d.status = 'running'
+             AND ($1::text IS NULL OR t.project_id = $1)) AS active_verification_leases
+    `, [pid(opts), hours]))[0] || {};
+    const completed = num(r.completed_reviews);
+    return {
+      completedReviews: completed,
+      perDay: hours > 0 ? completed / (hours / 24) : 0,
+      activeVerificationLeases: num(r.active_verification_leases),
+    };
+  }
+
+  /**
+   * Rework rate + average repair loops from the custody ledger.
+   * Denominator: execution dispatches FINISHED in window that were reviewed
+   * (review_count > 0). reworkRate = reworked / reviewed. avgRepairLoops =
+   * mean(repair_count) over reviewed. Empty denominator degrades to 0.
+   */
+  static async reworkRate(opts: ConveyorMetricsOptions = {}): Promise<Rework> {
+    const r = (await postgresClient.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE d.review_count > 0) AS reviewed,
+        COUNT(*) FILTER (WHERE d.review_count > 0 AND d.repair_count > 0) AS reworked,
+        COALESCE(AVG(d.repair_count) FILTER (WHERE d.review_count > 0), 0)::float8 AS avg_repair_loops
+      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+      WHERE d.kind = 'execution' AND d.finished_at >= now() - make_interval(hours => $2)
+        AND ($1::text IS NULL OR t.project_id = $1)
+    `, [pid(opts), win(opts)]))[0] || {};
+    const reviewed = num(r.reviewed);
+    const reworked = num(r.reworked);
+    return { reviewed, reworked, reworkRate: reviewed > 0 ? reworked / reviewed : 0, avgRepairLoops: num(r.avg_repair_loops) };
+  }
+
+  /**
+   * AC#3 — structured custody completeness by artifact type. Denominator:
+   * terminal (status='done') execution dispatches. Four disjoint classes:
+   *   structured = real run + artifact_type + (content_hash OR artifact_ref)
+   *   legacy     = run_kind='legacy-worker' (pre-custody rows; not penalised)
+   *   missing    = real run, no artifact_type at all
+   *   invalid    = real run, claims an artifact_type but no hash/ref/url locator
+   */
+  static async custodyCompleteness(opts: ConveyorMetricsOptions = {}): Promise<CustodyRow[]> {
+    const rows = await postgresClient.query(`
+      SELECT
+        COALESCE(d.artifact_type, '(none)') AS artifact_type,
+        COUNT(*) AS total,
+        COUNT(*) FILTER (WHERE d.run_kind <> 'legacy-worker' AND d.artifact_type IS NOT NULL
+                           AND (d.content_hash IS NOT NULL OR d.artifact_ref IS NOT NULL)) AS structured,
+        COUNT(*) FILTER (WHERE d.run_kind = 'legacy-worker') AS legacy,
+        COUNT(*) FILTER (WHERE d.run_kind <> 'legacy-worker' AND d.artifact_type IS NULL) AS missing,
+        COUNT(*) FILTER (WHERE d.run_kind <> 'legacy-worker' AND d.artifact_type IS NOT NULL
+                           AND d.content_hash IS NULL AND d.artifact_ref IS NULL AND d.artifact_url IS NULL) AS invalid
+      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+      WHERE d.kind = 'execution' AND t.status = 'done'
+        AND ($1::text IS NULL OR t.project_id = $1)
+      GROUP BY COALESCE(d.artifact_type, '(none)')
+      ORDER BY total DESC
+      LIMIT 50
+    `, [pid(opts)]);
+    return rows.map((r: any) => ({
+      artifactType: String(r.artifact_type),
+      total: num(r.total), structured: num(r.structured), legacy: num(r.legacy),
+      missing: num(r.missing), invalid: num(r.invalid),
+    }));
+  }
+
+  /**
+   * AC#4 — durable-wait adoption for blocked external gates. Denominator:
+   * non-archived tasks whose semantic stage is 'blocked'. A blocked task counts
+   * as adopted only when it has a work_task_waits row with status='active'.
+   */
+  static async waitAdoption(opts: ConveyorMetricsOptions = {}): Promise<WaitAdoption> {
+    const r = (await postgresClient.query(`
+      WITH blocked AS (
+        SELECT t.id FROM work_tasks t
+        WHERE t.archived = false
+          AND resolve_work_task_lane_role(t.id, t.status) = 'blocked'
+          AND ($1::text IS NULL OR t.project_id = $1)
+      )
+      SELECT
+        (SELECT COUNT(*) FROM blocked) AS blocked_total,
+        (SELECT COUNT(*) FROM blocked b WHERE EXISTS (
+           SELECT 1 FROM work_task_waits w WHERE w.task_id = b.id AND w.status = 'active')) AS blocked_with_active_wait
+    `, [pid(opts)]))[0] || {};
+    const total = num(r.blocked_total);
+    const withWait = num(r.blocked_with_active_wait);
+    return { blockedTotal: total, blockedWithActiveWait: withWait, adoptionRate: total > 0 ? withWait / total : 0 };
+  }
+
+  /**
+   * Zombie/stale lease count. Denominator: currently-running dispatches
+   * (execution + verification). A lease is stale when heartbeat_at is older
+   * than staleMinutes (default 20).
+   */
+  static async staleLeases(opts: ConveyorMetricsOptions = {}): Promise<StaleLeases> {
+    const r = (await postgresClient.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE d.status = 'running' AND d.heartbeat_at < now() - make_interval(mins => $2)) AS stale_leases,
+        COUNT(*) FILTER (WHERE d.status = 'running') AS active_leases
+      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+      WHERE ($1::text IS NULL OR t.project_id = $1)
+    `, [pid(opts), stale(opts)]))[0] || {};
+    return { staleLeases: num(r.stale_leases), activeLeases: num(r.active_leases) };
+  }
+
+  /**
+   * Dependency-held count. Denominator: non-archived, non-terminal tasks that
+   * have a non-archived dependency on another non-terminal task.
+   */
+  static async dependencyHeld(opts: ConveyorMetricsOptions = {}): Promise<{ dependencyHeld: number }> {
+    const r = (await postgresClient.query(`
+      SELECT COUNT(DISTINCT t.id) AS dependency_held
+      FROM work_tasks t
+      JOIN work_task_dependencies dep ON dep.task_id = t.id AND dep.archived = false
+      JOIN work_tasks dt ON dt.id = dep.depends_on_task_id
+      WHERE t.archived = false
+        AND resolve_work_task_lane_role(t.id, t.status) <> 'terminal'
+        AND resolve_work_task_lane_role(dt.id, dt.status) <> 'terminal'
+        AND ($1::text IS NULL OR t.project_id = $1)
+    `, [pid(opts)]))[0] || {};
+    return { dependencyHeld: num(r.dependency_held) };
+  }
+
+  /**
+   * WIP limit and active backpressure reason. active_execution_wip is the count
+   * of running execution leases; the soft limit is a configurable default (no
+   * authoritative WIP store exists in the schema). backpressureReason is
+   * derived: stale leases holding slots > wip saturation > idle.
+   */
+  static async wipPressure(opts: ConveyorMetricsOptions = {}): Promise<WipPressure> {
+    const r = (await postgresClient.query(`
+      SELECT
+        COUNT(*) FILTER (WHERE d.kind = 'execution' AND d.status = 'running') AS active_execution_wip,
+        COUNT(*) FILTER (WHERE d.kind = 'verification' AND d.status = 'running') AS active_verification_wip,
+        COUNT(*) FILTER (WHERE d.status = 'running' AND d.heartbeat_at < now() - make_interval(mins => $2)) AS stale_wip
+      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+      WHERE ($1::text IS NULL OR t.project_id = $1)
+    `, [pid(opts), stale(opts)]))[0] || {};
+    const activeExec = num(r.active_execution_wip);
+    const staleWip = num(r.stale_wip);
+    const limit = wipLimit(opts);
+    const over = activeExec >= limit;
+    let reason: string | null = null;
+    if (staleWip > 0) reason = 'stale_leases_holding_slots';
+    else if (over) reason = 'wip_limit_reached';
+    else if (activeExec === 0) reason = 'idle';
+    return {
+      activeExecutionWip: activeExec,
+      activeVerificationWip: num(r.active_verification_wip),
+      staleWip, wipLimit: limit, over, backpressureReason: reason,
+    };
+  }
+
+  /**
+   * AC#6 — completed independent shipments separated from integration-train
+   * closures. Denominator: tasks with status='done' and completed_at in window.
+   * A done task is an INDEPENDENT shipment when it carries its own artifact
+   * custody (an execution dispatch with content_hash or artifact_ref). Done
+   * tasks closed WITHOUT their own custody are integration-train closures
+   * (rolled up with another shipment) and are reported separately, never as
+   * independent shipments. (No explicit integration-train marker exists in the
+   * schema; artifact custody is the authoritative available signal.)
+   */
+  static async shipments(opts: ConveyorMetricsOptions = {}): Promise<Shipments> {
+    const r = (await postgresClient.query(`
+      WITH done AS (
+        SELECT t.id,
+          EXISTS (SELECT 1 FROM work_task_dispatches d
+                  WHERE d.task_id = t.id AND d.kind = 'execution'
+                    AND (d.content_hash IS NOT NULL OR d.artifact_ref IS NOT NULL)) AS has_custody
+        FROM work_tasks t
+        WHERE t.status = 'done' AND t.completed_at >= now() - make_interval(hours => $2)
+          AND ($1::text IS NULL OR t.project_id = $1)
+      )
+      SELECT
+        COUNT(*) FILTER (WHERE has_custody) AS independent_shipments,
+        COUNT(*) FILTER (WHERE NOT has_custody) AS integration_train_closures
+      FROM done
+    `, [pid(opts), win(opts)]))[0] || {};
+    return {
+      independentShipments: num(r.independent_shipments),
+      integrationTrainClosures: num(r.integration_train_closures),
+    };
+  }
+
+  /** Bounded drill-down: oldest N tasks in a semantic stage (AC#2/#7). */
+  static async oldestItems(opts: ConveyorMetricsOptions, stage: SemanticStage) {
+    const rows = await postgresClient.query(`
+      SELECT t.id, t.title, t.status, t.project_id,
+             EXTRACT(EPOCH FROM (now() - t.last_moved_at))::bigint AS age_seconds,
+             t.last_moved_at
+      FROM work_tasks t
+      WHERE t.archived = false
+        AND resolve_work_task_lane_role(t.id, t.status) = $2
+        AND ($1::text IS NULL OR t.project_id = $1)
+      ORDER BY t.last_moved_at ASC
+      LIMIT $3
+    `, [pid(opts), stage, drill(opts)]);
+    return rows.map((r: any) => ({
+      id: r.id, title: r.title, status: r.status, projectId: r.project_id,
+      ageSeconds: num(r.age_seconds), lastMovedAt: r.last_moved_at ? String(r.last_moved_at) : null,
+    }));
+  }
+
+  /** Bounded drill-down: the stale/zombie running leases (AC#7). */
+  static async staleLeaseItems(opts: ConveyorMetricsOptions = {}) {
+    const rows = await postgresClient.query(`
+      SELECT d.id AS dispatch_id, d.task_id, d.kind, d.agent_id, d.heartbeat_at,
+             EXTRACT(EPOCH FROM (now() - d.heartbeat_at))::bigint AS silent_seconds, t.title
+      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+      WHERE d.status = 'running' AND d.heartbeat_at < now() - make_interval(mins => $2)
+        AND ($1::text IS NULL OR t.project_id = $1)
+      ORDER BY d.heartbeat_at ASC
+      LIMIT $3
+    `, [pid(opts), stale(opts), drill(opts)]);
+    return rows.map((r: any) => ({
+      dispatchId: r.dispatch_id, taskId: r.task_id, kind: r.kind, agentId: r.agent_id,
+      silentSeconds: num(r.silent_seconds), title: r.title,
+    }));
+  }
+
+  /** Aggregate snapshot of every conveyor metric (all queries run concurrently). */
+  static async snapshot(opts: ConveyorMetricsOptions = {}) {
+    const [stages, agePercentiles, throughput, verifier, rework, custody, waits, leases, deps, wip, shipments] =
+      await Promise.all([
+        this.stageCounts(opts), this.stageAgePercentiles(opts), this.throughput(opts),
+        this.verifierThroughput(opts), this.reworkRate(opts), this.custodyCompleteness(opts),
+        this.waitAdoption(opts), this.staleLeases(opts), this.dependencyHeld(opts),
+        this.wipPressure(opts), this.shipments(opts),
+      ]);
+    return {
+      metric: 'conveyor_health',
+      window_hours: win(opts),
+      project_id: pid(opts),
+      stages, agePercentiles, throughput, verifier, rework, custody,
+      waits, leases, deps, wip, shipments,
+    };
+  }
+}

--- a/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
@@ -27,7 +27,9 @@ export interface ConveyorMetricsOptions {
   /** Rolling window for rate/throughput metrics (hours). Default 168 (7d). */
   windowHours?: number;
   /** Soft WIP ceiling for active execution leases. Default 6. */
-  wipLimit?: number;
+  wipLimit?: number | null;
+  /** Configured verification capacity. Default 3. */
+  reviewLimit?: number | null;
   /** Lease is stale/zombie when its heartbeat is older than this (minutes). Default 20. */
   staleMinutes?: number;
   /** Drill-down row cap. Default 20, hard-capped at 100. */
@@ -36,6 +38,7 @@ export interface ConveyorMetricsOptions {
 
 const DEFAULT_WINDOW_HOURS = 168;
 const DEFAULT_WIP_LIMIT = 6;
+const DEFAULT_REVIEW_LIMIT = 3;
 const DEFAULT_STALE_MINUTES = 20;
 const DEFAULT_DRILL_LIMIT = 20;
 const MAX_DRILL_LIMIT = 100;
@@ -52,8 +55,13 @@ function drill(o: ConveyorMetricsOptions): number {
   const d = o.drillLimit ?? DEFAULT_DRILL_LIMIT;
   return Math.max(1, Math.min(MAX_DRILL_LIMIT, Math.floor(d)));
 }
-function wipLimit(o: ConveyorMetricsOptions): number {
+function wipLimit(o: ConveyorMetricsOptions): number | null {
+  if (o.wipLimit === null) return null;
   return o.wipLimit && o.wipLimit > 0 ? Math.floor(o.wipLimit) : DEFAULT_WIP_LIMIT;
+}
+function reviewLimit(o: ConveyorMetricsOptions): number | null {
+  if (o.reviewLimit === null) return null;
+  return o.reviewLimit && o.reviewLimit > 0 ? Math.floor(o.reviewLimit) : DEFAULT_REVIEW_LIMIT;
 }
 
 export interface StageCount {
@@ -66,7 +74,10 @@ export interface StageAge {
   p50AgeSeconds: number; p90AgeSeconds: number;
 }
 export interface Throughput { enteredReview: number; reviewsCompleted: number; reachedDone: number; }
-export interface VerifierThroughput { completedReviews: number; perDay: number; activeVerificationLeases: number; }
+export interface VerifierThroughput {
+  completedReviews: number; perDay: number; activeVerificationLeases: number;
+  capacity: number | null; utilization: number | null;
+}
 export interface Rework { reviewed: number; reworked: number; reworkRate: number; avgRepairLoops: number; }
 export interface CustodyRow {
   artifactType: string; total: number;
@@ -76,9 +87,9 @@ export interface WaitAdoption { blockedTotal: number; blockedWithActiveWait: num
 export interface StaleLeases { staleLeases: number; activeLeases: number; }
 export interface WipPressure {
   activeExecutionWip: number; activeVerificationWip: number; staleWip: number;
-  wipLimit: number; over: boolean; backpressureReason: string | null;
+  wipLimit: number | null; over: boolean; backpressureReason: string | null;
 }
-export interface Shipments { independentShipments: number; integrationTrainClosures: number; }
+export interface Shipments { independentShipments: number; integrationTrainClosures: number; missingEvidence: number; }
 
 export class WorkConveyorMetricsModel {
   /**
@@ -164,7 +175,9 @@ export class WorkConveyorMetricsModel {
               SELECT DISTINCT d.task_id, d.review_generation_hash
               FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
               WHERE d.kind = 'verification' AND d.finished_at >= now() - make_interval(hours => $2)
-                AND d.status <> 'cancelled' AND d.review_generation_hash IS NOT NULL
+                AND d.status = 'completed'
+                AND COALESCE(d.result, '') NOT ILIKE 'suppressed identical terminal generation%'
+                AND d.review_generation_hash IS NOT NULL
                 AND ($1::text IS NULL OR t.project_id = $1)
            ) g) AS reviews_completed,
         (SELECT COUNT(*) FROM work_tasks t
@@ -182,12 +195,11 @@ export class WorkConveyorMetricsModel {
    * AC#5 — verifier throughput + utilization, EXCLUDING duplicate/suppressed
    * generations. Duplicates are collapsed by DISTINCT (task_id,
    * review_generation_hash) — the same dedup key WorkTaskDispatchModel uses to
-   * detect duplicate review generations. Suppressed generations
-   * (terminal_reason ILIKE 'suppress%') and cancelled leases are excluded.
+   * detect duplicate review generations. Suppressed generations are completed
+   * rows whose result starts with the dispatcher suppression marker.
    * Denominator: distinct completed review generations in window.
    * perDay is completed_reviews normalised to a 24h rate.
-   * Utilization is expressed as the count of currently-running verification
-   * leases (no capacity value is stored in the schema).
+   * Utilization = running verification leases / configured review capacity.
    */
   static async verifierThroughput(opts: ConveyorMetricsOptions = {}): Promise<VerifierThroughput> {
     const hours = win(opts);
@@ -197,8 +209,8 @@ export class WorkConveyorMetricsModel {
            SELECT DISTINCT d.task_id, d.review_generation_hash
            FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
            WHERE d.kind = 'verification' AND d.finished_at >= now() - make_interval(hours => $2)
-             AND d.status <> 'cancelled'
-             AND COALESCE(d.terminal_reason, '') NOT ILIKE 'suppress%'
+             AND d.status = 'completed'
+             AND COALESCE(d.result, '') NOT ILIKE 'suppressed identical terminal generation%'
              AND d.review_generation_hash IS NOT NULL
              AND ($1::text IS NULL OR t.project_id = $1)
          ) g) AS completed_reviews,
@@ -207,10 +219,14 @@ export class WorkConveyorMetricsModel {
              AND ($1::text IS NULL OR t.project_id = $1)) AS active_verification_leases
     `, [pid(opts), hours]))[0] || {};
     const completed = num(r.completed_reviews);
+    const active = num(r.active_verification_leases);
+    const capacity = reviewLimit(opts);
     return {
       completedReviews: completed,
       perDay: hours > 0 ? completed / (hours / 24) : 0,
-      activeVerificationLeases: num(r.active_verification_leases),
+      activeVerificationLeases: active,
+      capacity,
+      utilization: capacity === null ? null : Math.min(1, active / capacity),
     };
   }
 
@@ -237,7 +253,8 @@ export class WorkConveyorMetricsModel {
 
   /**
    * AC#3 — structured custody completeness by artifact type. Denominator:
-   * terminal (status='done') execution dispatches. Four disjoint classes:
+   * terminal (status='done') tasks, using only each task's latest execution
+   * dispatch so retries cannot inflate the denominator. Four disjoint classes:
    *   structured = real run + artifact_type + (content_hash OR artifact_ref)
    *   legacy     = run_kind='legacy-worker' (pre-custody rows; not penalised)
    *   missing    = real run, no artifact_type at all
@@ -245,6 +262,13 @@ export class WorkConveyorMetricsModel {
    */
   static async custodyCompleteness(opts: ConveyorMetricsOptions = {}): Promise<CustodyRow[]> {
     const rows = await postgresClient.query(`
+      WITH latest AS (
+        SELECT DISTINCT ON (d.task_id) d.*
+        FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+        WHERE d.kind = 'execution' AND t.status = 'done'
+          AND ($1::text IS NULL OR t.project_id = $1)
+        ORDER BY d.task_id, COALESCE(d.finished_at, d.started_at) DESC, d.id DESC
+      )
       SELECT
         COALESCE(d.artifact_type, '(none)') AS artifact_type,
         COUNT(*) AS total,
@@ -254,9 +278,7 @@ export class WorkConveyorMetricsModel {
         COUNT(*) FILTER (WHERE d.run_kind <> 'legacy-worker' AND d.artifact_type IS NULL) AS missing,
         COUNT(*) FILTER (WHERE d.run_kind <> 'legacy-worker' AND d.artifact_type IS NOT NULL
                            AND d.content_hash IS NULL AND d.artifact_ref IS NULL AND d.artifact_url IS NULL) AS invalid
-      FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
-      WHERE d.kind = 'execution' AND t.status = 'done'
-        AND ($1::text IS NULL OR t.project_id = $1)
+      FROM latest d
       GROUP BY COALESCE(d.artifact_type, '(none)')
       ORDER BY total DESC
       LIMIT 50
@@ -269,8 +291,9 @@ export class WorkConveyorMetricsModel {
   }
 
   /**
-   * AC#4 — durable-wait adoption for blocked external gates. Denominator:
-   * non-archived tasks whose semantic stage is 'blocked'. A blocked task counts
+   * AC#4 — durable-wait adoption for blocked external/human gates. Denominator:
+   * non-archived blocked tasks carrying wait history, an external/human-gate
+   * label, or an external_wait receipt. A candidate counts
    * as adopted only when it has a work_task_waits row with status='active'.
    */
   static async waitAdoption(opts: ConveyorMetricsOptions = {}): Promise<WaitAdoption> {
@@ -280,6 +303,12 @@ export class WorkConveyorMetricsModel {
         WHERE t.archived = false
           AND resolve_work_task_lane_role(t.id, t.status) = 'blocked'
           AND ($1::text IS NULL OR t.project_id = $1)
+          AND (
+            EXISTS (SELECT 1 FROM work_task_waits wh WHERE wh.task_id = t.id)
+            OR COALESCE(t.labels, '{}'::text[]) && ARRAY['durable-wait', 'waiting-external', 'human-gate']
+            OR EXISTS (SELECT 1 FROM work_artifact_receipts ar
+                       WHERE ar.task_id = t.id AND ar.event_type = 'external_wait')
+          )
       )
       SELECT
         (SELECT COUNT(*) FROM blocked) AS blocked_total,
@@ -309,17 +338,18 @@ export class WorkConveyorMetricsModel {
 
   /**
    * Dependency-held count. Denominator: non-archived, non-terminal tasks that
-   * have a non-archived dependency on another non-terminal task.
+   * have an active dependency whose prerequisite is not done. Cancelled and
+   * parked prerequisites remain blocking per the claim-gate contract.
    */
   static async dependencyHeld(opts: ConveyorMetricsOptions = {}): Promise<{ dependencyHeld: number }> {
     const r = (await postgresClient.query(`
       SELECT COUNT(DISTINCT t.id) AS dependency_held
       FROM work_tasks t
-      JOIN work_task_dependencies dep ON dep.task_id = t.id AND dep.archived = false
+      JOIN work_task_dependencies dep ON dep.dependent_task_id = t.id AND dep.archived_at IS NULL
       JOIN work_tasks dt ON dt.id = dep.depends_on_task_id
       WHERE t.archived = false
         AND resolve_work_task_lane_role(t.id, t.status) <> 'terminal'
-        AND resolve_work_task_lane_role(dt.id, dt.status) <> 'terminal'
+        AND dt.status IS DISTINCT FROM 'done'
         AND ($1::text IS NULL OR t.project_id = $1)
     `, [pid(opts)]))[0] || {};
     return { dependencyHeld: num(r.dependency_held) };
@@ -343,7 +373,7 @@ export class WorkConveyorMetricsModel {
     const activeExec = num(r.active_execution_wip);
     const staleWip = num(r.stale_wip);
     const limit = wipLimit(opts);
-    const over = activeExec >= limit;
+    const over = limit !== null && activeExec >= limit;
     let reason: string | null = null;
     if (staleWip > 0) reason = 'stale_leases_holding_slots';
     else if (over) reason = 'wip_limit_reached';
@@ -358,32 +388,39 @@ export class WorkConveyorMetricsModel {
   /**
    * AC#6 — completed independent shipments separated from integration-train
    * closures. Denominator: tasks with status='done' and completed_at in window.
-   * A done task is an INDEPENDENT shipment when it carries its own artifact
-   * custody (an execution dispatch with content_hash or artifact_ref). Done
-   * tasks closed WITHOUT their own custody are integration-train closures
-   * (rolled up with another shipment) and are reported separately, never as
-   * independent shipments. (No explicit integration-train marker exists in the
-   * schema; artifact custody is the authoritative available signal.)
+   * A done task is independent when its latest custody key is unique, and is
+   * an integration-train closure only when two or more done tasks share that
+   * exact key. Missing custody is reported separately; absence of evidence is
+   * never promoted into evidence of an integration train.
    */
   static async shipments(opts: ConveyorMetricsOptions = {}): Promise<Shipments> {
     const r = (await postgresClient.query(`
       WITH done AS (
-        SELECT t.id,
-          EXISTS (SELECT 1 FROM work_task_dispatches d
-                  WHERE d.task_id = t.id AND d.kind = 'execution'
-                    AND (d.content_hash IS NOT NULL OR d.artifact_ref IS NOT NULL)) AS has_custody
+        SELECT t.id, custody.custody_key
         FROM work_tasks t
+        LEFT JOIN LATERAL (
+          SELECT COALESCE(d.content_hash, d.artifact_ref, d.artifact_url) AS custody_key
+          FROM work_task_dispatches d
+          WHERE d.task_id = t.id AND d.kind = 'execution'
+          ORDER BY COALESCE(d.finished_at, d.started_at) DESC, d.id DESC
+          LIMIT 1
+        ) custody ON true
         WHERE t.status = 'done' AND t.completed_at >= now() - make_interval(hours => $2)
           AND ($1::text IS NULL OR t.project_id = $1)
+      ), classified AS (
+        SELECT d.*, COUNT(*) OVER (PARTITION BY d.custody_key) AS key_uses
+        FROM done d
       )
       SELECT
-        COUNT(*) FILTER (WHERE has_custody) AS independent_shipments,
-        COUNT(*) FILTER (WHERE NOT has_custody) AS integration_train_closures
-      FROM done
+        COUNT(*) FILTER (WHERE custody_key IS NOT NULL AND key_uses = 1) AS independent_shipments,
+        COUNT(*) FILTER (WHERE custody_key IS NOT NULL AND key_uses > 1) AS integration_train_closures,
+        COUNT(*) FILTER (WHERE custody_key IS NULL) AS missing_evidence
+      FROM classified
     `, [pid(opts), win(opts)]))[0] || {};
     return {
       independentShipments: num(r.independent_shipments),
       integrationTrainClosures: num(r.integration_train_closures),
+      missingEvidence: num(r.missing_evidence),
     };
   }
 

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkConveyorMetricsModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkConveyorMetricsModel.test.ts
@@ -35,18 +35,21 @@ describe('WorkConveyorMetricsModel', () => {
 
   it('verifier throughput excludes duplicate and suppressed generations (AC#5)', async () => {
     mock([{ completed_reviews: '4', active_verification_leases: '1' }]);
-    const v = await WorkConveyorMetricsModel.verifierThroughput({ windowHours: 24 });
+    const v = await WorkConveyorMetricsModel.verifierThroughput({ windowHours: 24, reviewLimit: 2 });
     expect(sqls[0]).toContain('DISTINCT');
     expect(sqls[0]).toContain('review_generation_hash');
     expect(sqls[0].toLowerCase()).toContain('suppress');
+    expect(sqls[0]).toContain("d.status = 'completed'");
     expect(v.completedReviews).toBe(4);
     expect(v.perDay).toBeCloseTo(4);
+    expect(v).toMatchObject({ capacity: 2, utilization: 0.5 });
   });
 
   it('custody completeness distinguishes structured/legacy/missing/invalid incl migrated data (AC#3)', async () => {
     mock([{ artifact_type: 'pull_request', total: '5', structured: '3', legacy: '1', missing: '1', invalid: '0' }]);
     const rows = await WorkConveyorMetricsModel.custodyCompleteness({});
     expect(sqls[0]).toContain("'legacy-worker'");
+    expect(sqls[0]).toContain('DISTINCT ON (d.task_id)');
     expect(rows[0]).toMatchObject({ artifactType: 'pull_request', total: 5, structured: 3, legacy: 1, missing: 1, invalid: 0 });
   });
 
@@ -55,14 +58,25 @@ describe('WorkConveyorMetricsModel', () => {
     const w = await WorkConveyorMetricsModel.waitAdoption({});
     expect(sqls[0]).toContain('resolve_work_task_lane_role');
     expect(sqls[0]).toContain("status = 'active'");
+    expect(sqls[0]).toContain("event_type = 'external_wait'");
     expect(w).toEqual({ blockedTotal: 2, blockedWithActiveWait: 1, adoptionRate: 0.5 });
   });
 
   it('separates independent shipments from integration-train closures via artifact custody (AC#6)', async () => {
-    mock([{ independent_shipments: '3', integration_train_closures: '2' }]);
+    mock([{ independent_shipments: '3', integration_train_closures: '2', missing_evidence: '1' }]);
     const s = await WorkConveyorMetricsModel.shipments({ windowHours: 168 });
     expect(sqls[0]).toContain('content_hash');
-    expect(s).toEqual({ independentShipments: 3, integrationTrainClosures: 2 });
+    expect(sqls[0]).toContain('key_uses > 1');
+    expect(s).toEqual({ independentShipments: 3, integrationTrainClosures: 2, missingEvidence: 1 });
+  });
+
+  it('dependency-held uses the first-class active-edge schema and only done resolves a gate', async () => {
+    mock([{ dependency_held: '2' }]);
+    const result = await WorkConveyorMetricsModel.dependencyHeld({});
+    expect(sqls[0]).toContain('dep.dependent_task_id');
+    expect(sqls[0]).toContain('dep.archived_at IS NULL');
+    expect(sqls[0]).toContain("dt.status IS DISTINCT FROM 'done'");
+    expect(result.dependencyHeld).toBe(2);
   });
 
   it('drill-down queries are bounded with LIMIT for query performance (AC#7)', async () => {

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkConveyorMetricsModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkConveyorMetricsModel.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { postgresClient } from '../../PostgresClient';
+import { WorkConveyorMetricsModel } from '../WorkConveyorMetricsModel';
+
+describe('WorkConveyorMetricsModel', () => {
+  let originalQuery: any;
+  let sqls: string[] = [];
+
+  beforeAll(() => { originalQuery = (postgresClient as any).query; });
+  afterEach(() => { (postgresClient as any).query = originalQuery; jest.restoreAllMocks(); sqls = []; });
+
+  function mock(rows: any[]) {
+    (postgresClient as any).query = jest.fn((sql: string, _params?: any[]) => {
+      sqls.push(sql);
+      return Promise.resolve(rows);
+    });
+  }
+
+  it('stageCounts groups by semantic lane role (custom-lane safe) and returns the exact oldest item (AC#2)', async () => {
+    mock([{ stage: 'execution', count: '3', oldest_task_id: 'task-9', oldest_title: 'Old one',
+            oldest_entered_at: '2026-08-01T00:00:00.000Z', oldest_age_seconds: '86400' }]);
+    const rows = await WorkConveyorMetricsModel.stageCounts({ projectId: 'p1' });
+    expect(sqls[0]).toContain('resolve_work_task_lane_role');
+    expect(sqls[0]).toContain('$1::text IS NULL OR');
+    expect(rows[0]).toMatchObject({ stage: 'execution', count: 3, oldestTaskId: 'task-9', oldestAgeSeconds: 86400 });
+  });
+
+  it('empty-state: rate aggregates degrade to zero without NaN', async () => {
+    mock([]);
+    const rework = await WorkConveyorMetricsModel.reworkRate({});
+    expect(rework).toEqual({ reviewed: 0, reworked: 0, reworkRate: 0, avgRepairLoops: 0 });
+    const waits = await WorkConveyorMetricsModel.waitAdoption({});
+    expect(waits.adoptionRate).toBe(0);
+  });
+
+  it('verifier throughput excludes duplicate and suppressed generations (AC#5)', async () => {
+    mock([{ completed_reviews: '4', active_verification_leases: '1' }]);
+    const v = await WorkConveyorMetricsModel.verifierThroughput({ windowHours: 24 });
+    expect(sqls[0]).toContain('DISTINCT');
+    expect(sqls[0]).toContain('review_generation_hash');
+    expect(sqls[0].toLowerCase()).toContain('suppress');
+    expect(v.completedReviews).toBe(4);
+    expect(v.perDay).toBeCloseTo(4);
+  });
+
+  it('custody completeness distinguishes structured/legacy/missing/invalid incl migrated data (AC#3)', async () => {
+    mock([{ artifact_type: 'pull_request', total: '5', structured: '3', legacy: '1', missing: '1', invalid: '0' }]);
+    const rows = await WorkConveyorMetricsModel.custodyCompleteness({});
+    expect(sqls[0]).toContain("'legacy-worker'");
+    expect(rows[0]).toMatchObject({ artifactType: 'pull_request', total: 5, structured: 3, legacy: 1, missing: 1, invalid: 0 });
+  });
+
+  it('wait adoption counts only blocked tasks with an active matching durable wait (AC#4)', async () => {
+    mock([{ blocked_total: '2', blocked_with_active_wait: '1' }]);
+    const w = await WorkConveyorMetricsModel.waitAdoption({});
+    expect(sqls[0]).toContain('resolve_work_task_lane_role');
+    expect(sqls[0]).toContain("status = 'active'");
+    expect(w).toEqual({ blockedTotal: 2, blockedWithActiveWait: 1, adoptionRate: 0.5 });
+  });
+
+  it('separates independent shipments from integration-train closures via artifact custody (AC#6)', async () => {
+    mock([{ independent_shipments: '3', integration_train_closures: '2' }]);
+    const s = await WorkConveyorMetricsModel.shipments({ windowHours: 168 });
+    expect(sqls[0]).toContain('content_hash');
+    expect(s).toEqual({ independentShipments: 3, integrationTrainClosures: 2 });
+  });
+
+  it('drill-down queries are bounded with LIMIT for query performance (AC#7)', async () => {
+    mock([]);
+    await WorkConveyorMetricsModel.oldestItems({ drillLimit: 10 }, 'execution');
+    await WorkConveyorMetricsModel.staleLeaseItems({});
+    expect(sqls[0]).toContain('LIMIT');
+    expect(sqls[1]).toContain('LIMIT');
+  });
+
+  it('wipPressure reports a documented WIP limit and derived backpressure reason', async () => {
+    mock([{ active_execution_wip: '6', active_verification_wip: '1', stale_wip: '0' }]);
+    const wip = await WorkConveyorMetricsModel.wipPressure({ wipLimit: 6 });
+    expect(wip.over).toBe(true);
+    expect(wip.backpressureReason).toBe('wip_limit_reached');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/project/__tests__/conveyor_health.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/conveyor_health.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from '@jest/globals';
+import { ConveyorHealthWorker } from '../conveyor_health';
+
+describe('ConveyorHealthWorker', () => {
+  it('is a BaseTool with a validated-call implementation', () => {
+    expect(typeof ConveyorHealthWorker).toBe('function');
+    expect(typeof (ConveyorHealthWorker.prototype as any)._validatedCall).toBe('function');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/project/conveyor_health.ts
+++ b/pkg/rancher-desktop/agent/tools/project/conveyor_health.ts
@@ -1,0 +1,58 @@
+import { BaseTool, ToolResponse } from '../base';
+import {
+  WorkConveyorMetricsModel,
+  type ConveyorMetricsOptions,
+} from '../../database/models/WorkConveyorMetricsModel';
+
+/**
+ * conveyor_health — read-only Projects conveyor-health & productivity snapshot
+ * (GitHub issue #717). Returns a compact human summary plus the full structured
+ * JSON the Projects UI panel/drill-down consumes. Every number is defined (with
+ * denominator) in WorkConveyorMetricsModel.
+ */
+export class ConveyorHealthWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    try {
+      const opts: ConveyorMetricsOptions = {
+        projectId:    typeof input?.project_id === 'string' ? input.project_id : null,
+        windowHours:  typeof input?.window_hours === 'number' ? input.window_hours : undefined,
+        wipLimit:     typeof input?.wip_limit === 'number' ? input.wip_limit : undefined,
+        staleMinutes: typeof input?.stale_minutes === 'number' ? input.stale_minutes : undefined,
+      };
+      const snap = await WorkConveyorMetricsModel.snapshot(opts);
+      const scope = snap.project_id ? `project ${ snap.project_id }` : 'all projects';
+      const lines: string[] = [];
+      lines.push(`# Projects conveyor health (window ${ snap.window_hours }h, ${ scope })`);
+      lines.push('');
+      lines.push('## Stage counts (oldest item per semantic stage)');
+      for (const s of snap.stages) {
+        const age = s.oldestAgeSeconds == null ? '-' : `${ Math.round(s.oldestAgeSeconds / 3600) }h`;
+        lines.push(`- ${ s.stage }: ${ s.count }  (oldest ${ age }${ s.oldestTaskId ? ` -> ${ s.oldestTaskId }` : '' })`);
+      }
+      lines.push('');
+      lines.push(`Throughput: entered_review=${ snap.throughput.enteredReview } reviews_completed=${ snap.throughput.reviewsCompleted } reached_done=${ snap.throughput.reachedDone }`);
+      lines.push(`Verifier: completed_reviews=${ snap.verifier.completedReviews } per_day=${ snap.verifier.perDay.toFixed(2) } active_leases=${ snap.verifier.activeVerificationLeases }`);
+      lines.push(`Rework: rate=${ (snap.rework.reworkRate * 100).toFixed(1) }% avg_repair_loops=${ snap.rework.avgRepairLoops.toFixed(2) } (reviewed ${ snap.rework.reviewed })`);
+      lines.push(`Wait adoption: ${ snap.waits.blockedWithActiveWait }/${ snap.waits.blockedTotal } blocked tasks have an active durable wait (${ (snap.waits.adoptionRate * 100).toFixed(0) }%)`);
+      lines.push(`Stale leases: ${ snap.leases.staleLeases }/${ snap.leases.activeLeases } running leases stale`);
+      lines.push(`Dependency-held: ${ snap.deps.dependencyHeld }`);
+      lines.push(`WIP: execution=${ snap.wip.activeExecutionWip }/${ snap.wip.wipLimit } verification=${ snap.wip.activeVerificationWip } backpressure=${ snap.wip.backpressureReason ?? 'none' }`);
+      lines.push(`Shipments: independent=${ snap.shipments.independentShipments } integration_train_closures=${ snap.shipments.integrationTrainClosures }`);
+      lines.push('');
+      lines.push('## Custody completeness by artifact type (structured/legacy/missing/invalid)');
+      for (const c of snap.custody) {
+        lines.push(`- ${ c.artifactType }: total=${ c.total } structured=${ c.structured } legacy=${ c.legacy } missing=${ c.missing } invalid=${ c.invalid }`);
+      }
+      lines.push('');
+      lines.push('```json');
+      lines.push(JSON.stringify(snap, null, 2));
+      lines.push('```');
+      return { successBoolean: true, responseString: lines.join('\n') };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to compute conveyor health: ${ err?.message }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/project/conveyor_health.ts
+++ b/pkg/rancher-desktop/agent/tools/project/conveyor_health.ts
@@ -3,6 +3,7 @@ import {
   WorkConveyorMetricsModel,
   type ConveyorMetricsOptions,
 } from '../../database/models/WorkConveyorMetricsModel';
+import { resolveWipLimits } from '../../services/ProjectAutomationWipLimits';
 
 /**
  * conveyor_health — read-only Projects conveyor-health & productivity snapshot
@@ -16,10 +17,12 @@ export class ConveyorHealthWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
+      const limits = await resolveWipLimits();
       const opts: ConveyorMetricsOptions = {
         projectId:    typeof input?.project_id === 'string' ? input.project_id : null,
         windowHours:  typeof input?.window_hours === 'number' ? input.window_hours : undefined,
-        wipLimit:     typeof input?.wip_limit === 'number' ? input.wip_limit : undefined,
+        wipLimit:     typeof input?.wip_limit === 'number' ? input.wip_limit : limits.execution,
+        reviewLimit:  limits.review,
         staleMinutes: typeof input?.stale_minutes === 'number' ? input.stale_minutes : undefined,
       };
       const snap = await WorkConveyorMetricsModel.snapshot(opts);
@@ -34,13 +37,14 @@ export class ConveyorHealthWorker extends BaseTool {
       }
       lines.push('');
       lines.push(`Throughput: entered_review=${ snap.throughput.enteredReview } reviews_completed=${ snap.throughput.reviewsCompleted } reached_done=${ snap.throughput.reachedDone }`);
-      lines.push(`Verifier: completed_reviews=${ snap.verifier.completedReviews } per_day=${ snap.verifier.perDay.toFixed(2) } active_leases=${ snap.verifier.activeVerificationLeases }`);
+      const utilization = snap.verifier.utilization == null ? 'unlimited' : `${ (snap.verifier.utilization * 100).toFixed(0) }%`;
+      lines.push(`Verifier: completed_reviews=${ snap.verifier.completedReviews } per_day=${ snap.verifier.perDay.toFixed(2) } active_leases=${ snap.verifier.activeVerificationLeases }/${ snap.verifier.capacity ?? 'unlimited' } utilization=${ utilization }`);
       lines.push(`Rework: rate=${ (snap.rework.reworkRate * 100).toFixed(1) }% avg_repair_loops=${ snap.rework.avgRepairLoops.toFixed(2) } (reviewed ${ snap.rework.reviewed })`);
       lines.push(`Wait adoption: ${ snap.waits.blockedWithActiveWait }/${ snap.waits.blockedTotal } blocked tasks have an active durable wait (${ (snap.waits.adoptionRate * 100).toFixed(0) }%)`);
       lines.push(`Stale leases: ${ snap.leases.staleLeases }/${ snap.leases.activeLeases } running leases stale`);
       lines.push(`Dependency-held: ${ snap.deps.dependencyHeld }`);
-      lines.push(`WIP: execution=${ snap.wip.activeExecutionWip }/${ snap.wip.wipLimit } verification=${ snap.wip.activeVerificationWip } backpressure=${ snap.wip.backpressureReason ?? 'none' }`);
-      lines.push(`Shipments: independent=${ snap.shipments.independentShipments } integration_train_closures=${ snap.shipments.integrationTrainClosures }`);
+      lines.push(`WIP: execution=${ snap.wip.activeExecutionWip }/${ snap.wip.wipLimit ?? 'unlimited' } verification=${ snap.wip.activeVerificationWip } backpressure=${ snap.wip.backpressureReason ?? 'none' }`);
+      lines.push(`Shipments: independent=${ snap.shipments.independentShipments } integration_train_closures=${ snap.shipments.integrationTrainClosures } missing_evidence=${ snap.shipments.missingEvidence }`);
       lines.push('');
       lines.push('## Custody completeness by artifact type (structured/legacy/missing/invalid)');
       for (const c of snap.custody) {

--- a/pkg/rancher-desktop/agent/tools/project/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/project/manifests.ts
@@ -552,4 +552,16 @@ export const projectToolManifests: ToolManifest[] = [
     operationTypes: ['read'],
     loader: () => import('./inspect_lane_entry_automation'),
   },
+  {
+    name:        'conveyor_health',
+    description: 'Read-only Projects conveyor-health & productivity snapshot (issue #717): count/oldest-age by semantic stage, stage-age percentiles, execution->review->done throughput, verifier throughput (dedup/suppression excluded), rework rate & repair loops, custody completeness, durable-wait adoption, stale leases, dependency-held, WIP pressure, and independent shipments vs integration-train closures. Optional project scope and time window.',
+    category:    'project',
+    schemaDef:   {
+      project_id:    { type: 'string', optional: true, description: 'Limit metrics to one project id (default: whole portfolio).' },
+      window_hours:  { type: 'number', optional: true, description: 'Rolling window for rate/throughput metrics in hours (default 168 = 7d).' },
+      wip_limit:     { type: 'number', optional: true, description: 'Soft WIP ceiling for active execution leases (default 6).' },
+      stale_minutes: { type: 'number', optional: true, description: 'Lease is stale when its heartbeat is older than this many minutes (default 20).' },
+    },
+    loader:      () => import('./conveyor_health'),
+  },
 ];

--- a/pkg/rancher-desktop/main/__tests__/workItemsEvents.conveyor-health.test.ts
+++ b/pkg/rancher-desktop/main/__tests__/workItemsEvents.conveyor-health.test.ts
@@ -1,0 +1,21 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from '@jest/globals';
+
+describe('work-items conveyor-health IPC contract', () => {
+  const source = fs.readFileSync(path.resolve(process.cwd(), 'pkg/rancher-desktop/main/workItemsEvents.ts'), 'utf8');
+
+  it('registers snapshot and bounded drill-down channels', () => {
+    expect(source).toContain("handle('work-items:conveyor-health'");
+    expect(source).toContain("handle('work-items:conveyor-oldest'");
+    expect(source).toContain('WorkConveyorMetricsModel.snapshot');
+    expect(source).toContain('WorkConveyorMetricsModel.oldestItems');
+  });
+
+  it('uses durable configured execution and review capacity', () => {
+    expect(source).toContain('resolveWipLimits');
+    expect(source).toContain('wipLimit: limits.execution');
+    expect(source).toContain('reviewLimit: limits.review');
+  });
+});

--- a/pkg/rancher-desktop/main/workItemsEvents.ts
+++ b/pkg/rancher-desktop/main/workItemsEvents.ts
@@ -172,6 +172,31 @@ export function initWorkItemsEvents(): void {
     };
   });
 
+  ipcMainProxy.handle('work-items:conveyor-health', async(_event: unknown, opts: {
+    projectId?: string | null; windowHours?: number;
+  } = {}) => {
+    const [{ WorkConveyorMetricsModel }, { resolveWipLimits }] = await Promise.all([
+      import('@pkg/agent/database/models/WorkConveyorMetricsModel'),
+      import('@pkg/agent/services/ProjectAutomationWipLimits'),
+    ]);
+    const limits = await resolveWipLimits();
+    return WorkConveyorMetricsModel.snapshot({
+      projectId: opts.projectId ?? null,
+      windowHours: opts.windowHours,
+      wipLimit: limits.execution,
+      reviewLimit: limits.review,
+    });
+  });
+
+  ipcMainProxy.handle('work-items:conveyor-oldest', async(_event: unknown, opts: {
+    projectId?: string | null; stage: import('@pkg/agent/database/models/WorkConveyorMetricsModel').SemanticStage;
+  }) => {
+    const { WorkConveyorMetricsModel } = await import('@pkg/agent/database/models/WorkConveyorMetricsModel');
+    const allowed = new Set(['backlog', 'planning', 'execution', 'review', 'blocked', 'terminal', 'manual']);
+    if (!allowed.has(opts.stage)) throw new Error(`Invalid semantic stage: ${ opts.stage }`);
+    return WorkConveyorMetricsModel.oldestItems({ projectId: opts.projectId ?? null, drillLimit: 20 }, opts.stage);
+  });
+
   ipcMainProxy.handle('work-items:views-list', async(_event: unknown, projectId?: string | null) => {
     const Model = await importWorkProjectViewModel();
     return Model.list(projectId);

--- a/pkg/rancher-desktop/pages/ProjectsHome.vue
+++ b/pkg/rancher-desktop/pages/ProjectsHome.vue
@@ -206,6 +206,49 @@
                 </span>
               </div>
             </div>
+            <section v-if="conveyorHealth" class="ph-health" aria-label="Projects conveyor health">
+              <header class="ph-health-head">
+                <div>
+                  <b>Conveyor health</b>
+                  <span> · {{ conveyorWindow }}h · {{ healthScopeProject ? 'current project' : 'portfolio' }}</span>
+                </div>
+                <div class="ph-health-controls">
+                  <label><input v-model="healthScopeProject" type="checkbox"> Project only</label>
+                  <select v-model.number="conveyorWindow" aria-label="Metrics window">
+                    <option :value="24">24 hours</option>
+                    <option :value="168">7 days</option>
+                    <option :value="720">30 days</option>
+                  </select>
+                  <button type="button" class="ph-btn ghost sm" @click="loadConveyorHealth">Refresh</button>
+                </div>
+              </header>
+              <div class="ph-health-grid">
+                <button
+                  v-for="stage in conveyorHealth.stages"
+                  :key="stage.stage"
+                  type="button"
+                  class="ph-health-stat stage"
+                  :class="{ on: healthStage === stage.stage }"
+                  @click="loadHealthStage(stage.stage)"
+                >
+                  <span>{{ stage.stage }}</span><b>{{ stage.count }}</b><small>oldest {{ duration(stage.oldestAgeSeconds) }}</small>
+                </button>
+                <div class="ph-health-stat"><span>Throughput</span><b>{{ conveyorHealth.throughput.reachedDone }}</b><small>done · {{ conveyorHealth.throughput.reviewsCompleted }} reviews</small></div>
+                <div class="ph-health-stat"><span>Verifier</span><b>{{ percent(conveyorHealth.verifier.utilization) }}</b><small>{{ conveyorHealth.verifier.activeVerificationLeases }}/{{ conveyorHealth.verifier.capacity ?? '∞' }} active</small></div>
+                <div class="ph-health-stat"><span>Rework</span><b>{{ percent(conveyorHealth.rework.reworkRate) }}</b><small>{{ conveyorHealth.rework.avgRepairLoops.toFixed(1) }} loops avg</small></div>
+                <div class="ph-health-stat"><span>Wait adoption</span><b>{{ percent(conveyorHealth.waits.adoptionRate) }}</b><small>{{ conveyorHealth.waits.blockedWithActiveWait }}/{{ conveyorHealth.waits.blockedTotal }} external gates</small></div>
+                <div class="ph-health-stat"><span>Custody</span><b>{{ custodyPercent }}</b><small>latest completed artifacts</small></div>
+                <div class="ph-health-stat"><span>Stale leases</span><b>{{ conveyorHealth.leases.staleLeases }}</b><small>{{ conveyorHealth.leases.activeLeases }} active total</small></div>
+                <div class="ph-health-stat"><span>Dependency held</span><b>{{ conveyorHealth.deps.dependencyHeld }}</b><small>claim-gated tasks</small></div>
+                <div class="ph-health-stat"><span>Shipments</span><b>{{ conveyorHealth.shipments.independentShipments }}</b><small>{{ conveyorHealth.shipments.integrationTrainClosures }} train · {{ conveyorHealth.shipments.missingEvidence }} missing</small></div>
+              </div>
+              <div v-if="healthItems.length" class="ph-health-drill">
+                <b>Oldest {{ healthStage }} work</b>
+                <button v-for="item in healthItems" :key="item.id" type="button" @click="openHealthTask(item.id)">
+                  <span>{{ item.title }}</span><small>{{ duration(item.ageSeconds) }}</small>
+                </button>
+              </div>
+            </section>
             <!-- TODAY -->
             <div
               v-show="tab === 'list'"
@@ -1353,6 +1396,7 @@ import type { LinkedWorkItemRecord } from '@pkg/agent/database/models/WorkItemKn
 import KnowledgeBrowserPanel from '@pkg/components/KnowledgeBrowserPanel.vue';
 import KnowledgeLinksPanel from '@pkg/components/KnowledgeLinksPanel.vue';
 import type { BackpressureDecision, RoleCounts, WipLimits } from '@pkg/agent/services/ProjectAutomationWipLimits';
+import type { SemanticStage, WorkConveyorMetricsModel } from '@pkg/agent/database/models/WorkConveyorMetricsModel';
 import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 import {
   useProjects,
@@ -1399,6 +1443,19 @@ let refreshTimer: ReturnType<typeof setInterval> | null = null;
 const laneSettings = ref<InstanceType<typeof LaneSettings> | null>(null);
 const automationRoles = ['terminal', 'review', 'blocked', 'execution', 'planning', 'backlog', 'manual'] as const;
 const automationStatus = ref<{ limits: WipLimits; counts: RoleCounts; decision: BackpressureDecision; at: string } | null>(null);
+type ConveyorSnapshot = Awaited<ReturnType<typeof WorkConveyorMetricsModel.snapshot>>;
+type HealthItem = Awaited<ReturnType<typeof WorkConveyorMetricsModel.oldestItems>>[number];
+const conveyorHealth = ref<ConveyorSnapshot | null>(null);
+const conveyorWindow = ref(168);
+const healthScopeProject = ref(true);
+const healthStage = ref<SemanticStage | null>(null);
+const healthItems = ref<HealthItem[]>([]);
+const custodyPercent = computed(() => {
+  const rows = conveyorHealth.value?.custody ?? [];
+  const total = rows.reduce((sum, row) => sum + row.total, 0);
+  const complete = rows.reduce((sum, row) => sum + row.structured, 0);
+  return percent(total ? complete / total : 0);
+});
 
 const selectedLanes = computed(() => selectedId.value ? (lanesByProject.value[selectedId.value] ?? []) : []);
 const COMPATIBILITY_LANE_KEYS = ['backlog', 'todo', 'planning', 'in_progress', 'in_review', 'blocked', 'done', 'cancelled', 'parked'];
@@ -1429,14 +1486,52 @@ onMounted(async() => {
   await loadAvailableViews();
   await restoreProjectView();
   automationStatus.value = await ipcRenderer.invoke('work-items:automation-status').catch(() => null);
+  await loadConveyorHealth();
   refreshTimer = setInterval(() => {
     if (!document.hidden && !saving.value) {
       load().catch(() => undefined);
       ipcRenderer.invoke('work-items:automation-status')
         .then(status => { automationStatus.value = status; })
         .catch(() => undefined);
+      loadConveyorHealth().catch(() => undefined);
     }
   }, 15_000);
+});
+
+function healthProjectId(): string | null {
+  return healthScopeProject.value ? (selectedId.value || null) : null;
+}
+
+async function loadConveyorHealth(): Promise<void> {
+  conveyorHealth.value = await ipcRenderer.invoke('work-items:conveyor-health', {
+    projectId: healthProjectId(), windowHours: conveyorWindow.value,
+  }).catch(() => null);
+  if (healthStage.value) await loadHealthStage(healthStage.value);
+}
+
+async function loadHealthStage(stage: SemanticStage): Promise<void> {
+  healthStage.value = stage;
+  healthItems.value = await ipcRenderer.invoke('work-items:conveyor-oldest', {
+    projectId: healthProjectId(), stage,
+  }).catch(() => []);
+}
+
+function duration(seconds: number | null): string {
+  if (seconds == null) return '-';
+  if (seconds < 3600) return `${ Math.max(1, Math.round(seconds / 60)) }m`;
+  if (seconds < 86_400) return `${ Math.round(seconds / 3600) }h`;
+  return `${ Math.round(seconds / 86_400) }d`;
+}
+
+function percent(value: number | null): string { return value == null ? 'unlimited' : `${ Math.round(value * 100) }%`; }
+
+async function openHealthTask(taskId: string): Promise<void> {
+  const row = allTasks.value.find(entry => entry.task.id === taskId);
+  if (row) await openTaskDrawer(row.task);
+}
+
+watch([conveyorWindow, healthScopeProject, selectedId], () => {
+  loadConveyorHealth().catch(() => undefined);
 });
 
 onBeforeUnmount(() => {
@@ -2355,6 +2450,24 @@ async function confirmArchiveEpic(e: EpicWithTasks): Promise<void> {
 .ph-automation-health { margin: 0 0 14px; padding: 10px 12px; border: 1px solid var(--pacc-line); border-radius: 9px; background: var(--pacc-soft); color: var(--ptext2); font-size: 12px; }
 .ph-automation-health.held { border-color: color-mix(in srgb, var(--pamber) 55%, transparent); background: color-mix(in srgb, var(--pamber) 10%, transparent); }
 .ph-automation-stages { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+.ph-health { margin: 0 0 20px; padding: 13px; border: 1px solid var(--pborder); border-radius: 11px; background: var(--psurface); }
+.ph-health-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; color: var(--ptext2); font-size: 12px; }
+.ph-health-head b { color: var(--ptext); }
+.ph-health-controls { display: flex; align-items: center; gap: 8px; font-size: 10px; color: var(--ptext3); }
+.ph-health-controls label { display: inline-flex; align-items: center; gap: 4px; }
+.ph-health-controls select { border: 1px solid var(--pborder); border-radius: 5px; background: var(--psurface2); color: var(--ptext2); padding: 4px 6px; font-size: 10px; }
+.ph-health-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 7px; margin-top: 11px; }
+.ph-health-stat { min-width: 0; padding: 8px 9px; border: 1px solid var(--pborder-soft); border-radius: 7px; background: var(--psurface2); color: var(--ptext2); text-align: left; }
+button.ph-health-stat { cursor: pointer; }
+button.ph-health-stat:hover, button.ph-health-stat.on { border-color: var(--pacc-line); background: var(--pacc-soft); }
+.ph-health-stat span, .ph-health-stat small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 9px var(--pmono); color: var(--ptext3); text-transform: uppercase; }
+.ph-health-stat b { display: block; margin: 4px 0 2px; color: var(--ptext); font: 600 17px var(--pmono); }
+.ph-health-stat small { text-transform: none; }
+.ph-health-drill { display: grid; gap: 4px; margin-top: 10px; padding-top: 9px; border-top: 1px solid var(--pborder-soft); }
+.ph-health-drill > b { color: var(--ptext2); font-size: 11px; }
+.ph-health-drill button { display: flex; justify-content: space-between; gap: 12px; border: 0; background: transparent; color: var(--ptext2); padding: 4px 2px; text-align: left; cursor: pointer; }
+.ph-health-drill button:hover { color: var(--pacc); }
+.ph-health-drill small { color: var(--ptext3); font-family: var(--pmono); }
 
 /* shared data projections */
 .ph-data-view { min-width: 0; }

--- a/pkg/rancher-desktop/pages/__tests__/ProjectsHome.conveyor-health.test.ts
+++ b/pkg/rancher-desktop/pages/__tests__/ProjectsHome.conveyor-health.test.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+
+import { describe, expect, it } from '@jest/globals';
+import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc';
+
+const source = fs.readFileSync('pkg/rancher-desktop/pages/ProjectsHome.vue', 'utf8');
+
+describe('Projects conveyor health panel', () => {
+  it('exposes selectable windows, project/portfolio scope, and bounded stage drill-down', () => {
+    expect(source).toContain('aria-label="Projects conveyor health"');
+    expect(source).toContain('v-model.number="conveyorWindow"');
+    expect(source).toContain('healthScopeProject');
+    expect(source).toContain("'work-items:conveyor-oldest'");
+    expect(source).toContain('openHealthTask');
+  });
+
+  it('renders all required health signals without trusting comments as evidence', () => {
+    for (const signal of [
+      'Throughput', 'Verifier', 'Rework', 'Wait adoption', 'Custody',
+      'Stale leases', 'Dependency held', 'Shipments',
+    ]) expect(source).toContain(signal);
+    expect(source).not.toContain('work_task_comments');
+  });
+
+  it('compiles the real SFC script and template without diagnostics', () => {
+    const { descriptor, errors } = parse(source, { filename: 'ProjectsHome.vue' });
+    expect(errors).toEqual([]);
+    expect(() => compileScript(descriptor, { id: 'projects-health' })).not.toThrow();
+    const template = compileTemplate({
+      id: 'projects-health', filename: 'ProjectsHome.vue', source: descriptor.template?.content ?? '',
+    });
+    expect(template.errors).toEqual([]);
+  });
+});

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -444,6 +444,11 @@ export interface IpcMainInvokeEvents {
     decision: import('@pkg/agent/services/ProjectAutomationWipLimits').BackpressureDecision;
     at: string;
   };
+  'work-items:conveyor-health': (opts?: { projectId?: string | null; windowHours?: number }) => Awaited<ReturnType<typeof import('@pkg/agent/database/models/WorkConveyorMetricsModel').WorkConveyorMetricsModel.snapshot>>;
+  'work-items:conveyor-oldest': (opts: {
+    projectId?: string | null;
+    stage: import('@pkg/agent/database/models/WorkConveyorMetricsModel').SemanticStage;
+  }) => Awaited<ReturnType<typeof import('@pkg/agent/database/models/WorkConveyorMetricsModel').WorkConveyorMetricsModel.oldestItems>>;
   'work-items:knowledge-list':  (input: { itemKind: import('@pkg/agent/database/models/WorkItemKnowledgeModel').KnowledgeWorkItemKind; itemId: string; includeInherited?: boolean; includeArchived?: boolean; limit?: number }) => import('@pkg/agent/database/models/WorkItemKnowledgeModel').LinkedKnowledgeRecord[];
   'work-items:knowledge-link':  (input: import('@pkg/agent/database/models/WorkItemKnowledgeModel').KnowledgeLinkInput) => import('@pkg/agent/database/models/WorkItemKnowledgeModel').KnowledgeLinkRecord;
   'work-items:knowledge-unlink': (input: import('@pkg/agent/database/models/WorkItemKnowledgeModel').KnowledgeLinkInput) => boolean;


### PR DESCRIPTION
Closes #717.

Replacement for stale draft #724, rebased onto current main after #710-#716 landed.

Adds the indexed conveyor metrics model and read-only tool, plus the missing Projects UI/IPC dashboard with selectable 24h/7d/30d windows, project/portfolio scope, and bounded oldest-stage drill-down.

Correctness repairs before merge:
- uses the first-class dependency schema and done-only resolution contract
- excludes suppressed/unfinished review generations from throughput
- measures custody from the latest execution per completed task
- scopes wait adoption to external/human gates
- separates shared-custody integration trains from missing evidence
- resolves actual configured execution/review capacity

Validation: git diff --check passed; all changed TypeScript and the ProjectsHome script transpile without diagnostics; electron IPC declarations parse cleanly. Focused Jest could not start because this checkout resolves the repo-wide broken node_modules tree and cannot import ts-jest. No hosted checks are registered.