### PR TITLE
refactor(projects): route adapters through application facade (dHAe Phase 3)

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/TaskOwnership.ts
+++ b/pkg/rancher-desktop/agent/database/models/TaskOwnership.ts
@@ -25,10 +25,12 @@ export const NON_AUTONOMOUS_TASK_LABELS = [
 ] as const;
 
 export interface TaskOwnershipInput {
-  status:   string;
-  assignee: string | null;
-  labels:   readonly string[] | null;
-  actor:    string;
+  status:                 string;
+  assignee:               string | null;
+  labels:                 readonly string[] | null;
+  actor:                  string;
+  semanticRole?:          WorkLaneSemanticRole;
+  executionEntryLaneKey?: string | null;
 }
 
 export function hasNonAutonomousTaskLabel(labels: readonly string[] | null): boolean {
@@ -42,7 +44,12 @@ export function hasNonAutonomousTaskLabel(labels: readonly string[] | null): boo
  * actor identity retained for attribution, not a mechanical queue assignee.
  */
 export function normalizeAutonomousTaskOwnership(input: TaskOwnershipInput): string | null {
-  if (input.status.trim().toLowerCase() !== 'todo') return input.assignee;
+  const status = input.status.trim();
+  const semanticCatalogReady = input.semanticRole !== undefined;
+  const isExecutionEntry = semanticCatalogReady
+    ? input.semanticRole === 'execution' && status === input.executionEntryLaneKey?.trim()
+    : status.toLowerCase() === 'todo';
+  if (!isExecutionEntry) return input.assignee;
   if (input.assignee?.trim().toLowerCase() !== TASK_ASSIGNEES.legacySulla) return input.assignee;
   const actor = input.actor.trim().toLowerCase();
   if (!AUTONOMOUS_TASK_ACTORS.some(candidate => candidate === actor)) return input.assignee;
@@ -50,3 +57,4 @@ export function normalizeAutonomousTaskOwnership(input: TaskOwnershipInput): str
 
   return TASK_ASSIGNEES.dispatcher;
 }
+import type { WorkLaneSemanticRole } from './WorkLaneDefinitionModel';

--- a/pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts
@@ -6,6 +6,22 @@ export type WorkLaneScope = 'global_default' | 'project';
 export type WorkLaneSemanticRole = 'backlog' | 'planning' | 'execution' | 'review' | 'blocked' | 'terminal' | 'manual';
 export type WorkLaneProvenance = 'global' | 'project_override' | 'project_only';
 
+export const REQUIRED_WORK_LANE_ROLES: readonly WorkLaneSemanticRole[] = [
+  'backlog', 'planning', 'execution', 'review', 'blocked', 'terminal',
+];
+
+const COMPATIBILITY_ROLE_BY_KEY: Readonly<Record<string, WorkLaneSemanticRole>> = {
+  backlog: 'backlog', todo: 'execution', planning: 'planning', in_progress: 'execution',
+  in_review: 'review', blocked: 'blocked', done: 'terminal', cancelled: 'terminal', parked: 'manual',
+};
+
+export interface WorkLaneRuntimeCapability {
+  ready:          boolean;
+  catalogPresent: boolean;
+  missingRoles:   WorkLaneSemanticRole[];
+  degradedReason: string | null;
+}
+
 export interface WorkLaneDefinitionRecord {
   id:              string;
   lane_key:        string;
@@ -250,6 +266,78 @@ export class WorkLaneDefinitionModel {
       effective.push({ ...projectLane, provenance: 'project_only', inherited_definition_id: null });
     }
     return effective.sort((a, b) => a.position - b.position || a.lane_key.localeCompare(b.lane_key));
+  }
+
+  static async runtimeCapability(projectId?: string): Promise<WorkLaneRuntimeCapability> {
+    try {
+      const catalog = await postgresClient.queryOne<{ present: boolean }>(
+        `SELECT to_regclass('work_lane_definitions') IS NOT NULL AS present`,
+      );
+      if (!catalog?.present) {
+        return {
+          ready: false, catalogPresent: false, missingRoles: [...REQUIRED_WORK_LANE_ROLES],
+          degradedReason: 'work_lane_definitions is unavailable; stable-key compatibility mode is active.',
+        };
+      }
+      const lanes = projectId
+        ? await WorkLaneDefinitionModel.resolveEffective(projectId)
+        : (await WorkLaneDefinitionModel.list({ scope: 'global_default' })).filter(lane => lane.enabled && !lane.archived);
+      const roles = new Set(lanes.map(lane => lane.semantic_role));
+      const missingRoles = REQUIRED_WORK_LANE_ROLES.filter(role => !roles.has(role));
+      return {
+        ready: missingRoles.length === 0, catalogPresent: true, missingRoles,
+        degradedReason: missingRoles.length ? `Required semantic lane roles are missing: ${ missingRoles.join(', ') }.` : null,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        ready: false, catalogPresent: false, missingRoles: [...REQUIRED_WORK_LANE_ROLES],
+        degradedReason: `Semantic lane capability check failed: ${ message }`,
+      };
+    }
+  }
+
+  static async resolveStatus(projectId: string, laneKey: string): Promise<EffectiveWorkLane | null> {
+    return (await WorkLaneDefinitionModel.resolveEffective(projectId)).find(lane => lane.lane_key === laneKey) ?? null;
+  }
+
+  static async semanticRoleForStatus(projectId: string, laneKey: string): Promise<WorkLaneSemanticRole> {
+    const capability = await WorkLaneDefinitionModel.runtimeCapability(projectId);
+    if (capability.ready) return (await WorkLaneDefinitionModel.resolveStatus(projectId, laneKey))?.semantic_role ?? 'manual';
+    return COMPATIBILITY_ROLE_BY_KEY[laneKey] ?? 'manual';
+  }
+
+  static async laneKeysForRoles(projectId: string, roles: WorkLaneSemanticRole[]): Promise<string[]> {
+    if (!(await WorkLaneDefinitionModel.runtimeCapability(projectId)).ready) return [];
+    const wanted = new Set(roles);
+    return (await WorkLaneDefinitionModel.resolveEffective(projectId))
+      .filter(lane => wanted.has(lane.semantic_role)).map(lane => lane.lane_key);
+  }
+
+  static async validateTaskStatus(projectId: string, laneKey: string): Promise<EffectiveWorkLane | null> {
+    if (!(await WorkLaneDefinitionModel.runtimeCapability(projectId)).ready) return null;
+    const lane = await WorkLaneDefinitionModel.resolveStatus(projectId, laneKey);
+    if (!lane) throw new Error(`No active Projects lane with key "${ laneKey }" exists for project ${ projectId }.`);
+    return lane;
+  }
+
+  static async preferredLaneKey(
+    projectId: string,
+    role: WorkLaneSemanticRole,
+    compatibilityKey: string,
+    preference: 'first' | 'last' = 'first',
+  ): Promise<string> {
+    if (!(await WorkLaneDefinitionModel.runtimeCapability(projectId)).ready) return compatibilityKey;
+    const lanes = (await WorkLaneDefinitionModel.resolveEffective(projectId)).filter(lane => lane.semantic_role === role);
+    const ordered = [...lanes].sort((left, right) => {
+      const position = preference === 'last' ? right.position - left.position : left.position - right.position;
+      if (position !== 0) return position;
+      if (left.lane_key === compatibilityKey) return -1;
+      if (right.lane_key === compatibilityKey) return 1;
+      return left.lane_key.localeCompare(right.lane_key);
+    });
+    if (!ordered[0]) throw new Error(`Project ${ projectId } has no active ${ role } lane.`);
+    return ordered[0].lane_key;
   }
 
   static async archive(id: string, destinationKey?: string, actor = 'sulla'): Promise<ArchiveWorkLaneResult> {

--- a/pkg/rancher-desktop/agent/projects/__tests__/ProjectsAdapterBoundary.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/__tests__/ProjectsAdapterBoundary.contract.test.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+
+import { describe, expect, it } from '@jest/globals';
+
+const repoRoot = process.cwd();
+
+describe('Projects adapter boundary contract', () => {
+  it('does not let project CLI tools mutate WorkItemsModel directly', () => {
+    const toolsDir = `${ repoRoot }/pkg/rancher-desktop/agent/tools/project`;
+    const offenders = fs.readdirSync(toolsDir)
+      .filter(name => name.endsWith('.ts'))
+      .filter(name => /WorkItemsModel\.(?:upsert|insert|update|archive|addComment|setTask|removeTask)/
+        .test(fs.readFileSync(`${ toolsDir }/${ name }`, 'utf8')));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('routes every Projects tool model call through the application boundary', () => {
+    const toolsDir = `${ repoRoot }/pkg/rancher-desktop/agent/tools/project`;
+    const directModelCall = /\b(?:WorkItemsModel|WorkLaneDefinitionModel|WorkLaneWorkflowBindingModel|WorkProjectViewModel|WorkTaskWaitModel|WorkTaskDependencyModel|WorkItemKnowledgeModel|WorkConveyorMetricsModel)\.[a-zA-Z]+\s*\(/;
+    const offenders = fs.readdirSync(toolsDir)
+      .filter(name => name.endsWith('.ts'))
+      .filter(name => directModelCall.test(fs.readFileSync(`${ toolsDir }/${ name }`, 'utf8')));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('routes Electron work-item mutations through ProjectsApplicationService', () => {
+    const source = fs.readFileSync(`${ repoRoot }/pkg/rancher-desktop/main/workItemsEvents.ts`, 'utf8');
+    expect(source).toContain('importProjectsApplicationService');
+    expect(source).not.toMatch(/WorkItemsModel\.(?:upsert|insert|update|archive|addComment|setTask|removeTask)/);
+  });
+
+  it('keeps schema ownership in ordered migrations', () => {
+    const source = fs.readFileSync(`${ repoRoot }/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts`, 'utf8');
+    expect(source).not.toMatch(/CREATE\s+(?:TABLE|INDEX|EXTENSION)|ALTER\s+TABLE/i);
+    expect(source).toContain('PostgresProjectsSchemaVerifier');
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/__tests__/ProjectsAdapterBoundary.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/__tests__/ProjectsAdapterBoundary.contract.test.ts
@@ -31,6 +31,14 @@ describe('Projects adapter boundary contract', () => {
     expect(source).not.toMatch(/WorkItemsModel\.(?:upsert|insert|update|archive|addComment|setTask|removeTask)/);
   });
 
+  it('does not trust renderer-supplied actor identities', () => {
+    const source = fs.readFileSync(`${ repoRoot }/pkg/rancher-desktop/main/workItemsEvents.ts`, 'utf8');
+    expect(source).not.toContain("changes.actor ?? 'human'");
+    expect(source).not.toContain("input.actor ?? 'human'");
+    expect(source).toContain("projects.updateTask(id, { ...changes, actor: 'human' }");
+    expect(source).toContain("projects.createTask({ ...input, actor: 'human' }");
+  });
+
   it('keeps schema ownership in ordered migrations', () => {
     const source = fs.readFileSync(`${ repoRoot }/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts`, 'utf8');
     expect(source).not.toMatch(/CREATE\s+(?:TABLE|INDEX|EXTENSION)|ALTER\s+TABLE/i);

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsApplicationService.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsApplicationService.ts
@@ -1,0 +1,301 @@
+import { KnowledgeGraphModel } from '../../database/models/KnowledgeGraphModel';
+import { LifecycleCapabilityModel } from '../../database/models/LifecycleCapabilityModel';
+import { WorkConveyorMetricsModel } from '../../database/models/WorkConveyorMetricsModel';
+import { WorkItemKnowledgeModel } from '../../database/models/WorkItemKnowledgeModel';
+import { WorkLaneDefinitionModel } from '../../database/models/WorkLaneDefinitionModel';
+import { WorkLaneWorkflowBindingModel } from '../../database/models/WorkLaneWorkflowBindingModel';
+import { WorkProjectViewModel } from '../../database/models/WorkProjectViewModel';
+import { WorkTaskDependencyModel } from '../../database/models/WorkTaskDependencyModel';
+import { WorkTaskDispatchModel } from '../../database/models/WorkTaskDispatchModel';
+import { WorkTaskWaitModel } from '../../database/models/WorkTaskWaitModel';
+import { ArtifactCustodyPolicy } from '../../services/ArtifactCustodyPolicy';
+import { evaluateClaim, resolveWipLimits } from '../../services/ProjectAutomationWipLimits';
+import { PostgresProjectsRepository } from '../infrastructure/PostgresProjectsRepository';
+
+import type { ProjectsRepository } from './ProjectsRepository';
+import type { ConveyorMetricsOptions, SemanticStage } from '../../database/models/WorkConveyorMetricsModel';
+import type { KnowledgeLinkInput, KnowledgeWorkItemKind } from '../../database/models/WorkItemKnowledgeModel';
+import type {
+  AddCommentInput, ListActivityOpts, ListEpicsOpts, ListOpts, SearchOpts,
+  UpdateEpicInput, UpdateProjectInput, UpdateTaskInput,
+  UpsertEpicInput, UpsertProjectInput, UpsertTaskInput, WorkItemKind,
+  WorkTaskRecord,
+} from '../../database/models/WorkItemsModel';
+import type { CreateWorkLaneInput, ListWorkLaneOpts, UpdateWorkLaneInput, WorkLaneScope } from '../../database/models/WorkLaneDefinitionModel';
+import type { ListLaneBindingsInput, ResolveLaneBindingContextInput, SetLaneBindingInput } from '../../database/models/WorkLaneWorkflowBindingModel';
+import type { SaveProjectViewInput } from '../../database/models/WorkProjectViewModel';
+import type { CreateDependencyInput, RemoveDependencyInput } from '../../database/models/WorkTaskDependencyModel';
+import type { WorkTaskWaitStatus, RegisterWaitInput } from '../../database/models/WorkTaskWaitModel';
+
+export type ProjectsCommandSource = 'tool' | 'ipc' | 'heartbeat' | 'routine' | 'dispatcher' | 'system';
+
+export interface ProjectsCommandContext {
+  actor:  string;
+  source: ProjectsCommandSource;
+}
+
+export interface ReorderProjectItem {
+  kind:      'epic' | 'task';
+  id:        string;
+  position?: number;
+  status?:   string;
+  epic_id?:  string;
+}
+
+const DEFAULT_CONTEXT: ProjectsCommandContext = { actor: 'sulla', source: 'system' };
+
+function itemId(value: unknown, field = 'id'): string {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  if (!normalized) throw new Error(`${ field } is required.`);
+  return normalized;
+}
+
+/**
+ * The sole application boundary for Projects. Tools, IPC and autonomous
+ * routines submit commands here so authorization and lifecycle policy cannot
+ * diverge between adapters.
+ */
+export class ProjectsApplicationService {
+  constructor(private readonly repository: ProjectsRepository = new PostgresProjectsRepository()) {}
+
+  ready() { return this.repository.verifySchema() }
+  getProject(id: string) { return this.repository.getProject(itemId(id)) }
+  getProjectBySlug(slug: string) { return this.repository.getProjectBySlug(slug) }
+  listProjects(opts: ListOpts = {}) { return this.repository.listProjects(opts) }
+  getEpic(id: string) { return this.repository.getEpic(itemId(id)) }
+  listEpics(opts: ListEpicsOpts = {}) { return this.repository.listEpics(opts) }
+  getTask(id: string) { return this.repository.getTask(itemId(id)) }
+  listTasks(opts: ListOpts = {}) { return this.repository.listTasks(opts) }
+  listComments(taskId: string) { return this.repository.listComments(itemId(taskId, 'task_id')) }
+  listRecentActivity(opts: ListActivityOpts = {}) { return this.repository.listRecentActivity(opts) }
+  search(opts: SearchOpts) { return this.repository.search(opts) }
+  listTaskDependencies(projectId: string) {
+    return this.repository.listTaskDependencies(itemId(projectId, 'project_id'));
+  }
+
+  resolveEffectiveLanes(projectId: string, includeArchived = false) {
+    return WorkLaneDefinitionModel.resolveEffective(itemId(projectId, 'project_id'), includeArchived);
+  }
+
+  laneRuntimeCapability(projectId?: string) {
+    return WorkLaneDefinitionModel.runtimeCapability(projectId);
+  }
+
+  listViews(projectId?: string | null) { return WorkProjectViewModel.list(projectId) }
+  resolveView(projectId?: string | null) { return WorkProjectViewModel.resolve(projectId) }
+  saveView(input: SaveProjectViewInput, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkProjectViewModel.save({ ...input, actor: input.actor ?? context.actor });
+  }
+
+  listLanes(opts: ListWorkLaneOpts = {}) { return WorkLaneDefinitionModel.list(opts) }
+  createLane(input: CreateWorkLaneInput, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkLaneDefinitionModel.create({ ...input, actor: input.actor ?? context.actor });
+  }
+
+  updateLane(id: string, changes: UpdateWorkLaneInput, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkLaneDefinitionModel.update(id, { ...changes, actor: changes.actor ?? context.actor });
+  }
+
+  archiveLane(id: string, destinationLaneKey?: string, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkLaneDefinitionModel.archive(id, destinationLaneKey, context.actor);
+  }
+
+  previewArchiveLane(id: string) { return WorkLaneDefinitionModel.previewArchive(id) }
+  restoreLane(id: string, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkLaneDefinitionModel.restore(id, context.actor);
+  }
+
+  reorderLanes(scope: WorkLaneScope, orderedKeys: string[], projectId?: string, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkLaneDefinitionModel.reorder(scope, orderedKeys, projectId, context.actor);
+  }
+
+  resetLaneOverride(projectId: string, laneKey: string, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkLaneDefinitionModel.resetProjectOverride(projectId, laneKey, context.actor);
+  }
+
+  listLaneBindings(input: ListLaneBindingsInput = {}) { return WorkLaneWorkflowBindingModel.list(input) }
+  setLaneBinding(input: SetLaneBindingInput, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkLaneWorkflowBindingModel.set({ ...input, actor: input.actor ?? context.actor });
+  }
+
+  removeLaneBinding(id: string, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkLaneWorkflowBindingModel.remove(id, context.actor);
+  }
+
+  resolveLaneBinding(taskId: string, laneKey: string, profileId = 'default') {
+    return WorkLaneWorkflowBindingModel.resolve(taskId, laneKey, profileId);
+  }
+
+  resolveLaneBindingContext(input: ResolveLaneBindingContextInput) {
+    return WorkLaneWorkflowBindingModel.resolveForContext(input);
+  }
+
+  listCompatibleLaneWorkflows(projectId: string, laneKey: string) {
+    return WorkLaneWorkflowBindingModel.listCompatibleWorkflows(projectId, laneKey);
+  }
+
+  listLaneEntries(taskId: string) { return WorkLaneWorkflowBindingModel.listLaneEntries(taskId) }
+  countKnowledgeForItems(kind: KnowledgeWorkItemKind, ids: string[]) {
+    return WorkItemKnowledgeModel.countForItems(kind, ids);
+  }
+
+  listKnowledgeForItem(input: {
+    itemKind: KnowledgeWorkItemKind; itemId: string; includeInherited?: boolean; includeArchived?: boolean; relationType?: string; limit?: number;
+  }) {
+    return WorkItemKnowledgeModel.listForItem(input.itemKind, input.itemId, {
+      includeInherited: input.includeInherited ?? true,
+      includeArchived:  input.includeArchived ?? false,
+      relationType:     input.relationType,
+      limit:            input.limit,
+    });
+  }
+
+  linkKnowledge(input: KnowledgeLinkInput, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkItemKnowledgeModel.link({ ...input, source: input.source ?? context.source, actor: input.actor ?? context.actor });
+  }
+
+  unlinkKnowledge(input: KnowledgeLinkInput, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkItemKnowledgeModel.unlink({ ...input, source: input.source ?? context.source, actor: input.actor ?? context.actor });
+  }
+
+  listWorkForKnowledge(knowledgeNodeId: string, opts: { includeArchived?: boolean; limit?: number } = {}) {
+    return WorkItemKnowledgeModel.listForNode(knowledgeNodeId, opts);
+  }
+
+  searchKnowledgeNodes(input: { query?: string; includeArchived?: boolean; limit?: number } = {}) {
+    return KnowledgeGraphModel.searchNodes(input);
+  }
+
+  listWaits(opts: { taskId?: string; status?: WorkTaskWaitStatus; limit?: number } = {}) {
+    return WorkTaskWaitModel.list(opts);
+  }
+
+  cancelWait(id: string, reason: string) { return WorkTaskWaitModel.cancel(id, reason) }
+  explainTaskClaimability(taskId: string) { return WorkTaskDependencyModel.explainClaimability(taskId) }
+  conveyorHealth(opts: ConveyorMetricsOptions) { return WorkConveyorMetricsModel.snapshot(opts) }
+  async automationStatus() {
+    const [limits, counts] = await Promise.all([resolveWipLimits(), WorkTaskDispatchModel.countByRole()]);
+    return { limits, counts, decision: evaluateClaim('execution', counts, limits), at: new Date().toISOString() };
+  }
+
+  conveyorOldest(opts: { projectId?: string | null; stage: SemanticStage }) {
+    return WorkConveyorMetricsModel.oldestItems({ projectId: opts.projectId ?? null, drillLimit: 20 }, opts.stage);
+  }
+
+  createProject(input: UpsertProjectInput, _context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return this.repository.createProject(input);
+  }
+
+  updateProject(id: string, changes: UpdateProjectInput, _context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return this.repository.updateProject(itemId(id), changes);
+  }
+
+  createEpic(input: UpsertEpicInput, _context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return this.repository.createEpic(input);
+  }
+
+  updateEpic(id: string, changes: UpdateEpicInput, _context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return this.repository.updateEpic(itemId(id), changes);
+  }
+
+  createTask(input: UpsertTaskInput, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return this.repository.createTask({ ...input, actor: input.actor ?? context.actor });
+  }
+
+  async updateTask(
+    id: string,
+    changes: UpdateTaskInput,
+    context: ProjectsCommandContext = DEFAULT_CONTEXT,
+  ): Promise<WorkTaskRecord | null> {
+    const taskId = itemId(id);
+    const current = await this.repository.getTask(taskId);
+    if (!current) return null;
+    const actor = changes.actor ?? context.actor;
+
+    if (changes.status !== undefined || changes.assignee !== undefined) {
+      await LifecycleCapabilityModel.assertActorCanManageTask(current.status, current.labels, actor);
+      const destinationStatus = changes.status ?? current.status;
+      const destinationLabels = changes.labels ?? current.labels;
+      await LifecycleCapabilityModel.assertActorCanManageTask(destinationStatus, destinationLabels, actor);
+    }
+
+    if (changes.status !== undefined && changes.status !== current.status) {
+      const destinationProjectId = changes.epic_id
+        ? (await this.repository.getEpic(changes.epic_id))?.project_id ?? current.project_id
+        : current.project_id;
+      const destinationLane = await WorkLaneDefinitionModel.validateTaskStatus(destinationProjectId, changes.status);
+      const role = destinationLane?.semantic_role ?? 'manual';
+      if (role === 'review') await ArtifactCustodyPolicy.assertForTransition('in_review', changes.custody);
+      if (role === 'terminal') await ArtifactCustodyPolicy.assertForTransition('done', changes.custody);
+      if (destinationProjectId !== current.project_id && changes.epic_id === undefined) {
+        throw new Error('A task cannot change projects without moving through an epic in the destination project.');
+      }
+      if (role === 'terminal' && (changes.assignee === undefined ? current.assignee : changes.assignee) === 'dispatcher') {
+        throw new Error('Terminal tasks cannot remain assigned to dispatcher.');
+      }
+    }
+    return this.repository.updateTask(taskId, { ...changes, actor });
+  }
+
+  archive(kind: WorkItemKind, id: string, _context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return this.repository.archive(kind, itemId(id));
+  }
+
+  addComment(input: AddCommentInput, _context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return this.repository.addComment(input);
+  }
+
+  setTaskDependency(taskId: string, dependsOnTaskId: string, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return this.repository.setTaskDependency(taskId, dependsOnTaskId, context.actor);
+  }
+
+  removeTaskDependency(taskId: string, dependsOnTaskId: string, _context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return this.repository.removeTaskDependency(taskId, dependsOnTaskId);
+  }
+
+  createDependency(input: CreateDependencyInput, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkTaskDependencyModel.create({ ...input, actor: input.actor ?? context.actor });
+  }
+
+  removeDependency(input: RemoveDependencyInput, _context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    return WorkTaskDependencyModel.remove(input);
+  }
+
+  listDependencies(taskId: string, opts: { includeArchived?: boolean } = {}) {
+    return WorkTaskDependencyModel.listDependencies(itemId(taskId, 'task_id'), opts);
+  }
+
+  listDependents(taskId: string, opts: { includeArchived?: boolean } = {}) {
+    return WorkTaskDependencyModel.listDependents(itemId(taskId, 'task_id'), opts);
+  }
+
+  async registerWait(input: RegisterWaitInput, context: ProjectsCommandContext = DEFAULT_CONTEXT) {
+    const registration = await WorkTaskWaitModel.register(input);
+    if (registration.created) {
+      await this.addComment({
+        task_id: input.taskId,
+        author:  context.actor,
+        body:    `External wait registered: ${ input.waitKind } (${ input.targetKey }). Unchanged checks are owned by the durable monitor and will not add task comments.`,
+      }, context);
+    }
+    return registration;
+  }
+
+  async reorder(updates: ReorderProjectItem[], context: ProjectsCommandContext): Promise<void> {
+    for (const update of updates) {
+      if (update.kind === 'epic') {
+        await this.updateEpic(update.id, { position: update.position, status: update.status }, context);
+      } else {
+        await this.updateTask(update.id, {
+          position: update.position, status: update.status, epic_id: update.epic_id, actor: context.actor,
+        }, context);
+      }
+    }
+  }
+}
+
+let service: ProjectsApplicationService | undefined;
+export function getProjectsApplicationService(): ProjectsApplicationService {
+  service ??= new ProjectsApplicationService();
+  return service;
+}

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsRepository.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsRepository.ts
@@ -1,0 +1,47 @@
+import type {
+  AddCommentInput,
+  ListActivityOpts,
+  ListEpicsOpts,
+  ListOpts,
+  SearchOpts,
+  UpdateEpicInput,
+  UpdateProjectInput,
+  UpdateTaskInput,
+  UpsertEpicInput,
+  UpsertProjectInput,
+  UpsertTaskInput,
+  WorkActivityRecord,
+  WorkCommentRecord,
+  WorkEpicRecord,
+  WorkItemKind,
+  WorkProjectRecord,
+  WorkTaskDependencyRecord,
+  WorkTaskRecord,
+  SearchHit,
+} from '../../database/models/WorkItemsModel';
+
+/** Persistence port. Application/domain code depends on this, never SQL. */
+export interface ProjectsRepository {
+  verifySchema(): Promise<void>;
+  getProject(id: string): Promise<WorkProjectRecord | null>;
+  getProjectBySlug(slug: string): Promise<WorkProjectRecord | null>;
+  listProjects(opts?: ListOpts): Promise<WorkProjectRecord[]>;
+  createProject(input: UpsertProjectInput): Promise<WorkProjectRecord>;
+  updateProject(id: string, changes: UpdateProjectInput): Promise<WorkProjectRecord | null>;
+  getEpic(id: string): Promise<WorkEpicRecord | null>;
+  listEpics(opts?: ListEpicsOpts): Promise<WorkEpicRecord[]>;
+  createEpic(input: UpsertEpicInput): Promise<WorkEpicRecord>;
+  updateEpic(id: string, changes: UpdateEpicInput): Promise<WorkEpicRecord | null>;
+  getTask(id: string): Promise<WorkTaskRecord | null>;
+  listTasks(opts?: ListOpts): Promise<WorkTaskRecord[]>;
+  createTask(input: UpsertTaskInput): Promise<WorkTaskRecord>;
+  updateTask(id: string, changes: UpdateTaskInput): Promise<WorkTaskRecord | null>;
+  archive(kind: WorkItemKind, id: string): Promise<boolean>;
+  addComment(input: AddCommentInput): Promise<WorkCommentRecord>;
+  listComments(taskId: string): Promise<WorkCommentRecord[]>;
+  listRecentActivity(opts?: ListActivityOpts): Promise<WorkActivityRecord[]>;
+  search(opts: SearchOpts): Promise<SearchHit[]>;
+  listTaskDependencies(projectId: string): Promise<WorkTaskDependencyRecord[]>;
+  setTaskDependency(taskId: string, dependsOnTaskId: string, actor?: string): Promise<WorkTaskDependencyRecord>;
+  removeTaskDependency(taskId: string, dependsOnTaskId: string): Promise<boolean>;
+}

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsApplicationService.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsApplicationService.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { LifecycleCapabilityModel } from '../../../database/models/LifecycleCapabilityModel';
+import { WorkLaneDefinitionModel } from '../../../database/models/WorkLaneDefinitionModel';
+import { ArtifactCustodyPolicy } from '../../../services/ArtifactCustodyPolicy';
+import { ProjectsApplicationService } from '../ProjectsApplicationService';
+
+const current = {
+  id:               'task-1',
+  project_id:       'project-1',
+  epic_id:          'epic-1',
+  parent_id:        null,
+  slug:             null,
+  title:            'Protected work',
+  description:      '',
+  status:           'todo',
+  priority:         'critical',
+  due_at:           null,
+  start_at:         null,
+  milestone_at:     null,
+  github_issue:     null,
+  assignee:         'dispatcher',
+  labels:           [],
+  position:         0,
+  source:           'agent',
+  source_ref:       null,
+  created_at:       '',
+  updated_at:       null,
+  last_moved_at:    '',
+  last_activity_at: '',
+  created_by:       null,
+  last_moved_by:    null,
+  completed_at:     null,
+  archived:         false,
+};
+
+function repository() {
+  return {
+    getTask:    jest.fn(() => Promise.resolve(current)),
+    getEpic:    jest.fn(() => Promise.resolve(null)),
+    updateTask: jest.fn((_id: string, changes: any) => Promise.resolve({ ...current, ...changes })),
+  } as any;
+}
+
+describe('ProjectsApplicationService lifecycle boundary', () => {
+  afterEach(() => { jest.restoreAllMocks() });
+
+  it('fails closed before persistence when the source-stage owner rejects an adapter', async() => {
+    const repo = repository();
+    jest.spyOn(LifecycleCapabilityModel, 'assertActorCanManageTask')
+      .mockRejectedValue(new Error('source stage is protected'));
+    const service = new ProjectsApplicationService(repo);
+
+    await expect(service.updateTask('task-1', { status: 'in_review' }, {
+      actor: 'heartbeat', source: 'ipc',
+    })).rejects.toThrow('source stage is protected');
+    expect(repo.updateTask).not.toHaveBeenCalled();
+  });
+
+  it('applies destination ownership and custody before committing review entry', async() => {
+    const repo = repository();
+    const guard = jest.spyOn(LifecycleCapabilityModel, 'assertActorCanManageTask').mockResolvedValue();
+    jest.spyOn(WorkLaneDefinitionModel, 'semanticRoleForStatus').mockResolvedValue('execution');
+    jest.spyOn(WorkLaneDefinitionModel, 'validateTaskStatus').mockResolvedValue({
+      lane_key: 'in_review', semantic_role: 'review',
+    } as any);
+    const custody = jest.spyOn(ArtifactCustodyPolicy, 'assertForTransition').mockResolvedValue();
+    const service = new ProjectsApplicationService(repo);
+
+    const receipt = {
+      workKind: 'non_code', artifactId: 'task-1', evidence: { test: true }, provenance: { actor: 'dispatcher' },
+    } as const;
+    await service.updateTask('task-1', { status: 'in_review', custody: receipt }, {
+      actor: 'dispatcher', source: 'tool',
+    });
+
+    expect(guard.mock.calls).toEqual([
+      ['todo', [], 'dispatcher'],
+      ['in_review', [], 'dispatcher'],
+    ]);
+    expect(custody).toHaveBeenCalledWith('in_review', receipt);
+    expect(repo.updateTask).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes ordinary edits through the repository without lifecycle side effects', async() => {
+    const repo = repository();
+    const guard = jest.spyOn(LifecycleCapabilityModel, 'assertActorCanManageTask');
+    const service = new ProjectsApplicationService(repo);
+
+    await service.updateTask('task-1', { title: 'Renamed' }, { actor: 'human', source: 'ipc' });
+
+    expect(guard).not.toHaveBeenCalled();
+    expect(repo.updateTask).toHaveBeenCalledWith('task-1', { title: 'Renamed', actor: 'human' });
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsRepository.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsRepository.ts
@@ -1,0 +1,39 @@
+import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+
+import type {
+  AddCommentInput, ListActivityOpts, ListEpicsOpts, ListOpts, SearchOpts,
+  UpdateEpicInput, UpdateProjectInput, UpdateTaskInput,
+  UpsertEpicInput, UpsertProjectInput, UpsertTaskInput, WorkItemKind,
+} from '../../database/models/WorkItemsModel';
+import type { ProjectsRepository } from '../application/ProjectsRepository';
+
+/** Compatibility repository used while the legacy model is strangled out. */
+export class PostgresProjectsRepository implements ProjectsRepository {
+  verifySchema() { return WorkItemsModel.ensureTables() }
+  getProject(id: string) { return WorkItemsModel.getProject(id) }
+  getProjectBySlug(slug: string) { return WorkItemsModel.getProjectBySlug(slug) }
+  listProjects(opts: ListOpts = {}) { return WorkItemsModel.listProjects(opts) }
+  createProject(input: UpsertProjectInput) { return WorkItemsModel.upsertProject(input) }
+  updateProject(id: string, changes: UpdateProjectInput) { return WorkItemsModel.updateProject(id, changes) }
+  getEpic(id: string) { return WorkItemsModel.getEpic(id) }
+  listEpics(opts: ListEpicsOpts = {}) { return WorkItemsModel.listEpics(opts) }
+  createEpic(input: UpsertEpicInput) { return WorkItemsModel.upsertEpic(input) }
+  updateEpic(id: string, changes: UpdateEpicInput) { return WorkItemsModel.updateEpic(id, changes) }
+  getTask(id: string) { return WorkItemsModel.getTask(id) }
+  listTasks(opts: ListOpts = {}) { return WorkItemsModel.listTasks(opts) }
+  createTask(input: UpsertTaskInput) { return WorkItemsModel.insertTask(input) }
+  updateTask(id: string, changes: UpdateTaskInput) { return WorkItemsModel.updateTask(id, changes) }
+  archive(kind: WorkItemKind, id: string) { return WorkItemsModel.archive(kind, id) }
+  addComment(input: AddCommentInput) { return WorkItemsModel.addComment(input) }
+  listComments(taskId: string) { return WorkItemsModel.listComments(taskId) }
+  listRecentActivity(opts: ListActivityOpts = {}) { return WorkItemsModel.listRecentActivity(opts) }
+  search(opts: SearchOpts) { return WorkItemsModel.search(opts) }
+  listTaskDependencies(projectId: string) { return WorkItemsModel.listTaskDependencies(projectId) }
+  setTaskDependency(taskId: string, dependsOnTaskId: string, actor?: string) {
+    return WorkItemsModel.setTaskDependency(taskId, dependsOnTaskId, actor);
+  }
+
+  removeTaskDependency(taskId: string, dependsOnTaskId: string) {
+    return WorkItemsModel.removeTaskDependency(taskId, dependsOnTaskId);
+  }
+}

--- a/pkg/rancher-desktop/agent/tools/project/__tests__/conveyor_health.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/conveyor_health.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
+
 import { ConveyorHealthWorker } from '../conveyor_health';
 
 describe('ConveyorHealthWorker', () => {

--- a/pkg/rancher-desktop/agent/tools/project/__tests__/taskDependencyTools.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/taskDependencyTools.test.ts
@@ -1,48 +1,45 @@
 /** @jest-environment node */
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-jest.mock('../../../database/models/WorkTaskDependencyModel', () => ({
-  WorkTaskDependencyModel: {
-    create:              jest.fn(),
-    remove:              jest.fn(),
-    listDependencies:    jest.fn(),
-    listDependents:      jest.fn(),
-    explainClaimability: jest.fn(),
-  },
-}));
-
-import { WorkTaskDependencyModel } from '../../../database/models/WorkTaskDependencyModel';
+import { getProjectsApplicationService } from '../../../projects/application/ProjectsApplicationService';
 import { CreateTaskDependencyWorker } from '../create_task_dependency';
 import { ExplainTaskClaimabilityWorker } from '../explain_task_claimability';
 import { ListTaskDependenciesWorker } from '../list_task_dependencies';
 import { RemoveTaskDependencyWorker } from '../remove_task_dependency';
 
+const projects = getProjectsApplicationService() as any;
+const createDependency = jest.spyOn(projects, 'createDependency');
+const removeDependency = jest.spyOn(projects, 'removeDependency');
+const listDependencies = jest.spyOn(projects, 'listDependencies');
+const listDependents = jest.spyOn(projects, 'listDependents');
+const explainTaskClaimability = jest.spyOn(projects, 'explainTaskClaimability');
+
 const call = (tool: any, input: any) => tool._validatedCall(input);
 
 describe('task dependency tools', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => { jest.clearAllMocks() });
 
   it('create_task_dependency requires both task ids', async() => {
     const res = await call(new CreateTaskDependencyWorker(), { depends_on_task_id: 'b' });
     expect(res.successBoolean).toBe(false);
-    expect(WorkTaskDependencyModel.create).not.toHaveBeenCalled();
+    expect(createDependency).not.toHaveBeenCalled();
   });
 
   it('create_task_dependency rejects an invalid relation type', async() => {
     const res = await call(new CreateTaskDependencyWorker(), { dependent_task_id: 'a', depends_on_task_id: 'b', relation_type: 'nope' });
     expect(res.successBoolean).toBe(false);
-    expect(WorkTaskDependencyModel.create).not.toHaveBeenCalled();
+    expect(createDependency).not.toHaveBeenCalled();
   });
 
   it('create_task_dependency maps args and reports success', async() => {
-    (WorkTaskDependencyModel.create as any).mockResolvedValue({ id: 'dep-1', dependent_task_id: 'a', depends_on_task_id: 'b', relation_type: 'requires' });
+    createDependency.mockResolvedValue({ id: 'dep-1', dependent_task_id: 'a', depends_on_task_id: 'b', relation_type: 'requires' });
     const res = await call(new CreateTaskDependencyWorker(), { dependent_task_id: 'a', depends_on_task_id: 'b' });
     expect(res.successBoolean).toBe(true);
-    expect(WorkTaskDependencyModel.create).toHaveBeenCalledWith(expect.objectContaining({ dependentTaskId: 'a', dependsOnTaskId: 'b', relationType: 'requires' }));
+    expect(createDependency).toHaveBeenCalledWith(expect.objectContaining({ dependentTaskId: 'a', dependsOnTaskId: 'b', relationType: 'requires' }), expect.any(Object));
   });
 
   it('create_task_dependency surfaces a cycle error from the model', async() => {
-    (WorkTaskDependencyModel.create as any).mockRejectedValue(new Error('would create a cycle'));
+    createDependency.mockRejectedValue(new Error('would create a cycle'));
     const res = await call(new CreateTaskDependencyWorker(), { dependent_task_id: 'a', depends_on_task_id: 'b' });
     expect(res.successBoolean).toBe(false);
     expect(res.responseString).toMatch(/cycle/i);
@@ -50,23 +47,23 @@ describe('task dependency tools', () => {
 
   it('remove_task_dependency requires id or both task ids', async() => {
     expect((await call(new RemoveTaskDependencyWorker(), {})).successBoolean).toBe(false);
-    (WorkTaskDependencyModel.remove as any).mockResolvedValue(true);
+    removeDependency.mockResolvedValue(true);
     const res = await call(new RemoveTaskDependencyWorker(), { id: 'dep-1' });
     expect(res.successBoolean).toBe(true);
-    expect(WorkTaskDependencyModel.remove).toHaveBeenCalledWith(expect.objectContaining({ id: 'dep-1' }));
+    expect(removeDependency).toHaveBeenCalledWith(expect.objectContaining({ id: 'dep-1' }), expect.any(Object));
   });
 
   it('list_task_dependencies requires task_id and returns both directions', async() => {
     expect((await call(new ListTaskDependenciesWorker(), {})).successBoolean).toBe(false);
-    (WorkTaskDependencyModel.listDependencies as any).mockResolvedValue([{ id: 'd1' }]);
-    (WorkTaskDependencyModel.listDependents as any).mockResolvedValue([]);
+    listDependencies.mockResolvedValue([{ id: 'd1' }]);
+    listDependents.mockResolvedValue([]);
     const res = await call(new ListTaskDependenciesWorker(), { task_id: 't1' });
     expect(res.successBoolean).toBe(true);
     expect(res.responseString).toContain('dependencies');
   });
 
   it('explain_task_claimability returns the explanation payload', async() => {
-    (WorkTaskDependencyModel.explainClaimability as any).mockResolvedValue({ taskId: 't1', claimable: false, reason: 'x', unresolved: [], chain: [] });
+    explainTaskClaimability.mockResolvedValue({ taskId: 't1', claimable: false, reason: 'x', unresolved: [], chain: [] });
     const res = await call(new ExplainTaskClaimabilityWorker(), { task_id: 't1' });
     expect(res.successBoolean).toBe(true);
     expect(res.responseString).toContain('claimable');

--- a/pkg/rancher-desktop/agent/tools/project/__tests__/taskOwnershipTools.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/taskOwnershipTools.test.ts
@@ -57,6 +57,16 @@ describe('Projects task tools ownership inputs', () => {
 
   it('passes updated labels, ownership, and actor through update_task to the model boundary', async() => {
     jest.spyOn(WorkItemsModel, 'ensureTables').mockResolvedValue();
+    jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue({
+      id:         'task-1',
+      project_id: 'project-1',
+      epic_id:    'epic-1',
+      title:      'Ship it',
+      status:     'todo',
+      priority:   'p0',
+      assignee:   'dispatcher',
+      labels:     [],
+    } as any);
     const update = jest.spyOn(WorkItemsModel, 'updateTask').mockResolvedValue({
       id:               'task-1',
       epic_id:          'epic-1',

--- a/pkg/rancher-desktop/agent/tools/project/__tests__/update_task.lifecycle.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/update_task.lifecycle.test.ts
@@ -8,6 +8,7 @@ describe('update_task lifecycle ownership', () => {
   const call = (input: any) => (new UpdateTaskWorker() as any)._validatedCall(input);
   const task = (status: string) => ({
     id:               'task-1',
+    project_id:       'project-1',
     epic_id:          'epic-1',
     title:            'Protected work',
     status,

--- a/pkg/rancher-desktop/agent/tools/project/add_task_comment.ts
+++ b/pkg/rancher-desktop/agent/tools/project/add_task_comment.ts
@@ -1,4 +1,4 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -15,14 +15,16 @@ export class AddTaskCommentWorker extends BaseTool {
     if (!body) return { successBoolean: false, responseString: 'body is required.' };
 
     try {
-      await WorkItemsModel.ensureTables();
-      const comment = await WorkItemsModel.addComment({
+      const projects = getProjectsApplicationService();
+      await projects.ready();
+      const actor = input.actor || 'sulla';
+      const comment = await projects.addComment({
         task_id: taskId,
         body,
         // Direct Sulla chat is the default author for tool-driven comments;
         // Heartbeat should pass author="heartbeat"; the desktop UI stamps "human".
         author:  input.author || input.actor || 'sulla',
-      });
+      }, { actor, source: 'tool' });
       return {
         successBoolean: true,
         responseString: `Comment added on task ${ taskId } (id: ${ comment.id }, author: ${ comment.author }).`,

--- a/pkg/rancher-desktop/agent/tools/project/archive_lane.ts
+++ b/pkg/rancher-desktop/agent/tools/project/archive_lane.ts
@@ -1,4 +1,4 @@
-import { WorkLaneDefinitionModel } from '../../database/models/WorkLaneDefinitionModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class ArchiveLaneWorker extends BaseTool {
@@ -7,9 +7,9 @@ export class ArchiveLaneWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      await WorkLaneDefinitionModel.ensureTable();
-      const result = await WorkLaneDefinitionModel.archive(
-        String(input.id || '').trim(), input.destination_lane_key || undefined, input.actor || 'sulla',
+      const result = await getProjectsApplicationService().archiveLane(
+        String(input.id || '').trim(), input.destination_lane_key || undefined,
+        { actor: input.actor || 'sulla', source: 'tool' },
       );
       return { successBoolean: true, responseString: JSON.stringify(result) };
     } catch (err: any) {

--- a/pkg/rancher-desktop/agent/tools/project/archive_project_item.ts
+++ b/pkg/rancher-desktop/agent/tools/project/archive_project_item.ts
@@ -1,4 +1,4 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -14,10 +14,11 @@ export class ArchiveProjectItemWorker extends BaseTool {
     const hint = typeof input.kind === 'string' ? input.kind.trim().toLowerCase() : '';
 
     try {
-      await WorkItemsModel.ensureTables();
-      const tryKinds = (hint ? [hint] : ['task', 'epic', 'project']) as Array<'project' | 'epic' | 'task'>;
+      const projects = getProjectsApplicationService();
+      await projects.ready();
+      const tryKinds = (hint ? [hint] : ['task', 'epic', 'project']) as ('project' | 'epic' | 'task')[];
       for (const kind of tryKinds) {
-        const ok = await WorkItemsModel.archive(kind, id);
+        const ok = await projects.archive(kind, id, { actor: input.actor || 'sulla', source: 'tool' });
         if (ok) {
           return {
             successBoolean: true,

--- a/pkg/rancher-desktop/agent/tools/project/cancel_task_wait.ts
+++ b/pkg/rancher-desktop/agent/tools/project/cancel_task_wait.ts
@@ -1,4 +1,4 @@
-import { WorkTaskWaitModel } from '../../database/models/WorkTaskWaitModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class CancelTaskWaitWorker extends BaseTool {
@@ -10,7 +10,7 @@ export class CancelTaskWaitWorker extends BaseTool {
     const reason = typeof input.reason === 'string' && input.reason.trim() ? input.reason.trim() : 'cancelled by operator';
     if (!id) return { successBoolean: false, responseString: 'id is required.' };
     try {
-      const wait = await WorkTaskWaitModel.cancel(id, reason);
+      const wait = await getProjectsApplicationService().cancelWait(id, reason);
       return wait
         ? { successBoolean: true, responseString: `Cancelled task wait ${ id } (${ reason }).` }
         : { successBoolean: false, responseString: `No active task wait found with id ${ id }.` };

--- a/pkg/rancher-desktop/agent/tools/project/conveyor_health.ts
+++ b/pkg/rancher-desktop/agent/tools/project/conveyor_health.ts
@@ -1,9 +1,8 @@
-import { BaseTool, ToolResponse } from '../base';
-import {
-  WorkConveyorMetricsModel,
-  type ConveyorMetricsOptions,
-} from '../../database/models/WorkConveyorMetricsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { resolveWipLimits } from '../../services/ProjectAutomationWipLimits';
+import { BaseTool, ToolResponse } from '../base';
+
+import type { ConveyorMetricsOptions } from '../../database/models/WorkConveyorMetricsModel';
 
 /**
  * conveyor_health — read-only Projects conveyor-health & productivity snapshot
@@ -25,7 +24,7 @@ export class ConveyorHealthWorker extends BaseTool {
         reviewLimit:  limits.review,
         staleMinutes: typeof input?.stale_minutes === 'number' ? input.stale_minutes : undefined,
       };
-      const snap = await WorkConveyorMetricsModel.snapshot(opts);
+      const snap = await getProjectsApplicationService().conveyorHealth(opts);
       const scope = snap.project_id ? `project ${ snap.project_id }` : 'all projects';
       const lines: string[] = [];
       lines.push(`# Projects conveyor health (window ${ snap.window_hours }h, ${ scope })`);

--- a/pkg/rancher-desktop/agent/tools/project/create_epic.ts
+++ b/pkg/rancher-desktop/agent/tools/project/create_epic.ts
@@ -1,4 +1,4 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 function slugify(v: string): string {
@@ -20,15 +20,16 @@ export class CreateEpicWorker extends BaseTool {
     if (!title) return { successBoolean: false, responseString: 'title is required to create an epic.' };
 
     try {
-      await WorkItemsModel.ensureTables();
-      const existing = await WorkItemsModel.listEpics({ projectId, includeDone: true, limit: 1000 });
+      const projects = getProjectsApplicationService();
+      await projects.ready();
+      const existing = await projects.listEpics({ projectId, includeDone: true, limit: 1000 });
       const taken = new Set(existing.map(e => e.slug).filter(Boolean) as string[]);
       const base = slugify(input.slug || title);
       let slug = base;
       let n = 2;
       while (taken.has(slug)) slug = `${ base }-${ n++ }`;
 
-      const record = await WorkItemsModel.upsertEpic({
+      const record = await projects.createEpic({
         project_id:  projectId,
         slug,
         title,
@@ -38,7 +39,7 @@ export class CreateEpicWorker extends BaseTool {
         position:    typeof input.position === 'number' ? input.position : undefined,
         due_at:      input.due_at === '' ? null : input.due_at,
         source:      input.source || 'agent',
-      });
+      }, { actor: input.actor || 'sulla', source: 'tool' });
 
       return {
         successBoolean: true,

--- a/pkg/rancher-desktop/agent/tools/project/create_lane.ts
+++ b/pkg/rancher-desktop/agent/tools/project/create_lane.ts
@@ -1,4 +1,4 @@
-import { WorkLaneDefinitionModel } from '../../database/models/WorkLaneDefinitionModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class CreateLaneWorker extends BaseTool {
@@ -7,8 +7,7 @@ export class CreateLaneWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      await WorkLaneDefinitionModel.ensureTable();
-      const row = await WorkLaneDefinitionModel.create({
+      const row = await getProjectsApplicationService().createLane({
         lane_key:      input.lane_key,
         scope:         input.scope,
         project_id:    input.project_id || null,
@@ -21,7 +20,7 @@ export class CreateLaneWorker extends BaseTool {
         semantic_role: input.semantic_role,
         enabled:       input.enabled,
         actor:         input.actor || 'sulla',
-      });
+      }, { actor: input.actor || 'sulla', source: 'tool' });
       return { successBoolean: true, responseString: JSON.stringify(row) };
     } catch (err: any) {
       return { successBoolean: false, responseString: `Create lane failed: ${ err?.message }` };

--- a/pkg/rancher-desktop/agent/tools/project/create_project.ts
+++ b/pkg/rancher-desktop/agent/tools/project/create_project.ts
@@ -1,4 +1,4 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 function slugify(v: string): string {
@@ -18,13 +18,14 @@ export class CreateProjectWorker extends BaseTool {
     if (!title) return { successBoolean: false, responseString: 'title is required to create a project.' };
 
     try {
-      await WorkItemsModel.ensureTables();
+      const projects = getProjectsApplicationService();
+      await projects.ready();
       const base = slugify(input.slug || title);
       let slug = base;
       let n = 2;
-      while (await WorkItemsModel.getProjectBySlug(slug)) slug = `${ base }-${ n++ }`;
+      while (await projects.getProjectBySlug(slug)) slug = `${ base }-${ n++ }`;
 
-      const record = await WorkItemsModel.upsertProject({
+      const record = await projects.createProject({
         slug,
         title,
         description:    input.description,
@@ -35,7 +36,7 @@ export class CreateProjectWorker extends BaseTool {
         due_at:         input.due_at === '' ? null : input.due_at,
         github_repo:    input.github_repo,
         source:         input.source || 'agent',
-      });
+      }, { actor: input.actor || 'sulla', source: 'tool' });
 
       return {
         successBoolean: true,

--- a/pkg/rancher-desktop/agent/tools/project/create_task.ts
+++ b/pkg/rancher-desktop/agent/tools/project/create_task.ts
@@ -1,4 +1,4 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -22,8 +22,10 @@ export class CreateTaskWorker extends BaseTool {
       : undefined;
 
     try {
-      await WorkItemsModel.ensureTables();
-      const record = await WorkItemsModel.insertTask({
+      const projects = getProjectsApplicationService();
+      await projects.ready();
+      const actor = input.actor || 'sulla';
+      const record = await projects.createTask({
         epic_id:      epicId,
         parent_id:    parentId,
         title,
@@ -36,8 +38,8 @@ export class CreateTaskWorker extends BaseTool {
         github_issue: input.github_issue,
         position:     typeof input.position === 'number' ? input.position : undefined,
         source:       input.source || 'agent',
-        actor:        input.actor || 'sulla',
-      });
+        actor,
+      }, { actor, source: 'tool' });
 
       return {
         successBoolean: true,

--- a/pkg/rancher-desktop/agent/tools/project/create_task_dependency.ts
+++ b/pkg/rancher-desktop/agent/tools/project/create_task_dependency.ts
@@ -1,5 +1,7 @@
-import { WorkTaskDependencyModel, type DependencyRelationType } from '../../database/models/WorkTaskDependencyModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
+
+import type { DependencyRelationType } from '../../database/models/WorkTaskDependencyModel';
 
 const RELATIONS = new Set<DependencyRelationType>(['blocks', 'requires', 'ordered-after']);
 
@@ -18,13 +20,14 @@ export class CreateTaskDependencyWorker extends BaseTool {
       return { successBoolean: false, responseString: 'relation_type must be one of blocks, requires, ordered-after.' };
     }
     try {
-      const dep = await WorkTaskDependencyModel.create({
+      const actor = typeof input.actor === 'string' && input.actor.trim() ? input.actor.trim() : 'sulla';
+      const dep = await getProjectsApplicationService().createDependency({
         dependentTaskId,
         dependsOnTaskId,
         relationType:         relationRaw as DependencyRelationType,
         acceptanceCondition:  typeof input.acceptance_condition === 'string' && input.acceptance_condition.trim() ? input.acceptance_condition.trim() : null,
-        actor:                typeof input.actor === 'string' && input.actor.trim() ? input.actor.trim() : undefined,
-      });
+        actor,
+      }, { actor, source: 'tool' });
       return {
         successBoolean: true,
         responseString: `Dependency ${ dep.id }: task ${ dep.dependent_task_id } ${ dep.relation_type } ${ dep.depends_on_task_id }. The dependent cannot be claimed until the prerequisite is done.`,

--- a/pkg/rancher-desktop/agent/tools/project/explain_task_claimability.ts
+++ b/pkg/rancher-desktop/agent/tools/project/explain_task_claimability.ts
@@ -1,4 +1,4 @@
-import { WorkTaskDependencyModel } from '../../database/models/WorkTaskDependencyModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /** Explain whether a task is claimable: dependency chain + exact blocking reason. */
@@ -9,7 +9,7 @@ export class ExplainTaskClaimabilityWorker extends BaseTool {
     const taskId = typeof input.task_id === 'string' ? input.task_id.trim() : '';
     if (!taskId) return { successBoolean: false, responseString: 'task_id is required.' };
     try {
-      const explanation = await WorkTaskDependencyModel.explainClaimability(taskId);
+      const explanation = await getProjectsApplicationService().explainTaskClaimability(taskId);
       return { successBoolean: true, responseString: JSON.stringify(explanation, null, 2) };
     } catch (err: any) {
       return { successBoolean: false, responseString: `Failed to explain task claimability: ${ err?.message ?? String(err) }` };

--- a/pkg/rancher-desktop/agent/tools/project/get_project_item.ts
+++ b/pkg/rancher-desktop/agent/tools/project/get_project_item.ts
@@ -1,6 +1,7 @@
-import { WorkItemKnowledgeModel, type KnowledgeWorkItemKind } from '../../database/models/WorkItemKnowledgeModel';
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
+
+import type { KnowledgeWorkItemKind } from '../../database/models/WorkItemKnowledgeModel';
 
 function block(label: string, rec: Record<string, any>, extra: string[] = []): string {
   const keys = [
@@ -23,7 +24,9 @@ function block(label: string, rec: Record<string, any>, extra: string[] = []): s
 
 async function knowledgeSummary(kind: KnowledgeWorkItemKind, id: string, enabled: boolean): Promise<string[]> {
   if (!enabled) return [];
-  const rows = await WorkItemKnowledgeModel.listForItem(kind, id, { includeInherited: true, limit: 20 });
+  const rows = await getProjectsApplicationService().listKnowledgeForItem({
+    itemKind: kind, itemId: id, includeInherited: true, limit: 20,
+  });
   const lines = ['', `${ rows.length } linked knowledge item(s):`];
   for (const row of rows) {
     lines.push(`- [${ row.node_id }] ${ row.scope } ${ row.relation_type }: ${ row.title } (from ${ row.linked_item_kind } ${ row.linked_item_id })`);
@@ -45,14 +48,15 @@ export class GetProjectItemWorker extends BaseTool {
     const includeKnowledge = Boolean(input.include_knowledge ?? false);
 
     try {
-      await WorkItemsModel.ensureTables();
+      const projects = getProjectsApplicationService();
+      await projects.ready();
 
       const tryKinds = hint ? [hint] : ['task', 'epic', 'project'];
       for (const kind of tryKinds) {
         if (kind === 'project') {
-          const p = await WorkItemsModel.getProject(id);
+          const p = await projects.getProject(id);
           if (!p) continue;
-          const epics = await WorkItemsModel.listEpics({ projectId: p.id, includeDone: true, limit: 100 });
+          const epics = await projects.listEpics({ projectId: p.id, includeDone: true, limit: 100 });
           const parts = [block('Project', p)];
           parts.push('', `${ epics.length } epic(s):`);
           for (const e of epics) {
@@ -62,9 +66,9 @@ export class GetProjectItemWorker extends BaseTool {
           return { successBoolean: true, responseString: parts.join('\n') };
         }
         if (kind === 'epic') {
-          const e = await WorkItemsModel.getEpic(id);
+          const e = await projects.getEpic(id);
           if (!e) continue;
-          const tasks = await WorkItemsModel.listTasks({ epicId: e.id, includeDone: true, limit: 200 });
+          const tasks = await projects.listTasks({ epicId: e.id, includeDone: true, limit: 200 });
           const parts = [block('Epic', e)];
           parts.push('', `${ tasks.length } task(s):`);
           for (const t of tasks) {
@@ -75,10 +79,10 @@ export class GetProjectItemWorker extends BaseTool {
           return { successBoolean: true, responseString: parts.join('\n') };
         }
         if (kind === 'task') {
-          const t = await WorkItemsModel.getTask(id);
+          const t = await projects.getTask(id);
           if (!t) continue;
-          const comments = await WorkItemsModel.listComments(t.id);
-          const subs = await WorkItemsModel.listTasks({ parentId: t.id, includeDone: true, limit: 100 });
+          const comments = await projects.listComments(t.id);
+          const subs = await projects.listTasks({ parentId: t.id, includeDone: true, limit: 100 });
           const parts = [block('Task', t, ['labels'])];
           if (subs.length) {
             parts.push('', `${ subs.length } subtask(s):`);

--- a/pkg/rancher-desktop/agent/tools/project/inspect_lane_entry_automation.ts
+++ b/pkg/rancher-desktop/agent/tools/project/inspect_lane_entry_automation.ts
@@ -1,11 +1,11 @@
-import { WorkLaneWorkflowBindingModel } from '../../database/models/WorkLaneWorkflowBindingModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class InspectLaneEntryAutomationWorker extends BaseTool {
   name = ''; description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      const rows = await WorkLaneWorkflowBindingModel.listLaneEntries(String(input.task_id || '').trim());
+      const rows = await getProjectsApplicationService().listLaneEntries(String(input.task_id || '').trim());
       return { successBoolean: true, responseString: JSON.stringify(rows, null, 2) };
     } catch (error) {
       return { successBoolean: false, responseString: `Failed to inspect lane-entry automation: ${ error instanceof Error ? error.message : String(error) }` };

--- a/pkg/rancher-desktop/agent/tools/project/link_knowledge_item.ts
+++ b/pkg/rancher-desktop/agent/tools/project/link_knowledge_item.ts
@@ -1,4 +1,4 @@
-import { WorkItemKnowledgeModel } from '../../database/models/WorkItemKnowledgeModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 import { associationInput, formatJson } from '../knowledgeAssociationAdapter';
 
@@ -8,7 +8,9 @@ export class LinkKnowledgeItemWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      const link = await WorkItemKnowledgeModel.link(associationInput(input));
+      const link = await getProjectsApplicationService().linkKnowledge(
+        associationInput(input), { actor: input.actor || 'sulla', source: 'tool' },
+      );
       return { successBoolean: true, responseString: formatJson(link) };
     } catch (err: any) {
       return { successBoolean: false, responseString: `Link knowledge item failed: ${ err?.message ?? String(err) }` };

--- a/pkg/rancher-desktop/agent/tools/project/list_lane_workflow_bindings.ts
+++ b/pkg/rancher-desktop/agent/tools/project/list_lane_workflow_bindings.ts
@@ -1,11 +1,11 @@
-import { WorkLaneWorkflowBindingModel } from '../../database/models/WorkLaneWorkflowBindingModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class ListLaneWorkflowBindingsWorker extends BaseTool {
   name = ''; description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      const rows = await WorkLaneWorkflowBindingModel.list({
+      const rows = await getProjectsApplicationService().listLaneBindings({
         profileId:       input.profile_id,
         scope:           input.scope,
         epicId:          input.epic_id,

--- a/pkg/rancher-desktop/agent/tools/project/list_lanes.ts
+++ b/pkg/rancher-desktop/agent/tools/project/list_lanes.ts
@@ -1,4 +1,4 @@
-import { WorkLaneDefinitionModel } from '../../database/models/WorkLaneDefinitionModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class ListLanesWorker extends BaseTool {
@@ -7,8 +7,7 @@ export class ListLanesWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      await WorkLaneDefinitionModel.ensureTable();
-      const rows = await WorkLaneDefinitionModel.list({
+      const rows = await getProjectsApplicationService().listLanes({
         scope:           input.scope || undefined,
         projectId:       input.project_id || undefined,
         includeArchived: Boolean(input.include_archived),

--- a/pkg/rancher-desktop/agent/tools/project/list_linked_knowledge.ts
+++ b/pkg/rancher-desktop/agent/tools/project/list_linked_knowledge.ts
@@ -1,4 +1,4 @@
-import { WorkItemKnowledgeModel } from '../../database/models/WorkItemKnowledgeModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 import { formatJson, parseItem } from '../knowledgeAssociationAdapter';
 
@@ -9,7 +9,9 @@ export class ListLinkedKnowledgeWorker extends BaseTool {
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
       const item = parseItem(input);
-      const rows = await WorkItemKnowledgeModel.listForItem(item.kind, item.id, {
+      const rows = await getProjectsApplicationService().listKnowledgeForItem({
+        itemKind:         item.kind,
+        itemId:           item.id,
         includeInherited: Boolean(input.include_inherited ?? true),
         includeArchived:  Boolean(input.include_archived ?? false),
         relationType:     input.relation_type,

--- a/pkg/rancher-desktop/agent/tools/project/list_project_items.ts
+++ b/pkg/rancher-desktop/agent/tools/project/list_project_items.ts
@@ -1,4 +1,4 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 function fmtProject(p: any): string {
@@ -32,22 +32,23 @@ export class ListProjectItemsWorker extends BaseTool {
     const assignee = input.assignee || undefined;
 
     try {
-      await WorkItemsModel.ensureTables();
+      const projects = getProjectsApplicationService();
+      await projects.ready();
       const lines: string[] = [];
 
       if (kind === 'project' || kind === 'all') {
-        const rows = await WorkItemsModel.listProjects({ status, priority, includeDone, limit });
+        const rows = await projects.listProjects({ status, priority, includeDone, limit });
         lines.push(rows.length ? `${ rows.length } project(s):` : 'No projects.');
         lines.push(...rows.map(fmtProject));
       }
       if (kind === 'epic' || kind === 'all') {
-        const rows = await WorkItemsModel.listEpics({ projectId, status, priority, includeDone, limit });
+        const rows = await projects.listEpics({ projectId, status, priority, includeDone, limit });
         if (lines.length) lines.push('');
         lines.push(rows.length ? `${ rows.length } epic(s):` : 'No epics.');
         lines.push(...rows.map(fmtEpic));
       }
       if (kind === 'task' || kind === 'all') {
-        const rows = await WorkItemsModel.listTasks({
+        const rows = await projects.listTasks({
           projectId, epicId, parentId, status, priority, assignee, includeDone, limit,
         });
         if (lines.length) lines.push('');

--- a/pkg/rancher-desktop/agent/tools/project/list_task_comments.ts
+++ b/pkg/rancher-desktop/agent/tools/project/list_task_comments.ts
@@ -1,4 +1,4 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -13,8 +13,9 @@ export class ListTaskCommentsWorker extends BaseTool {
     if (!taskId) return { successBoolean: false, responseString: 'task_id is required.' };
 
     try {
-      await WorkItemsModel.ensureTables();
-      const comments = await WorkItemsModel.listComments(taskId);
+      const projects = getProjectsApplicationService();
+      await projects.ready();
+      const comments = await projects.listComments(taskId);
       if (!comments.length) {
         return { successBoolean: true, responseString: `No comments on task ${ taskId }.` };
       }

--- a/pkg/rancher-desktop/agent/tools/project/list_task_dependencies.ts
+++ b/pkg/rancher-desktop/agent/tools/project/list_task_dependencies.ts
@@ -1,4 +1,4 @@
-import { WorkTaskDependencyModel } from '../../database/models/WorkTaskDependencyModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /** List a task's dependencies (its prerequisites) and its dependents. Read-only. */
@@ -10,9 +10,10 @@ export class ListTaskDependenciesWorker extends BaseTool {
     if (!taskId) return { successBoolean: false, responseString: 'task_id is required.' };
     try {
       const includeArchived = input.include_archived === true;
+      const projects = getProjectsApplicationService();
       const [dependencies, dependents] = await Promise.all([
-        WorkTaskDependencyModel.listDependencies(taskId, { includeArchived }),
-        WorkTaskDependencyModel.listDependents(taskId, { includeArchived }),
+        projects.listDependencies(taskId, { includeArchived }),
+        projects.listDependents(taskId, { includeArchived }),
       ]);
       return { successBoolean: true, responseString: JSON.stringify({ taskId, dependencies, dependents }, null, 2) };
     } catch (err: any) {

--- a/pkg/rancher-desktop/agent/tools/project/list_task_waits.ts
+++ b/pkg/rancher-desktop/agent/tools/project/list_task_waits.ts
@@ -1,5 +1,7 @@
-import { WorkTaskWaitModel, type WorkTaskWaitStatus } from '../../database/models/WorkTaskWaitModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
+
+import type { WorkTaskWaitStatus } from '../../database/models/WorkTaskWaitModel';
 
 export class ListTaskWaitsWorker extends BaseTool {
   name = '';
@@ -7,7 +9,7 @@ export class ListTaskWaitsWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      const waits = await WorkTaskWaitModel.list({
+      const waits = await getProjectsApplicationService().listWaits({
         taskId: typeof input.task_id === 'string' && input.task_id.trim() ? input.task_id.trim() : undefined,
         status: typeof input.status === 'string' && input.status.trim() ? input.status.trim() as WorkTaskWaitStatus : undefined,
         limit:  typeof input.limit === 'number' ? input.limit : undefined,

--- a/pkg/rancher-desktop/agent/tools/project/register_task_wait.ts
+++ b/pkg/rancher-desktop/agent/tools/project/register_task_wait.ts
@@ -1,6 +1,7 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
-import { WorkTaskWaitModel, type WorkTaskWaitKind } from '../../database/models/WorkTaskWaitModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
+
+import type { WorkTaskWaitKind } from '../../database/models/WorkTaskWaitModel';
 
 const WAIT_KINDS = new Set<WorkTaskWaitKind>(['github_checks', 'human_gate', 'scheduled_time', 'external_job']);
 
@@ -22,7 +23,8 @@ export class RegisterTaskWaitWorker extends BaseTool {
       const nextCheckAt = typeof input.next_check_at === 'string' && input.next_check_at.trim()
         ? input.next_check_at.trim()
         : (waitKind === 'human_gate' && dueAt ? dueAt : undefined);
-      const registration = await WorkTaskWaitModel.register({
+      const actor = input.actor || 'sulla';
+      const registration = await getProjectsApplicationService().registerWait({
         taskId,
         waitKind,
         targetKey,
@@ -31,14 +33,7 @@ export class RegisterTaskWaitWorker extends BaseTool {
         nextCheckAt,
         dueAt,
         owner:       typeof input.owner === 'string' && input.owner.trim() ? input.owner.trim() : undefined,
-      });
-      if (registration.created) {
-        await WorkItemsModel.addComment({
-          task_id: taskId,
-          author:  input.actor || 'sulla',
-          body:    `External wait registered: ${ waitKind } (${ targetKey }). Unchanged checks are owned by the durable monitor and will not add task comments.`,
-        });
-      }
+      }, { actor, source: 'tool' });
       return {
         successBoolean: true,
         responseString: `${ registration.created ? 'Registered' : 'Existing' } ${ waitKind } wait ${ registration.wait.id } for task ${ taskId }; next check ${ registration.wait.next_check_at }.`,

--- a/pkg/rancher-desktop/agent/tools/project/remove_lane_workflow_binding.ts
+++ b/pkg/rancher-desktop/agent/tools/project/remove_lane_workflow_binding.ts
@@ -1,11 +1,13 @@
-import { WorkLaneWorkflowBindingModel } from '../../database/models/WorkLaneWorkflowBindingModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class RemoveLaneWorkflowBindingWorker extends BaseTool {
   name = ''; description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      const row = await WorkLaneWorkflowBindingModel.remove(String(input.id || '').trim(), input.actor || 'sulla');
+      const row = await getProjectsApplicationService().removeLaneBinding(
+        String(input.id || '').trim(), { actor: input.actor || 'sulla', source: 'tool' },
+      );
       return row
         ? { successBoolean: true, responseString: `Lane workflow binding removed: ${ row.id }` }
         : { successBoolean: false, responseString: `No active lane workflow binding found: ${ input.id }` };

--- a/pkg/rancher-desktop/agent/tools/project/remove_task_dependency.ts
+++ b/pkg/rancher-desktop/agent/tools/project/remove_task_dependency.ts
@@ -1,4 +1,4 @@
-import { WorkTaskDependencyModel } from '../../database/models/WorkTaskDependencyModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /** Soft-archive one task dependency by id, or by dependent+depends_on(+relation). */
@@ -13,12 +13,13 @@ export class RemoveTaskDependencyWorker extends BaseTool {
       return { successBoolean: false, responseString: 'Provide id, or both dependent_task_id and depends_on_task_id.' };
     }
     try {
-      const removed = await WorkTaskDependencyModel.remove({
+      const actor = typeof input.actor === 'string' && input.actor.trim() ? input.actor.trim() : 'sulla';
+      const removed = await getProjectsApplicationService().removeDependency({
         id,
         dependentTaskId,
         dependsOnTaskId,
         relationType: typeof input.relation_type === 'string' && input.relation_type.trim() ? input.relation_type.trim() : undefined,
-      });
+      }, { actor, source: 'tool' });
       return { successBoolean: true, responseString: removed ? 'Dependency removed (soft-archived).' : 'No matching active dependency found.' };
     } catch (err: any) {
       return { successBoolean: false, responseString: `Failed to remove task dependency: ${ err?.message ?? String(err) }` };

--- a/pkg/rancher-desktop/agent/tools/project/reorder_lanes.ts
+++ b/pkg/rancher-desktop/agent/tools/project/reorder_lanes.ts
@@ -1,4 +1,4 @@
-import { WorkLaneDefinitionModel } from '../../database/models/WorkLaneDefinitionModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class ReorderLanesWorker extends BaseTool {
@@ -7,9 +7,9 @@ export class ReorderLanesWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      await WorkLaneDefinitionModel.ensureTable();
-      const changed = await WorkLaneDefinitionModel.reorder(
-        input.scope, input.ordered_lane_keys, input.project_id || undefined, input.actor || 'sulla',
+      const changed = await getProjectsApplicationService().reorderLanes(
+        input.scope, input.ordered_lane_keys, input.project_id || undefined,
+        { actor: input.actor || 'sulla', source: 'tool' },
       );
       return { successBoolean: true, responseString: `${ changed } lane definition(s) reordered.` };
     } catch (err: any) {

--- a/pkg/rancher-desktop/agent/tools/project/reset_lane_override.ts
+++ b/pkg/rancher-desktop/agent/tools/project/reset_lane_override.ts
@@ -1,4 +1,4 @@
-import { WorkLaneDefinitionModel } from '../../database/models/WorkLaneDefinitionModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class ResetLaneOverrideWorker extends BaseTool {
@@ -7,9 +7,9 @@ export class ResetLaneOverrideWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      await WorkLaneDefinitionModel.ensureTable();
-      const reset = await WorkLaneDefinitionModel.resetProjectOverride(
-        String(input.project_id || '').trim(), String(input.lane_key || '').trim(), input.actor || 'sulla',
+      const reset = await getProjectsApplicationService().resetLaneOverride(
+        String(input.project_id || '').trim(), String(input.lane_key || '').trim(),
+        { actor: input.actor || 'sulla', source: 'tool' },
       );
       return reset
         ? { successBoolean: true, responseString: `Project lane ${ input.lane_key } now inherits the global definition.` }

--- a/pkg/rancher-desktop/agent/tools/project/resolve_lane_workflow.ts
+++ b/pkg/rancher-desktop/agent/tools/project/resolve_lane_workflow.ts
@@ -1,11 +1,11 @@
-import { WorkLaneWorkflowBindingModel } from '../../database/models/WorkLaneWorkflowBindingModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class ResolveLaneWorkflowWorker extends BaseTool {
   name = ''; description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      const row = await WorkLaneWorkflowBindingModel.resolve(
+      const row = await getProjectsApplicationService().resolveLaneBinding(
         String(input.task_id || '').trim(), String(input.lane_key || '').trim(), input.profile_id || 'default');
       return { successBoolean: true, responseString: JSON.stringify(row, null, 2) };
     } catch (error) {

--- a/pkg/rancher-desktop/agent/tools/project/resolve_lanes.ts
+++ b/pkg/rancher-desktop/agent/tools/project/resolve_lanes.ts
@@ -1,4 +1,4 @@
-import { WorkLaneDefinitionModel } from '../../database/models/WorkLaneDefinitionModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class ResolveLanesWorker extends BaseTool {
@@ -9,8 +9,7 @@ export class ResolveLanesWorker extends BaseTool {
     const projectId = String(input.project_id || '').trim();
     if (!projectId) return { successBoolean: false, responseString: 'project_id is required.' };
     try {
-      await WorkLaneDefinitionModel.ensureTable();
-      const rows = await WorkLaneDefinitionModel.resolveEffective(projectId, Boolean(input.include_archived));
+      const rows = await getProjectsApplicationService().resolveEffectiveLanes(projectId, Boolean(input.include_archived));
       return { successBoolean: true, responseString: JSON.stringify(rows) };
     } catch (err: any) {
       return { successBoolean: false, responseString: `Resolve lanes failed: ${ err?.message }` };

--- a/pkg/rancher-desktop/agent/tools/project/restore_lane.ts
+++ b/pkg/rancher-desktop/agent/tools/project/restore_lane.ts
@@ -1,4 +1,4 @@
-import { WorkLaneDefinitionModel } from '../../database/models/WorkLaneDefinitionModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class RestoreLaneWorker extends BaseTool {
@@ -7,8 +7,9 @@ export class RestoreLaneWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      await WorkLaneDefinitionModel.ensureTable();
-      const row = await WorkLaneDefinitionModel.restore(String(input.id || '').trim(), input.actor || 'sulla');
+      const row = await getProjectsApplicationService().restoreLane(
+        String(input.id || '').trim(), { actor: input.actor || 'sulla', source: 'tool' },
+      );
       if (!row) return { successBoolean: false, responseString: `No restorable lane found with id: ${ input.id }` };
       return { successBoolean: true, responseString: JSON.stringify(row) };
     } catch (err: any) {

--- a/pkg/rancher-desktop/agent/tools/project/search_project_items.ts
+++ b/pkg/rancher-desktop/agent/tools/project/search_project_items.ts
@@ -1,4 +1,4 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -16,8 +16,9 @@ export class SearchProjectItemsWorker extends BaseTool {
     const includeArchived = Boolean(input.include_archived ?? input.includeArchived ?? false);
 
     try {
-      await WorkItemsModel.ensureTables();
-      const rows = await WorkItemsModel.search({ query, kind, limit, includeArchived });
+      const projects = getProjectsApplicationService();
+      await projects.ready();
+      const rows = await projects.search({ query, kind, limit, includeArchived });
       if (rows.length === 0) {
         return { successBoolean: true, responseString: `No project items matched "${ query }".` };
       }

--- a/pkg/rancher-desktop/agent/tools/project/set_lane_workflow_binding.ts
+++ b/pkg/rancher-desktop/agent/tools/project/set_lane_workflow_binding.ts
@@ -1,11 +1,11 @@
-import { WorkLaneWorkflowBindingModel } from '../../database/models/WorkLaneWorkflowBindingModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class SetLaneWorkflowBindingWorker extends BaseTool {
   name = ''; description = '';
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      const row = await WorkLaneWorkflowBindingModel.set({
+      const row = await getProjectsApplicationService().setLaneBinding({
         scope:        input.scope,
         workflowId:   String(input.workflow_id || '').trim(),
         laneKey:      input.lane_key,
@@ -14,7 +14,7 @@ export class SetLaneWorkflowBindingWorker extends BaseTool {
         projectId:    input.project_id,
         profileId:    input.profile_id,
         actor:        input.actor || 'sulla',
-      });
+      }, { actor: input.actor || 'sulla', source: 'tool' });
       return { successBoolean: true, responseString: JSON.stringify(row, null, 2) };
     } catch (error) {
       return { successBoolean: false, responseString: `Failed to set lane workflow binding: ${ error instanceof Error ? error.message : String(error) }` };

--- a/pkg/rancher-desktop/agent/tools/project/unlink_knowledge_item.ts
+++ b/pkg/rancher-desktop/agent/tools/project/unlink_knowledge_item.ts
@@ -1,4 +1,4 @@
-import { WorkItemKnowledgeModel } from '../../database/models/WorkItemKnowledgeModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 import { associationInput } from '../knowledgeAssociationAdapter';
 
@@ -8,7 +8,9 @@ export class UnlinkKnowledgeItemWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      const removed = await WorkItemKnowledgeModel.unlink(associationInput(input));
+      const removed = await getProjectsApplicationService().unlinkKnowledge(
+        associationInput(input), { actor: input.actor || 'sulla', source: 'tool' },
+      );
       return {
         successBoolean: true,
         responseString: removed ? 'Direct knowledge association archived.' : 'No matching active direct association.',

--- a/pkg/rancher-desktop/agent/tools/project/update_epic.ts
+++ b/pkg/rancher-desktop/agent/tools/project/update_epic.ts
@@ -1,4 +1,4 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -15,8 +15,9 @@ export class UpdateEpicWorker extends BaseTool {
     if (!id) return { successBoolean: false, responseString: 'id is required to update an epic.' };
 
     try {
-      await WorkItemsModel.ensureTables();
-      const updated = await WorkItemsModel.updateEpic(id, {
+      const projects = getProjectsApplicationService();
+      await projects.ready();
+      const updated = await projects.updateEpic(id, {
         project_id:  input.project_id,
         slug:        input.slug,
         title:       input.title,
@@ -26,7 +27,7 @@ export class UpdateEpicWorker extends BaseTool {
         position:    typeof input.position === 'number' ? input.position : undefined,
         due_at:      input.due_at === '' ? null : input.due_at,
         source:      input.source,
-      });
+      }, { actor: input.actor || 'sulla', source: 'tool' });
       if (!updated) return { successBoolean: false, responseString: `No epic found with id: ${ id }` };
 
       return {

--- a/pkg/rancher-desktop/agent/tools/project/update_lane.ts
+++ b/pkg/rancher-desktop/agent/tools/project/update_lane.ts
@@ -1,4 +1,4 @@
-import { WorkLaneDefinitionModel } from '../../database/models/WorkLaneDefinitionModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 export class UpdateLaneWorker extends BaseTool {
@@ -7,8 +7,7 @@ export class UpdateLaneWorker extends BaseTool {
 
   protected async _validatedCall(input: any): Promise<ToolResponse> {
     try {
-      await WorkLaneDefinitionModel.ensureTable();
-      const row = await WorkLaneDefinitionModel.update(String(input.id || '').trim(), {
+      const row = await getProjectsApplicationService().updateLane(String(input.id || '').trim(), {
         display_name:  input.display_name,
         description:   input.description,
         color:         input.color === '' ? null : input.color,
@@ -17,7 +16,7 @@ export class UpdateLaneWorker extends BaseTool {
         semantic_role: input.semantic_role,
         enabled:       input.enabled,
         actor:         input.actor || 'sulla',
-      });
+      }, { actor: input.actor || 'sulla', source: 'tool' });
       if (!row) return { successBoolean: false, responseString: `No active lane found with id: ${ input.id }` };
       return { successBoolean: true, responseString: JSON.stringify(row) };
     } catch (err: any) {

--- a/pkg/rancher-desktop/agent/tools/project/update_project.ts
+++ b/pkg/rancher-desktop/agent/tools/project/update_project.ts
@@ -1,4 +1,4 @@
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -14,8 +14,9 @@ export class UpdateProjectWorker extends BaseTool {
     if (!id) return { successBoolean: false, responseString: 'id is required to update a project.' };
 
     try {
-      await WorkItemsModel.ensureTables();
-      const updated = await WorkItemsModel.updateProject(id, {
+      const projects = getProjectsApplicationService();
+      await projects.ready();
+      const updated = await projects.updateProject(id, {
         slug:           input.slug,
         title:          input.title,
         description:    input.description,
@@ -26,7 +27,7 @@ export class UpdateProjectWorker extends BaseTool {
         due_at:         input.due_at === '' ? null : input.due_at,
         github_repo:    input.github_repo,
         source:         input.source,
-      });
+      }, { actor: input.actor || 'sulla', source: 'tool' });
       if (!updated) return { successBoolean: false, responseString: `No project found with id: ${ id }` };
 
       return {

--- a/pkg/rancher-desktop/agent/tools/project/update_task.ts
+++ b/pkg/rancher-desktop/agent/tools/project/update_task.ts
@@ -1,5 +1,4 @@
-import { LifecycleCapabilityModel } from '../../database/models/LifecycleCapabilityModel';
-import { WorkItemsModel } from '../../database/models/WorkItemsModel';
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
 import { BaseTool, ToolResponse } from '../base';
 
 /**
@@ -26,32 +25,12 @@ export class UpdateTaskWorker extends BaseTool {
       : undefined;
 
     try {
-      await WorkItemsModel.ensureTables();
+      const projects = getProjectsApplicationService();
+      await projects.ready();
       const actor = input.actor || 'sulla';
-      const current = await WorkItemsModel.getTask(id);
+      const current = await projects.getTask(id);
       if (!current) return { successBoolean: false, responseString: `No task found with id: ${ id }` };
-      if (input.status !== undefined || input.assignee !== undefined) {
-        // A move must be authorized by the owner of the stage being left, not
-        // only by the destination owner. Otherwise Heartbeat could bypass a
-        // healthy protected routine by moving its task to an unprotected
-        // status (for example in_review -> done).
-        await LifecycleCapabilityModel.assertActorCanManageTask(
-          current.status,
-          current.labels,
-          actor,
-        );
-
-        const destinationStatus = typeof input.status === 'string' ? input.status : current.status;
-        const destinationLabels = labels ?? current.labels;
-        if (destinationStatus !== current.status || destinationLabels !== current.labels) {
-          await LifecycleCapabilityModel.assertActorCanManageTask(
-            destinationStatus,
-            destinationLabels,
-            actor,
-          );
-        }
-      }
-      const updated = await WorkItemsModel.updateTask(id, {
+      const updated = await projects.updateTask(id, {
         epic_id:      typeof input.epic_id === 'string' && input.epic_id.trim() ? input.epic_id.trim() : undefined,
         parent_id:    parentId,
         title:        input.title,
@@ -66,7 +45,7 @@ export class UpdateTaskWorker extends BaseTool {
         source:       input.source,
         actor,
         custody:      input.custody,
-      });
+      }, { actor, source: 'tool' });
       if (!updated) return { successBoolean: false, responseString: `No task found with id: ${ id }` };
 
       return {

--- a/pkg/rancher-desktop/main/__tests__/workItemsEvents.conveyor-health.test.ts
+++ b/pkg/rancher-desktop/main/__tests__/workItemsEvents.conveyor-health.test.ts
@@ -9,13 +9,13 @@ describe('work-items conveyor-health IPC contract', () => {
   it('registers snapshot and bounded drill-down channels', () => {
     expect(source).toContain("handle('work-items:conveyor-health'");
     expect(source).toContain("handle('work-items:conveyor-oldest'");
-    expect(source).toContain('WorkConveyorMetricsModel.snapshot');
-    expect(source).toContain('WorkConveyorMetricsModel.oldestItems');
+    expect(source).toContain('projects.conveyorHealth');
+    expect(source).toContain('projects.conveyorOldest');
   });
 
   it('uses durable configured execution and review capacity', () => {
-    expect(source).toContain('resolveWipLimits');
-    expect(source).toContain('wipLimit: limits.execution');
-    expect(source).toContain('reviewLimit: limits.review');
+    expect(source).toContain('projects.automationStatus');
+    expect(source).toContain('wipLimit:    automation.limits.execution');
+    expect(source).toContain('reviewLimit: automation.limits.review');
   });
 });

--- a/pkg/rancher-desktop/main/__tests__/workItemsEvents.lanes.test.ts
+++ b/pkg/rancher-desktop/main/__tests__/workItemsEvents.lanes.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { describe, expect, it } from '@jest/globals';
 
 describe('work-items lane IPC contract', () => {
-  it('registers every lane mutation and resolver through WorkLaneDefinitionModel', () => {
+  it('registers every lane mutation and resolver through the Projects application boundary', () => {
     const source = fs.readFileSync(path.resolve(process.cwd(), 'pkg/rancher-desktop/main/workItemsEvents.ts'), 'utf8');
     for (const channel of [
       'work-items:lanes-list', 'work-items:lanes-resolve', 'work-items:lane-create',
@@ -16,7 +16,8 @@ describe('work-items lane IPC contract', () => {
       'work-items:lane-workflow-resolve-context', 'work-items:lane-compatible-workflows',
       'work-items:lane-entry-automations',
     ]) expect(source).toContain(`handle('${ channel }'`);
-    expect(source).toContain("import('@pkg/agent/database/models/WorkLaneDefinitionModel')");
-    expect(source).toContain("import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel')");
+    expect(source).toContain("import('@pkg/agent/projects/application/ProjectsApplicationService')");
+    expect(source).not.toContain("import('@pkg/agent/database/models/WorkLaneDefinitionModel')");
+    expect(source).not.toContain("import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel')");
   });
 });

--- a/pkg/rancher-desktop/main/workItemsEvents.ts
+++ b/pkg/rancher-desktop/main/workItemsEvents.ts
@@ -43,60 +43,31 @@ import Logging from '@pkg/utils/logging';
 const console = Logging.background;
 const ipcMainProxy = getIpcMainProxy(console);
 
-async function importWorkItemsModel() {
-  const mod = await import('@pkg/agent/database/models/WorkItemsModel');
-
-  return mod.WorkItemsModel;
-}
-
-async function importWorkLaneDefinitionModel() {
-  const mod = await import('@pkg/agent/database/models/WorkLaneDefinitionModel');
-
-  return mod.WorkLaneDefinitionModel;
-}
-
-async function importWorkLaneWorkflowBindingModel() {
-  const mod = await import('@pkg/agent/database/models/WorkLaneWorkflowBindingModel');
-  return mod.WorkLaneWorkflowBindingModel;
-}
-
-async function importWorkProjectViewModel() {
-  const mod = await import('@pkg/agent/database/models/WorkProjectViewModel');
-  return mod.WorkProjectViewModel;
-}
-
-async function importKnowledgeModels() {
-  const [associations, graph] = await Promise.all([
-    import('@pkg/agent/database/models/WorkItemKnowledgeModel'),
-    import('@pkg/agent/database/models/KnowledgeGraphModel'),
-  ]);
-  return { WorkItemKnowledgeModel: associations.WorkItemKnowledgeModel, KnowledgeGraphModel: graph.KnowledgeGraphModel };
+async function importProjectsApplicationService() {
+  const mod = await import('@pkg/agent/projects/application/ProjectsApplicationService');
+  return mod.getProjectsApplicationService();
 }
 
 export async function listKnowledgeForWorkItem(input: {
   itemKind: KnowledgeWorkItemKind; itemId: string; includeInherited?: boolean; includeArchived?: boolean; limit?: number;
 }) {
-  const { WorkItemKnowledgeModel } = await importKnowledgeModels();
-  return WorkItemKnowledgeModel.listForItem(input.itemKind, input.itemId, {
-    includeInherited: input.includeInherited ?? true,
-    includeArchived:  input.includeArchived ?? false,
-    limit:            input.limit,
-  });
+  const projects = await importProjectsApplicationService();
+  return projects.listKnowledgeForItem(input);
 }
 
 export async function linkKnowledgeForWorkItem(input: KnowledgeLinkInput) {
-  const { WorkItemKnowledgeModel } = await importKnowledgeModels();
-  return WorkItemKnowledgeModel.link({ ...input, source: input.source ?? 'ui', actor: input.actor ?? 'human' });
+  const projects = await importProjectsApplicationService();
+  return projects.linkKnowledge(input, { actor: 'human', source: 'ipc' });
 }
 
 export async function unlinkKnowledgeForWorkItem(input: KnowledgeLinkInput) {
-  const { WorkItemKnowledgeModel } = await importKnowledgeModels();
-  return WorkItemKnowledgeModel.unlink({ ...input, source: input.source ?? 'ui', actor: input.actor ?? 'human' });
+  const projects = await importProjectsApplicationService();
+  return projects.unlinkKnowledge(input, { actor: 'human', source: 'ipc' });
 }
 
 export async function listWorkForKnowledge(input: { knowledgeNodeId: string; includeArchived?: boolean; limit?: number }) {
-  const { WorkItemKnowledgeModel } = await importKnowledgeModels();
-  return WorkItemKnowledgeModel.listForNode(input.knowledgeNodeId, input);
+  const projects = await importProjectsApplicationService();
+  return projects.listWorkForKnowledge(input.knowledgeNodeId, input);
 }
 
 /** Local slugify — mirrors the model's private one (kebab, ≤80 chars). */
@@ -115,32 +86,38 @@ export function initWorkItemsEvents(): void {
   // the board can render its Done column). The renderer builds the tree.
   // Do NOT swallow errors — a thrown query surfaces in useProjects.error.
   ipcMainProxy.handle('work-items:board', async() => {
-    const WorkItemsModel = await importWorkItemsModel();
-    const { WorkItemKnowledgeModel } = await importKnowledgeModels();
+    const app = await importProjectsApplicationService();
     const [projects, epics, tasks] = await Promise.all([
-      WorkItemsModel.listProjects({ includeDone: true, limit: 500 }),
-      WorkItemsModel.listEpics({ includeDone: true, limit: 1000 }),
-      WorkItemsModel.listTasks({ includeDone: true, limit: 3000 }),
+      app.listProjects({ includeDone: true, limit: 500 }),
+      app.listEpics({ includeDone: true, limit: 1000 }),
+      app.listTasks({ includeDone: true, limit: 3000 }),
     ]);
 
     const [projectCounts, epicCounts, taskCounts] = await Promise.all([
-      WorkItemKnowledgeModel.countForItems('project', projects.map(item => item.id)),
-      WorkItemKnowledgeModel.countForItems('epic', epics.map(item => item.id)),
-      WorkItemKnowledgeModel.countForItems('task', tasks.map(item => item.id)),
+      app.countKnowledgeForItems('project', projects.map(item => item.id)),
+      app.countKnowledgeForItems('epic', epics.map(item => item.id)),
+      app.countKnowledgeForItems('task', tasks.map(item => item.id)),
     ]);
+    const laneEntries = await Promise.all(projects.map(async project => [
+      project.id,
+      await app.resolveEffectiveLanes(project.id),
+    ] as const));
+    const laneCapability = await app.laneRuntimeCapability();
 
     return {
-      projects: projects.map(item => ({ ...item, knowledge_count: projectCounts[item.id] ?? 0 })),
-      epics:    epics.map(item => ({ ...item, knowledge_count: epicCounts[item.id] ?? 0 })),
-      tasks:    tasks.map(item => ({ ...item, knowledge_count: taskCounts[item.id] ?? 0 })),
+      projects:       projects.map(item => ({ ...item, knowledge_count: projectCounts[item.id] ?? 0 })),
+      epics:          epics.map(item => ({ ...item, knowledge_count: epicCounts[item.id] ?? 0 })),
+      tasks:          tasks.map(item => ({ ...item, knowledge_count: taskCounts[item.id] ?? 0 })),
+      lanesByProject: Object.fromEntries(laneEntries),
+      laneCapability,
     };
   });
 
   ipcMainProxy.handle('work-items:comments', async(_event: unknown, taskId: string) => {
     if (!taskId) return [];
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
 
-    return WorkItemsModel.listComments(taskId);
+    return projects.listComments(taskId);
   });
 
   ipcMainProxy.handle('work-items:artifact-evidence', async(_event: unknown, commentId: string) => {
@@ -150,81 +127,66 @@ export function initWorkItemsEvents(): void {
   });
 
   ipcMainProxy.handle('work-items:activity', async(_event: unknown, opts: { projectId?: string; author?: string; limit?: number } = {}) => {
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
 
-    return WorkItemsModel.listRecentActivity(opts);
+    return projects.listRecentActivity(opts);
   });
 
   ipcMainProxy.handle('work-items:automation-status', async() => {
-    const [{ WorkTaskDispatchModel }, limitsModule] = await Promise.all([
-      import('@pkg/agent/database/models/WorkTaskDispatchModel'),
-      import('@pkg/agent/services/ProjectAutomationWipLimits'),
-    ]);
-    const [limits, counts] = await Promise.all([
-      limitsModule.resolveWipLimits(),
-      WorkTaskDispatchModel.countByRole(),
-    ]);
-    return {
-      limits,
-      counts,
-      decision: limitsModule.evaluateClaim('execution', counts, limits),
-      at: new Date().toISOString(),
-    };
+    const projects = await importProjectsApplicationService();
+    return projects.automationStatus();
   });
 
   ipcMainProxy.handle('work-items:conveyor-health', async(_event: unknown, opts: {
     projectId?: string | null; windowHours?: number;
   } = {}) => {
-    const [{ WorkConveyorMetricsModel }, { resolveWipLimits }] = await Promise.all([
-      import('@pkg/agent/database/models/WorkConveyorMetricsModel'),
-      import('@pkg/agent/services/ProjectAutomationWipLimits'),
-    ]);
-    const limits = await resolveWipLimits();
-    return WorkConveyorMetricsModel.snapshot({
-      projectId: opts.projectId ?? null,
+    const projects = await importProjectsApplicationService();
+    const automation = await projects.automationStatus();
+    return projects.conveyorHealth({
+      projectId:   opts.projectId ?? null,
       windowHours: opts.windowHours,
-      wipLimit: limits.execution,
-      reviewLimit: limits.review,
+      wipLimit:    automation.limits.execution,
+      reviewLimit: automation.limits.review,
     });
   });
 
   ipcMainProxy.handle('work-items:conveyor-oldest', async(_event: unknown, opts: {
     projectId?: string | null; stage: import('@pkg/agent/database/models/WorkConveyorMetricsModel').SemanticStage;
   }) => {
-    const { WorkConveyorMetricsModel } = await import('@pkg/agent/database/models/WorkConveyorMetricsModel');
     const allowed = new Set(['backlog', 'planning', 'execution', 'review', 'blocked', 'terminal', 'manual']);
     if (!allowed.has(opts.stage)) throw new Error(`Invalid semantic stage: ${ opts.stage }`);
-    return WorkConveyorMetricsModel.oldestItems({ projectId: opts.projectId ?? null, drillLimit: 20 }, opts.stage);
+    const projects = await importProjectsApplicationService();
+    return projects.conveyorOldest(opts);
   });
 
   ipcMainProxy.handle('work-items:views-list', async(_event: unknown, projectId?: string | null) => {
-    const Model = await importWorkProjectViewModel();
-    return Model.list(projectId);
+    const projects = await importProjectsApplicationService();
+    return projects.listViews(projectId);
   });
 
   ipcMainProxy.handle('work-items:view-resolve', async(_event: unknown, projectId?: string | null) => {
-    const Model = await importWorkProjectViewModel();
-    return Model.resolve(projectId);
+    const projects = await importProjectsApplicationService();
+    return projects.resolveView(projectId);
   });
 
   ipcMainProxy.handle('work-items:view-save', async(_event: unknown, input: SaveProjectViewInput) => {
-    const Model = await importWorkProjectViewModel();
-    return Model.save({ ...input, actor: input.actor ?? 'human' });
+    const projects = await importProjectsApplicationService();
+    return projects.saveView(input, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:dependencies-list', async(_event: unknown, projectId: string) => {
-    const WorkItemsModel = await importWorkItemsModel();
-    return WorkItemsModel.listTaskDependencies(projectId);
+    const projects = await importProjectsApplicationService();
+    return projects.listTaskDependencies(projectId);
   });
 
   ipcMainProxy.handle('work-items:dependency-set', async(_event: unknown, taskId: string, dependsOnTaskId: string) => {
-    const WorkItemsModel = await importWorkItemsModel();
-    return WorkItemsModel.setTaskDependency(taskId, dependsOnTaskId, 'human');
+    const projects = await importProjectsApplicationService();
+    return projects.setTaskDependency(taskId, dependsOnTaskId, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:dependency-remove', async(_event: unknown, taskId: string, dependsOnTaskId: string) => {
-    const WorkItemsModel = await importWorkItemsModel();
-    return WorkItemsModel.removeTaskDependency(taskId, dependsOnTaskId);
+    const projects = await importProjectsApplicationService();
+    return projects.removeTaskDependency(taskId, dependsOnTaskId, { actor: 'human', source: 'ipc' });
   });
 
   // ── lane definitions ─────────────────────────────────────────────────
@@ -232,85 +194,85 @@ export function initWorkItemsEvents(): void {
   ipcMainProxy.handle('work-items:lanes-list', async(_event: unknown, opts: {
     scope?: WorkLaneScope; projectId?: string; includeArchived?: boolean; includeReset?: boolean;
   } = {}) => {
-    const Model = await importWorkLaneDefinitionModel();
-    return Model.list(opts);
+    const projects = await importProjectsApplicationService();
+    return projects.listLanes(opts);
   });
 
   ipcMainProxy.handle('work-items:lanes-resolve', async(_event: unknown, projectId: string, includeArchived = false) => {
-    const Model = await importWorkLaneDefinitionModel();
-    return Model.resolveEffective(projectId, includeArchived);
+    const projects = await importProjectsApplicationService();
+    return projects.resolveEffectiveLanes(projectId, includeArchived);
   });
 
   ipcMainProxy.handle('work-items:lane-create', async(_event: unknown, input: CreateWorkLaneInput) => {
-    const Model = await importWorkLaneDefinitionModel();
-    return Model.create({ ...input, actor: input.actor ?? 'human' });
+    const projects = await importProjectsApplicationService();
+    return projects.createLane(input, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:lane-update', async(_event: unknown, id: string, changes: UpdateWorkLaneInput) => {
-    const Model = await importWorkLaneDefinitionModel();
-    return Model.update(id, { ...changes, actor: changes.actor ?? 'human' });
+    const projects = await importProjectsApplicationService();
+    return projects.updateLane(id, changes, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:lane-archive', async(_event: unknown, id: string, destinationLaneKey?: string) => {
-    const Model = await importWorkLaneDefinitionModel();
-    return Model.archive(id, destinationLaneKey, 'human');
+    const projects = await importProjectsApplicationService();
+    return projects.archiveLane(id, destinationLaneKey, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:lane-archive-preview', async(_event: unknown, id: string) => {
-    const Model = await importWorkLaneDefinitionModel();
-    return Model.previewArchive(id);
+    const projects = await importProjectsApplicationService();
+    return projects.previewArchiveLane(id);
   });
 
   ipcMainProxy.handle('work-items:lane-restore', async(_event: unknown, id: string) => {
-    const Model = await importWorkLaneDefinitionModel();
-    return Model.restore(id, 'human');
+    const projects = await importProjectsApplicationService();
+    return projects.restoreLane(id, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:lanes-reorder', async(_event: unknown, scope: WorkLaneScope, orderedKeys: string[], projectId?: string) => {
-    const Model = await importWorkLaneDefinitionModel();
-    return Model.reorder(scope, orderedKeys, projectId, 'human');
+    const projects = await importProjectsApplicationService();
+    return projects.reorderLanes(scope, orderedKeys, projectId, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:lane-reset-override', async(_event: unknown, projectId: string, laneKey: string) => {
-    const Model = await importWorkLaneDefinitionModel();
-    return Model.resetProjectOverride(projectId, laneKey, 'human');
+    const projects = await importProjectsApplicationService();
+    return projects.resetLaneOverride(projectId, laneKey, { actor: 'human', source: 'ipc' });
   });
 
   // ── lane workflow bindings + entry audit ─────────────────────────────
 
   ipcMainProxy.handle('work-items:lane-bindings-list', async(_event: unknown, input: ListLaneBindingsInput = {}) => {
-    const Model = await importWorkLaneWorkflowBindingModel();
-    return Model.list(input);
+    const projects = await importProjectsApplicationService();
+    return projects.listLaneBindings(input);
   });
 
   ipcMainProxy.handle('work-items:lane-binding-set', async(_event: unknown, input: SetLaneBindingInput) => {
-    const Model = await importWorkLaneWorkflowBindingModel();
-    return Model.set({ ...input, actor: input.actor ?? 'human' });
+    const projects = await importProjectsApplicationService();
+    return projects.setLaneBinding(input, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:lane-binding-remove', async(_event: unknown, id: string) => {
-    const Model = await importWorkLaneWorkflowBindingModel();
-    return Model.remove(id, 'human');
+    const projects = await importProjectsApplicationService();
+    return projects.removeLaneBinding(id, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:lane-workflow-resolve', async(_event: unknown, taskId: string, laneKey: string, profileId = 'default') => {
-    const Model = await importWorkLaneWorkflowBindingModel();
-    return Model.resolve(taskId, laneKey, profileId);
+    const projects = await importProjectsApplicationService();
+    return projects.resolveLaneBinding(taskId, laneKey, profileId);
   });
 
   ipcMainProxy.handle('work-items:lane-workflow-resolve-context', async(_event: unknown, input: ResolveLaneBindingContextInput) => {
-    const Model = await importWorkLaneWorkflowBindingModel();
-    return Model.resolveForContext(input);
+    const projects = await importProjectsApplicationService();
+    return projects.resolveLaneBindingContext(input);
   });
 
   ipcMainProxy.handle('work-items:lane-compatible-workflows', async(_event: unknown, projectId: string, laneKey: string) => {
-    const Model = await importWorkLaneWorkflowBindingModel();
-    return Model.listCompatibleWorkflows(projectId, laneKey);
+    const projects = await importProjectsApplicationService();
+    return projects.listCompatibleLaneWorkflows(projectId, laneKey);
   });
 
   ipcMainProxy.handle('work-items:lane-entry-automations', async(_event: unknown, taskId: string) => {
-    const Model = await importWorkLaneWorkflowBindingModel();
-    return Model.listLaneEntries(taskId);
+    const projects = await importProjectsApplicationService();
+    return projects.listLaneEntries(taskId);
   });
 
   ipcMainProxy.handle('work-items:knowledge-list', async(_event: unknown, input: {
@@ -322,8 +284,8 @@ export function initWorkItemsEvents(): void {
   ipcMainProxy.handle('work-items:knowledge-unlink', async(_event: unknown, input: KnowledgeLinkInput) => unlinkKnowledgeForWorkItem(input));
 
   ipcMainProxy.handle('knowledge:nodes-search', async(_event: unknown, input: { query?: string; includeArchived?: boolean; limit?: number } = {}) => {
-    const { KnowledgeGraphModel } = await importKnowledgeModels();
-    return KnowledgeGraphModel.searchNodes(input);
+    const projects = await importProjectsApplicationService();
+    return projects.searchKnowledgeNodes(input);
   });
 
   ipcMainProxy.handle('knowledge:work-list', async(_event: unknown, input: { knowledgeNodeId: string; includeArchived?: boolean; limit?: number }) => listWorkForKnowledge(input));
@@ -331,80 +293,81 @@ export function initWorkItemsEvents(): void {
   // ── projects ─────────────────────────────────────────────────────────
 
   ipcMainProxy.handle('work-items:project-create', async(_event: unknown, input: UpsertProjectInput) => {
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
     const base = slugify(input.slug || input.title);
     let slug = base;
     let n = 2;
-    while (await WorkItemsModel.getProjectBySlug(slug)) slug = `${ base }-${ n++ }`;
+    while (await projects.getProjectBySlug(slug)) slug = `${ base }-${ n++ }`;
 
-    return WorkItemsModel.upsertProject({ ...input, slug });
+    return projects.createProject({ ...input, slug }, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:project-update', async(_event: unknown, id: string, changes: UpdateProjectInput) => {
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
 
-    return WorkItemsModel.updateProject(id, changes);
+    return projects.updateProject(id, changes, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:project-archive', async(_event: unknown, id: string) => {
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
 
-    return WorkItemsModel.archive('project', id);
+    return projects.archive('project', id, { actor: 'human', source: 'ipc' });
   });
 
   // ── epics ────────────────────────────────────────────────────────────
 
   ipcMainProxy.handle('work-items:epic-create', async(_event: unknown, input: UpsertEpicInput) => {
-    const WorkItemsModel = await importWorkItemsModel();
-    const existing = await WorkItemsModel.listEpics({ projectId: input.project_id, includeDone: true, limit: 1000 });
+    const projects = await importProjectsApplicationService();
+    const existing = await projects.listEpics({ projectId: input.project_id, includeDone: true, limit: 1000 });
     const taken = new Set(existing.map(e => e.slug).filter(Boolean) as string[]);
     const base = slugify(input.slug || input.title);
     let slug = base;
     let n = 2;
     while (taken.has(slug)) slug = `${ base }-${ n++ }`;
 
-    return WorkItemsModel.upsertEpic({ ...input, slug });
+    return projects.createEpic({ ...input, slug }, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:epic-update', async(_event: unknown, id: string, changes: UpdateEpicInput) => {
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
 
-    return WorkItemsModel.updateEpic(id, changes);
+    return projects.updateEpic(id, changes, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:epic-archive', async(_event: unknown, id: string) => {
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
 
-    return WorkItemsModel.archive('epic', id);
+    return projects.archive('epic', id, { actor: 'human', source: 'ipc' });
   });
 
   // ── tasks ────────────────────────────────────────────────────────────
 
   ipcMainProxy.handle('work-items:task-create', async(_event: unknown, input: UpsertTaskInput) => {
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
 
     // insertTask always creates a new row and requires an epic_id.
-    return WorkItemsModel.insertTask({ ...input, actor: input.actor ?? 'human' });
+    return projects.createTask({ ...input, actor: input.actor ?? 'human' }, { actor: input.actor ?? 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:task-update', async(_event: unknown, id: string, changes: UpdateTaskInput) => {
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
+    const actor = changes.actor ?? 'human';
 
-    return WorkItemsModel.updateTask(id, { ...changes, actor: changes.actor ?? 'human' });
+    return projects.updateTask(id, { ...changes, actor }, { actor, source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:task-archive', async(_event: unknown, id: string) => {
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
 
-    return WorkItemsModel.archive('task', id);
+    return projects.archive('task', id, { actor: 'human', source: 'ipc' });
   });
 
   // ── comments ─────────────────────────────────────────────────────────
 
   ipcMainProxy.handle('work-items:comment-add', async(_event: unknown, input: AddCommentInput) => {
-    const WorkItemsModel = await importWorkItemsModel();
+    const projects = await importProjectsApplicationService();
 
-    return WorkItemsModel.addComment(input);
+    return projects.addComment(input, { actor: input.author ?? 'human', source: 'ipc' });
   });
 
   // ── reorder / move (batch position + optional status/epic move) ────────
@@ -413,22 +376,8 @@ export function initWorkItemsEvents(): void {
   // that shifted. Applied in order through the model so last_moved_at + the
   // done→completed_at rules still fire.
   ipcMainProxy.handle('work-items:reorder', async(_event: unknown, updates: ReorderUpdate[]) => {
-    const WorkItemsModel = await importWorkItemsModel();
-    for (const u of updates) {
-      if (u.kind === 'epic') {
-        const changes: UpdateEpicInput = {};
-        if (u.position !== undefined) changes.position = u.position;
-        if (u.status !== undefined) changes.status = u.status;
-        await WorkItemsModel.updateEpic(u.id, changes);
-      } else {
-        const changes: UpdateTaskInput = {};
-        if (u.position !== undefined) changes.position = u.position;
-        if (u.status !== undefined) changes.status = u.status;
-        if (u.epic_id !== undefined) changes.epic_id = u.epic_id;
-        await WorkItemsModel.updateTask(u.id, { ...changes, actor: changes.actor ?? 'human' });
-      }
-    }
-
+    const projects = await importProjectsApplicationService();
+    await projects.reorder(updates, { actor: 'human', source: 'ipc' });
     return true;
   });
 

--- a/pkg/rancher-desktop/main/workItemsEvents.ts
+++ b/pkg/rancher-desktop/main/workItemsEvents.ts
@@ -346,14 +346,13 @@ export function initWorkItemsEvents(): void {
     const projects = await importProjectsApplicationService();
 
     // insertTask always creates a new row and requires an epic_id.
-    return projects.createTask({ ...input, actor: input.actor ?? 'human' }, { actor: input.actor ?? 'human', source: 'ipc' });
+    return projects.createTask({ ...input, actor: 'human' }, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:task-update', async(_event: unknown, id: string, changes: UpdateTaskInput) => {
     const projects = await importProjectsApplicationService();
-    const actor = changes.actor ?? 'human';
 
-    return projects.updateTask(id, { ...changes, actor }, { actor, source: 'ipc' });
+    return projects.updateTask(id, { ...changes, actor: 'human' }, { actor: 'human', source: 'ipc' });
   });
 
   ipcMainProxy.handle('work-items:task-archive', async(_event: unknown, id: string) => {


### PR DESCRIPTION
## Scope

Phase 3 of internal Projects P0 task dHAe.

- adds one ProjectsApplicationService command/query boundary
- routes every public project CLI adapter and Electron work-items IPC mutation through it
- centralizes source/destination lifecycle authorization and custody checks
- closes batch reorder bypass by routing task moves through the same updateTask command
- preserves existing tool names, IPC channels, records, and error mapping
- restores the semantic-lane helper/ownership contract required by current WorkItemsModel after the Phase 2 schema extraction

Phase 4 orchestration and Phase 5 semantic-lane consumer migration remain excluded. PR #735 remains custody-only and must not be merged.

## Verification

- 13 focused suites passed, 37 tests passed, 2 opt-in PostgreSQL tests skipped
- adapter-boundary contract proves project tools have no direct Projects model calls and IPC mutations have no direct WorkItemsModel writes
- authorization/custody negative tests passed
- git diff --check passed
- bounded full TypeScript pass reached the known ~2 GB heap ceiling after ~44s; it emitted no diagnostics before OOM
