### PR TITLE
fix(projects): suppress blocked->planning claims while a durable wait is active (cv68)

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { WorkTaskDependencyModel } from './WorkTaskDependencyModel';
+import { WorkTaskWaitModel } from './WorkTaskWaitModel';
 
 import { postgresClient } from '../PostgresClient';
 import { LifecycleCapabilityModel } from './LifecycleCapabilityModel';
@@ -75,6 +76,13 @@ export class WorkTaskPlanningRunModel {
       const task = taskResult.rows[0];
       if (!task || !planningKeys.includes(task.status)) return null;
       if ((await WorkTaskDependencyModel.listUnresolvedDependencies(taskId, client)).length > 0) return null;
+      // A blocked task with an active monitor-owned durable wait is not eligible
+      // for planning re-entry: its wait monitor moves the task out of 'blocked'
+      // (to in_review, or to planning on failure) once the external state
+      // changes, is satisfied, or is cancelled. Claiming planning while the wait
+      // is still 'active' spuriously burns a council attempt on an unchanged gate
+      // (regression: KEfo planning attempt 5 fired against an active external_job wait).
+      if (triggerStatus === 'blocked' && await WorkTaskWaitModel.hasActiveWait(taskId, client)) return null;
 
       const active = await client.query<{ id: string }>(`
         SELECT id FROM work_task_planning_runs

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskWaitModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskWaitModel.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 
 import { postgresClient } from '../PostgresClient';
+import type { PoolClient } from 'pg';
 
 export type WorkTaskWaitKind = 'github_checks' | 'human_gate' | 'scheduled_time' | 'external_job';
 export type WorkTaskWaitStatus = 'active' | 'changed' | 'satisfied' | 'cancelled' | 'failed';
@@ -56,6 +57,18 @@ export interface GithubCheckFingerprintInput {
 }
 
 export class WorkTaskWaitModel {
+  /**
+   * True when the task still has a monitor-owned durable wait in the 'active'
+   * state. A wait that has moved to 'changed', 'satisfied', 'cancelled', or
+   * 'failed' no longer suppresses downstream transitions. Callers inside a
+   * claim transaction pass their PoolClient so the check reads the live row
+   * atomically with the FOR UPDATE task lock.
+   */
+  static async hasActiveWait(taskId: string, client?: PoolClient): Promise<boolean> {
+    const sql = `SELECT id FROM work_task_waits WHERE task_id = $1 AND status = 'active' LIMIT 1`;
+    const rows = client ? (await client.query(sql, [taskId])).rows : await postgresClient.query<{ id: string }>(sql, [taskId]);
+    return rows.length > 0;
+  }
   static fingerprintGithubChecks(input: GithubCheckFingerprintInput): string {
     const normalized = {
       headSha: input.headSha.trim().toLowerCase(),

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskPlanningRunModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskPlanningRunModel.test.ts
@@ -4,12 +4,17 @@ import { postgresClient } from '../../PostgresClient';
 import { LifecycleCapabilityModel } from '../LifecycleCapabilityModel';
 import { WorkLaneDefinitionModel } from '../WorkLaneDefinitionModel';
 import { WorkTaskPlanningRunModel } from '../WorkTaskPlanningRunModel';
+import { WorkTaskWaitModel } from '../WorkTaskWaitModel';
 
 describe('WorkTaskPlanningRunModel', () => {
   let originalTransaction: any;
 
   beforeAll(() => {
     originalTransaction = postgresClient.transaction;
+  });
+
+  beforeEach(() => {
+    jest.spyOn(WorkTaskWaitModel, 'hasActiveWait').mockResolvedValue(false);
   });
 
   afterEach(() => {

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskPlanningRunModel.waitSuppression.postgres.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskPlanningRunModel.waitSuppression.postgres.test.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { Pool } from 'pg';
+
+import { migrationsRegistry } from '../../migrations';
+import { postgresClient } from '../../PostgresClient';
+import { WorkLaneDefinitionModel } from '../WorkLaneDefinitionModel';
+import { WorkTaskPlanningRunModel } from '../WorkTaskPlanningRunModel';
+import { WorkTaskWaitModel } from '../WorkTaskWaitModel';
+
+// Real migrated-Postgres coverage for the blocked -> planning claim boundary.
+// Set SULLA_INTEGRATION_POSTGRES_URL to a reachable Postgres to exercise it;
+// the suite provisions an isolated throwaway schema and drops it afterwards, so
+// it never touches application data.
+const connectionString = process.env.SULLA_INTEGRATION_POSTGRES_URL;
+const describeWithPostgres = connectionString ? describe : describe.skip;
+
+// Only the work-item / wait / planning-run / dependency migrations are needed
+// here; run them in registry order so numbering stays authoritative.
+const NEEDED = new Set([
+  '0044_create_work_items_tables',
+  '0047_add_work_task_actor',
+  '0061_add_work_task_activity',
+  '0065_create_work_task_waits',
+  '0072_create_work_task_planning_runs',
+  '0083_create_work_task_dependencies',
+]);
+
+describeWithPostgres('WorkTaskPlanningRunModel blocked->planning wait suppression (postgres)', () => {
+  let bootstrapPool: Pool;
+  let pool: Pool;
+  let schemaCreated = false;
+  let original: Record<string, unknown> | null = null;
+  const schema = `plan_wait_${ randomUUID().replaceAll('-', '') }`;
+
+  beforeAll(async() => {
+    bootstrapPool = new Pool({ connectionString, max: 1 });
+    await bootstrapPool.query(`CREATE SCHEMA "${ schema }"`);
+    schemaCreated = true;
+    pool = new Pool({ connectionString, max: 8, options: `-c search_path=${ schema }` });
+    for (const migration of migrationsRegistry) {
+      if (NEEDED.has(migration.name)) await pool.query(migration.up);
+    }
+
+    original = {
+      query:       (postgresClient as any).query,
+      queryOne:    (postgresClient as any).queryOne,
+      queryAll:    (postgresClient as any).queryAll,
+      transaction: (postgresClient as any).transaction,
+    };
+    (postgresClient as any).query = async(text: string, params: unknown[] = []) =>
+      (await pool.query(text, params)).rows;
+    (postgresClient as any).queryOne = async(text: string, params: unknown[] = []) =>
+      (await pool.query(text, params)).rows[0] ?? null;
+    (postgresClient as any).queryAll = async(text: string, params: unknown[] = []) =>
+      (await pool.query(text, params)).rows;
+    (postgresClient as any).transaction = async(callback: (client: any) => Promise<unknown>) => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        const result = await callback(client);
+        await client.query('COMMIT');
+        return result;
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+      }
+    };
+
+    // Force the catalog-not-ready compatibility path so the claim boundary does
+    // not depend on lane-catalog seeding; the durable-wait gate is the subject.
+    jest.spyOn(WorkLaneDefinitionModel, 'runtimeCapability').mockResolvedValue({
+      ready: false, catalogPresent: false, missingRoles: ['planning'], degradedReason: 'compatibility',
+    } as any);
+    jest.spyOn(WorkLaneDefinitionModel, 'preferredLaneKey').mockResolvedValue('planning');
+  });
+
+  afterAll(async() => {
+    if (original) Object.assign(postgresClient as any, original);
+    jest.restoreAllMocks();
+    if (pool) await pool.end();
+    if (bootstrapPool) {
+      if (schemaCreated) await bootstrapPool.query(`DROP SCHEMA IF EXISTS "${ schema }" CASCADE`);
+      await bootstrapPool.end();
+    }
+  });
+
+  afterEach(async() => {
+    await pool.query('DELETE FROM work_task_planning_runs');
+    await pool.query('DELETE FROM work_task_waits');
+    await pool.query('DELETE FROM work_tasks');
+    await pool.query('DELETE FROM work_epics');
+    await pool.query('DELETE FROM work_projects');
+  });
+
+  async function seedBlockedTask(): Promise<string> {
+    const projectId = `project-${ randomUUID() }`;
+    const epicId = `epic-${ randomUUID() }`;
+    const taskId = `task-${ randomUUID() }`;
+    await pool.query(
+      `INSERT INTO work_projects (id, slug, title) VALUES ($1, $2, 'Wait suppression')`,
+      [projectId, `wait-${ randomUUID().slice(0, 8) }`],
+    );
+    await pool.query(
+      `INSERT INTO work_epics (id, project_id, title) VALUES ($1, $2, 'Durable waits')`,
+      [epicId, projectId],
+    );
+    await pool.query(
+      `INSERT INTO work_tasks (id, project_id, epic_id, title, status, assignee)
+       VALUES ($1, $2, $3, 'Gated task', 'blocked', 'heartbeat')`,
+      [taskId, projectId, epicId],
+    );
+    return taskId;
+  }
+
+  function registerActiveWait(taskId: string) {
+    return WorkTaskWaitModel.register({
+      taskId, waitKind: 'external_job', targetKey: 'gate:test-merge',
+      target: { pr: 1 }, fingerprint: 'fp-1',
+    } as any);
+  }
+
+  async function countRuns(taskId: string): Promise<number> {
+    const result = await pool.query('SELECT id FROM work_task_planning_runs WHERE task_id = $1', [taskId]);
+    return result.rows.length;
+  }
+
+  it('does not claim planning for a blocked task while a durable wait is active', async() => {
+    const taskId = await seedBlockedTask();
+    await registerActiveWait(taskId);
+
+    const claim = await WorkTaskPlanningRunModel.claim(taskId, 'blocked', 'heartbeat');
+
+    expect(claim).toBeNull();
+    expect(await countRuns(taskId)).toBe(0);
+  });
+
+  it('does not re-enter planning on an unchanged repeat while the wait stays active', async() => {
+    const taskId = await seedBlockedTask();
+    await registerActiveWait(taskId);
+
+    await WorkTaskPlanningRunModel.claim(taskId, 'blocked', 'heartbeat');
+    const second = await WorkTaskPlanningRunModel.claim(taskId, 'blocked', 'heartbeat');
+
+    expect(second).toBeNull();
+    expect(await countRuns(taskId)).toBe(0);
+  });
+
+  it('permits the planning claim once the wait is cancelled', async() => {
+    const taskId = await seedBlockedTask();
+    const { wait } = await registerActiveWait(taskId);
+
+    expect(await WorkTaskPlanningRunModel.claim(taskId, 'blocked', 'heartbeat')).toBeNull();
+
+    await WorkTaskWaitModel.cancel(wait.id, 'test: gate resolved');
+
+    const claim = await WorkTaskPlanningRunModel.claim(taskId, 'blocked', 'heartbeat');
+    expect(claim).not.toBeNull();
+    expect(claim?.run.status).toBe('active');
+    expect(await countRuns(taskId)).toBe(1);
+  });
+
+  it('routes a satisfied wait to the next transition (in_review) rather than planning', async() => {
+    const taskId = await seedBlockedTask();
+    const { wait } = await registerActiveWait(taskId);
+
+    await WorkTaskWaitModel.observe(wait.id, {
+      fingerprint: 'fp-2', outcome: 'satisfied', summary: 'external job merged',
+      nextCheckAt: new Date(Date.now() + 60_000),
+    } as any);
+
+    const taskRow = await pool.query('SELECT status FROM work_tasks WHERE id = $1', [taskId]);
+    expect(taskRow.rows[0].status).toBe('in_review');
+
+    expect(await WorkTaskPlanningRunModel.claim(taskId, 'blocked', 'heartbeat')).toBeNull();
+    expect(await countRuns(taskId)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes a P0 regression (task **cv68**): a `blocked` task with an **active monitor-owned durable wait** could still be claimed by the planning council on each blocked-status event. Observed live on **KEfo** — planning **attempt 5** fired against an active `external_job` wait (`gate:KEfo-730-merge`).

## Root cause
`WorkTaskPlanningRunModel.claim()` gated **unresolved task dependencies** (`WorkTaskDependencyModel.listUnresolvedDependencies`) but had **no gate for active durable waits**, and `PlanningCouncilService` had no wait-awareness. So repeated blocked-status transitions each burned a new planning attempt while the wait sat `active`.

## Fix
- Add a typed `WorkTaskWaitModel.hasActiveWait(taskId, client?)` (SQL stays in the model — no raw SQL in service/business logic; mirrors the dependency-gate idiom, accepts the claim transaction's `PoolClient`).
- In `claim()`, right beside the dependency gate and inside the `FOR UPDATE` transaction, refuse a `blocked`-triggered claim while any wait for the task is still `active`.
- A wait that has moved to `changed` / `satisfied` / `cancelled` / `failed` no longer suppresses — the wait monitor (`observe`) routes the task to its correct next transition (`in_review`, or `planning` on failure). `planning`-triggered claims are never suppressed.

## Tests
- `WorkTaskPlanningRunModel.waitSuppression.postgres.test.ts` — migrated-Postgres coverage (isolated throwaway schema) proving: (a) active wait blocks the claim, (b) unchanged repeat does not re-enter, (c) a cancelled wait permits the claim, (d) a satisfied wait routes to `in_review`, not planning.
- `WorkTaskPlanningRunModel.test.ts` — stub `hasActiveWait` in the existing claim specs so the query-sequence assertions are preserved.

## Verification status (please note)
Code and tests are authored and diff-reviewed, but the focused Jest run and typecheck **could not be executed in this worker environment**: the shared `node_modules` (symlinked from the primary clone) is missing `typescript` and `ts-jest` and appears mid-reinstall while other agents are active, so I deliberately did **not** `npm install` into it. **Please run** `jest WorkTaskPlanningRunModel` (with `SULLA_INTEGRATION_POSTGRES_URL` set for the postgres suite) and the project typecheck before merge.

Task: cv68
