### PR TITLE
refactor(projects): introduce pure domain kernel (dHAe Phase 1)

### DIFF
--- a/pkg/rancher-desktop/agent/domain/projects/README.md
+++ b/pkg/rancher-desktop/agent/domain/projects/README.md
@@ -1,0 +1,37 @@
+# Projects domain kernel (dHAe Phase 1)
+
+Pure, framework-free primitives for the Projects work-graph. **No SQL, no Electron, no
+persistence imports** — everything here is unit-testable in isolation.
+
+## Phase 1 contents
+
+| Value object | Purpose | Grounded in |
+|---|---|---|
+| `TaskId` | Work-item identity (slug, e.g. `YceX`) | `WorkItemsModel` id shape |
+| `LaneKey` | Stable, immutable lane column key | `WorkLaneDefinitionModel` `lane_key` |
+| `SemanticRole` | Stage-independent lane meaning | `WorkLaneSemanticRole`, `REQUIRED_WORK_LANE_ROLES`, `COMPATIBILITY_ROLE_BY_KEY` |
+| `TaskStatus` | Task lifecycle status | `WorkItemsModel` status set + default lane role map, including manual `parked` |
+| `ArtifactGeneration` | Monotonic lane-entry / custody generation | `scope_generation` (`WorkflowExecutionModel`), review generation hash |
+
+Characterization tests reproduce the exact canonical constants (the seven semantic roles,
+the required-role set, the lane-key -> role map, and the nine default statuses and their
+role mapping) so drift from the SQL models is caught.
+
+- Immutable `Project`, `Epic`, `Task`, and `Board` aggregates hold invariants without persistence.
+- `LifecycleTransition` emits generation-scoped domain events.
+- `LifecyclePolicy` evaluates dependencies, WIP, leases, durable waits, and custody from facts
+  supplied by the application layer; it performs no reads or writes itself.
+- `DispatchLease`, `Dependency`, `DurableWait`, `CustodyReceipt`, and `DomainEvent` model the
+  lifecycle concepts that were previously coupled to SQL models and orchestration services.
+- `LegacyProjectsMapper` accepts structural legacy records without importing their SQL-backed
+  model modules. Existing adapters can adopt it incrementally without public tool or IPC changes.
+- Boundary tests fail if production domain files import database, Electron, tool, or service code.
+
+## Deliberately deferred
+
+Repository interfaces, UnitOfWork, Postgres adapters, production tool/IPC routing, outbox-backed
+orchestration, and runtime schema changes belong to Phases 2-4. This branch does not modify those
+surfaces. Migrated-Postgres behavior parity is therefore a Phase 2 gate, not hidden inside Phase 1.
+
+These require behavior reverse-engineering of the SQL models and a migrated-Postgres test run,
+tracked under task dHAe / YceX.

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/Aggregates.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/Aggregates.test.ts
@@ -1,0 +1,68 @@
+import { Board, Epic, Project, Task } from '../entities';
+import { DomainError } from '../errors';
+import { EpicId, LaneKey, ProjectId, SemanticRole, TaskId } from '../values';
+
+describe('Projects aggregates', () => {
+  const projectId = ProjectId.of('project-1');
+  const epicId = EpicId.of('epic-1');
+
+  it('constructs immutable project, epic, and task aggregates', () => {
+    const project = new Project({ id: projectId, title: ' Project ' });
+    const epic = new Epic({ id: epicId, projectId, title: ' Epic ' });
+    const task = new Task({
+      id: TaskId.of('task-1'), projectId, epicId, title: ' Task ',
+      lane: LaneKey.of('todo'), semanticRole: SemanticRole.EXECUTION, labels: ['p0'],
+    });
+    expect(project.title).toBe('Project');
+    expect(epic.title).toBe('Epic');
+    expect(task.title).toBe('Task');
+    expect(task.labels).toEqual(['p0']);
+    expect(Object.isFrozen(task)).toBe(true);
+  });
+
+  it('moves active tasks without mutating the source aggregate', () => {
+    const task = new Task({
+      id: TaskId.of('task-1'), projectId, epicId: null, title: 'Task',
+      lane: LaneKey.of('blocked'), semanticRole: SemanticRole.BLOCKED,
+    });
+    const moved = task.moveTo(LaneKey.of('planning'), SemanticRole.PLANNING);
+    expect(task.lane.value).toBe('blocked');
+    expect(moved.lane.value).toBe('planning');
+    expect(moved.id).toBe(task.id);
+  });
+
+  it('rejects empty titles and archived-task transitions', () => {
+    expect(() => new Project({ id: projectId, title: ' ' })).toThrow(DomainError);
+    const task = new Task({
+      id: TaskId.of('task-1'), projectId, epicId, title: 'Task', archived: true,
+      lane: LaneKey.of('todo'), semanticRole: SemanticRole.EXECUTION,
+    });
+    expect(() => task.moveTo(LaneKey.of('in_progress'), SemanticRole.EXECUTION)).toThrow(DomainError);
+  });
+
+  it('orders configured lanes and advances through custom keys, not literal statuses', () => {
+    const board = new Board(projectId, [
+      { key: LaneKey.of('verify'), semanticRole: SemanticRole.REVIEW, position: 20, enabled: true },
+      { key: LaneKey.of('build'), semanticRole: SemanticRole.EXECUTION, position: 10, enabled: true },
+      { key: LaneKey.of('paused'), semanticRole: SemanticRole.MANUAL, position: 15, enabled: false },
+    ]);
+    expect(board.lanes.map(lane => lane.key.value)).toEqual(['build', 'paused', 'verify']);
+    expect(board.nextLane(LaneKey.of('build'))?.key.value).toBe('verify');
+    expect(board.nextLane(LaneKey.of('verify'))).toBeNull();
+    expect(() => board.lane(LaneKey.of('paused'))).toThrow(DomainError);
+  });
+
+  it('rejects duplicate lane keys and invalid positions', () => {
+    const lane = { key: LaneKey.of('todo'), semanticRole: SemanticRole.EXECUTION, position: 0, enabled: true };
+    expect(() => new Board(projectId, [lane, { ...lane, position: 1 }])).toThrow('unique');
+    expect(() => new Board(projectId, [{ ...lane, position: -1 }])).toThrow('non-negative');
+  });
+
+  it('can validate whether a resolved board contains every required semantic role', () => {
+    const lanes = SemanticRole.REQUIRED.map((role, position) => ({
+      key: LaneKey.of(`lane_${ role }`), semanticRole: SemanticRole.of(role), position, enabled: true,
+    }));
+    expect(() => new Board(projectId, lanes).assertOperational()).not.toThrow();
+    expect(() => new Board(projectId, lanes.slice(1)).assertOperational()).toThrow('backlog');
+  });
+});

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/ArtifactGeneration.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/ArtifactGeneration.test.ts
@@ -1,0 +1,46 @@
+import { ArtifactGeneration } from '../values/ArtifactGeneration';
+import { DomainError } from '../errors';
+
+describe('ArtifactGeneration', () => {
+  it('starts at generation 0 with no hash', () => {
+    const g = ArtifactGeneration.initial();
+    expect(g.generation).toBe(0);
+    expect(g.hash).toBeNull();
+  });
+  it('rejects negative / non-integer / non-number generations', () => {
+    expect(() => ArtifactGeneration.of(-1)).toThrow(DomainError);
+    expect(() => ArtifactGeneration.of(1.5)).toThrow(DomainError);
+    expect(() => ArtifactGeneration.of('2' as unknown)).toThrow(DomainError);
+  });
+  it('rejects a non-string hash', () => {
+    expect(() => ArtifactGeneration.of(1, 5 as unknown)).toThrow(DomainError);
+  });
+  it('next() increments and clears the hash', () => {
+    const g = ArtifactGeneration.of(3, 'abc').next();
+    expect(g.generation).toBe(4);
+    expect(g.hash).toBeNull();
+  });
+  it('withHash binds a non-empty content hash and rejects blank', () => {
+    expect(ArtifactGeneration.of(1).withHash('deadbeef').hash).toBe('deadbeef');
+    expect(() => ArtifactGeneration.of(1).withHash('   ')).toThrow(DomainError);
+  });
+  it('supersedes compares generation ordering', () => {
+    expect(ArtifactGeneration.of(2).supersedes(ArtifactGeneration.of(1))).toBe(true);
+    expect(ArtifactGeneration.of(1).supersedes(ArtifactGeneration.of(1))).toBe(false);
+    expect(ArtifactGeneration.of(1).supersedes(ArtifactGeneration.of(2))).toBe(false);
+  });
+  it('sameArtifacts detects identical bound hashes only', () => {
+    const a = ArtifactGeneration.of(1, 'h');
+    const b = ArtifactGeneration.of(2, 'h');
+    const c = ArtifactGeneration.of(3, 'other');
+    expect(a.sameArtifacts(b)).toBe(true);
+    expect(a.sameArtifacts(c)).toBe(false);
+    expect(ArtifactGeneration.initial().sameArtifacts(ArtifactGeneration.initial())).toBe(false);
+  });
+  it('has value equality and immutability', () => {
+    expect(ArtifactGeneration.of(1, 'h').equals(ArtifactGeneration.of(1, 'h'))).toBe(true);
+    expect(ArtifactGeneration.of(1, 'h').equals(ArtifactGeneration.of(1, 'x'))).toBe(false);
+    expect(ArtifactGeneration.of(1).equals(ArtifactGeneration.of(2))).toBe(false);
+    expect(Object.isFrozen(ArtifactGeneration.initial())).toBe(true);
+  });
+});

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/ArtifactGeneration.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/ArtifactGeneration.test.ts
@@ -31,9 +31,10 @@ describe('ArtifactGeneration', () => {
   });
   it('sameArtifacts detects identical bound hashes only', () => {
     const a = ArtifactGeneration.of(1, 'h');
-    const b = ArtifactGeneration.of(2, 'h');
+    const b = ArtifactGeneration.of(1, 'h');
     const c = ArtifactGeneration.of(3, 'other');
     expect(a.sameArtifacts(b)).toBe(true);
+    expect(a.sameArtifacts(ArtifactGeneration.of(2, 'h'))).toBe(false);
     expect(a.sameArtifacts(c)).toBe(false);
     expect(ArtifactGeneration.initial().sameArtifacts(ArtifactGeneration.initial())).toBe(false);
   });

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/CanonicalCharacterization.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/CanonicalCharacterization.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { LaneKey, SemanticRole, TaskStatus } from '../values';
+
+const repoRoot = process.cwd();
+const laneModelSource = fs.readFileSync(path.join(
+  repoRoot, 'pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts',
+), 'utf8');
+const workItemsSource = fs.readFileSync(path.join(
+  repoRoot, 'pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts',
+), 'utf8');
+
+function requiredBlock(source: string, pattern: RegExp, label: string): string {
+  const match = source.match(pattern);
+  if (!match) throw new Error(`Canonical source block not found: ${ label }`);
+  return match[1];
+}
+
+describe('Projects canonical legacy characterization', () => {
+  it('derives default lane keys and roles from the canonical model source', () => {
+    const block = requiredBlock(
+      laneModelSource, /export const DEFAULT_WORK_LANES[^=]*= \[([\s\S]*?)\] as const;/,
+      'DEFAULT_WORK_LANES',
+    );
+    const rows = [...block.matchAll(/lane_key: '([^']+)'.*semantic_role: '([^']+)'/g)]
+      .map(match => ({ key: match[1], role: match[2] }));
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect([...LaneKey.SYSTEM]).toEqual(rows.map(row => row.key));
+    for (const row of rows) {
+      expect(SemanticRole.forLaneKey(row.key)?.value).toBe(row.role);
+    }
+  });
+
+  it('derives required roles from canonical system-required lanes', () => {
+    const block = requiredBlock(
+      laneModelSource, /export const DEFAULT_WORK_LANES[^=]*= \[([\s\S]*?)\] as const;/,
+      'DEFAULT_WORK_LANES',
+    );
+    const requiredRoles = [...block.matchAll(/semantic_role: '([^']+)'.*system_required: true/g)]
+      .map(match => match[1])
+      .filter((role, index, roles) => roles.indexOf(role) === index);
+    expect([...SemanticRole.REQUIRED]).toEqual(requiredRoles);
+  });
+
+  it('derives status-role compatibility from the canonical model source', () => {
+    const block = requiredBlock(
+      laneModelSource, /export const DEFAULT_STATUS_SEMANTIC_ROLE[^=]*= \{([\s\S]*?)\};/,
+      'DEFAULT_STATUS_SEMANTIC_ROLE',
+    );
+    const mappings = [...block.matchAll(/^\s*([a-z_]+):\s*'([^']+)'/gm)]
+      .map(match => ({ status: match[1], role: match[2] }));
+    expect(mappings.map(mapping => mapping.status)).toEqual(TaskStatus.ALL.map(status => status.value));
+    for (const mapping of mappings) {
+      expect(TaskStatus.of(mapping.status).semanticRole().value).toBe(mapping.role);
+    }
+  });
+
+  it('derives closed states from the canonical WorkItemsModel predicate', () => {
+    const block = requiredBlock(
+      workItemsSource, /const CLOSED_STATUSES = `status IN \(([^)]+)\)`;/,
+      'CLOSED_STATUSES',
+    );
+    const closed = [...block.matchAll(/'([^']+)'/g)].map(match => match[1]);
+    expect(TaskStatus.ALL.filter(status => status.isClosed()).map(status => status.value)).toEqual(closed);
+  });
+});

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/Compatibility.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/Compatibility.test.ts
@@ -41,7 +41,7 @@ describe('Projects legacy compatibility', () => {
     ])).toThrow(DomainError);
   });
 
