### PR TITLE
[DRAFT] feat(projects): add readiness frontier and blocked explanations

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/ProjectReadinessModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/ProjectReadinessModel.ts
@@ -1,0 +1,167 @@
+import { WorkItemsModel, type WorkTaskRecord } from './WorkItemsModel';
+import { WorkTaskDependencyModel, type UnresolvedDependency } from './WorkTaskDependencyModel';
+import { WorkTaskDispatchModel } from './WorkTaskDispatchModel';
+import { WorkTaskWaitModel, type WorkTaskWaitRecord } from './WorkTaskWaitModel';
+import { postgresClient } from '../PostgresClient';
+
+export type ReadinessReasonType =
+  | 'unmet_prerequisite'
+  | 'downstream_backpressure'
+  | 'external_wait'
+  | 'worker_lease'
+  | 'stage_wip'
+  | 'human_gate';
+
+export interface ReadinessBlockReason {
+  type: ReadinessReasonType;
+  message: string;
+  unevaluated?: boolean;
+  details?: Record<string, unknown>;
+}
+
+export interface ReadinessCapabilities {
+  prerequisites: 'live' | 'pending';
+  external_waits: 'live' | 'pending';
+  worker_leases: 'live' | 'pending';
+  stage_wip: 'live' | 'pending';
+  human_gates: 'live' | 'pending';
+}
+
+export interface TaskReadiness {
+  taskId: string;
+  title: string;
+  status: string;
+  claimable: boolean;
+  reasons: ReadinessBlockReason[];
+  capabilities: ReadinessCapabilities;
+}
+
+export interface ReadinessFrontier {
+  tasks: TaskReadiness[];
+  capabilities: ReadinessCapabilities;
+  evaluatedAt: string;
+}
+
+const DEFAULT_WIP_LIMIT = 6;
+const DEFAULT_REVIEW_LIMIT = 3;
+const HUMAN_LABELS = new Set(['gated', 'human', 'manual', 'no-auto-dispatch']);
+
+function dependencyReason(unresolved: UnresolvedDependency): ReadinessBlockReason {
+  return {
+    type: 'unmet_prerequisite',
+    message: unresolved.reason,
+    details: {
+      prerequisiteTaskId: unresolved.dependsOnTaskId,
+      prerequisiteStatus: unresolved.dependsOnStatus,
+      policy: unresolved.policy,
+    },
+  };
+}
+
+function waitReason(wait: WorkTaskWaitRecord): ReadinessBlockReason {
+  return {
+    type: 'external_wait',
+    message: `Task is waiting on ${ wait.wait_kind }: ${ wait.target_key }`,
+    details: { waitId: wait.id, targetKey: wait.target_key, status: wait.status, dueAt: wait.due_at },
+  };
+}
+
+export function classifyHumanGate(task: Pick<WorkTaskRecord, 'assignee' | 'labels'>): ReadinessBlockReason | null {
+  const labels = (task.labels ?? []).map(label => label.toLowerCase());
+  if (task.assignee?.toLowerCase() === 'human' || labels.some(label => HUMAN_LABELS.has(label))) {
+    return {
+      type: 'human_gate',
+      message: 'Task is explicitly owned or gated by a human.',
+      details: { assignee: task.assignee, labels: task.labels ?? [] },
+    };
+  }
+  return null;
+}
+
+export class ProjectReadinessModel {
+  static async explainBlocked(taskId: string): Promise<TaskReadiness> {
+    const task = await WorkItemsModel.getTask(taskId);
+    if (!task) throw new Error(`Task not found: ${ taskId }`);
+    return this.evaluate(task);
+  }
+
+  static async ready(opts: { projectId?: string; limit?: number } = {}): Promise<ReadinessFrontier> {
+    const tasks = await WorkItemsModel.listTasks({
+      projectId: opts.projectId,
+      semanticRoles: ['execution'],
+      includeDone: false,
+      limit: Math.max(1, Math.min(200, opts.limit ?? 50)),
+    });
+    const evaluations = await Promise.all(tasks
+      .filter(task => task.status !== 'in_progress')
+      .map(task => this.evaluate(task)));
+    const capabilities = this.capabilities();
+    return {
+      tasks: evaluations.filter(task => task.claimable),
+      capabilities,
+      evaluatedAt: new Date().toISOString(),
+    };
+  }
+
+  private static capabilities(): ReadinessCapabilities {
+    return {
+      prerequisites: 'live',
+      external_waits: 'live',
+      worker_leases: 'live',
+      stage_wip: 'live',
+      human_gates: 'live',
+    };
+  }
+
+  private static async evaluate(task: WorkTaskRecord): Promise<TaskReadiness> {
+    const reasons: ReadinessBlockReason[] = [];
+    const unresolved = await WorkTaskDependencyModel.listUnresolvedDependencies(task.id);
+    reasons.push(...unresolved.map(dependencyReason));
+
+    const waits = await WorkTaskWaitModel.list({ taskId: task.id, status: 'active', limit: 50 });
+    reasons.push(...waits.map(waitReason));
+
+    const lease = await postgresClient.queryOne<{ id: string; agent_id: string; kind: string }>(
+      `SELECT id, agent_id, kind FROM work_task_dispatches WHERE task_id = $1 AND status = 'running' LIMIT 1`,
+      [task.id],
+    );
+    if (lease) {
+      reasons.push({
+        type: 'worker_lease',
+        message: `Task already has a live ${ lease.kind } lease held by ${ lease.agent_id }.`,
+        details: { dispatchId: lease.id, agentId: lease.agent_id, kind: lease.kind },
+      });
+    }
+
+    const humanGate = classifyHumanGate(task);
+    if (humanGate) reasons.push(humanGate);
+
+    const [running, reviewBacklog] = await Promise.all([
+      WorkTaskDispatchModel.countRunning('execution'),
+      WorkTaskDispatchModel.countReviewBacklog(),
+    ]);
+    if (task.status === 'todo' && running >= DEFAULT_WIP_LIMIT) {
+      reasons.push({
+        type: 'stage_wip',
+        message: `Execution WIP limit reached (${ running }/${ DEFAULT_WIP_LIMIT }).`,
+        details: { activeExecutionWip: running, wipLimit: DEFAULT_WIP_LIMIT },
+      });
+    }
+    if (task.status === 'todo' && reviewBacklog >= DEFAULT_REVIEW_LIMIT) {
+      reasons.push({
+        type: 'downstream_backpressure',
+        message: `Review backlog is applying downstream backpressure (${ reviewBacklog }/${ DEFAULT_REVIEW_LIMIT }).`,
+        details: { reviewBacklog, reviewLimit: DEFAULT_REVIEW_LIMIT },
+      });
+    }
+
+    return {
+      taskId: task.id,
+      title: task.title,
+      status: task.status,
+      claimable: reasons.length === 0,
+      reasons,
+      capabilities: this.capabilities(),
+    };
+  }
+}

