### PR TITLE
refactor(projects): add repositories and UnitOfWork (dHAe Phase 2)

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -94,13 +94,13 @@ export interface WorkTaskRecord {
 }
 
 export interface WorkTaskDependencyRecord {
-  task_id:            string;
-  depends_on_task_id: string;
-  relation_type:      string;
+  task_id:              string;
+  depends_on_task_id:   string;
+  relation_type:        string;
   acceptance_condition: string | null;
-  created_at:         string;
-  created_by:         string | null;
-  archived:           boolean;
+  created_at:           string;
+  created_by:           string | null;
+  archived:             boolean;
 }
 
 export interface WorkCommentRecord {
@@ -446,177 +446,10 @@ export class WorkItemsModel {
   // ──────────────────────────────────────────────
 
   static async ensureTables(): Promise<void> {
-    try {
-      await postgresClient.query(`
-        CREATE TABLE IF NOT EXISTS ${ WorkItemsModel.PROJECTS } (
-          id              TEXT        PRIMARY KEY,
-          slug            TEXT        NOT NULL UNIQUE,
-          title           TEXT        NOT NULL,
-          description     TEXT        NOT NULL DEFAULT '',
-          outcome_metric  TEXT,
-          status          TEXT        NOT NULL DEFAULT 'working',
-          priority        TEXT        NOT NULL DEFAULT 'p2',
-          owner           TEXT,
-          source          TEXT,
-          source_path     TEXT,
-          github_repo     TEXT,
-          due_at          TIMESTAMPTZ,
-          created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-          updated_at      TIMESTAMPTZ,
-          last_moved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
-          archived        BOOLEAN     NOT NULL DEFAULT false
-        )
-      `);
-      await postgresClient.query(`
-        CREATE INDEX IF NOT EXISTS idx_work_projects_board
-          ON ${ WorkItemsModel.PROJECTS } (archived, status, priority, last_moved_at ASC)
-      `);
-
-      await postgresClient.query(`
-        CREATE TABLE IF NOT EXISTS ${ WorkItemsModel.EPICS } (
-          id              TEXT        PRIMARY KEY,
-          project_id      TEXT        NOT NULL REFERENCES ${ WorkItemsModel.PROJECTS }(id),
-          slug            TEXT,
-          title           TEXT        NOT NULL,
-          description     TEXT        NOT NULL DEFAULT '',
-          status          TEXT        NOT NULL DEFAULT 'working',
-          priority        TEXT        NOT NULL DEFAULT 'p2',
-          position        INTEGER     NOT NULL DEFAULT 0,
-          due_at          TIMESTAMPTZ,
-          source          TEXT,
-          source_ref      TEXT,
-          created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-          updated_at      TIMESTAMPTZ,
-          last_moved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
-          archived        BOOLEAN     NOT NULL DEFAULT false
-        )
-      `);
-      await postgresClient.query(`
-        CREATE INDEX IF NOT EXISTS idx_work_epics_project
-          ON ${ WorkItemsModel.EPICS } (project_id, archived, position, status)
-      `);
-      await postgresClient.query(`
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_work_epics_project_slug
-          ON ${ WorkItemsModel.EPICS } (project_id, slug)
-          WHERE slug IS NOT NULL
-      `);
-
-      await postgresClient.query(`
-        CREATE TABLE IF NOT EXISTS ${ WorkItemsModel.TASKS } (
-          id              TEXT        PRIMARY KEY,
-          project_id      TEXT        NOT NULL REFERENCES ${ WorkItemsModel.PROJECTS }(id),
-          epic_id         TEXT        REFERENCES ${ WorkItemsModel.EPICS }(id),
-          parent_id       TEXT        REFERENCES ${ WorkItemsModel.TASKS }(id),
-          slug            TEXT,
-          title           TEXT        NOT NULL,
-          description     TEXT        NOT NULL DEFAULT '',
-          status          TEXT        NOT NULL DEFAULT 'todo',
-          priority        TEXT        NOT NULL DEFAULT 'p2',
-          due_at          TIMESTAMPTZ,
-          github_issue    TEXT,
-          assignee        TEXT,
-          labels          TEXT[],
-          position        INTEGER     NOT NULL DEFAULT 0,
-          source          TEXT,
-          source_ref      TEXT,
-          created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-          updated_at      TIMESTAMPTZ,
-          last_moved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
-          last_activity_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-          created_by      TEXT,
-          last_moved_by   TEXT,
-          completed_at    TIMESTAMPTZ,
-          archived        BOOLEAN     NOT NULL DEFAULT false
-        )
-      `);
-      await postgresClient.query(`
-        ALTER TABLE ${ WorkItemsModel.TASKS }
-          ADD COLUMN IF NOT EXISTS last_activity_at TIMESTAMPTZ
-      `);
-      await postgresClient.query(`
-        CREATE INDEX IF NOT EXISTS idx_work_tasks_epic
-          ON ${ WorkItemsModel.TASKS } (epic_id, archived, status, position)
-      `);
-      await postgresClient.query(`
-        CREATE INDEX IF NOT EXISTS idx_work_tasks_project
-          ON ${ WorkItemsModel.TASKS } (project_id, archived, status, priority, due_at)
-      `);
-      await postgresClient.query(`
-        CREATE INDEX IF NOT EXISTS idx_work_tasks_parent
-          ON ${ WorkItemsModel.TASKS } (parent_id) WHERE parent_id IS NOT NULL
-      `);
-      await postgresClient.query(`
-        CREATE INDEX IF NOT EXISTS idx_work_tasks_due
-          ON ${ WorkItemsModel.TASKS } (archived, due_at)
-          WHERE due_at IS NOT NULL AND archived = false
-      `);
-      await postgresClient.query(`
-        CREATE UNIQUE INDEX IF NOT EXISTS idx_work_tasks_epic_slug
-          ON ${ WorkItemsModel.TASKS } (epic_id, slug)
-          WHERE slug IS NOT NULL
-      `);
-
-      await postgresClient.query(`
-        CREATE TABLE IF NOT EXISTS ${ WorkItemsModel.COMMENTS } (
-          id              TEXT        PRIMARY KEY,
-          task_id         TEXT        NOT NULL REFERENCES ${ WorkItemsModel.TASKS }(id),
-          body            TEXT        NOT NULL,
-          author          TEXT,
-          created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-          updated_at      TIMESTAMPTZ,
-          archived        BOOLEAN     NOT NULL DEFAULT false
-        )
-      `);
-      await postgresClient.query(`
-        CREATE INDEX IF NOT EXISTS idx_work_task_comments_task
-          ON ${ WorkItemsModel.COMMENTS } (task_id, archived, created_at ASC)
-      `);
-      await postgresClient.query(`
-        UPDATE ${ WorkItemsModel.TASKS } t
-           SET last_activity_at = GREATEST(
-             t.last_moved_at,
-             COALESCE(t.updated_at, t.last_moved_at),
-             COALESCE((
-               SELECT MAX(c.created_at)
-                 FROM ${ WorkItemsModel.COMMENTS } c
-                WHERE c.task_id = t.id AND c.archived = false
-             ), t.last_moved_at)
-           )
-         WHERE t.last_activity_at IS NULL
-      `);
-      await postgresClient.query(`
-        ALTER TABLE ${ WorkItemsModel.TASKS }
-          ALTER COLUMN last_activity_at SET DEFAULT now(),
-          ALTER COLUMN last_activity_at SET NOT NULL
-      `);
-      await postgresClient.query(`
-        CREATE INDEX IF NOT EXISTS idx_work_tasks_activity
-          ON ${ WorkItemsModel.TASKS } (archived, status, priority, last_activity_at ASC)
-      `);
-
-      try {
-        await postgresClient.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
-        await postgresClient.query(`
-          CREATE INDEX IF NOT EXISTS idx_work_projects_title_trgm
-            ON ${ WorkItemsModel.PROJECTS } USING gin (title gin_trgm_ops)
-        `);
-        await postgresClient.query(`
-          CREATE INDEX IF NOT EXISTS idx_work_epics_title_trgm
-            ON ${ WorkItemsModel.EPICS } USING gin (title gin_trgm_ops)
-        `);
-        await postgresClient.query(`
-          CREATE INDEX IF NOT EXISTS idx_work_tasks_title_trgm
-            ON ${ WorkItemsModel.TASKS } USING gin (title gin_trgm_ops)
-        `);
-      } catch (trgmErr) {
-        console.warn('[WorkItemsModel] pg_trgm index unavailable (non-fatal):', trgmErr);
-      }
-    } catch (err) {
-      console.error('[WorkItemsModel] Failed to ensure tables:', err);
-    }
+    const { PostgresProjectsSchemaVerifier } = await import('../../projects/infrastructure/PostgresProjectsSchemaVerifier');
+    return PostgresProjectsSchemaVerifier.verify();
   }
 
-  /** Alias — ObservationsModel/RulesModel style. */
   static async ensureTable(): Promise<void> {
     return WorkItemsModel.ensureTables();
   }
@@ -962,17 +795,17 @@ export class WorkItemsModel {
     const dependency = await WorkTaskDependencyModel.create({
       dependentTaskId: taskId,
       dependsOnTaskId,
-      relationType: 'requires',
+      relationType:    'requires',
       actor,
     });
     return {
-      task_id: dependency.dependent_task_id,
-      depends_on_task_id: dependency.depends_on_task_id,
-      relation_type: dependency.relation_type,
+      task_id:              dependency.dependent_task_id,
+      depends_on_task_id:   dependency.depends_on_task_id,
+      relation_type:        dependency.relation_type,
       acceptance_condition: dependency.acceptance_condition,
-      created_at: dependency.created_at,
-      created_by: dependency.created_by,
-      archived: dependency.archived_at !== null,
+      created_at:           dependency.created_at,
+      created_by:           dependency.created_by,
+      archived:             dependency.archived_at !== null,
     };
   }
 
@@ -980,7 +813,7 @@ export class WorkItemsModel {
     return WorkTaskDependencyModel.remove({
       dependentTaskId: taskId,
       dependsOnTaskId,
-      relationType: 'requires',
+      relationType:    'requires',
     });
   }
 
@@ -1088,12 +921,12 @@ export class WorkItemsModel {
     const targetLane = changes.status !== undefined
       ? await WorkLaneDefinitionModel.validateTaskStatus(nextProjectId ?? existing.project_id, changes.status)
       : null;
-    const enteringReview = changes.status !== undefined
-      && changes.status !== existing.status
-      && (targetLane?.semantic_role === 'review' || (!targetLane && changes.status === 'in_review'));
-    const enteringDone = changes.status !== undefined
-      && changes.status !== existing.status
-      && changes.status === 'done';
+    const enteringReview = changes.status !== undefined &&
+      changes.status !== existing.status &&
+      (targetLane?.semantic_role === 'review' || (!targetLane && changes.status === 'in_review'));
+    const enteringDone = changes.status !== undefined &&
+      changes.status !== existing.status &&
+      changes.status === 'done';
     if (enteringReview) {
       await ArtifactCustodyPolicy.assertForTransition('in_review', changes.custody);
     }

--- a/pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts
@@ -110,43 +110,8 @@ function titleFromKey(key: string): string {
 
 export class WorkLaneDefinitionModel {
   static async ensureTable(): Promise<void> {
-    await postgresClient.query(`
-      CREATE TABLE IF NOT EXISTS work_lane_definitions (
-        id TEXT PRIMARY KEY,
-        lane_key TEXT NOT NULL CHECK (length(lane_key) >= 1),
-        scope TEXT NOT NULL CHECK (scope IN ('global_default', 'project')),
-        project_id TEXT REFERENCES work_projects(id),
-        base_lane_key TEXT,
-        display_name TEXT NOT NULL,
-        description TEXT NOT NULL DEFAULT '',
-        color TEXT,
-        icon TEXT,
-        position INTEGER NOT NULL DEFAULT 0,
-        semantic_role TEXT NOT NULL CHECK (semantic_role IN ('backlog', 'planning', 'execution', 'review', 'blocked', 'terminal', 'manual')),
-        enabled BOOLEAN NOT NULL DEFAULT true,
-        archived BOOLEAN NOT NULL DEFAULT false,
-        system_required BOOLEAN NOT NULL DEFAULT false,
-        created_by TEXT,
-        updated_by TEXT,
-        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-        updated_at TIMESTAMPTZ,
-        archived_at TIMESTAMPTZ,
-        reset_at TIMESTAMPTZ,
-        CONSTRAINT work_lane_scope_project_check CHECK (
-          (scope = 'global_default' AND project_id IS NULL AND base_lane_key IS NULL)
-          OR (scope = 'project' AND project_id IS NOT NULL)
-        )
-      )
-    `);
-    await postgresClient.query(`
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_work_lane_definitions_active_key
-        ON work_lane_definitions (scope, COALESCE(project_id, ''), lane_key)
-        WHERE reset_at IS NULL
-    `);
-    await postgresClient.query(`
-      CREATE INDEX IF NOT EXISTS idx_work_lane_definitions_resolve
-        ON work_lane_definitions (scope, project_id, reset_at, archived, enabled, position)
-    `);
+    const { PostgresProjectsSchemaVerifier } = await import('../../projects/infrastructure/PostgresProjectsSchemaVerifier');
+    return PostgresProjectsSchemaVerifier.verify(['work_lane_definitions']);
   }
 
   static async get(id: string): Promise<WorkLaneDefinitionRecord | null> {
@@ -537,7 +502,7 @@ export const DEFAULT_STATUS_SEMANTIC_ROLE: Record<string, WorkLaneSemanticRole> 
 
 export function resolveRoleForStatus(
   status: string,
-  effectiveLanes: ReadonlyArray<{ lane_key: string; semantic_role?: WorkLaneSemanticRole | null }> = [],
+  effectiveLanes: readonly { lane_key: string; semantic_role?: WorkLaneSemanticRole | null }[] = [],
 ): WorkLaneSemanticRole {
   const match = effectiveLanes.find(lane => lane.lane_key === status);
   if (match?.semantic_role) return match.semantic_role;

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsRepositories.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsRepositories.ts
@@ -1,0 +1,68 @@
+export interface ProjectSnapshot {
+  id:       string;
+  title:    string;
+  archived: boolean;
+}
+
+export interface EpicSnapshot {
+  id:         string;
+  project_id: string;
+  title:      string;
+  archived:   boolean;
+}
+
+export interface TaskSnapshot {
+  id:         string;
+  project_id: string;
+  epic_id:    string | null;
+  title:      string;
+  status:     string;
+  assignee:   string | null;
+  labels:     string[];
+  archived:   boolean;
+}
+
+export interface TaskCommentSnapshot {
+  id:         string;
+  task_id:    string;
+  body:       string;
+  author:     string | null;
+  created_at: string;
+}
+
+export interface ProjectsProjectRepository {
+  get(id: string): Promise<ProjectSnapshot | null>;
+}
+
+export interface ProjectsEpicRepository {
+  get(id: string): Promise<EpicSnapshot | null>;
+}
+
+export interface ProjectsTaskRepository {
+  get(id: string): Promise<TaskSnapshot | null>;
+  lock(id: string): Promise<TaskSnapshot | null>;
+  compareAndSetLane(input: {
+    taskId:          string;
+    expectedLane:    string;
+    destinationLane: string;
+    actor:           string;
+    assignee?:       string | null;
+  }): Promise<TaskSnapshot | null>;
+}
+
+export interface ProjectsCommentRepository {
+  append(input: {
+    id:     string;
+    taskId: string;
+    body:   string;
+    author: string;
+  }): Promise<TaskCommentSnapshot>;
+}
+
+/** Every repository in this object is scoped to the same database transaction. */
+export interface ProjectsRepositories {
+  projects: ProjectsProjectRepository;
+  epics:    ProjectsEpicRepository;
+  tasks:    ProjectsTaskRepository;
+  comments: ProjectsCommentRepository;
+}

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsUnitOfWork.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsUnitOfWork.ts
@@ -1,0 +1,9 @@
+import type { ProjectsRepositories } from './ProjectsRepositories';
+
+/**
+ * Caller-owned transaction boundary. The callback decides the complete atomic
+ * operation; repositories cannot escape the transaction that created them.
+ */
+export interface ProjectsUnitOfWork {
+  execute<T>(work: (repositories: ProjectsRepositories) => Promise<T>): Promise<T>;
+}

--- a/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsRepositories.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsRepositories.ts
@@ -1,0 +1,121 @@
+import type {
+  EpicSnapshot,
+  ProjectSnapshot,
+  ProjectsCommentRepository,
+  ProjectsEpicRepository,
+  ProjectsProjectRepository,
+  ProjectsRepositories,
+  ProjectsTaskRepository,
+  TaskCommentSnapshot,
+  TaskSnapshot,
+} from '../application/ProjectsRepositories';
+import type { QueryResultRow } from 'pg';
+
+export interface ProjectsSqlClient {
+  query<T extends QueryResultRow = any>(text: string, values?: any[]): Promise<{ rows: T[] }>;
+}
+
+function task(row: TaskSnapshot | undefined): TaskSnapshot | null {
+  if (!row) return null;
+  return { ...row, labels: row.labels ?? [] };
+}
+
+class PostgresProjectRepository implements ProjectsProjectRepository {
+  constructor(private readonly client: ProjectsSqlClient) {}
+
+  async get(id: string): Promise<ProjectSnapshot | null> {
+    const result = await this.client.query<ProjectSnapshot>(
+      'SELECT id, title, archived FROM work_projects WHERE id = $1 LIMIT 1', [id],
+    );
+    return result.rows[0] ?? null;
+  }
+}
+
+class PostgresEpicRepository implements ProjectsEpicRepository {
+  constructor(private readonly client: ProjectsSqlClient) {}
+
+  async get(id: string): Promise<EpicSnapshot | null> {
+    const result = await this.client.query<EpicSnapshot>(
+      'SELECT id, project_id, title, archived FROM work_epics WHERE id = $1 LIMIT 1', [id],
+    );
+    return result.rows[0] ?? null;
+  }
+}
+
+class PostgresTaskRepository implements ProjectsTaskRepository {
+  constructor(private readonly client: ProjectsSqlClient) {}
+
+  async get(id: string): Promise<TaskSnapshot | null> {
+    const result = await this.client.query<TaskSnapshot>(
+      `SELECT id, project_id, epic_id, title, status, assignee, labels, archived
+         FROM work_tasks WHERE id = $1 LIMIT 1`, [id],
+    );
+    return task(result.rows[0]);
+  }
+
+  async lock(id: string): Promise<TaskSnapshot | null> {
+    const result = await this.client.query<TaskSnapshot>(
+      `SELECT id, project_id, epic_id, title, status, assignee, labels, archived
+         FROM work_tasks WHERE id = $1 FOR UPDATE`, [id],
+    );
+    return task(result.rows[0]);
+  }
+
+  async compareAndSetLane(input: {
+    taskId:          string;
+    expectedLane:    string;
+    destinationLane: string;
+    actor:           string;
+    assignee?:       string | null;
+  }): Promise<TaskSnapshot | null> {
+    const result = await this.client.query<TaskSnapshot>(
+      `UPDATE work_tasks
+          SET status = $2,
+              assignee = CASE WHEN $4::boolean THEN $5 ELSE assignee END,
+              updated_at = now(),
+              last_moved_at = now(),
+              last_activity_at = now(),
+              last_moved_by = $3
+        WHERE id = $1 AND status = $6 AND archived = false
+      RETURNING id, project_id, epic_id, title, status, assignee, labels, archived`,
+      [
+        input.taskId,
+        input.destinationLane,
+        input.actor,
+        input.assignee !== undefined,
+        input.assignee ?? null,
+        input.expectedLane,
+      ],
+    );
+    return task(result.rows[0]);
+  }
+}
+
+class PostgresCommentRepository implements ProjectsCommentRepository {
+  constructor(private readonly client: ProjectsSqlClient) {}
+
+  async append(input: {
+    id:     string;
+    taskId: string;
+    body:   string;
+    author: string;
+  }): Promise<TaskCommentSnapshot> {
+    const result = await this.client.query<TaskCommentSnapshot>(
+      `INSERT INTO work_task_comments (id, task_id, body, author)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id, task_id, body, author, created_at`,
+      [input.id, input.taskId, input.body, input.author],
+    );
+    if (!result.rows[0]) throw new Error('Projects comment insert returned no row.');
+    return result.rows[0];
+  }
+}
+
+export function createPostgresProjectsRepositories(client: ProjectsSqlClient): ProjectsRepositories {
+  return {
+    projects: new PostgresProjectRepository(client),
+    epics:    new PostgresEpicRepository(client),
+    tasks:    new PostgresTaskRepository(client),
+    comments: new PostgresCommentRepository(client),
+  };
+}

--- a/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsSchemaVerifier.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsSchemaVerifier.ts
@@ -1,0 +1,22 @@
+import { postgresClient } from '../../database/PostgresClient';
+
+export const PROJECTS_CORE_RELATIONS = Object.freeze([
+  'work_projects',
+  'work_epics',
+  'work_tasks',
+  'work_task_comments',
+]);
+
+export class PostgresProjectsSchemaVerifier {
+  static async verify(relations: readonly string[] = PROJECTS_CORE_RELATIONS): Promise<void> {
+    const rows = await postgresClient.query<{ relation_name: string; relation: string | null }>(
+      `SELECT relation_name, to_regclass('public.' || relation_name)::text AS relation
+         FROM unnest($1::text[]) AS required(relation_name)`,
+      [[...relations]],
+    );
+    const missing = rows.filter(row => row.relation === null).map(row => row.relation_name);
+    if (missing.length > 0) {
+      throw new Error(`Projects schema is not migrated; missing relations: ${ missing.join(', ') }`);
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsUnitOfWork.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsUnitOfWork.ts
@@ -1,0 +1,33 @@
+import { createPostgresProjectsRepositories } from './PostgresProjectsRepositories';
+import { postgresClient } from '../../database/PostgresClient';
+
+import type { ProjectsRepositories } from '../application/ProjectsRepositories';
+import type { ProjectsUnitOfWork } from '../application/ProjectsUnitOfWork';
+import type { PoolClient } from 'pg';
+
+type ClientFactory = () => Promise<PoolClient>;
+
+/** PostgreSQL transaction adapter. It never nests or commits a caller-owned client. */
+export class PostgresProjectsUnitOfWork implements ProjectsUnitOfWork {
+  constructor(private readonly getClient: ClientFactory = () => postgresClient.getClient()) {}
+
+  async execute<T>(work: (repositories: ProjectsRepositories) => Promise<T>): Promise<T> {
+    const client = await this.getClient();
+    try {
+      await client.query('BEGIN');
+      const result = await work(createPostgresProjectsRepositories(client));
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  /** Compose repositories into a transaction already owned by an outer service. */
+  static useExisting<T>(client: PoolClient, work: (repositories: ProjectsRepositories) => Promise<T>): Promise<T> {
+    return work(createPostgresProjectsRepositories(client));
+  }
+}

--- a/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/PostgresProjectsRepositories.test.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/PostgresProjectsRepositories.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { createPostgresProjectsRepositories } from '../PostgresProjectsRepositories';
+
+describe('PostgresProjectsRepositories', () => {
+  it('uses compare-and-set lane persistence and preserves an omitted assignee', async() => {
+    const query = jest.fn<(sql: string, values?: any[]) => Promise<{ rows: any[] }>>(() => Promise.resolve({
+      rows: [{
+        id:         'task-1',
+        project_id: 'project-1',
+        epic_id:    null,
+        title:      'Task',
+        status:     'in_progress',
+        assignee:   'dispatcher',
+        labels:     ['p0'],
+        archived:   false,
+      }],
+    }));
+    const repositories = createPostgresProjectsRepositories({ query } as any);
+
+    await expect(repositories.tasks.compareAndSetLane({
+      taskId: 'task-1', expectedLane: 'todo', destinationLane: 'in_progress', actor: 'dispatcher',
+    })).resolves.toMatchObject({ status: 'in_progress', labels: ['p0'] });
+
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('status = $6'), [
+      'task-1', 'in_progress', 'dispatcher', false, null, 'todo',
+    ]);
+  });
+
+  it('returns null when another transaction won the expected-lane race', async() => {
+    const query = jest.fn<(sql: string, values?: any[]) => Promise<{ rows: any[] }>>(() => Promise.resolve({ rows: [] }));
+    const repositories = createPostgresProjectsRepositories({ query } as any);
+
+    await expect(repositories.tasks.compareAndSetLane({
+      taskId: 'task-1', expectedLane: 'todo', destinationLane: 'in_progress', actor: 'dispatcher',
+    })).resolves.toBeNull();
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/PostgresProjectsSchemaVerifier.test.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/PostgresProjectsSchemaVerifier.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { postgresClient } from '../../../database/PostgresClient';
+import { PostgresProjectsSchemaVerifier } from '../PostgresProjectsSchemaVerifier';
+
+describe('PostgresProjectsSchemaVerifier', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('verifies migrated relations without issuing DDL', async() => {
+    const query = jest.spyOn(postgresClient, 'query').mockResolvedValue([
+      { relation_name: 'work_projects', relation: 'work_projects' },
+    ]);
+
+    await expect(PostgresProjectsSchemaVerifier.verify(['work_projects'])).resolves.toBeUndefined();
+    expect(query.mock.calls[0][0]).toContain('to_regclass');
+    expect(query.mock.calls[0][0]).not.toMatch(/CREATE|ALTER|DROP/i);
+  });
+
+  it('fails closed when an ordered migration has not installed a relation', async() => {
+    jest.spyOn(postgresClient, 'query').mockResolvedValue([
+      { relation_name: 'work_tasks', relation: null },
+    ]);
+
+    await expect(PostgresProjectsSchemaVerifier.verify(['work_tasks']))
+      .rejects.toThrow('missing relations: work_tasks');
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/PostgresProjectsUnitOfWork.integration.test.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/PostgresProjectsUnitOfWork.integration.test.ts
@@ -1,0 +1,100 @@
+/** @jest-environment node */
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { Pool } from 'pg';
+
+import { up as createWorkItems } from '../../../database/migrations/0044_create_work_items_tables';
+import { up as addTaskActors } from '../../../database/migrations/0047_add_work_task_actor';
+import { PostgresProjectsUnitOfWork } from '../PostgresProjectsUnitOfWork';
+
+const integration = process.env.PROJECTS_POSTGRES_INTEGRATION === '1' ? describe : describe.skip;
+
+integration('PostgresProjectsUnitOfWork migrated PostgreSQL', () => {
+  const schema = `projects_oop_${ randomUUID().replaceAll('-', '') }`;
+  const config = {
+    host:     '127.0.0.1',
+    port:     30116,
+    user:     'sulla',
+    password: process.env.SULLA_POSTGRES_PASSWORD ?? 'sulla_dev_password',
+    database: 'sulla',
+    max:      4,
+  };
+  let pool = new Pool(config);
+
+  const acquire = async() => {
+    const client = await pool.connect();
+    await client.query(`SET search_path TO "${ schema }"`);
+    return client;
+  };
+
+  beforeAll(async() => {
+    const client = await pool.connect();
+    try {
+      await client.query(`CREATE SCHEMA "${ schema }"`);
+      await client.query(`SET search_path TO "${ schema }"`);
+      await client.query(createWorkItems);
+      await client.query(addTaskActors);
+      await client.query(`INSERT INTO work_projects (id, slug, title) VALUES ('project-1', 'project-1', 'Project')`);
+      await client.query(`INSERT INTO work_epics (id, project_id, title) VALUES ('epic-1', 'project-1', 'Epic')`);
+      await client.query(`INSERT INTO work_tasks (id, project_id, epic_id, title) VALUES ('task-1', 'project-1', 'epic-1', 'Task')`);
+    } finally {
+      client.release();
+    }
+  });
+
+  afterAll(async() => {
+    const client = await pool.connect();
+    try {
+      await client.query(`DROP SCHEMA IF EXISTS "${ schema }" CASCADE`);
+    } finally {
+      client.release();
+      await pool.end();
+    }
+  });
+
+  it('rolls back a multi-record lifecycle command', async() => {
+    const unitOfWork = new PostgresProjectsUnitOfWork(acquire);
+    await expect(unitOfWork.execute(async(repositories) => {
+      await repositories.tasks.compareAndSetLane({
+        taskId: 'task-1', expectedLane: 'todo', destinationLane: 'in_progress', actor: 'test',
+      });
+      await repositories.comments.append({ id: 'rollback-comment', taskId: 'task-1', body: 'rollback', author: 'test' });
+      throw new Error('rollback probe');
+    })).rejects.toThrow('rollback probe');
+
+    const client = await acquire();
+    try {
+      const task = await client.query(`SELECT status FROM work_tasks WHERE id = 'task-1'`);
+      const comment = await client.query(`SELECT id FROM work_task_comments WHERE id = 'rollback-comment'`);
+      expect(task.rows[0].status).toBe('todo');
+      expect(comment.rows).toEqual([]);
+    } finally {
+      client.release();
+    }
+  });
+
+  it('allows exactly one concurrent compare-and-set winner and survives pool restart', async() => {
+    const first = new PostgresProjectsUnitOfWork(acquire);
+    const second = new PostgresProjectsUnitOfWork(acquire);
+    const results = await Promise.all([
+      first.execute(repositories => repositories.tasks.compareAndSetLane({
+        taskId: 'task-1', expectedLane: 'todo', destinationLane: 'in_progress', actor: 'first',
+      })),
+      second.execute(repositories => repositories.tasks.compareAndSetLane({
+        taskId: 'task-1', expectedLane: 'todo', destinationLane: 'planning', actor: 'second',
+      })),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+
+    await pool.end();
+    pool = new Pool(config);
+    const client = await acquire();
+    try {
+      const persisted = await client.query(`SELECT status FROM work_tasks WHERE id = 'task-1'`);
+      expect(['in_progress', 'planning']).toContain(persisted.rows[0].status);
+    } finally {
+      client.release();
+    }
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/PostgresProjectsUnitOfWork.test.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/PostgresProjectsUnitOfWork.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { PostgresProjectsUnitOfWork } from '../PostgresProjectsUnitOfWork';
+
+function clientWith(query: any) {
+  return { query, release: jest.fn() } as any;
+}
+
+describe('PostgresProjectsUnitOfWork', () => {
+  it('commits every repository operation through one client', async() => {
+    const query = jest.fn<(sql: string) => Promise<{ rows: any[] }>>(async(sql: string) => {
+      if (sql.includes('FROM work_tasks')) {
+        return {
+          rows: [{
+            id:         'task-1',
+            project_id: 'project-1',
+            epic_id:    'epic-1',
+            title:      'Task',
+            status:     'todo',
+            assignee:   null,
+            labels:     null,
+            archived:   false,
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+    const client = clientWith(query);
+    const unitOfWork = new PostgresProjectsUnitOfWork(() => Promise.resolve(client));
+
+    const task = await unitOfWork.execute(repositories => repositories.tasks.lock('task-1'));
+
+    expect(task?.labels).toEqual([]);
+    expect(query.mock.calls.map(call => call[0])).toEqual([
+      'BEGIN', expect.stringContaining('FOR UPDATE'), 'COMMIT',
+    ]);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back and rethrows without leaking the client', async() => {
+    const query = jest.fn<(sql: string) => Promise<{ rows: any[] }>>(() => Promise.resolve({ rows: [] }));
+    const client = clientWith(query);
+    const unitOfWork = new PostgresProjectsUnitOfWork(() => Promise.resolve(client));
+
+    await expect(unitOfWork.execute(async() => {
+      throw new Error('fail the atomic command');
+    })).rejects.toThrow('fail the atomic command');
+
+    expect(query.mock.calls.map(call => call[0])).toEqual(['BEGIN', 'ROLLBACK']);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('composes with a caller-owned transaction without begin, commit, rollback, or release', async() => {
+    const query = jest.fn<(sql: string, values?: any[]) => Promise<{ rows: any[] }>>(() => Promise.resolve({
+      rows: [{ id: 'project-1', title: 'Project', archived: false }],
+    }));
+    const client = clientWith(query);
+
+    const project = await PostgresProjectsUnitOfWork.useExisting(
+      client,
+      repositories => repositories.projects.get('project-1'),
+    );
+
+    expect(project?.id).toBe('project-1');
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(client.release).not.toHaveBeenCalled();
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/ProjectsSchemaOwnership.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/ProjectsSchemaOwnership.contract.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from '@jest/globals';
+
+describe('Projects schema ownership', () => {
+  it('keeps runtime Projects models verification-only', () => {
+    for (const path of [
+      'pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts',
+      'pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts',
+    ]) {
+      const source = readFileSync(resolve(process.cwd(), path), 'utf8');
+      expect(source).not.toMatch(/CREATE\s+(TABLE|INDEX|EXTENSION)|ALTER\s+TABLE/i);
+      expect(source).toContain('PostgresProjectsSchemaVerifier');
+    }
+  });
+});


### PR DESCRIPTION
## Scope

Implements internal Projects task Et0W / dHAe Phase 2.

- transaction-scoped Project, Epic, Task, and Comment repository ports
- caller-owned Postgres UnitOfWork with explicit commit/rollback/release semantics
- existing-client composition without nested transaction ownership
- compare-and-set task lane persistence for concurrency safety
- ordered migrations become sole Projects schema authority; runtime ensureTable paths only verify relations
- migrated-Postgres rollback, concurrent winner, and pool-restart proof

## Verification

- unit/contract suites: 4 suites, 8 tests passed; integration suite is opt-in
- real migrated PostgreSQL integration: 1 suite, 2 tests passed (rollback, concurrent CAS, restart persistence)
- git diff --check passed
- exact commit: d62cdfb67

No public tool/IPC routing, deployment, rebuild, or runtime activation in this phase.