-  it('keeps the domain kernel free of database, Electron, tool, and service imports', () => {
+  it('allows production kernel imports only from inside the kernel', () => {
     const root = path.resolve(process.cwd(), 'pkg/rancher-desktop/agent/domain/projects');
     const files: string[] = [];
     const visit = (directory: string) => {
@@ -52,7 +52,17 @@ describe('Projects legacy compatibility', () => {
       }
     };
     visit(root);
-    const forbidden = /from ['"][^'"]*(?:database|electron|tools|services)[^'"]*['"]/;
-    expect(files.filter(file => forbidden.test(fs.readFileSync(file, 'utf8')))).toEqual([]);
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = fs.readFileSync(file, 'utf8');
+      for (const match of source.matchAll(/from ['"]([^'"]+)['"]/g)) {
+        const specifier = match[1];
+        const resolved = path.resolve(path.dirname(file), specifier);
+        if (!specifier.startsWith('.') || !resolved.startsWith(`${ root }${ path.sep }`)) {
+          offenders.push(`${ path.relative(root, file) }:${ specifier }`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/Compatibility.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/Compatibility.test.ts
@@ -1,0 +1,58 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { LegacyProjectsMapper } from '../compatibility';
+import { DomainError } from '../errors';
+
+describe('Projects legacy compatibility', () => {
+  it.each([
+    ['backlog', 'backlog'], ['todo', 'execution'], ['planning', 'planning'],
+    ['in_progress', 'execution'], ['in_review', 'review'], ['blocked', 'blocked'],
+    ['done', 'terminal'], ['cancelled', 'terminal'], ['parked', 'manual'],
+  ])('maps legacy status %s to semantic role %s', (status, role) => {
+    const task = LegacyProjectsMapper.task({
+      id: 'task-1', project_id: 'project-1', epic_id: null, title: 'Task', status,
+      assignee: null, labels: null, archived: false,
+    });
+    expect(task.lane.value).toBe(status);
+    expect(task.semanticRole.value).toBe(role);
+  });
+
+  it('preserves nullable epic, labels, archive state, and artifact identity', () => {
+    const task = LegacyProjectsMapper.task({
+      id: 'task-1', project_id: 'project-1', epic_id: null, title: 'Task', status: 'todo',
+      assignee: ' worker ', labels: ['p0'], archived: true,
+    }, { generation: 4, artifact_hash: 'sha-4' });
+    expect(task.epicId).toBeNull();
+    expect(task.assignee).toBe('worker');
+    expect(task.labels).toEqual(['p0']);
+    expect(task.archived).toBe(true);
+    expect(task.artifactGeneration.toString()).toBe('gen:4#sha-4');
+  });
+
+  it('uses configured semantic roles for custom lanes and fails closed when absent', () => {
+    const board = LegacyProjectsMapper.board('project-1', [
+      { lane_key: 'build_it', semantic_role: 'execution', position: 0, enabled: true },
+      { lane_key: 'verify_it', semantic_role: 'review', position: 1, enabled: true },
+    ]);
+    expect(board.nextLane(board.lanes[0].key)?.key.value).toBe('verify_it');
+    expect(() => LegacyProjectsMapper.board('project-1', [
+      { lane_key: 'mystery', semantic_role: null, position: 0, enabled: true },
+    ])).toThrow(DomainError);
+  });
+
+  it('keeps the domain kernel free of database, Electron, tool, and service imports', () => {
+    const root = path.resolve(process.cwd(), 'pkg/rancher-desktop/agent/domain/projects');
+    const files: string[] = [];
+    const visit = (directory: string) => {
+      for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const target = path.join(directory, entry.name);
+        if (entry.isDirectory()) visit(target);
+        else if (entry.name.endsWith('.ts') && !target.includes(`${ path.sep }__tests__${ path.sep }`)) files.push(target);
+      }
+    };
+    visit(root);
+    const forbidden = /from ['"][^'"]*(?:database|electron|tools|services)[^'"]*['"]/;
+    expect(files.filter(file => forbidden.test(fs.readFileSync(file, 'utf8')))).toEqual([]);
+  });
+});

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/LaneKey.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/LaneKey.test.ts
@@ -1,0 +1,29 @@
+import { LaneKey } from '../values/LaneKey';
+import { DomainError } from '../errors';
+
+describe('LaneKey', () => {
+  it('accepts valid keys', () => {
+    expect(LaneKey.of('in_progress').value).toBe('in_progress');
+    expect(LaneKey.of('  todo ').value).toBe('todo');
+  });
+  it('rejects invalid keys', () => {
+    for (const bad of ['', 'In_Progress', '1abc', 'has space', '_leading', 'trailing-', 'a'.repeat(65)]) {
+      expect(() => LaneKey.of(bad)).toThrow(DomainError);
+    }
+    expect(LaneKey.tryOf(42 as unknown)).toBeNull();
+  });
+  it('recognises exactly the nine default lane keys', () => {
+    expect([...LaneKey.SYSTEM]).toEqual([
+      'backlog', 'todo', 'planning', 'in_progress', 'in_review', 'blocked', 'done', 'cancelled', 'parked',
+    ]);
+    for (const key of LaneKey.SYSTEM) {
+      expect(LaneKey.of(key).isSystem()).toBe(true);
+    }
+    expect(LaneKey.of('custom_lane').isSystem()).toBe(false);
+  });
+  it('has value equality and is immutable', () => {
+    expect(LaneKey.of('todo').equals(LaneKey.of('todo'))).toBe(true);
+    expect(LaneKey.of('todo').equals(LaneKey.of('done'))).toBe(false);
+    expect(Object.isFrozen(LaneKey.of('todo'))).toBe(true);
+  });
+});

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/Lifecycle.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/Lifecycle.test.ts
@@ -1,0 +1,79 @@
+import { Task } from '../entities';
+import { DomainError } from '../errors';
+import {
+  CustodyReceipt, Dependency, DispatchLease, DurableWait, LifecyclePolicy, LifecycleTransition,
+} from '../lifecycle';
+import { ArtifactGeneration, LaneKey, ProjectId, SemanticRole, TaskId } from '../values';
+
+const taskId = TaskId.of('task-1');
+const projectId = ProjectId.of('project-1');
+const generation = ArtifactGeneration.of(3, 'sha-3');
+
+function task(lane: string, role: SemanticRole): Task {
+  return new Task({
+    id: taskId, projectId, epicId: null, title: 'Task', lane: LaneKey.of(lane),
+    semanticRole: role, artifactGeneration: generation, assignee: 'worker',
+  });
+}
+
+describe('Projects lifecycle', () => {
+  const now = new Date('2026-08-24T23:00:00.000Z');
+
+  it('creates an immutable generation-scoped domain event', () => {
+    const transition = new LifecycleTransition(
+      task('todo', SemanticRole.EXECUTION), task('in_progress', SemanticRole.EXECUTION),
+      'worker', 'dispatcher',
+    );
+    const event = transition.toEvent('event-1', now);
+    expect(event.payload).toMatchObject({ fromLane: 'todo', toLane: 'in_progress', actor: 'worker' });
+    expect(event.generation.equals(generation)).toBe(true);
+    expect(Object.isFrozen(event)).toBe(true);
+  });
+
+  it('rejects identity, aggregate, actor, and no-op transition violations', () => {
+    const from = task('todo', SemanticRole.EXECUTION);
+    expect(() => new LifecycleTransition(from, task('todo', SemanticRole.EXECUTION), 'worker', 'tool'))
+      .toThrow('change lanes');
+    expect(() => new LifecycleTransition(from, task('in_progress', SemanticRole.EXECUTION), ' ', 'tool'))
+      .toThrow('actor');
+    const other = new Task({ ...from, id: TaskId.of('other'), lane: LaneKey.of('in_progress') });
+    expect(() => new LifecycleTransition(from, other, 'worker', 'tool')).toThrow('identity');
+  });
+
+  it('blocks execution while dependencies, WIP, or current-generation waits are unresolved', () => {
+    const transition = new LifecycleTransition(
+      task('backlog', SemanticRole.BACKLOG), task('todo', SemanticRole.EXECUTION), 'worker', 'tool',
+    );
+    expect(() => LifecyclePolicy.authorize(transition, {
+      now, dependencies: [new Dependency(taskId, TaskId.of('dep'), false)],
+    })).toThrow('dependencies');
+    expect(() => LifecyclePolicy.authorize(transition, { now, wipAvailable: false })).toThrow('WIP');
+    expect(() => LifecyclePolicy.authorize(transition, {
+      now, waits: [new DurableWait(taskId, 'human_gate', 'approval', generation, true)],
+    })).toThrow('durable wait');
+  });
+
+  it('enforces active lease ownership and exact artifact custody', () => {
+    const transition = new LifecycleTransition(
+      task('in_progress', SemanticRole.EXECUTION), task('in_review', SemanticRole.REVIEW),
+      'worker', 'dispatcher',
+    );
+    const lease = new DispatchLease(taskId, 'other', generation, new Date(now.getTime() + 60_000));
+    expect(() => LifecyclePolicy.authorize(transition, { now, lease, custody: [] })).toThrow('lease');
+    const ownedLease = new DispatchLease(taskId, 'worker', generation, new Date(now.getTime() + 60_000));
+    expect(() => LifecyclePolicy.authorize(transition, { now, lease: ownedLease, custody: [] })).toThrow('custody');
+    const wrongGeneration = new CustodyReceipt(taskId, ArtifactGeneration.of(2), 'code', 'pr:1', 'sha-2');
+    expect(() => LifecyclePolicy.authorize(transition, {
+      now, lease: ownedLease, custody: [wrongGeneration],
+    })).toThrow('custody');
+    const receipt = new CustodyReceipt(taskId, generation, 'code', 'pr:1', 'sha-3');
+    expect(() => LifecyclePolicy.authorize(transition, { now, lease: ownedLease, custody: [receipt] }))
+      .not.toThrow();
+  });
+
+  it('rejects self-dependencies and malformed domain objects', () => {
+    expect(() => new Dependency(taskId, taskId, false)).toThrow(DomainError);
+    expect(() => new DurableWait(taskId, 'human_gate', ' ', generation, true)).toThrow(DomainError);
+    expect(() => new CustodyReceipt(taskId, generation, 'code', '', 'sha')).toThrow(DomainError);
+  });
+});

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/Lifecycle.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/Lifecycle.test.ts
@@ -71,6 +71,32 @@ describe('Projects lifecycle', () => {
       .not.toThrow();
   });
 
+  it('fails closed when repositories supply facts for another task', () => {
+    const transition = new LifecycleTransition(
+      task('backlog', SemanticRole.BACKLOG), task('todo', SemanticRole.EXECUTION), 'worker', 'tool',
+    );
+    const otherTask = TaskId.of('other');
+    expect(() => LifecyclePolicy.authorize(transition, {
+      now, dependencies: [new Dependency(otherTask, TaskId.of('dep'), true)],
+    })).toThrow('another task');
+    expect(() => LifecyclePolicy.authorize(transition, {
+      now, waits: [new DurableWait(otherTask, 'human_gate', 'approval', generation, false)],
+    })).toThrow('another task');
+    expect(() => LifecyclePolicy.authorize(transition, {
+      now, lease: new DispatchLease(otherTask, 'worker', generation, new Date(now.getTime() + 60_000)),
+    })).toThrow('another task');
+  });
+
+  it('does not let callers mutate a dispatch lease expiry after construction', () => {
+    const mutableExpiry = new Date(now.getTime() + 60_000);
+    const lease = new DispatchLease(taskId, 'worker', generation, mutableExpiry);
+    mutableExpiry.setTime(now.getTime() - 1);
+    expect(lease.isActive(now)).toBe(true);
+    const exposed = lease.expiresAt;
+    exposed.setTime(now.getTime() - 1);
+    expect(lease.isActive(now)).toBe(true);
+  });
+
   it('rejects self-dependencies and malformed domain objects', () => {
     expect(() => new Dependency(taskId, taskId, false)).toThrow(DomainError);
     expect(() => new DurableWait(taskId, 'human_gate', ' ', generation, true)).toThrow(DomainError);

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/SemanticRole.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/SemanticRole.test.ts
@@ -9,7 +9,7 @@ describe('SemanticRole', () => {
   });
   it('REQUIRED mirrors REQUIRED_WORK_LANE_ROLES (manual excluded)', () => {
     expect([...SemanticRole.REQUIRED]).toEqual([
-      'backlog', 'planning', 'execution', 'review', 'blocked', 'terminal',
+      'backlog', 'execution', 'planning', 'review', 'blocked', 'terminal',
     ]);
     expect(SemanticRole.MANUAL.isRequired()).toBe(false);
     for (const v of SemanticRole.REQUIRED) {

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/SemanticRole.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/SemanticRole.test.ts
@@ -1,0 +1,40 @@
+import { SemanticRole } from '../values/SemanticRole';
+import { DomainError } from '../errors';
+
+describe('SemanticRole', () => {
+  it('exposes the seven canonical roles in order', () => {
+    expect(SemanticRole.ALL.map(r => r.value)).toEqual([
+      'backlog', 'planning', 'execution', 'review', 'blocked', 'terminal', 'manual',
+    ]);
+  });
+  it('REQUIRED mirrors REQUIRED_WORK_LANE_ROLES (manual excluded)', () => {
+    expect([...SemanticRole.REQUIRED]).toEqual([
+      'backlog', 'planning', 'execution', 'review', 'blocked', 'terminal',
+    ]);
+    expect(SemanticRole.MANUAL.isRequired()).toBe(false);
+    for (const v of SemanticRole.REQUIRED) {
+      expect(SemanticRole.of(v).isRequired()).toBe(true);
+    }
+  });
+  it('forLaneKey reproduces COMPATIBILITY_ROLE_BY_KEY', () => {
+    const expected: Record<string, string> = {
+      backlog: 'backlog', planning: 'planning', todo: 'execution', in_progress: 'execution',
+      in_review: 'review', blocked: 'blocked', done: 'terminal', cancelled: 'terminal', parked: 'manual',
+    };
+    for (const [key, role] of Object.entries(expected)) {
+      expect(SemanticRole.forLaneKey(key)?.value).toBe(role);
+    }
+    expect(SemanticRole.forLaneKey('unknown_key')).toBeNull();
+    expect(SemanticRole.forLaneKey(42)).toBeNull();
+  });
+  it('detects the terminal role', () => {
+    expect(SemanticRole.TERMINAL.isTerminal()).toBe(true);
+    expect(SemanticRole.EXECUTION.isTerminal()).toBe(false);
+  });
+  it('of() rejects unknown values; tryOf returns null; identity passthrough', () => {
+    expect(() => SemanticRole.of('nope')).toThrow(DomainError);
+    expect(SemanticRole.tryOf('nope')).toBeNull();
+    expect(SemanticRole.tryOf(SemanticRole.REVIEW)).toBe(SemanticRole.REVIEW);
+    expect(SemanticRole.REVIEW.equals(SemanticRole.of('review'))).toBe(true);
+  });
+});

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/TaskId.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/TaskId.test.ts
@@ -1,0 +1,34 @@
+import { TaskId } from '../values/TaskId';
+import { DomainError } from '../errors';
+
+describe('TaskId', () => {
+  it('accepts a valid slug id and exposes its value', () => {
+    expect(TaskId.of('YceX').value).toBe('YceX');
+  });
+  it('trims surrounding whitespace', () => {
+    expect(TaskId.of('  YceX  ').value).toBe('YceX');
+  });
+  it('rejects empty / non-string / oversized ids', () => {
+    expect(() => TaskId.of('')).toThrow(DomainError);
+    expect(() => TaskId.of('   ')).toThrow(DomainError);
+    expect(() => TaskId.of(123 as unknown)).toThrow(DomainError);
+    expect(() => TaskId.of(null)).toThrow(DomainError);
+    expect(() => TaskId.of('x'.repeat(129))).toThrow(DomainError);
+  });
+  it('tryOf returns null instead of throwing; isValid reflects it', () => {
+    expect(TaskId.tryOf('')).toBeNull();
+    expect(TaskId.tryOf('YceX')).not.toBeNull();
+    expect(TaskId.isValid('YceX')).toBe(true);
+    expect(TaskId.isValid('')).toBe(false);
+  });
+  it('has value equality', () => {
+    expect(TaskId.of('a').equals(TaskId.of('a'))).toBe(true);
+    expect(TaskId.of('a').equals(TaskId.of('b'))).toBe(false);
+    expect(TaskId.of('a').equals(null)).toBe(false);
+  });
+  it('is immutable and stringifies to its value', () => {
+    const id = TaskId.of('abc');
+    expect(Object.isFrozen(id)).toBe(true);
+    expect(String(id)).toBe('abc');
+  });
+});

--- a/pkg/rancher-desktop/agent/domain/projects/__tests__/TaskStatus.test.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/__tests__/TaskStatus.test.ts
@@ -1,0 +1,41 @@
+import { TaskStatus } from '../values/TaskStatus';
+import { SemanticRole } from '../values/SemanticRole';
+import { DomainError } from '../errors';
+
+describe('TaskStatus', () => {
+  it('exposes the nine default statuses in order', () => {
+    expect(TaskStatus.ALL.map(s => s.value)).toEqual([
+      'backlog', 'todo', 'planning', 'in_progress', 'in_review', 'blocked', 'done', 'cancelled', 'parked',
+    ]);
+  });
+  it('maps each status to the default lane semantic role', () => {
+    const expected: Record<string, SemanticRole> = {
+      backlog: SemanticRole.BACKLOG,
+      todo: SemanticRole.EXECUTION,
+      planning: SemanticRole.PLANNING,
+      in_progress: SemanticRole.EXECUTION,
+      in_review: SemanticRole.REVIEW,
+      blocked: SemanticRole.BLOCKED,
+      done: SemanticRole.TERMINAL,
+      cancelled: SemanticRole.TERMINAL,
+      parked: SemanticRole.MANUAL,
+    };
+    for (const status of TaskStatus.ALL) {
+      expect(status.semanticRole()).toBe(expected[status.value]);
+    }
+  });
+  it('identifies terminal statuses', () => {
+    expect(TaskStatus.DONE.isTerminal()).toBe(true);
+    expect(TaskStatus.CANCELLED.isTerminal()).toBe(true);
+    expect(TaskStatus.PARKED.isTerminal()).toBe(false);
+    expect(TaskStatus.PARKED.isClosed()).toBe(true);
+    expect(TaskStatus.IN_PROGRESS.isTerminal()).toBe(false);
+    expect(TaskStatus.BACKLOG.isTerminal()).toBe(false);
+  });
+  it('of() rejects unknown; tryOf returns null; equality holds', () => {
+    expect(() => TaskStatus.of('shipped')).toThrow(DomainError);
+    expect(TaskStatus.tryOf('shipped')).toBeNull();
+    expect(TaskStatus.of('todo').equals(TaskStatus.TODO)).toBe(true);
+    expect(TaskStatus.tryOf(TaskStatus.DONE)).toBe(TaskStatus.DONE);
+  });
+});

--- a/pkg/rancher-desktop/agent/domain/projects/compatibility/LegacyProjectsMapper.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/compatibility/LegacyProjectsMapper.ts
@@ -1,0 +1,86 @@
+import { Board, Epic, Project, Task } from '../entities';
+import { DomainError } from '../errors';
+import {
+  ArtifactGeneration, EpicId, LaneKey, ProjectId, SemanticRole, TaskId,
+} from '../values';
+
+/** Structural legacy records keep this adapter independent from SQL model modules. */
+export interface LegacyProjectRecord {
+  id: string;
+  title: string;
+  archived: boolean;
+}
+
+export interface LegacyEpicRecord {
+  id: string;
+  project_id: string;
+  title: string;
+  archived: boolean;
+}
+
+export interface LegacyTaskRecord {
+  id: string;
+  project_id: string;
+  epic_id: string | null;
+  title: string;
+  status: string;
+  assignee: string | null;
+  labels: string[] | null;
+  archived: boolean;
+}
+
+export interface LegacyLaneRecord {
+  lane_key: string;
+  semantic_role?: string | null;
+  position: number;
+  enabled: boolean;
+}
+
+export interface LegacyArtifactIdentity {
+  generation?: number | null;
+  artifact_hash?: string | null;
+}
+
+export class LegacyProjectsMapper {
+  static project(record: LegacyProjectRecord): Project {
+    return new Project({ id: ProjectId.of(record.id), title: record.title, archived: record.archived });
+  }
+
+  static epic(record: LegacyEpicRecord): Epic {
+    return new Epic({
+      id: EpicId.of(record.id),
+      projectId: ProjectId.of(record.project_id),
+      title: record.title,
+      archived: record.archived,
+    });
+  }
+
+  static task(record: LegacyTaskRecord, artifact: LegacyArtifactIdentity = {}): Task {
+    const lane = LaneKey.of(record.status);
+    const semanticRole = SemanticRole.forLaneKey(lane.value);
+    if (!semanticRole) {
+      throw new DomainError(`Legacy task lane requires an explicit configured role: ${ lane.value }`);
+    }
+    return new Task({
+      id: TaskId.of(record.id),
+      projectId: ProjectId.of(record.project_id),
+      epicId: record.epic_id ? EpicId.of(record.epic_id) : null,
+      title: record.title,
+      lane,
+      semanticRole,
+      artifactGeneration: ArtifactGeneration.of(artifact.generation ?? 0, artifact.artifact_hash),
+      assignee: record.assignee,
+      labels: record.labels ?? [],
+      archived: record.archived,
+    });
+  }
+
+  static board(projectId: string, records: readonly LegacyLaneRecord[]): Board {
+    return new Board(ProjectId.of(projectId), records.map(record => {
+      const key = LaneKey.of(record.lane_key);
+      const role = SemanticRole.tryOf(record.semantic_role) ?? SemanticRole.forLaneKey(key.value);
+      if (!role) throw new DomainError(`Lane requires a semantic role: ${ key.value }`);
+      return { key, semanticRole: role, position: record.position, enabled: record.enabled };
+    }));
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/compatibility/index.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/compatibility/index.ts
@@ -1,0 +1,4 @@
+export { LegacyProjectsMapper } from './LegacyProjectsMapper';
+export type {
+  LegacyArtifactIdentity, LegacyEpicRecord, LegacyLaneRecord, LegacyProjectRecord, LegacyTaskRecord,
+} from './LegacyProjectsMapper';

--- a/pkg/rancher-desktop/agent/domain/projects/entities/Board.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/entities/Board.ts
@@ -1,0 +1,46 @@
+import { DomainError } from '../errors';
+import { LaneKey, ProjectId, SemanticRole } from '../values';
+
+export interface BoardLane {
+  key: LaneKey;
+  semanticRole: SemanticRole;
+  position: number;
+  enabled: boolean;
+}
+
+export class Board {
+  readonly projectId: ProjectId;
+  readonly lanes: readonly Readonly<BoardLane>[];
+
+  constructor(projectId: ProjectId, lanes: readonly BoardLane[]) {
+    const keys = lanes.map(lane => lane.key.value);
+    if (new Set(keys).size !== keys.length) throw new DomainError('Board lane keys must be unique');
+    if (lanes.some(lane => !Number.isInteger(lane.position) || lane.position < 0)) {
+      throw new DomainError('Board lane positions must be non-negative integers');
+    }
+    this.projectId = projectId;
+    this.lanes = Object.freeze([...lanes]
+      .map(lane => Object.freeze({ ...lane }))
+      .sort((a, b) => a.position - b.position));
+    Object.freeze(this);
+  }
+
+  lane(key: LaneKey): Readonly<BoardLane> {
+    const lane = this.lanes.find(candidate => candidate.key.equals(key));
+    if (!lane || !lane.enabled) throw new DomainError(`Unknown or disabled lane: ${ key.value }`);
+    return lane;
+  }
+
+  nextLane(key: LaneKey): Readonly<BoardLane> | null {
+    const enabled = this.lanes.filter(lane => lane.enabled);
+    const index = enabled.findIndex(lane => lane.key.equals(key));
+    if (index < 0) throw new DomainError(`Unknown or disabled lane: ${ key.value }`);
+    return enabled[index + 1] ?? null;
+  }
+
+  assertOperational(): void {
+    const roles = new Set(this.lanes.filter(lane => lane.enabled).map(lane => lane.semanticRole.value));
+    const missing = SemanticRole.REQUIRED.filter(role => !roles.has(role));
+    if (missing.length > 0) throw new DomainError(`Board is missing required semantic roles: ${ missing.join(', ') }`);
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/entities/Epic.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/entities/Epic.ts
@@ -1,0 +1,26 @@
+import { DomainError } from '../errors';
+import { EpicId, ProjectId } from '../values';
+
+export interface EpicProps {
+  id: EpicId;
+  projectId: ProjectId;
+  title: string;
+  archived?: boolean;
+}
+
+export class Epic {
+  readonly id: EpicId;
+  readonly projectId: ProjectId;
+  readonly title: string;
+  readonly archived: boolean;
+
+  constructor(props: EpicProps) {
+    const title = props.title.trim();
+    if (!title) throw new DomainError('Epic title is required');
+    this.id = props.id;
+    this.projectId = props.projectId;
+    this.title = title;
+    this.archived = props.archived ?? false;
+    Object.freeze(this);
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/entities/Project.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/entities/Project.ts
@@ -1,0 +1,23 @@
+import { DomainError } from '../errors';
+import { ProjectId } from '../values';
+
+export interface ProjectProps {
+  id: ProjectId;
+  title: string;
+  archived?: boolean;
+}
+
+export class Project {
+  readonly id: ProjectId;
+  readonly title: string;
+  readonly archived: boolean;
+
+  constructor(props: ProjectProps) {
+    const title = props.title.trim();
+    if (!title) throw new DomainError('Project title is required');
+    this.id = props.id;
+    this.title = title;
+    this.archived = props.archived ?? false;
+    Object.freeze(this);
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/entities/Task.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/entities/Task.ts
@@ -1,0 +1,49 @@
+import { DomainError } from '../errors';
+import { ArtifactGeneration, EpicId, LaneKey, ProjectId, SemanticRole, TaskId } from '../values';
+
+export interface TaskProps {
+  id: TaskId;
+  projectId: ProjectId;
+  epicId: EpicId | null;
+  title: string;
+  lane: LaneKey;
+  semanticRole: SemanticRole;
+  artifactGeneration?: ArtifactGeneration;
+  assignee?: string | null;
+  labels?: readonly string[];
+  archived?: boolean;
+}
+
+export class Task {
+  readonly id: TaskId;
+  readonly projectId: ProjectId;
+  readonly epicId: EpicId | null;
+  readonly title: string;
+  readonly lane: LaneKey;
+  readonly semanticRole: SemanticRole;
+  readonly artifactGeneration: ArtifactGeneration;
+  readonly assignee: string | null;
+  readonly labels: readonly string[];
+  readonly archived: boolean;
+
+  constructor(props: TaskProps) {
+    const title = props.title.trim();
+    if (!title) throw new DomainError('Task title is required');
+    this.id = props.id;
+    this.projectId = props.projectId;
+    this.epicId = props.epicId;
+    this.title = title;
+    this.lane = props.lane;
+    this.semanticRole = props.semanticRole;
+    this.artifactGeneration = props.artifactGeneration ?? ArtifactGeneration.initial();
+    this.assignee = props.assignee?.trim() || null;
+    this.labels = Object.freeze([...(props.labels ?? [])]);
+    this.archived = props.archived ?? false;
+    Object.freeze(this);
+  }
+
+  moveTo(lane: LaneKey, semanticRole: SemanticRole): Task {
+    if (this.archived) throw new DomainError('Archived tasks cannot transition');
+    return new Task({ ...this, lane, semanticRole });
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/entities/index.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/entities/index.ts
@@ -1,0 +1,8 @@
+export { Project } from './Project';
+export type { ProjectProps } from './Project';
+export { Epic } from './Epic';
+export type { EpicProps } from './Epic';
+export { Task } from './Task';
+export type { TaskProps } from './Task';
+export { Board } from './Board';
+export type { BoardLane } from './Board';

--- a/pkg/rancher-desktop/agent/domain/projects/errors.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/errors.ts
@@ -1,0 +1,8 @@
+/** Base error for Projects domain-kernel invariant violations. Framework-free. */
+export class DomainError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DomainError';
+    Object.setPrototypeOf(this, DomainError.prototype);
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/index.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Projects domain kernel (dHAe refactor, Phase 1).
+ *
+ * Pure, framework-free domain primitives for the Projects work-graph. No SQL, no Electron,
+ * no persistence imports. Existing SQL-backed models (WorkItemsModel, WorkLaneDefinitionModel,
+ * WorkflowExecutionModel, ...) are intended to route through this kernel via compatibility
+ * adapters in later phases. This kernel changes no public tool or IPC contract.
+ */
+export * from './values';
+export * from './entities';
+export * from './lifecycle';
+export * from './compatibility';
+export { DomainError } from './errors';

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/CustodyReceipt.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/CustodyReceipt.ts
@@ -1,0 +1,22 @@
+import { DomainError } from '../errors';
+import { ArtifactGeneration, TaskId } from '../values';
+
+export type CustodyArtifactKind = 'code' | 'document' | 'external';
+
+export class CustodyReceipt {
+  constructor(
+    readonly taskId: TaskId,
+    readonly generation: ArtifactGeneration,
+    readonly kind: CustodyArtifactKind,
+    readonly locator: string,
+    readonly exactIdentity: string,
+  ) {
+    if (!locator.trim()) throw new DomainError('Custody artifact locator is required');
+    if (!exactIdentity.trim()) throw new DomainError('Custody artifact identity is required');
+    Object.freeze(this);
+  }
+
+  matches(taskId: TaskId, generation: ArtifactGeneration): boolean {
+    return this.taskId.equals(taskId) && this.generation.equals(generation);
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/Dependency.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/Dependency.ts
@@ -1,0 +1,13 @@
+import { DomainError } from '../errors';
+import { TaskId } from '../values';
+
+export class Dependency {
+  constructor(
+    readonly taskId: TaskId,
+    readonly dependsOnTaskId: TaskId,
+    readonly satisfied: boolean,
+  ) {
+    if (taskId.equals(dependsOnTaskId)) throw new DomainError('A task cannot depend on itself');
+    Object.freeze(this);
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/Dependency.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/Dependency.ts
@@ -10,4 +10,8 @@ export class Dependency {
     if (taskId.equals(dependsOnTaskId)) throw new DomainError('A task cannot depend on itself');
     Object.freeze(this);
   }
+
+  belongsTo(taskId: TaskId): boolean {
+    return this.taskId.equals(taskId);
+  }
 }

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/DispatchLease.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/DispatchLease.ts
@@ -1,0 +1,23 @@
+import { DomainError } from '../errors';
+import { ArtifactGeneration, TaskId } from '../values';
+
+export class DispatchLease {
+  constructor(
+    readonly taskId: TaskId,
+    readonly owner: string,
+    readonly generation: ArtifactGeneration,
+    readonly expiresAt: Date,
+  ) {
+    if (!owner.trim()) throw new DomainError('Dispatch lease owner is required');
+    if (Number.isNaN(expiresAt.getTime())) throw new DomainError('Dispatch lease expiry is invalid');
+    Object.freeze(this);
+  }
+
+  isActive(at: Date): boolean {
+    return this.expiresAt.getTime() > at.getTime();
+  }
+
+  isOwnedBy(actor: string, generation: ArtifactGeneration): boolean {
+    return this.owner === actor && this.generation.equals(generation);
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/DispatchLease.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/DispatchLease.ts
@@ -2,22 +2,33 @@ import { DomainError } from '../errors';
 import { ArtifactGeneration, TaskId } from '../values';
 
 export class DispatchLease {
+  private readonly expiresAtEpochMs: number;
+
   constructor(
     readonly taskId: TaskId,
     readonly owner: string,
     readonly generation: ArtifactGeneration,
-    readonly expiresAt: Date,
+    expiresAt: Date,
   ) {
     if (!owner.trim()) throw new DomainError('Dispatch lease owner is required');
     if (Number.isNaN(expiresAt.getTime())) throw new DomainError('Dispatch lease expiry is invalid');
+    this.expiresAtEpochMs = expiresAt.getTime();
     Object.freeze(this);
   }
 
+  get expiresAt(): Date {
+    return new Date(this.expiresAtEpochMs);
+  }
+
   isActive(at: Date): boolean {
-    return this.expiresAt.getTime() > at.getTime();
+    return this.expiresAtEpochMs > at.getTime();
   }
 
   isOwnedBy(actor: string, generation: ArtifactGeneration): boolean {
     return this.owner === actor && this.generation.equals(generation);
+  }
+
+  belongsTo(taskId: TaskId): boolean {
+    return this.taskId.equals(taskId);
   }
 }

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/DomainEvent.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/DomainEvent.ts
@@ -1,0 +1,33 @@
+import { DomainError } from '../errors';
+import { ArtifactGeneration, TaskId } from '../values';
+
+export interface DomainEventProps<TPayload extends Readonly<Record<string, unknown>>> {
+  id: string;
+  type: string;
+  taskId: TaskId;
+  generation: ArtifactGeneration;
+  occurredAt: Date;
+  payload: TPayload;
+}
+
+export class DomainEvent<TPayload extends Readonly<Record<string, unknown>> = Readonly<Record<string, unknown>>> {
+  readonly id: string;
+  readonly type: string;
+  readonly taskId: TaskId;
+  readonly generation: ArtifactGeneration;
+  readonly occurredAt: Date;
+  readonly payload: TPayload;
+
+  constructor(props: DomainEventProps<TPayload>) {
+    if (!props.id.trim()) throw new DomainError('Domain event id is required');
+    if (!props.type.trim()) throw new DomainError('Domain event type is required');
+    if (Number.isNaN(props.occurredAt.getTime())) throw new DomainError('Domain event timestamp is invalid');
+    this.id = props.id.trim();
+    this.type = props.type.trim();
+    this.taskId = props.taskId;
+    this.generation = props.generation;
+    this.occurredAt = new Date(props.occurredAt.getTime());
+    this.payload = Object.freeze({ ...props.payload }) as TPayload;
+    Object.freeze(this);
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/DurableWait.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/DurableWait.ts
@@ -1,0 +1,17 @@
+import { DomainError } from '../errors';
+import { ArtifactGeneration, TaskId } from '../values';
+
+export type DurableWaitKind = 'external_job' | 'human_gate' | 'time';
+
+export class DurableWait {
+  constructor(
+    readonly taskId: TaskId,
+    readonly kind: DurableWaitKind,
+    readonly targetKey: string,
+    readonly generation: ArtifactGeneration,
+    readonly active: boolean,
+  ) {
+    if (!targetKey.trim()) throw new DomainError('Durable wait target key is required');
+    Object.freeze(this);
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/DurableWait.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/DurableWait.ts
@@ -14,4 +14,8 @@ export class DurableWait {
     if (!targetKey.trim()) throw new DomainError('Durable wait target key is required');
     Object.freeze(this);
   }
+
+  belongsTo(taskId: TaskId, generation: ArtifactGeneration): boolean {
+    return this.taskId.equals(taskId) && this.generation.equals(generation);
+  }
 }

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/LifecyclePolicy.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/LifecyclePolicy.ts
@@ -22,13 +22,24 @@ export class LifecyclePolicy {
     const enteringReview = transition.to.semanticRole.equals(SemanticRole.REVIEW);
     const enteringTerminal = transition.to.semanticRole.equals(SemanticRole.TERMINAL);
 
+    if (context.dependencies?.some(dependency => !dependency.belongsTo(transition.to.id))) {
+      throw new DomainError('Lifecycle dependency facts include another task');
+    }
+    if (context.waits?.some(wait => !wait.taskId.equals(transition.to.id))) {
+      throw new DomainError('Lifecycle wait facts include another task');
+    }
+    if (context.lease && !context.lease.belongsTo(transition.to.id)) {
+      throw new DomainError('Lifecycle lease belongs to another task');
+    }
+
     if (enteringExecution && context.dependencies?.some(dependency => !dependency.satisfied)) {
       throw new DomainError('Task has unsatisfied dependencies');
     }
     if (enteringExecution && context.wipAvailable === false) {
       throw new DomainError('Destination lane WIP limit is reached');
     }
-    if (context.waits?.some(wait => wait.active && wait.generation.equals(transition.from.artifactGeneration))) {
+    if (context.waits?.some(wait => wait.active
+      && wait.belongsTo(transition.from.id, transition.from.artifactGeneration))) {
       throw new DomainError('Task has an active durable wait for this generation');
     }
     if (transition.from.semanticRole.equals(SemanticRole.EXECUTION) && context.lease?.isActive(context.now)) {

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/LifecyclePolicy.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/LifecyclePolicy.ts
@@ -1,0 +1,45 @@
+import { DomainError } from '../errors';
+import { SemanticRole } from '../values';
+import { CustodyReceipt } from './CustodyReceipt';
+import { Dependency } from './Dependency';
+import { DispatchLease } from './DispatchLease';
+import { DurableWait } from './DurableWait';
+import { LifecycleTransition } from './LifecycleTransition';
+
+export interface LifecyclePolicyContext {
+  dependencies?: readonly Dependency[];
+  lease?: DispatchLease | null;
+  waits?: readonly DurableWait[];
+  custody?: readonly CustodyReceipt[];
+  wipAvailable?: boolean;
+  now: Date;
+}
+
+/** Pure invariant chain; persistence supplies the facts and commits only after this succeeds. */
+export class LifecyclePolicy {
+  static authorize(transition: LifecycleTransition, context: LifecyclePolicyContext): void {
+    const enteringExecution = transition.to.semanticRole.equals(SemanticRole.EXECUTION);
+    const enteringReview = transition.to.semanticRole.equals(SemanticRole.REVIEW);
+    const enteringTerminal = transition.to.semanticRole.equals(SemanticRole.TERMINAL);
+
+    if (enteringExecution && context.dependencies?.some(dependency => !dependency.satisfied)) {
+      throw new DomainError('Task has unsatisfied dependencies');
+    }
+    if (enteringExecution && context.wipAvailable === false) {
+      throw new DomainError('Destination lane WIP limit is reached');
+    }
+    if (context.waits?.some(wait => wait.active && wait.generation.equals(transition.from.artifactGeneration))) {
+      throw new DomainError('Task has an active durable wait for this generation');
+    }
+    if (transition.from.semanticRole.equals(SemanticRole.EXECUTION) && context.lease?.isActive(context.now)) {
+      if (!context.lease.isOwnedBy(transition.actor, transition.from.artifactGeneration)) {
+        throw new DomainError('Active dispatch lease is owned by another actor or generation');
+      }
+    }
+    if (enteringReview || enteringTerminal) {
+      const hasCustody = context.custody?.some(receipt =>
+        receipt.matches(transition.to.id, transition.to.artifactGeneration)) ?? false;
+      if (!hasCustody) throw new DomainError('Artifact custody is required for review or terminal entry');
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/LifecycleTransition.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/LifecycleTransition.ts
@@ -1,0 +1,45 @@
+import { DomainError } from '../errors';
+import { Task } from '../entities';
+import { DomainEvent } from './DomainEvent';
+
+export type TransitionSource = 'tool' | 'ipc' | 'heartbeat' | 'routine' | 'dispatcher' | 'system';
+
+export class LifecycleTransition {
+  readonly from: Task;
+  readonly to: Task;
+  readonly actor: string;
+  readonly source: TransitionSource;
+
+  constructor(from: Task, to: Task, actor: string, source: TransitionSource) {
+    if (!from.id.equals(to.id)) throw new DomainError('A lifecycle transition cannot change task identity');
+    const sameEpic = from.epicId === null ? to.epicId === null : from.epicId.equals(to.epicId);
+    if (!from.projectId.equals(to.projectId) || !sameEpic) {
+      throw new DomainError('A lifecycle transition cannot move a task between aggregates');
+    }
+    if (!actor.trim()) throw new DomainError('Lifecycle transition actor is required');
+    if (from.lane.equals(to.lane)) throw new DomainError('Lifecycle transition must change lanes');
+    this.from = from;
+    this.to = to;
+    this.actor = actor.trim();
+    this.source = source;
+    Object.freeze(this);
+  }
+
+  toEvent(id: string, occurredAt: Date): DomainEvent {
+    return new DomainEvent({
+      id,
+      type: 'projects.task.transitioned',
+      taskId: this.to.id,
+      generation: this.to.artifactGeneration,
+      occurredAt,
+      payload: Object.freeze({
+        actor: this.actor,
+        source: this.source,
+        fromLane: this.from.lane.value,
+        toLane: this.to.lane.value,
+        fromRole: this.from.semanticRole.value,
+        toRole: this.to.semanticRole.value,
+      }),
+    });
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/lifecycle/index.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/lifecycle/index.ts
@@ -1,0 +1,12 @@
+export { DomainEvent } from './DomainEvent';
+export type { DomainEventProps } from './DomainEvent';
+export { DispatchLease } from './DispatchLease';
+export { Dependency } from './Dependency';
+export { DurableWait } from './DurableWait';
+export type { DurableWaitKind } from './DurableWait';
+export { CustodyReceipt } from './CustodyReceipt';
+export type { CustodyArtifactKind } from './CustodyReceipt';
+export { LifecycleTransition } from './LifecycleTransition';
+export type { TransitionSource } from './LifecycleTransition';
+export { LifecyclePolicy } from './LifecyclePolicy';
+export type { LifecyclePolicyContext } from './LifecyclePolicy';

--- a/pkg/rancher-desktop/agent/domain/projects/values/ArtifactGeneration.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/values/ArtifactGeneration.ts
@@ -55,7 +55,7 @@ export class ArtifactGeneration {
 
   /** True if both carry the same non-null artifact hash (identical terminal generation). */
   sameArtifacts(other: ArtifactGeneration): boolean {
-    return this.hash !== null && this.hash === other.hash;
+    return this.generation === other.generation && this.hash !== null && this.hash === other.hash;
   }
 
   equals(other: ArtifactGeneration | null | undefined): boolean {

--- a/pkg/rancher-desktop/agent/domain/projects/values/ArtifactGeneration.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/values/ArtifactGeneration.ts
@@ -1,0 +1,70 @@
+import { DomainError } from '../errors';
+
+/**
+ * A monotonic generation marker for a task's lane-entry / artifact custody. Ports the
+ * numeric scope_generation used by WorkflowExecutionModel.findActiveByLaneScope and the
+ * review generation hash used to suppress identical terminal generations. Pure value object.
+ */
+export class ArtifactGeneration {
+  private constructor(
+    public readonly generation: number,
+    public readonly hash: string | null,
+  ) {
+    Object.freeze(this);
+  }
+
+  /** The initial generation (0, no artifacts bound yet). */
+  static initial(): ArtifactGeneration {
+    return new ArtifactGeneration(0, null);
+  }
+
+  static of(generation: unknown, hash: unknown = null): ArtifactGeneration {
+    if (typeof generation !== 'number' || !Number.isInteger(generation) || generation < 0) {
+      throw new DomainError(`Invalid ArtifactGeneration: ${JSON.stringify(generation)}`);
+    }
+    return new ArtifactGeneration(generation, ArtifactGeneration.normalizeHash(hash));
+  }
+
+  private static normalizeHash(hash: unknown): string | null {
+    if (hash === null || hash === undefined) return null;
+    if (typeof hash !== 'string') {
+      throw new DomainError(`Invalid ArtifactGeneration hash: ${JSON.stringify(hash)}`);
+    }
+    const trimmed = hash.trim();
+    return trimmed.length === 0 ? null : trimmed;
+  }
+
+  /** Next generation (increment), dropping any bound artifact hash. */
+  next(): ArtifactGeneration {
+    return new ArtifactGeneration(this.generation + 1, null);
+  }
+
+  /** Bind an artifact content hash to this generation (custody identity). */
+  withHash(hash: string): ArtifactGeneration {
+    const normalized = ArtifactGeneration.normalizeHash(hash);
+    if (normalized === null) {
+      throw new DomainError('ArtifactGeneration hash must be non-empty');
+    }
+    return new ArtifactGeneration(this.generation, normalized);
+  }
+
+  /** True if this generation strictly supersedes (comes after) another. */
+  supersedes(other: ArtifactGeneration): boolean {
+    return this.generation > other.generation;
+  }
+
+  /** True if both carry the same non-null artifact hash (identical terminal generation). */
+  sameArtifacts(other: ArtifactGeneration): boolean {
+    return this.hash !== null && this.hash === other.hash;
+  }
+
+  equals(other: ArtifactGeneration | null | undefined): boolean {
+    return other instanceof ArtifactGeneration
+      && other.generation === this.generation
+      && other.hash === this.hash;
+  }
+
+  toString(): string {
+    return this.hash === null ? `gen:${this.generation}` : `gen:${this.generation}#${this.hash}`;
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/values/EpicId.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/values/EpicId.ts
@@ -1,0 +1,22 @@
+import { DomainError } from '../errors';
+
+export class EpicId {
+  private constructor(public readonly value: string) {
+    Object.freeze(this);
+  }
+
+  static of(raw: unknown): EpicId {
+    if (typeof raw !== 'string' || raw.trim().length === 0 || raw.trim().length > 128) {
+      throw new DomainError(`Invalid EpicId: ${ JSON.stringify(raw) }`);
+    }
+    return new EpicId(raw.trim());
+  }
+
+  equals(other: EpicId | null | undefined): boolean {
+    return other instanceof EpicId && other.value === this.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/values/LaneKey.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/values/LaneKey.ts
@@ -1,0 +1,55 @@
+import { DomainError } from '../errors';
+
+/**
+ * Stable, immutable key of a Projects lane (column). Mirrors WorkLaneDefinitionModel
+ * lane_key semantics: immutable after creation, drawn from a fixed system set plus
+ * project-defined custom keys.
+ */
+export class LaneKey {
+  /** Canonical system lane keys (WorkLaneDefinitionModel default lane set, in order). */
+  static readonly SYSTEM = Object.freeze([
+    'backlog', 'todo', 'planning', 'in_progress', 'in_review', 'blocked', 'done', 'cancelled', 'parked',
+  ] as const);
+
+  private static readonly PATTERN = /^[a-z][a-z0-9_]*$/;
+
+  private constructor(public readonly value: string) {
+    Object.freeze(this);
+  }
+
+  static of(raw: unknown): LaneKey {
+    const key = LaneKey.normalize(raw);
+    if (key === null) {
+      throw new DomainError(`Invalid LaneKey: ${JSON.stringify(raw)}`);
+    }
+    return new LaneKey(key);
+  }
+
+  static tryOf(raw: unknown): LaneKey | null {
+    const key = LaneKey.normalize(raw);
+    return key === null ? null : new LaneKey(key);
+  }
+
+  static isValid(raw: unknown): boolean {
+    return LaneKey.normalize(raw) !== null;
+  }
+
+  private static normalize(raw: unknown): string | null {
+    if (typeof raw !== 'string') return null;
+    const trimmed = raw.trim();
+    if (trimmed.length > 64 || !LaneKey.PATTERN.test(trimmed)) return null;
+    return trimmed;
+  }
+
+  isSystem(): boolean {
+    return (LaneKey.SYSTEM as readonly string[]).includes(this.value);
+  }
+
+  equals(other: LaneKey | null | undefined): boolean {
+    return other instanceof LaneKey && other.value === this.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/values/ProjectId.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/values/ProjectId.ts
@@ -1,0 +1,22 @@
+import { DomainError } from '../errors';
+
+export class ProjectId {
+  private constructor(public readonly value: string) {
+    Object.freeze(this);
+  }
+
+  static of(raw: unknown): ProjectId {
+    if (typeof raw !== 'string' || raw.trim().length === 0 || raw.trim().length > 128) {
+      throw new DomainError(`Invalid ProjectId: ${ JSON.stringify(raw) }`);
+    }
+    return new ProjectId(raw.trim());
+  }
+
+  equals(other: ProjectId | null | undefined): boolean {
+    return other instanceof ProjectId && other.value === this.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/values/SemanticRole.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/values/SemanticRole.ts
@@ -1,0 +1,85 @@
+import { DomainError } from '../errors';
+
+/** The semantic role vocabulary — faithful port of WorkLaneSemanticRole. */
+export type SemanticRoleValue =
+  | 'backlog' | 'planning' | 'execution' | 'review' | 'blocked' | 'terminal' | 'manual';
+
+/**
+ * Semantic role of a lane — the stage-independent meaning that drives routine/workflow
+ * selection. Ports WorkLaneDefinitionModel's WorkLaneSemanticRole together with its
+ * REQUIRED_WORK_LANE_ROLES and COMPATIBILITY_ROLE_BY_KEY constants.
+ */
+export class SemanticRole {
+  static readonly BACKLOG = new SemanticRole('backlog');
+  static readonly PLANNING = new SemanticRole('planning');
+  static readonly EXECUTION = new SemanticRole('execution');
+  static readonly REVIEW = new SemanticRole('review');
+  static readonly BLOCKED = new SemanticRole('blocked');
+  static readonly TERMINAL = new SemanticRole('terminal');
+  static readonly MANUAL = new SemanticRole('manual');
+
+  /** All roles, canonical order. */
+  static readonly ALL: readonly SemanticRole[] = Object.freeze([
+    SemanticRole.BACKLOG, SemanticRole.PLANNING, SemanticRole.EXECUTION,
+    SemanticRole.REVIEW, SemanticRole.BLOCKED, SemanticRole.TERMINAL, SemanticRole.MANUAL,
+  ]);
+
+  /** Roles a runtime lane catalog must provide (mirrors REQUIRED_WORK_LANE_ROLES; manual excluded). */
+  static readonly REQUIRED: readonly SemanticRoleValue[] = Object.freeze([
+    'backlog', 'planning', 'execution', 'review', 'blocked', 'terminal',
+  ]);
+
+  /** Compatibility mapping from a known lane key to its semantic role (COMPATIBILITY_ROLE_BY_KEY). */
+  private static readonly ROLE_BY_KEY: Readonly<Record<string, SemanticRoleValue>> = Object.freeze({
+    backlog: 'backlog',
+    planning: 'planning',
+    todo: 'execution',
+    in_progress: 'execution',
+    in_review: 'review',
+    blocked: 'blocked',
+    done: 'terminal',
+    cancelled: 'terminal',
+    parked: 'manual',
+  });
+
+  private constructor(public readonly value: SemanticRoleValue) {
+    Object.freeze(this);
+  }
+
+  static of(raw: unknown): SemanticRole {
+    const role = SemanticRole.tryOf(raw);
+    if (role === null) {
+      throw new DomainError(`Invalid SemanticRole: ${JSON.stringify(raw)}`);
+    }
+    return role;
+  }
+
+  static tryOf(raw: unknown): SemanticRole | null {
+    if (raw instanceof SemanticRole) return raw;
+    if (typeof raw !== 'string') return null;
+    return SemanticRole.ALL.find(r => r.value === raw) ?? null;
+  }
+
+  /** Resolve the compatibility role for a known lane key, or null if unmapped. */
+  static forLaneKey(laneKey: unknown): SemanticRole | null {
+    if (typeof laneKey !== 'string') return null;
+    const mapped = SemanticRole.ROLE_BY_KEY[laneKey];
+    return mapped ? SemanticRole.of(mapped) : null;
+  }
+
+  isRequired(): boolean {
+    return SemanticRole.REQUIRED.includes(this.value);
+  }
+
+  isTerminal(): boolean {
+    return this.value === 'terminal';
+  }
+
+  equals(other: SemanticRole | null | undefined): boolean {
+    return other instanceof SemanticRole && other.value === this.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/values/SemanticRole.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/values/SemanticRole.ts
@@ -26,7 +26,7 @@ export class SemanticRole {
 
   /** Roles a runtime lane catalog must provide (mirrors REQUIRED_WORK_LANE_ROLES; manual excluded). */
   static readonly REQUIRED: readonly SemanticRoleValue[] = Object.freeze([
-    'backlog', 'planning', 'execution', 'review', 'blocked', 'terminal',
+    'backlog', 'execution', 'planning', 'review', 'blocked', 'terminal',
   ]);
 
   /** Compatibility mapping from a known lane key to its semantic role (COMPATIBILITY_ROLE_BY_KEY). */

--- a/pkg/rancher-desktop/agent/domain/projects/values/TaskId.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/values/TaskId.ts
@@ -1,0 +1,43 @@
+import { DomainError } from '../errors';
+
+/**
+ * Identity of a Projects work item. Task/epic/project ids share the same short slug shape
+ * (e.g. "YceX"). Pure value object — no persistence concerns.
+ */
+export class TaskId {
+  private constructor(public readonly value: string) {
+    Object.freeze(this);
+  }
+
+  static of(raw: unknown): TaskId {
+    const id = TaskId.normalize(raw);
+    if (id === null) {
+      throw new DomainError(`Invalid TaskId: ${JSON.stringify(raw)}`);
+    }
+    return new TaskId(id);
+  }
+
+  static tryOf(raw: unknown): TaskId | null {
+    const id = TaskId.normalize(raw);
+    return id === null ? null : new TaskId(id);
+  }
+
+  static isValid(raw: unknown): boolean {
+    return TaskId.normalize(raw) !== null;
+  }
+
+  private static normalize(raw: unknown): string | null {
+    if (typeof raw !== 'string') return null;
+    const trimmed = raw.trim();
+    if (trimmed.length === 0 || trimmed.length > 128) return null;
+    return trimmed;
+  }
+
+  equals(other: TaskId | null | undefined): boolean {
+    return other instanceof TaskId && other.value === this.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/values/TaskStatus.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/values/TaskStatus.ts
@@ -1,0 +1,82 @@
+import { DomainError } from '../errors';
+import { SemanticRole } from './SemanticRole';
+
+export type TaskStatusValue =
+  | 'backlog' | 'todo' | 'planning' | 'in_progress' | 'in_review' | 'blocked' | 'done' | 'cancelled' | 'parked';
+
+/**
+ * Lifecycle status of a Projects task. The eight system statuses correspond 1:1 to the
+ * system lane keys in WorkLaneDefinitionModel's default lane set and carry the same
+ * semantic-role mapping.
+ */
+export class TaskStatus {
+  static readonly BACKLOG = new TaskStatus('backlog');
+  static readonly TODO = new TaskStatus('todo');
+  static readonly PLANNING = new TaskStatus('planning');
+  static readonly IN_PROGRESS = new TaskStatus('in_progress');
+  static readonly IN_REVIEW = new TaskStatus('in_review');
+  static readonly BLOCKED = new TaskStatus('blocked');
+  static readonly DONE = new TaskStatus('done');
+  static readonly CANCELLED = new TaskStatus('cancelled');
+  static readonly PARKED = new TaskStatus('parked');
+
+  static readonly ALL: readonly TaskStatus[] = Object.freeze([
+    TaskStatus.BACKLOG, TaskStatus.TODO, TaskStatus.PLANNING, TaskStatus.IN_PROGRESS,
+    TaskStatus.IN_REVIEW, TaskStatus.BLOCKED, TaskStatus.DONE, TaskStatus.CANCELLED, TaskStatus.PARKED,
+  ]);
+
+  /** Terminal (absorbing) statuses — no outbound lifecycle transitions. */
+  static readonly CLOSED: readonly TaskStatusValue[] = Object.freeze(['done', 'cancelled', 'parked']);
+
+  /** Default status to semantic role, mirroring the system lane default map. */
+  private static readonly ROLE_BY_STATUS: Readonly<Record<TaskStatusValue, SemanticRole>> = Object.freeze({
+    backlog: SemanticRole.BACKLOG,
+    todo: SemanticRole.EXECUTION,
+    planning: SemanticRole.PLANNING,
+    in_progress: SemanticRole.EXECUTION,
+    in_review: SemanticRole.REVIEW,
+    blocked: SemanticRole.BLOCKED,
+    done: SemanticRole.TERMINAL,
+    cancelled: SemanticRole.TERMINAL,
+    parked: SemanticRole.MANUAL,
+  });
+
+  private constructor(public readonly value: TaskStatusValue) {
+    Object.freeze(this);
+  }
+
+  static of(raw: unknown): TaskStatus {
+    const status = TaskStatus.tryOf(raw);
+    if (status === null) {
+      throw new DomainError(`Invalid TaskStatus: ${JSON.stringify(raw)}`);
+    }
+    return status;
+  }
+
+  static tryOf(raw: unknown): TaskStatus | null {
+    if (raw instanceof TaskStatus) return raw;
+    if (typeof raw !== 'string') return null;
+    return TaskStatus.ALL.find(s => s.value === raw) ?? null;
+  }
+
+  /** The default semantic role for this status (system lane mapping). */
+  semanticRole(): SemanticRole {
+    return TaskStatus.ROLE_BY_STATUS[this.value];
+  }
+
+  isTerminal(): boolean {
+    return this.semanticRole().isTerminal();
+  }
+
+  isClosed(): boolean {
+    return TaskStatus.CLOSED.includes(this.value);
+  }
+
+  equals(other: TaskStatus | null | undefined): boolean {
+    return other instanceof TaskStatus && other.value === this.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/pkg/rancher-desktop/agent/domain/projects/values/index.ts
+++ b/pkg/rancher-desktop/agent/domain/projects/values/index.ts
@@ -1,0 +1,9 @@
+export { TaskId } from './TaskId';
+export { ProjectId } from './ProjectId';
+export { EpicId } from './EpicId';
+export { LaneKey } from './LaneKey';
+export { SemanticRole } from './SemanticRole';
+export type { SemanticRoleValue } from './SemanticRole';
+export { TaskStatus } from './TaskStatus';
+export type { TaskStatusValue } from './TaskStatus';
+export { ArtifactGeneration } from './ArtifactGeneration';


### PR DESCRIPTION
## Scope

Implements Projects task YceX / dHAe Phase 1 as an independently reversible pure domain slice.

- value objects: TaskId, ProjectId, EpicId, LaneKey, SemanticRole, TaskStatus, ArtifactGeneration
- immutable Project, Epic, Task, and Board aggregates
- generation-scoped lifecycle transitions and domain events
- task-scoped dependency, WIP, lease, durable-wait, and custody policy chain
- structural legacy compatibility mapper with no SQL-model imports
- canonical source-derived characterization including parked -> manual/closed
- intra-kernel relative-import allowlist boundary
- no production routing, schema, SQL, Electron, tool, IPC, service, runtime, or lockfile changes

## Verification

- focused Jest: 9 suites, 56 tests passed
- strict isolated TypeScript compile passed
- git diff --check passed
- independent exact-head verifier: PASS
- no hosted check runs available

Exact head: be8683c565b648c052629b8c62d30c0d81abcb67
Base: 7a12415d6