--- a/pkg/rancher-desktop/agent/database/models/__tests__/ProjectReadinessModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/ProjectReadinessModel.test.ts
@@ -1,0 +1,16 @@
+import { classifyHumanGate } from '../ProjectReadinessModel';
+
+describe('ProjectReadinessModel human-gate classifier', () => {
+  it.each([
+    { assignee: 'human', labels: [] },
+    { assignee: null, labels: ['gated'] },
+    { assignee: null, labels: ['manual'] },
+    { assignee: null, labels: ['no-auto-dispatch'] },
+  ])('recognizes an explicit human gate: %#', task => {
+    expect(classifyHumanGate(task)).toMatchObject({ type: 'human_gate' });
+  });
+
+  it('does not turn an ordinary autonomous task into a human gate', () => {
+    expect(classifyHumanGate({ assignee: 'dispatcher', labels: ['backend'] })).toBeNull();
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/project/explain_blocked.ts
+++ b/pkg/rancher-desktop/agent/tools/project/explain_blocked.ts
@@ -1,0 +1,18 @@
+import { ProjectReadinessModel } from '../../database/models/ProjectReadinessModel';
+import { BaseTool, ToolResponse } from '../base';
+
+export class ExplainBlockedWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const taskId = typeof input.task_id === 'string' ? input.task_id.trim() : '';
+    if (!taskId) return { successBoolean: false, responseString: 'task_id is required.' };
+    try {
+      const explanation = await ProjectReadinessModel.explainBlocked(taskId);
+      return { successBoolean: true, responseString: JSON.stringify(explanation, null, 2) };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to explain blocked task: ${ err?.message ?? String(err) }` };
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/project/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/project/manifests.ts
@@ -224,6 +224,27 @@ export const projectToolManifests: ToolManifest[] = [
     operationTypes: ['read'],
     loader:         () => import('./explain_task_claimability'),
   },
+  {
+    name:        'ready',
+    description: 'Return the authoritative claimable Projects frontier as structured JSON. Read-only: tasks are evaluated against live dependencies, waits, worker leases, WIP pressure, downstream review backpressure, and explicit human gates.',
+    category:    'project',
+    schemaDef:   {
+      project_id: { type: 'string', optional: true, description: 'Limit the frontier to one project.' },
+      limit:      { type: 'number', optional: true, description: 'Maximum tasks to evaluate (default 50, hard cap 200).' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./ready'),
+  },
+  {
+    name:        'explain_blocked',
+    description: 'Explain exactly why a Projects task is not claimable without reading comments. Returns structured reason types, live details, and capability status.',
+    category:    'project',
+    schemaDef:   {
+      task_id: { type: 'string', description: 'Projects task id.' },
+    },
+    operationTypes: ['read'],
+    loader:         () => import('./explain_blocked'),
+  },
   // ── projects ─────────────────────────────────────────────────────────
   {
     name:        'create_project',

--- a/pkg/rancher-desktop/agent/tools/project/ready.ts
+++ b/pkg/rancher-desktop/agent/tools/project/ready.ts
@@ -1,0 +1,19 @@
+import { ProjectReadinessModel } from '../../database/models/ProjectReadinessModel';
+import { BaseTool, ToolResponse } from '../base';
+
+export class ProjectReadyWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    try {
+      const frontier = await ProjectReadinessModel.ready({
+        projectId: typeof input.project_id === 'string' ? input.project_id : undefined,
+        limit: typeof input.limit === 'number' ? input.limit : undefined,
+      });
+      return { successBoolean: true, responseString: JSON.stringify(frontier, null, 2) };
+    } catch (err: any) {
+      return { successBoolean: false, responseString: `Failed to compute project ready frontier: ${ err?.message ?? String(err) }` };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the first executable slice of task bviQ / #730:
- adds read-only ProjectReadinessModel with live prerequisite, external-wait, worker-lease, WIP, downstream-backpressure, and human-gate reasons
- adds `project/ready` and `project/explain_blocked` structured tool surfaces
- adds focused human-gate classifier coverage

## Scope and safety

This is additive and migration-free. It does not change dispatcher selection or delete existing heuristics yet. Dependency-edge evaluation is now live because task 3wqs / #714 is merged; consumer cutover remains a separately reviewable step.

## Verification

- TypeScript transpile syntax check: 5 changed TS files, 0 diagnostics
- `git diff --check`: clean
- Full repo Jest/typecheck unavailable in this checkout because the host node_modules install is missing `tsx`; CI should run the focused suite and full typecheck.

No merge or deploy.