### PR TITLE
WIP: move Projects orchestration onto durable domain events (dHAe Phase 4)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0086_create_projects_domain_event_outbox.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0086_create_projects_domain_event_outbox.ts
@@ -1,0 +1,42 @@
+/** Durable, generation-scoped Projects domain-event outbox (dHAe Phase 4). */
+export const up = `
+  CREATE TABLE IF NOT EXISTS work_project_domain_events (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL REFERENCES work_tasks(id),
+    generation INTEGER NOT NULL CHECK (generation >= 0),
+    generation_hash TEXT,
+    event_type TEXT NOT NULL CHECK (length(event_type) > 0),
+    idempotency_key TEXT NOT NULL UNIQUE,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'pending'
+      CHECK (status IN ('pending', 'processing', 'completed')),
+    attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    available_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    lease_owner TEXT,
+    leased_until TIMESTAMPTZ,
+    last_error TEXT,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    CONSTRAINT work_project_domain_events_lease_pair CHECK (
+      (lease_owner IS NULL AND leased_until IS NULL)
+      OR (lease_owner IS NOT NULL AND leased_until IS NOT NULL)
+    )
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_work_project_domain_events_pending
+    ON work_project_domain_events (available_at, created_at)
+    WHERE status = 'pending';
+
+  CREATE INDEX IF NOT EXISTS idx_work_project_domain_events_expired
+    ON work_project_domain_events (leased_until)
+    WHERE status = 'processing';
+
+  CREATE INDEX IF NOT EXISTS idx_work_project_domain_events_generation
+    ON work_project_domain_events (task_id, generation, event_type);
+`;
+
+export const down = `
+  DROP TABLE IF EXISTS work_project_domain_events;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0086_create_projects_domain_event_outbox.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0086_create_projects_domain_event_outbox.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { down, up } from '../0086_create_projects_domain_event_outbox';
+
+describe('0086 Projects domain-event outbox migration', () => {
+  it('creates a generation-scoped idempotent lease outbox', () => {
+    expect(up).toContain('CREATE TABLE IF NOT EXISTS work_project_domain_events');
+    expect(up).toContain('idempotency_key TEXT NOT NULL UNIQUE');
+    expect(up).toContain('generation INTEGER NOT NULL');
+    expect(up).toContain("status IN ('pending', 'processing', 'completed')");
+    expect(up).toContain('work_project_domain_events_lease_pair');
+    expect(up).toContain('idx_work_project_domain_events_expired');
+  });
+
+  it('remains additive on upgrade and reversible in isolation', () => {
+    expect(up).not.toMatch(/DROP\s+(?:TABLE|COLUMN)/i);
+    expect(down).toContain('DROP TABLE IF EXISTS work_project_domain_events');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -72,6 +72,7 @@ import { up as up_0082, down as down_0082 } from './0082_create_artifact_receipt
 import { up as up_0083, down as down_0083 } from './0083_create_work_task_dependencies';
 import { up as up_0084, down as down_0084 } from './0084_activate_protected_review';
 import { up as up_0085, down as down_0085 } from './0085_add_conveyor_metrics_indexes';
+import { up as up_0086, down as down_0086 } from './0086_create_projects_domain_event_outbox';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -145,4 +146,5 @@ export const migrationsRegistry = [
   { name: '0083_create_work_task_dependencies',                    up: up_0083, down: down_0083 },
   { name: '0084_activate_protected_review',                        up: up_0084, down: down_0084 },
   { name: '0085_add_conveyor_metrics_indexes',                     up: up_0085, down: down_0085 },
+  { name: '0086_create_projects_domain_event_outbox',              up: up_0086, down: down_0086 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from 'node:crypto';
 
 import { postgresClient } from '../PostgresClient';
+import { appendTaskTransitionEvent } from '../../projects/infrastructure/appendTaskTransitionEvent';
 
 import type { PoolClient } from 'pg';
+import type { WorkTaskRecord } from './WorkItemsModel';
 
 export const LIFECYCLE_CAPABILITY_KEYS = [
   'planning-council',
@@ -357,7 +359,10 @@ export class LifecycleCapabilityModel {
       `);
       const target = context.rows[0];
       if (!target) return;
-      await client.query(`
+      const prior = await client.query<WorkTaskRecord>(
+        'SELECT * FROM work_tasks WHERE id = $1 FOR UPDATE', [id],
+      );
+      const upserted = await client.query<WorkTaskRecord>(`
         INSERT INTO work_tasks (
           id, project_id, epic_id, title, description, status, priority,
           assignee, labels, source, source_ref, created_by, last_moved_by
@@ -368,6 +373,7 @@ export class LifecycleCapabilityModel {
           description = EXCLUDED.description,
           status = CASE WHEN work_tasks.status IN ('done', 'cancelled', 'parked') THEN 'todo' ELSE work_tasks.status END,
           priority = 'critical', archived = false, updated_at = now(), last_activity_at = now()
+        RETURNING *
       `, [
         id,
         target.project_id,
@@ -376,6 +382,13 @@ export class LifecycleCapabilityModel {
         `Capability ${ current.capability_key } is degraded. Owner: ${ current.active_owner ?? 'none' }. Error: ${ current.last_error ?? 'unknown' }. Exception count: ${ current.exception_count }. Restore health without bypassing its single-owner claim.`,
         `lifecycle-capability:${ current.capability_key }`,
       ]);
+      const recoveryTask = upserted.rows[0];
+      const previousStatus = prior.rows[0]?.status ?? '';
+      if (recoveryTask && recoveryTask.status !== previousStatus) {
+        await appendTaskTransitionEvent(
+          client, recoveryTask, previousStatus, 'lifecycle-control-plane', 'capability-recovery-open',
+        );
+      }
       await client.query(
         'UPDATE lifecycle_capabilities SET recovery_task_id = $2 WHERE capability_key = $1',
         [current.capability_key, id],
@@ -385,13 +398,23 @@ export class LifecycleCapabilityModel {
 
   private static async resolveRecoveryTask(capability: LifecycleCapabilityRecord): Promise<void> {
     await postgresClient.transaction(async(client) => {
-      await client.query(`
+      const prior = await client.query<WorkTaskRecord>(
+        'SELECT * FROM work_tasks WHERE id = $1 FOR UPDATE', [capability.recovery_task_id],
+      );
+      const resolved = await client.query<WorkTaskRecord>(`
         UPDATE work_tasks
            SET status = 'done', completed_at = now(), updated_at = now(),
                last_moved_at = now(), last_activity_at = now(),
                last_moved_by = 'lifecycle-control-plane'
          WHERE id = $1 AND status NOT IN ('done', 'cancelled', 'parked')
+         RETURNING *
       `, [capability.recovery_task_id]);
+      if (prior.rows[0] && resolved.rows[0] && resolved.rows[0].status !== prior.rows[0].status) {
+        await appendTaskTransitionEvent(
+          client, resolved.rows[0], prior.rows[0].status,
+          'lifecycle-control-plane', 'capability-recovery-resolved',
+        );
+      }
       await client.query(
         'UPDATE lifecycle_capabilities SET recovery_task_id = NULL WHERE capability_key = $1',
         [capability.capability_key],

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -1002,7 +1002,6 @@ export class WorkItemsModel {
     setClauses.push('last_activity_at = now()');
 
     values.push(id);
-    let laneEntryId: string | null = null;
     const updateSql = `UPDATE ${ WorkItemsModel.TASKS } SET ${ setClauses.join(', ') }
       WHERE id = $${ idx } RETURNING *`;
     let updated: WorkTaskRecord | null;
@@ -1028,7 +1027,6 @@ export class WorkItemsModel {
           const { WorkLaneWorkflowBindingModel } = await import('./WorkLaneWorkflowBindingModel');
           const claimed = await WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction(
             client, committed.id, committed.status, changes.actor ?? 'sulla');
-          if (claimed.created && claimed.entry.status === 'pending') laneEntryId = claimed.entry.id;
           const { createPostgresProjectsRepositories } = await import('../../projects/infrastructure/PostgresProjectsRepositories');
           await createPostgresProjectsRepositories(client).events.append({
             id:             `projects-event-${ committed.id }-${ claimed.entry.generation }-transition`,
@@ -1058,12 +1056,12 @@ export class WorkItemsModel {
       updated = rows[0] ?? null;
     }
 
-    if (laneEntryId) {
+    if (updated && changes.status !== undefined && updated.status !== existing.status) {
       try {
-        const { LaneEntryAutomationService } = await import('../../services/LaneEntryAutomationService');
-        await LaneEntryAutomationService.dispatchEntry(laneEntryId);
+        const { getProjectsOrchestrationEventService } = await import('../../projects/application/ProjectsOrchestrationEventService');
+        await getProjectsOrchestrationEventService().drain();
       } catch (error) {
-        console.warn(`[WorkItems] Lane entry ${ laneEntryId } remains recoverable after dispatch failure:`, error);
+        console.warn(`[WorkItems] Transition events for task ${ updated.id } remain recoverable after dispatch failure:`, error);
       }
     }
     if (updated && changes.status !== undefined) {

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -393,46 +393,6 @@ function fallbackKeys(roles: WorkLaneSemanticRole[]): string[] {
   return Array.from(new Set(roles.flatMap(role => FALLBACK_ROLE_KEYS[role])));
 }
 
-/**
- * Bridge committed Projects status writes into the sole matching routine.
- * Dynamic import keeps the Projects model free of main-process/workflow cycles.
- * The task write is already durable when this runs, so bridge failures do not
- * misreport the Projects mutation to its caller.
- */
-async function notifyTaskStatusCommitted(
-  task: WorkTaskRecord,
-  previousStatus: string,
-  actor?: string,
-): Promise<void> {
-  try {
-    const capability = await WorkLaneDefinitionModel.runtimeCapability(task.project_id);
-    const currentRole = capability.ready
-      ? (await WorkLaneDefinitionModel.resolveStatus(task.project_id, task.status))?.semantic_role ?? 'manual'
-      : (FALLBACK_ROLE_KEYS.planning.includes(task.status)
-        ? 'planning'
-        : FALLBACK_ROLE_KEYS.blocked.includes(task.status)
-          ? 'blocked'
-          : FALLBACK_ROLE_KEYS.execution.includes(task.status) ? 'execution' : 'manual');
-    const previousRole = capability.ready
-      ? (await WorkLaneDefinitionModel.resolveStatus(task.project_id, previousStatus))?.semantic_role ?? 'manual'
-      : (FALLBACK_ROLE_KEYS.planning.includes(previousStatus)
-        ? 'planning'
-        : FALLBACK_ROLE_KEYS.blocked.includes(previousStatus)
-          ? 'blocked'
-          : FALLBACK_ROLE_KEYS.execution.includes(previousStatus) ? 'execution' : 'manual');
-    if ([currentRole, previousRole].some(role => role === 'blocked' || role === 'planning')) {
-      const { PlanningCouncilService } = await import('../../services/PlanningCouncilService');
-      await PlanningCouncilService.handleTaskStatusTransition(task, previousStatus, actor);
-    }
-    if (currentRole === 'execution' && previousRole !== 'execution') {
-      const { getTaskDispatcherService } = await import('../../services/TaskDispatcherService');
-      await getTaskDispatcherService().forceCheck();
-    }
-  } catch (err) {
-    console.error(`[WorkItemsModel] Post-commit status bridge failed for task ${ task.id }:`, err);
-  }
-}
-
 // ── Model ──────────────────────────────────────────────────────────────
 
 export class WorkItemsModel {
@@ -871,7 +831,12 @@ export class WorkItemsModel {
     );
     const created = rows[0];
     if (created) {
-      await notifyTaskStatusCommitted(created, '', input.actor);
+      try {
+        const { TaskLifecycleOrchestrationService } = await import('../../projects/application/TaskLifecycleOrchestrationService');
+        await TaskLifecycleOrchestrationService.handleCommittedTransition(created, '', input.actor);
+      } catch (error) {
+        console.error(`[WorkItemsModel] Post-create orchestration failed for task ${ created.id }:`, error);
+      }
     }
     return created;
   }
@@ -1063,9 +1028,6 @@ export class WorkItemsModel {
       } catch (error) {
         console.warn(`[WorkItems] Transition events for task ${ updated.id } remain recoverable after dispatch failure:`, error);
       }
-    }
-    if (updated && changes.status !== undefined) {
-      await notifyTaskStatusCommitted(updated, existing.status, changes.actor);
     }
     return updated;
   }

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -1029,6 +1029,23 @@ export class WorkItemsModel {
           const claimed = await WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction(
             client, committed.id, committed.status, changes.actor ?? 'sulla');
           if (claimed.created && claimed.entry.status === 'pending') laneEntryId = claimed.entry.id;
+          const { createPostgresProjectsRepositories } = await import('../../projects/infrastructure/PostgresProjectsRepositories');
+          await createPostgresProjectsRepositories(client).events.append({
+            id:             `projects-event-${ committed.id }-${ claimed.entry.generation }-transition`,
+            taskId:         committed.id,
+            generation:     claimed.entry.generation,
+            eventType:      'projects.task.transitioned',
+            idempotencyKey: `projects.task.transitioned:${ committed.id }:${ claimed.entry.generation }`,
+            occurredAt:     new Date(),
+            payload:        {
+              actor,
+              source:        changes.source ?? 'system',
+              fromLane:      current.rows[0].status,
+              toLane:        committed.status,
+              laneEntryId:   claimed.entry.id,
+              laneAutomated: claimed.entry.status === 'pending',
+            },
+          });
         }
         if (committed && changesSchedule) {
           await WorkItemsModel.auditScheduleChangesWithClient(

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -18,6 +18,7 @@ import { normalizeAutonomousTaskOwnership } from './TaskOwnership';
 import { WorkLaneDefinitionModel, type WorkLaneSemanticRole } from './WorkLaneDefinitionModel';
 import { WorkTaskDependencyModel } from './WorkTaskDependencyModel';
 import { ArtifactCustodyPolicy, type ArtifactCustody } from '../../services/ArtifactCustodyPolicy';
+import { appendTaskTransitionEvent } from '../../projects/infrastructure/appendTaskTransitionEvent';
 
 import type { PoolClient } from 'pg';
 
@@ -989,26 +990,9 @@ export class WorkItemsModel {
             client, committed.id, 'done', changes.custody, actor);
         }
         if (committed && committed.status !== current.rows[0].status) {
-          const { WorkLaneWorkflowBindingModel } = await import('./WorkLaneWorkflowBindingModel');
-          const claimed = await WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction(
-            client, committed.id, committed.status, changes.actor ?? 'sulla');
-          const { createPostgresProjectsRepositories } = await import('../../projects/infrastructure/PostgresProjectsRepositories');
-          await createPostgresProjectsRepositories(client).events.append({
-            id:             `projects-event-${ committed.id }-${ claimed.entry.generation }-transition`,
-            taskId:         committed.id,
-            generation:     claimed.entry.generation,
-            eventType:      'projects.task.transitioned',
-            idempotencyKey: `projects.task.transitioned:${ committed.id }:${ claimed.entry.generation }`,
-            occurredAt:     new Date(),
-            payload:        {
-              actor,
-              source:        changes.source ?? 'system',
-              fromLane:      current.rows[0].status,
-              toLane:        committed.status,
-              laneEntryId:   claimed.entry.id,
-              laneAutomated: claimed.entry.status === 'pending',
-            },
-          });
+          await appendTaskTransitionEvent(
+            client, committed, current.rows[0].status, actor, changes.source ?? 'system',
+          );
         }
         if (committed && changesSchedule) {
           await WorkItemsModel.auditScheduleChangesWithClient(

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -1079,24 +1079,57 @@ export class WorkItemsModel {
   // ──────────────────────────────────────────────
 
   static async addComment(input: AddCommentInput): Promise<WorkCommentRecord> {
-    const task = await WorkItemsModel.getTask(input.task_id);
-    if (!task) throw new Error(`No task found with id: ${ input.task_id }`);
     const id = input.id || await WorkItemsModel.uniqueId(WorkItemsModel.COMMENTS);
-    const rows = await postgresClient.query<WorkCommentRecord>(
-      `WITH inserted AS (
-         INSERT INTO ${ WorkItemsModel.COMMENTS } (id, task_id, body, author)
-         VALUES ($1, $2, $3, $4)
-         RETURNING *
-       ), touched AS (
-         UPDATE ${ WorkItemsModel.TASKS }
-            SET last_activity_at = now()
-          WHERE id = $2
-          RETURNING id
-       )
-       SELECT inserted.* FROM inserted JOIN touched ON true`,
-      [id, input.task_id, input.body, input.author ?? input.actor ?? 'sulla'],
-    );
-    return rows[0];
+    const author = input.author ?? input.actor ?? 'sulla';
+    let transitioned = false;
+    const comment = await postgresClient.transaction(async(client) => {
+      await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`lane-entry:${ input.task_id }`]);
+      const before = await client.query<WorkTaskRecord>(
+        `SELECT * FROM ${ WorkItemsModel.TASKS } WHERE id = $1 AND archived = false FOR UPDATE`,
+        [input.task_id],
+      );
+      if (!before.rows[0]) throw new Error(`No task found with id: ${ input.task_id }`);
+
+      const rows = await client.query<WorkCommentRecord>(
+        `WITH inserted AS (
+           INSERT INTO ${ WorkItemsModel.COMMENTS } (id, task_id, body, author)
+           VALUES ($1, $2, $3, $4)
+           RETURNING *
+         ), touched AS (
+           UPDATE ${ WorkItemsModel.TASKS }
+              SET last_activity_at = now()
+            WHERE id = $2
+            RETURNING id
+         )
+         SELECT inserted.* FROM inserted JOIN touched ON true`,
+        [id, input.task_id, input.body, author],
+      );
+
+      // The packaged human-comment trigger may move a blocked task to its
+      // review lane while invalidating an active wait. Re-read inside this
+      // same transaction and append the durable handoff before commit, so
+      // the trigger can never create a split task/outbox state.
+      const after = await client.query<WorkTaskRecord>(
+        `SELECT * FROM ${ WorkItemsModel.TASKS } WHERE id = $1`, [input.task_id],
+      );
+      if (after.rows[0] && after.rows[0].status !== before.rows[0].status) {
+        await appendTaskTransitionEvent(
+          client, after.rows[0], before.rows[0].status, author, 'human-comment-wait-invalidation',
+        );
+        transitioned = true;
+      }
+      return rows.rows[0];
+    });
+
+    if (transitioned) {
+      try {
+        const { getProjectsOrchestrationEventService } = await import('../../projects/application/ProjectsOrchestrationEventService');
+        await getProjectsOrchestrationEventService().drain();
+      } catch (error) {
+        console.warn(`[WorkItems] Comment transition events for task ${ input.task_id } remain recoverable after dispatch failure:`, error);
+      }
+    }
+    return comment;
   }
 
   static async listComments(taskId: string): Promise<WorkCommentRecord[]> {

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -800,43 +800,49 @@ export class WorkItemsModel {
       executionEntryLaneKey,
     });
 
-    const rows = await postgresClient.query<WorkTaskRecord>(
-      `INSERT INTO ${ WorkItemsModel.TASKS }
-         (id, project_id, epic_id, parent_id, slug, title, description, status,
-          priority, due_at, github_issue, assignee, labels, position, source,
-          source_ref, created_by, completed_at, start_at, milestone_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
-       RETURNING *`,
-      [
-        id,
-        projectId,
-        input.epic_id,
-        input.parent_id ?? null,
-        slug,
-        input.title,
-        input.description ?? '',
-        status,
-        input.priority ?? 'p2',
-        input.due_at ?? null,
-        input.github_issue ?? null,
-        assignee,
-        labels,
-        input.position ?? 0,
-        input.source ?? null,
-        input.source_ref ?? null,
-        actor,
-        (lane ? lane.semantic_role === 'terminal' : isClosedStatus(status)) ? new Date().toISOString() : null,
-        input.start_at ?? null,
-        input.milestone_at ?? null,
-      ],
-    );
-    const created = rows[0];
+    const created = await postgresClient.transaction(async(client) => {
+      const rows = await client.query<WorkTaskRecord>(
+        `INSERT INTO ${ WorkItemsModel.TASKS }
+           (id, project_id, epic_id, parent_id, slug, title, description, status,
+            priority, due_at, github_issue, assignee, labels, position, source,
+            source_ref, created_by, completed_at, start_at, milestone_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+         RETURNING *`,
+        [
+          id,
+          projectId,
+          input.epic_id,
+          input.parent_id ?? null,
+          slug,
+          input.title,
+          input.description ?? '',
+          status,
+          input.priority ?? 'p2',
+          input.due_at ?? null,
+          input.github_issue ?? null,
+          assignee,
+          labels,
+          input.position ?? 0,
+          input.source ?? null,
+          input.source_ref ?? null,
+          actor,
+          (lane ? lane.semantic_role === 'terminal' : isClosedStatus(status)) ? new Date().toISOString() : null,
+          input.start_at ?? null,
+          input.milestone_at ?? null,
+        ],
+      );
+      const inserted = rows.rows[0];
+      if (inserted) {
+        await appendTaskTransitionEvent(client, inserted, '', actor, input.source ?? 'task-create');
+      }
+      return inserted;
+    });
     if (created) {
       try {
-        const { TaskLifecycleOrchestrationService } = await import('../../projects/application/TaskLifecycleOrchestrationService');
-        await TaskLifecycleOrchestrationService.handleCommittedTransition(created, '', input.actor);
+        const { getProjectsOrchestrationEventService } = await import('../../projects/application/ProjectsOrchestrationEventService');
+        await getProjectsOrchestrationEventService().drain();
       } catch (error) {
-        console.error(`[WorkItemsModel] Post-create orchestration failed for task ${ created.id }:`, error);
+        console.error(`[WorkItemsModel] Created task ${ created.id } has recoverable orchestration events:`, error);
       }
     }
     return created;

--- a/pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts
@@ -1,6 +1,8 @@
 import { postgresClient } from '../PostgresClient';
+import { appendTaskTransitionEvent } from '../../projects/infrastructure/appendTaskTransitionEvent';
 
 import type { PoolClient } from 'pg';
+import type { WorkTaskRecord } from './WorkItemsModel';
 
 export type WorkLaneScope = 'global_default' | 'project';
 export type WorkLaneSemanticRole = 'backlog' | 'planning' | 'execution' | 'review' | 'blocked' | 'terminal' | 'manual';
@@ -384,11 +386,15 @@ export class WorkLaneDefinitionModel {
                   AND project_lane.lane_key = $3
                   AND project_lane.reset_at IS NULL
              )`;
-        await client.query(
+        const moved = await client.query<WorkTaskRecord>(
           `UPDATE work_tasks SET status = $1, updated_at = now(), last_moved_at = now(),
              last_activity_at = now(), last_moved_by = $2
-            WHERE archived = false AND status = $3 ${ moveFilter }`, moveParams,
+            WHERE archived = false AND status = $3 ${ moveFilter }
+            RETURNING *`, moveParams,
         );
+        for (const task of moved.rows) {
+          await appendTaskTransitionEvent(client, task, lane.lane_key, actor, 'lane-archive-move');
+        }
       }
       const updated = await client.query<WorkLaneDefinitionRecord>(`
         UPDATE work_lane_definitions

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -1007,13 +1007,19 @@ export class WorkTaskDispatchModel {
              AND status = 'active'
         `, [executionTaskIds]);
 
-        await client.query(`
+        const recoveredTasks = await client.query<WorkTaskRecord>(`
           UPDATE work_tasks
              SET status = 'todo', assignee = NULL,
                  updated_at = now(), last_moved_at = now(),
                  last_activity_at = now(), last_moved_by = 'dispatcher'
            WHERE id = ANY($1::text[]) AND status = 'in_progress' AND assignee = 'dispatcher'
+          RETURNING *
         `, [executionTaskIds]);
+        for (const task of recoveredTasks.rows) {
+          await appendTaskTransitionEvent(
+            client, task, 'in_progress', 'dispatcher', 'expired-execution-lease-recovery',
+          );
+        }
       }
       if (verificationTaskIds.length > 0) {
         await client.query(`

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -717,7 +717,7 @@ export class WorkTaskDispatchModel {
           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         `, [auditId, task.id, attemptNumber, outcome, reason, task.status, task.assignee, task.last_activity_at]);
 
-        await client.query(`
+        const moved = await client.query<WorkTaskRecord>(`
           WITH inserted AS (
             INSERT INTO work_task_comments (id, task_id, body, author)
             VALUES ($1, $2, $3, 'dispatcher')
@@ -730,11 +730,17 @@ export class WorkTaskDispatchModel {
                  last_activity_at = now(),
                  last_moved_by = 'dispatcher'
            WHERE id = $2
+          RETURNING work_tasks.*
         `, [
           `comment-${ randomUUID() }`, task.id,
           `Orphan recovery attempt ${ attemptNumber }: ${ reason }. Prior owner: ${ task.assignee ?? 'unassigned' }. Prior activity: ${ task.last_activity_at }. Outcome: ${ nextStatus }/${ nextAssignee }. Undo path: ${ undo }.`,
           nextStatus, nextAssignee,
         ]);
+        if (moved.rows[0]) {
+          await appendTaskTransitionEvent(
+            client, moved.rows[0], task.status, 'dispatcher', 'orphan-execution-recovery',
+          );
+        }
         results.push({ taskId: task.id, outcome, attemptNumber });
       }
       return results;
@@ -844,12 +850,18 @@ export class WorkTaskDispatchModel {
         `, [id, `suppressed identical terminal generation ${ terminal.rows[0].id }`, generationHash,
           [...new Set(artifacts.map(value => value.type))], JSON.stringify(artifacts), [...excluded], priorDisposition,
           [...workers], [...custodians]]);
-        await client.query(`
+        const moved = await client.query<WorkTaskRecord>(`
           UPDATE work_tasks SET status = $2, assignee = $3, updated_at = now(),
             last_moved_at = now(), last_activity_at = now(), last_moved_by = 'verifier',
             completed_at = CASE WHEN $2 = 'done' THEN now() ELSE NULL END
           WHERE id = $1 AND status = 'in_review'
+          RETURNING *
         `, [taskId, transition.status, transition.assignee]);
+        if (moved.rows[0]) {
+          await appendTaskTransitionEvent(
+            client, moved.rows[0], 'in_review', 'verifier', 'duplicate-review-generation',
+          );
+        }
         return { generationHash, excludedAgentIds: [...excluded], suppressed: true };
       }
 

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -4,6 +4,7 @@ import { WorkTaskDependencyModel } from './WorkTaskDependencyModel';
 import { postgresClient } from '../PostgresClient';
 import { ArtifactCustodyPolicy, type ArtifactCustody } from '../../services/ArtifactCustodyPolicy';
 import { evaluateClaim, type WipLimits } from '../../services/ProjectAutomationWipLimits';
+import { appendTaskTransitionEvent } from '../../projects/infrastructure/appendTaskTransitionEvent';
 import {
   buildReceipt, receiptInsertInput, renderReceiptComment,
   type ArtifactReceipt, type ArtifactReceiptInput,
@@ -353,6 +354,7 @@ export class WorkTaskDispatchModel {
       if (!updated.rows[0]) {
         throw new Error(`Atomic dispatch lost task ${ task.id } before execution handoff`);
       }
+      await appendTaskTransitionEvent(client, updated.rows[0], task.status, 'dispatcher', 'task-dispatch-claim');
 
       return { dispatch: inserted.rows[0], task: updated.rows[0], stage_claim: stageClaim.claim };
     });
@@ -961,6 +963,9 @@ export class WorkTaskDispatchModel {
       if (!moved.rows[0]) {
         throw new Error(`Task ${ taskId } is no longer owned by dispatch ${ id }`);
       }
+      await appendTaskTransitionEvent(
+        client, moved.rows[0], 'in_progress', 'dispatcher', 'task-dispatch-finalize',
+      );
       return moved.rows[0];
     });
   }
@@ -1158,14 +1163,20 @@ export class WorkTaskDispatchModel {
         artifacts:          [{ type: 'reviewed_artifact', canonicalRef: artifactSha, hash: artifactSha }],
         evidence:           { kind: 'dispatch', ref: id },
       }), 'verifier');
-      await client.query(`
+      const moved = await client.query<WorkTaskRecord>(`
         UPDATE work_tasks
            SET status = $2, assignee = $3, updated_at = now(),
                last_moved_at = now(), last_activity_at = now(),
                last_moved_by = 'verifier',
                completed_at = CASE WHEN $2 = 'done' THEN now() ELSE NULL END
          WHERE id = $1 AND status = 'in_review'
+        RETURNING *
       `, [taskId, transition.status, transition.assignee]);
+      if (moved.rows[0]) {
+        await appendTaskTransitionEvent(
+          client, moved.rows[0], 'in_review', 'verifier', 'legacy-review-finalize',
+        );
+      }
       return finalVerdict;
     });
   }
@@ -1329,14 +1340,20 @@ export class WorkTaskDispatchModel {
         }), 'verifier');
       }
 
-      await client.query(`
+      const moved = await client.query<WorkTaskRecord>(`
         UPDATE work_tasks
            SET status = $2, assignee = $3, updated_at = now(),
                last_moved_at = now(), last_activity_at = now(),
                last_moved_by = 'verifier',
                completed_at = CASE WHEN $2 = 'done' THEN now() ELSE NULL END
          WHERE id = $1 AND status = 'in_review'
+        RETURNING *
       `, [taskId, transition.status, transition.assignee]);
+      if (moved.rows[0]) {
+        await appendTaskTransitionEvent(
+          client, moved.rows[0], 'in_review', 'verifier', 'protected-review-finalize',
+        );
+      }
       return finalDisposition;
     });
   }
@@ -1387,12 +1404,18 @@ export class WorkTaskDispatchModel {
           evidence:          { kind: 'dispatch', ref: id },
         }), 'verifier');
       }
-      await client.query(`
+      const moved = await client.query<WorkTaskRecord>(`
         UPDATE work_tasks
            SET status = $2, assignee = $3, updated_at = now(),
                last_moved_at = now(), last_activity_at = now(), last_moved_by = 'verifier'
          WHERE id = $1 AND status = 'in_review'
+        RETURNING *
       `, [taskId, terminal ? 'planning' : 'in_review', terminal ? 'dispatcher' : 'heartbeat']);
+      if (moved.rows[0] && terminal) {
+        await appendTaskTransitionEvent(
+          client, moved.rows[0], 'in_review', 'verifier', 'verification-failure-escalation',
+        );
+      }
       return true;
     });
   }

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -860,6 +860,7 @@ export class WorkTaskDispatchModel {
         if (moved.rows[0]) {
           await appendTaskTransitionEvent(
             client, moved.rows[0], 'in_review', 'verifier', 'duplicate-review-generation',
+            { generationHash, metadata: { dispatchId: id, disposition: priorDisposition } },
           );
         }
         return { generationHash, excludedAgentIds: [...excluded], suppressed: true };
@@ -977,6 +978,7 @@ export class WorkTaskDispatchModel {
       }
       await appendTaskTransitionEvent(
         client, moved.rows[0], 'in_progress', 'dispatcher', 'task-dispatch-finalize',
+        { generationHash: evidence.contentHash ?? evidence.artifactRef ?? null, metadata: { dispatchId: id } },
       );
       return moved.rows[0];
     });
@@ -1193,6 +1195,7 @@ export class WorkTaskDispatchModel {
       if (moved.rows[0]) {
         await appendTaskTransitionEvent(
           client, moved.rows[0], 'in_review', 'verifier', 'legacy-review-finalize',
+          { generationHash: artifactSha, metadata: { dispatchId: id, disposition: finalVerdict } },
         );
       }
       return finalVerdict;
@@ -1370,6 +1373,7 @@ export class WorkTaskDispatchModel {
       if (moved.rows[0]) {
         await appendTaskTransitionEvent(
           client, moved.rows[0], 'in_review', 'verifier', 'protected-review-finalize',
+          { generationHash: evidence.generationHash, metadata: { dispatchId: id, disposition: finalDisposition } },
         );
       }
       return finalDisposition;
@@ -1432,6 +1436,7 @@ export class WorkTaskDispatchModel {
       if (moved.rows[0] && terminal) {
         await appendTaskTransitionEvent(
           client, moved.rows[0], 'in_review', 'verifier', 'verification-failure-escalation',
+          { generationHash, metadata: { dispatchId: id, disposition: 'REPLAN' } },
         );
       }
       return true;

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts
@@ -4,6 +4,7 @@ import { WorkTaskDependencyModel } from './WorkTaskDependencyModel';
 import { postgresClient } from '../PostgresClient';
 import { LifecycleCapabilityModel } from './LifecycleCapabilityModel';
 import { WorkLaneDefinitionModel } from './WorkLaneDefinitionModel';
+import { appendTaskTransitionEvent } from '../../projects/infrastructure/appendTaskTransitionEvent';
 
 import type { WorkTaskRecord } from './WorkItemsModel';
 import type { PoolClient } from 'pg';
@@ -111,6 +112,11 @@ export class WorkTaskPlanningRunModel {
            RETURNING *
         `, [taskId, planningLaneKey]);
         claimedTask = moved.rows[0] ?? task;
+        if (moved.rows[0]) {
+          await appendTaskTransitionEvent(
+            client, moved.rows[0], task.status, 'planning-council', 'planning-run-claim',
+          );
+        }
       }
 
       return { run: inserted.rows[0], task: claimedTask };

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskWaitModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskWaitModel.ts
@@ -1,6 +1,9 @@
 import { createHash, randomUUID } from 'node:crypto';
 
 import { postgresClient } from '../PostgresClient';
+import { appendTaskTransitionEvent } from '../../projects/infrastructure/appendTaskTransitionEvent';
+
+import type { WorkTaskRecord } from './WorkItemsModel';
 
 export type WorkTaskWaitKind = 'github_checks' | 'human_gate' | 'scheduled_time' | 'external_job';
 export type WorkTaskWaitStatus = 'active' | 'changed' | 'satisfied' | 'cancelled' | 'failed';
@@ -199,13 +202,19 @@ export class WorkTaskWaitModel {
          RETURNING *
       `, [id, observation.fingerprint, nextStatus, observation.nextCheckAt, changed, terminal]);
       if (changed || terminal) {
-        await client.query(`
+        const moved = await client.query<WorkTaskRecord>(`
           UPDATE work_tasks
              SET status = $2, assignee = $3, updated_at = now(),
                  last_moved_at = now(), last_activity_at = now(),
                  last_moved_by = 'external-wait-monitor'
            WHERE id = $1 AND status = 'blocked'
+          RETURNING *
         `, [current.task_id, nextStatus === 'failed' ? 'planning' : 'in_review', nextStatus === 'failed' ? 'dispatcher' : 'heartbeat']);
+        if (moved.rows[0]) {
+          await appendTaskTransitionEvent(
+            client, moved.rows[0], 'blocked', 'external-wait-monitor', 'durable-wait-observation',
+          );
+        }
       }
       return { changed: changed || terminal, wait: updated.rows[0] ?? null };
     });
@@ -226,12 +235,18 @@ export class WorkTaskWaitModel {
       `, [id, message.slice(0, 2000), nextCheckAt, terminalAfter]);
       const wait = result.rows[0] ?? null;
       if (wait?.status === 'failed') {
-        await client.query(`
+        const moved = await client.query<WorkTaskRecord>(`
           UPDATE work_tasks SET status = 'planning', assignee = 'dispatcher',
             updated_at = now(), last_moved_at = now(), last_activity_at = now(),
             last_moved_by = 'external-wait-monitor'
           WHERE id = $1 AND status = 'blocked'
+          RETURNING *
         `, [wait.task_id]);
+        if (moved.rows[0]) {
+          await appendTaskTransitionEvent(
+            client, moved.rows[0], 'blocked', 'external-wait-monitor', 'durable-wait-failure',
+          );
+        }
       }
       return { terminal: wait?.status === 'failed', wait };
     });

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkItemsModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkItemsModel.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals'
 
 import { postgresClient } from '../../PostgresClient';
 import { WorkItemsModel } from '../WorkItemsModel';
+import { WorkLaneDefinitionModel } from '../WorkLaneDefinitionModel';
 
 describe('WorkItemsModel', () => {
   let originalQuery: any;

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
@@ -4,6 +4,9 @@ import { postgresClient } from '../../PostgresClient';
 import { WorkItemsModel } from '../WorkItemsModel';
 import { ArtifactReceiptModel } from '../ArtifactReceiptModel';
 import { classifyInProgressRow, WorkTaskDispatchModel } from '../WorkTaskDispatchModel';
+import { WorkLaneWorkflowBindingModel } from '../WorkLaneWorkflowBindingModel';
+import { ArtifactCustodyPolicy } from '../../../services/ArtifactCustodyPolicy';
+import { ProjectsDomainEventOutbox } from '../../../projects/infrastructure/ProjectsDomainEventOutbox';
 
 describe('WorkTaskDispatchModel', () => {
   let originalTransaction: any;
@@ -15,6 +18,16 @@ describe('WorkTaskDispatchModel', () => {
   });
 
   beforeEach(() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([]);
+    jest.spyOn(ArtifactCustodyPolicy, 'assertForTransition').mockResolvedValue();
+    jest.spyOn(WorkLaneWorkflowBindingModel, 'claimLaneEntryInTransaction')
+      .mockImplementation(async(_client, taskId, laneKey) => ({
+        created: true,
+        entry: {
+          id: `lane-entry-${ taskId }`, task_id: taskId, lane_key: laneKey,
+          generation: 1, status: 'unautomated', workflow_id: null,
+        } as any,
+      }));
     jest.spyOn(ArtifactReceiptModel, 'insertIfAbsentWithClient').mockResolvedValue({
       inserted: true,
       row: { id: 'receipt-1' } as any,
@@ -69,7 +82,8 @@ describe('WorkTaskDispatchModel', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [stageClaim] })
       .mockResolvedValueOnce({ rows: [dispatch] })
-      .mockResolvedValueOnce({ rows: [executingTask] });
+      .mockResolvedValueOnce({ rows: [executingTask] })
+      .mockResolvedValue({ rows: [{ id: 'event-task-1' }] });
 
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
@@ -194,6 +208,21 @@ describe('WorkTaskDispatchModel', () => {
         archived:    false,
       }]));
 
+    const createQuery = (jest.fn() as any)
+      .mockImplementationOnce((_sql: string, params: any[]) => Promise.resolve({ rows: [{
+        id:          params[0],
+        project_id:  params[1],
+        epic_id:     params[2],
+        title:       params[5],
+        status:      params[7],
+        priority:    params[8],
+        assignee:    params[11],
+        labels:      params[12],
+        archived:    false,
+      }] }))
+      .mockResolvedValue({ rows: [{ id: 'event-task-new' }] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query: createQuery }));
+
     const created = await WorkItemsModel.insertTask({
       id:       'task-new',
       epic_id:  'epic-1',
@@ -230,7 +259,8 @@ describe('WorkTaskDispatchModel', () => {
       .mockResolvedValueOnce({ rows: [{
         id: 'dispatch-1', task_id: created.id, agent_id: 'opus-worker', status: 'running',
       }] })
-      .mockResolvedValueOnce({ rows: [executingTask] });
+      .mockResolvedValueOnce({ rows: [executingTask] })
+      .mockResolvedValue({ rows: [{ id: 'event-task-new-claim' }] });
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query: clientQuery }));
 
     const claim = await WorkTaskDispatchModel.claimNext('opus-worker', 'runtime-1');
@@ -291,7 +321,9 @@ describe('WorkTaskDispatchModel', () => {
   it('releases stale execution dispatch and stage ownership before making the task reclaimable', async() => {
     const query = (jest.fn() as any)
       .mockResolvedValueOnce({ rows: [{ id: 'dispatch-1', task_id: 'task-1', kind: 'execution' }] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 'task-1', status: 'todo' }] })
+      .mockResolvedValue({ rows: [{ id: 'event-task-1' }] });
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     await expect(WorkTaskDispatchModel.recoverStale(45)).resolves.toEqual(['task-1']);
@@ -351,17 +383,17 @@ describe('WorkTaskDispatchModel', () => {
       .mockResolvedValueOnce({ rows: [{ task_id: 'task-2' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [{ id: 'task-2', status: 'done' }] })
+      .mockResolvedValue({ rows: [{ id: 'event-task-2' }] });
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     await expect(WorkTaskDispatchModel.finalizeVerification(
       'dispatch-2', 'APPROVE', 'a'.repeat(40), 'a'.repeat(40), 'All criteria verified.',
     )).resolves.toBe('APPROVE');
-    expect(query.mock.calls[1][0]).toContain('artifact_sha = $3');
-    expect(query.mock.calls[2][0]).toContain('INSERT INTO work_task_comments');
-    expect(query.mock.calls[2][1][2]).toContain('<!-- artifact-receipt');
-    expect(query.mock.calls[3][0]).toContain("completed_at = CASE WHEN $2 = 'done'");
-    expect(query.mock.calls[3][1]).toEqual(['task-2', 'done', null]);
+    expect(query.mock.calls.some(([sql]: [string]) => sql.includes('artifact_sha = $3'))).toBe(true);
+    const taskMove = query.mock.calls.find(([sql]: [string]) =>
+      sql.includes('UPDATE work_tasks') && sql.includes("completed_at = CASE WHEN $2 = 'done'"));
+    expect(taskMove?.[1]).toEqual(['task-2', 'done', null]);
   });
 
   it('refuses to settle approval when the server-resolved head differs', async() => {
@@ -396,7 +428,8 @@ describe('WorkTaskDispatchModel', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: 'older' }] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [{ id: 'task-fail', status: 'planning' }] })
+      .mockResolvedValue({ rows: [{ id: 'event-task-fail' }] });
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     await expect(WorkTaskDispatchModel.failVerification('dispatch-fail', 'adapter_unavailable')).resolves.toBe(true);
@@ -669,7 +702,8 @@ describe('WorkTaskDispatchModel', () => {
       .mockResolvedValueOnce({ rows: [{ status: 'running' }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ id: 'task-1', status: 'in_review', assignee: 'heartbeat' }] });
+      .mockResolvedValueOnce({ rows: [{ id: 'task-1', status: 'in_review', assignee: 'heartbeat' }] })
+      .mockResolvedValue({ rows: [{ id: 'event-task-1' }] });
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     const committed = await WorkTaskDispatchModel.finalize('dispatch-1', 'task-1', {

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskPlanningRunModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskPlanningRunModel.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals'
 import { postgresClient } from '../../PostgresClient';
 import { LifecycleCapabilityModel } from '../LifecycleCapabilityModel';
 import { WorkLaneDefinitionModel } from '../WorkLaneDefinitionModel';
+import { WorkLaneWorkflowBindingModel } from '../WorkLaneWorkflowBindingModel';
 import { WorkTaskPlanningRunModel } from '../WorkTaskPlanningRunModel';
 
 describe('WorkTaskPlanningRunModel', () => {
@@ -23,25 +24,31 @@ describe('WorkTaskPlanningRunModel', () => {
       ready: false, catalogPresent: false, missingRoles: ['planning'], degradedReason: 'compatibility',
     });
     jest.spyOn(WorkLaneDefinitionModel, 'preferredLaneKey').mockResolvedValue('planning');
+    jest.spyOn(WorkLaneWorkflowBindingModel, 'claimLaneEntryInTransaction').mockResolvedValue({
+      created: true,
+      entry: { id: 'lane-entry-planning', generation: 1, status: 'unautomated' } as any,
+    });
     const blocked = { id: 'task-1', project_id: 'project-1', status: 'blocked', archived: false } as any;
     const planning = { ...blocked, status: 'planning', assignee: 'planning-council' };
     const run = { id: 'planning-1', task_id: 'task-1', status: 'active', attempt: 1 } as any;
     const query = (jest.fn() as any)
       .mockResolvedValueOnce({ rows: [blocked] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ attempt: 1 }] })
       .mockResolvedValueOnce({ rows: [run] })
-      .mockResolvedValueOnce({ rows: [planning] });
+      .mockResolvedValueOnce({ rows: [planning] })
+      .mockResolvedValue({ rows: [{ id: 'event-planning' }] });
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     const claimed = await WorkTaskPlanningRunModel.claim('task-1', 'blocked', 'heartbeat');
 
     expect(claimed).toMatchObject({ run: { status: 'active' }, task: { status: 'planning' } });
     expect(query.mock.calls[0][0]).toContain('FOR UPDATE');
-    expect(query.mock.calls[1][0]).toContain("status = 'active'");
-    expect(query.mock.calls[3][0]).toContain('INSERT INTO work_task_planning_runs');
-    expect(query.mock.calls[4][0]).toContain('status = $2');
-    expect(query.mock.calls[4][1]).toEqual(['task-1', 'planning']);
+    expect(query.mock.calls[2][0]).toContain("status = 'active'");
+    expect(query.mock.calls[4][0]).toContain('INSERT INTO work_task_planning_runs');
+    expect(query.mock.calls[5][0]).toContain('status = $2');
+    expect(query.mock.calls[5][1]).toEqual(['task-1', 'planning']);
   });
 
   it('does not launch a duplicate when a task already has an active council', async() => {
@@ -53,11 +60,12 @@ describe('WorkTaskPlanningRunModel', () => {
     const task = { id: 'task-1', project_id: 'project-1', status: 'planning', archived: false } as any;
     const query = (jest.fn() as any)
       .mockResolvedValueOnce({ rows: [task] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ id: 'planning-existing' }] });
     (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
 
     await expect(WorkTaskPlanningRunModel.claim('task-1', 'planning')).resolves.toBeNull();
-    expect(query).toHaveBeenCalledTimes(2);
+    expect(query).toHaveBeenCalledTimes(3);
   });
 
   it('refreshes the active task-scoped lease by workflow execution id', async() => {

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsDomainEventDispatcher.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsDomainEventDispatcher.ts
@@ -1,0 +1,47 @@
+import { ProjectsDomainEventOutbox } from '../infrastructure/ProjectsDomainEventOutbox';
+
+import type { ProjectsDomainEventRecord } from './ProjectsRepositories';
+
+export type ProjectsDomainEventHandler = (event: ProjectsDomainEventRecord) => Promise<void>;
+
+/** Lease-backed, replay-safe dispatcher. Handlers must be idempotent by event id. */
+export class ProjectsDomainEventDispatcher {
+  private readonly handlers = new Map<string, ProjectsDomainEventHandler>();
+
+  constructor(private readonly owner: string) {
+    if (!owner.trim()) throw new Error('Projects domain-event dispatcher owner is required.');
+  }
+
+  register(eventType: string, handler: ProjectsDomainEventHandler): this {
+    if (!eventType.trim()) throw new Error('Projects domain-event type is required.');
+    this.handlers.set(eventType, handler);
+    return this;
+  }
+
+  async drain(limit = 25): Promise<{ completed: number; retried: number; unhandled: number }> {
+    const events = await ProjectsDomainEventOutbox.claim(this.owner, limit);
+    let completed = 0;
+    let retried = 0;
+    let unhandled = 0;
+    for (const event of events) {
+      const handler = this.handlers.get(event.event_type);
+      if (!handler) {
+        unhandled++;
+        await ProjectsDomainEventOutbox.retry(
+          event.id, this.owner, `No handler registered for ${ event.event_type }`, new Date(Date.now() + 60_000),
+        );
+        continue;
+      }
+      try {
+        await handler(event);
+        if (await ProjectsDomainEventOutbox.complete(event.id, this.owner)) completed++;
+      } catch (error) {
+        retried++;
+        const message = error instanceof Error ? error.message : String(error);
+        const delayMs = Math.min(300_000, 1_000 * (2 ** Math.min(event.attempts, 8)));
+        await ProjectsDomainEventOutbox.retry(event.id, this.owner, message, new Date(Date.now() + delayMs));
+      }
+    }
+    return { completed, retried, unhandled };
+  }
+}

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsOrchestrationEventService.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsOrchestrationEventService.ts
@@ -1,6 +1,8 @@
 import { LaneEntryAutomationService } from '../../services/LaneEntryAutomationService';
+import { WorkItemsModel } from '../../database/models/WorkItemsModel';
 
 import { ProjectsDomainEventDispatcher } from './ProjectsDomainEventDispatcher';
+import { TaskLifecycleOrchestrationService } from './TaskLifecycleOrchestrationService';
 
 import type { ProjectsDomainEventRecord } from './ProjectsRepositories';
 
@@ -27,12 +29,28 @@ export class ProjectsOrchestrationEventService {
     event: ProjectsDomainEventRecord,
     dispatchLaneEntry: LaneEntryDispatcher,
   ): Promise<void> {
-    if (event.payload.laneAutomated !== true) return;
-    const laneEntryId = event.payload.laneEntryId;
-    if (typeof laneEntryId !== 'string' || !laneEntryId.trim()) {
-      throw new Error(`Projects transition event ${ event.id } has no lane-entry identity.`);
+    if (event.payload.laneAutomated === true) {
+      const laneEntryId = event.payload.laneEntryId;
+      if (typeof laneEntryId !== 'string' || !laneEntryId.trim()) {
+        throw new Error(`Projects transition event ${ event.id } has no lane-entry identity.`);
+      }
+      await dispatchLaneEntry(laneEntryId);
     }
-    await dispatchLaneEntry(laneEntryId);
+    await this.dispatchLifecycleIfCurrent(event);
+  }
+
+  private async dispatchLifecycleIfCurrent(event: ProjectsDomainEventRecord): Promise<void> {
+    const fromLane = event.payload.fromLane;
+    const toLane = event.payload.toLane;
+    if (typeof fromLane !== 'string' || typeof toLane !== 'string') {
+      throw new Error(`Projects transition event ${ event.id } has no lane contract.`);
+    }
+    const task = await WorkItemsModel.getTask(event.task_id);
+    // A later generation already superseded this event. Its lane-entry handler
+    // remains replay-safe, but lifecycle reactions must never act on stale state.
+    if (!task || task.status !== toLane) return;
+    const actor = typeof event.payload.actor === 'string' ? event.payload.actor : undefined;
+    await TaskLifecycleOrchestrationService.handleCommittedTransition(task, fromLane, actor);
   }
 }
 

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsOrchestrationEventService.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsOrchestrationEventService.ts
@@ -1,0 +1,44 @@
+import { LaneEntryAutomationService } from '../../services/LaneEntryAutomationService';
+
+import { ProjectsDomainEventDispatcher } from './ProjectsDomainEventDispatcher';
+
+import type { ProjectsDomainEventRecord } from './ProjectsRepositories';
+
+type LaneEntryDispatcher = (entryId: string) => Promise<unknown>;
+
+/**
+ * The single runtime boundary between committed Projects domain events and
+ * orchestration side effects. Event handlers must remain replay-safe: a crash
+ * after the side effect and before outbox settlement will invoke them again.
+ */
+export class ProjectsOrchestrationEventService {
+  private readonly dispatcher: ProjectsDomainEventDispatcher;
+
+  constructor(owner: string, dispatchLaneEntry: LaneEntryDispatcher = LaneEntryAutomationService.dispatchEntry) {
+    this.dispatcher = new ProjectsDomainEventDispatcher(owner)
+      .register('projects.task.transitioned', event => this.handleTaskTransitioned(event, dispatchLaneEntry));
+  }
+
+  drain(limit = 25): Promise<{ completed: number; retried: number; unhandled: number }> {
+    return this.dispatcher.drain(limit);
+  }
+
+  private async handleTaskTransitioned(
+    event: ProjectsDomainEventRecord,
+    dispatchLaneEntry: LaneEntryDispatcher,
+  ): Promise<void> {
+    if (event.payload.laneAutomated !== true) return;
+    const laneEntryId = event.payload.laneEntryId;
+    if (typeof laneEntryId !== 'string' || !laneEntryId.trim()) {
+      throw new Error(`Projects transition event ${ event.id } has no lane-entry identity.`);
+    }
+    await dispatchLaneEntry(laneEntryId);
+  }
+}
+
+let service: ProjectsOrchestrationEventService | null = null;
+
+export function getProjectsOrchestrationEventService(): ProjectsOrchestrationEventService {
+  service ??= new ProjectsOrchestrationEventService(`projects-orchestration-${ process.pid }`);
+  return service;
+}

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsRepositories.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsRepositories.ts
@@ -59,10 +59,44 @@ export interface ProjectsCommentRepository {
   }): Promise<TaskCommentSnapshot>;
 }
 
+export interface ProjectsDomainEventRecord {
+  id:              string;
+  task_id:         string;
+  generation:      number;
+  generation_hash: string | null;
+  event_type:      string;
+  idempotency_key: string;
+  payload:         Readonly<Record<string, unknown>>;
+  status:          'pending' | 'processing' | 'completed';
+  attempts:        number;
+  available_at:    string;
+  lease_owner:     string | null;
+  leased_until:    string | null;
+  last_error:      string | null;
+  occurred_at:     string;
+  created_at:      string;
+  updated_at:      string | null;
+  completed_at:    string | null;
+}
+
+export interface ProjectsDomainEventRepository {
+  append(input: {
+    id:              string;
+    taskId:          string;
+    generation:      number;
+    generationHash?: string | null;
+    eventType:       string;
+    idempotencyKey:  string;
+    payload:         Readonly<Record<string, unknown>>;
+    occurredAt:      Date;
+  }): Promise<ProjectsDomainEventRecord>;
+}
+
 /** Every repository in this object is scoped to the same database transaction. */
 export interface ProjectsRepositories {
   projects: ProjectsProjectRepository;
   epics:    ProjectsEpicRepository;
   tasks:    ProjectsTaskRepository;
   comments: ProjectsCommentRepository;
+  events:   ProjectsDomainEventRepository;
 }

--- a/pkg/rancher-desktop/agent/projects/application/TaskLifecycleOrchestrationService.ts
+++ b/pkg/rancher-desktop/agent/projects/application/TaskLifecycleOrchestrationService.ts
@@ -1,0 +1,49 @@
+import { WorkLaneDefinitionModel, type WorkLaneSemanticRole } from '../../database/models/WorkLaneDefinitionModel';
+
+import type { WorkTaskRecord } from '../../database/models/WorkItemsModel';
+
+const FALLBACK_ROLE_KEYS: Record<WorkLaneSemanticRole, string[]> = {
+  backlog:   ['backlog'],
+  planning:  ['planning'],
+  execution: ['todo', 'in_progress'],
+  review:    ['in_review'],
+  blocked:   ['blocked'],
+  terminal:  ['done', 'cancelled'],
+  manual:    ['parked'],
+};
+
+function fallbackRole(status: string): WorkLaneSemanticRole {
+  if (FALLBACK_ROLE_KEYS.planning.includes(status)) return 'planning';
+  if (FALLBACK_ROLE_KEYS.blocked.includes(status)) return 'blocked';
+  if (FALLBACK_ROLE_KEYS.execution.includes(status)) return 'execution';
+  if (FALLBACK_ROLE_KEYS.review.includes(status)) return 'review';
+  if (FALLBACK_ROLE_KEYS.terminal.includes(status)) return 'terminal';
+  if (FALLBACK_ROLE_KEYS.backlog.includes(status)) return 'backlog';
+  return 'manual';
+}
+
+/** Idempotent orchestration reactions to an already-committed task transition. */
+export class TaskLifecycleOrchestrationService {
+  static async handleCommittedTransition(
+    task: WorkTaskRecord,
+    previousStatus: string,
+    actor?: string,
+  ): Promise<void> {
+    const capability = await WorkLaneDefinitionModel.runtimeCapability(task.project_id);
+    const currentRole = capability.ready
+      ? (await WorkLaneDefinitionModel.resolveStatus(task.project_id, task.status))?.semantic_role ?? 'manual'
+      : fallbackRole(task.status);
+    const previousRole = capability.ready
+      ? (await WorkLaneDefinitionModel.resolveStatus(task.project_id, previousStatus))?.semantic_role ?? 'manual'
+      : fallbackRole(previousStatus);
+
+    if ([currentRole, previousRole].some(role => role === 'blocked' || role === 'planning')) {
+      const { PlanningCouncilService } = await import('../../services/PlanningCouncilService');
+      await PlanningCouncilService.handleTaskStatusTransition(task, previousStatus, actor);
+    }
+    if (currentRole === 'execution' && previousRole !== 'execution') {
+      const { getTaskDispatcherService } = await import('../../services/TaskDispatcherService');
+      await getTaskDispatcherService().forceCheck();
+    }
+  }
+}

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsDomainEventDispatcher.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsDomainEventDispatcher.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { ProjectsDomainEventOutbox } from '../../infrastructure/ProjectsDomainEventOutbox';
+import { ProjectsDomainEventDispatcher } from '../ProjectsDomainEventDispatcher';
+
+const event = { id: 'event-1', event_type: 'projects.task.review-requested', attempts: 1 } as any;
+
+describe('ProjectsDomainEventDispatcher', () => {
+  afterEach(() => { jest.restoreAllMocks() });
+
+  it('settles an exact leased event after its idempotent handler succeeds', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([event]);
+    const complete = jest.spyOn(ProjectsDomainEventOutbox, 'complete').mockResolvedValue(true);
+    const handler = jest.fn<(claimed: typeof event) => Promise<void>>().mockResolvedValue();
+    const dispatcher = new ProjectsDomainEventDispatcher('dispatcher-1').register(event.event_type, handler);
+
+    await expect(dispatcher.drain()).resolves.toEqual({ completed: 1, retried: 0, unhandled: 0 });
+    expect(handler).toHaveBeenCalledWith(event);
+    expect(complete).toHaveBeenCalledWith(event.id, 'dispatcher-1');
+  });
+
+  it('returns failures to the durable queue with bounded backoff', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([event]);
+    const retry = jest.spyOn(ProjectsDomainEventOutbox, 'retry').mockResolvedValue(true);
+    const dispatcher = new ProjectsDomainEventDispatcher('dispatcher-1')
+      .register(event.event_type, async() => { throw new Error('transient'); });
+
+    await expect(dispatcher.drain()).resolves.toEqual({ completed: 0, retried: 1, unhandled: 0 });
+    expect(retry).toHaveBeenCalledWith(event.id, 'dispatcher-1', 'transient', expect.any(Date));
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationEventService.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationEventService.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
 import { ProjectsDomainEventOutbox } from '../../infrastructure/ProjectsDomainEventOutbox';
 import { ProjectsOrchestrationEventService } from '../ProjectsOrchestrationEventService';
+import { WorkItemsModel } from '../../../database/models/WorkItemsModel';
+import { TaskLifecycleOrchestrationService } from '../TaskLifecycleOrchestrationService';
 
 const transition = (payload: Record<string, unknown>) => ({
-  id: 'transition-1', event_type: 'projects.task.transitioned', attempts: 1, payload,
+  id: 'transition-1', task_id: 'task-1', event_type: 'projects.task.transitioned', attempts: 1,
+  payload: { fromLane: 'backlog', toLane: 'todo', ...payload },
 }) as any;
 
 describe('ProjectsOrchestrationEventService', () => {
@@ -15,6 +18,8 @@ describe('ProjectsOrchestrationEventService', () => {
       transition({ laneAutomated: true, laneEntryId: 'lane-entry-7' }),
     ]);
     const complete = jest.spyOn(ProjectsDomainEventOutbox, 'complete').mockResolvedValue(true);
+    jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue({ id: 'task-1', status: 'todo' } as any);
+    const lifecycle = jest.spyOn(TaskLifecycleOrchestrationService, 'handleCommittedTransition').mockResolvedValue();
     const dispatchLane = jest.fn<(id: string) => Promise<unknown>>().mockResolvedValue({ status: 'running' });
 
     await expect(new ProjectsOrchestrationEventService('owner-1', dispatchLane).drain())
@@ -22,6 +27,7 @@ describe('ProjectsOrchestrationEventService', () => {
     expect(dispatchLane).toHaveBeenCalledTimes(1);
     expect(dispatchLane).toHaveBeenCalledWith('lane-entry-7');
     expect(complete).toHaveBeenCalledWith('transition-1', 'owner-1');
+    expect(lifecycle).toHaveBeenCalledWith(expect.objectContaining({ id: 'task-1' }), 'backlog', undefined);
   });
 
   it('settles an unautomated transition without launching a workflow', async() => {
@@ -29,6 +35,8 @@ describe('ProjectsOrchestrationEventService', () => {
       transition({ laneAutomated: false, laneEntryId: 'lane-entry-8' }),
     ]);
     jest.spyOn(ProjectsDomainEventOutbox, 'complete').mockResolvedValue(true);
+    jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue({ id: 'task-1', status: 'todo' } as any);
+    jest.spyOn(TaskLifecycleOrchestrationService, 'handleCommittedTransition').mockResolvedValue();
     const dispatchLane = jest.fn<(id: string) => Promise<unknown>>();
 
     await expect(new ProjectsOrchestrationEventService('owner-1', dispatchLane).drain())
@@ -48,5 +56,17 @@ describe('ProjectsOrchestrationEventService', () => {
     expect(retry).toHaveBeenCalledWith(
       'transition-1', 'owner-1', 'runtime unavailable', expect.any(Date),
     );
+  });
+
+  it('does not run lifecycle reactions for a superseded task generation', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([
+      transition({ laneAutomated: true, laneEntryId: 'lane-entry-old', fromLane: 'todo', toLane: 'in_review' }),
+    ]);
+    jest.spyOn(ProjectsDomainEventOutbox, 'complete').mockResolvedValue(true);
+    jest.spyOn(WorkItemsModel, 'getTask').mockResolvedValue({ id: 'task-1', status: 'done' } as any);
+    const lifecycle = jest.spyOn(TaskLifecycleOrchestrationService, 'handleCommittedTransition').mockResolvedValue();
+
+    await new ProjectsOrchestrationEventService('owner-1', async() => undefined).drain();
+    expect(lifecycle).not.toHaveBeenCalled();
   });
 });

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationEventService.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationEventService.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { ProjectsDomainEventOutbox } from '../../infrastructure/ProjectsDomainEventOutbox';
+import { ProjectsOrchestrationEventService } from '../ProjectsOrchestrationEventService';
+
+const transition = (payload: Record<string, unknown>) => ({
+  id: 'transition-1', event_type: 'projects.task.transitioned', attempts: 1, payload,
+}) as any;
+
+describe('ProjectsOrchestrationEventService', () => {
+  afterEach(() => { jest.restoreAllMocks() });
+
+  it('dispatches the exact committed lane entry and settles its event', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([
+      transition({ laneAutomated: true, laneEntryId: 'lane-entry-7' }),
+    ]);
+    const complete = jest.spyOn(ProjectsDomainEventOutbox, 'complete').mockResolvedValue(true);
+    const dispatchLane = jest.fn<(id: string) => Promise<unknown>>().mockResolvedValue({ status: 'running' });
+
+    await expect(new ProjectsOrchestrationEventService('owner-1', dispatchLane).drain())
+      .resolves.toEqual({ completed: 1, retried: 0, unhandled: 0 });
+    expect(dispatchLane).toHaveBeenCalledTimes(1);
+    expect(dispatchLane).toHaveBeenCalledWith('lane-entry-7');
+    expect(complete).toHaveBeenCalledWith('transition-1', 'owner-1');
+  });
+
+  it('settles an unautomated transition without launching a workflow', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([
+      transition({ laneAutomated: false, laneEntryId: 'lane-entry-8' }),
+    ]);
+    jest.spyOn(ProjectsDomainEventOutbox, 'complete').mockResolvedValue(true);
+    const dispatchLane = jest.fn<(id: string) => Promise<unknown>>();
+
+    await expect(new ProjectsOrchestrationEventService('owner-1', dispatchLane).drain())
+      .resolves.toEqual({ completed: 1, retried: 0, unhandled: 0 });
+    expect(dispatchLane).not.toHaveBeenCalled();
+  });
+
+  it('returns a malformed or failed lane dispatch to the durable queue', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([
+      transition({ laneAutomated: true, laneEntryId: 'lane-entry-9' }),
+    ]);
+    const retry = jest.spyOn(ProjectsDomainEventOutbox, 'retry').mockResolvedValue(true);
+    const dispatchLane = jest.fn<(id: string) => Promise<unknown>>().mockRejectedValue(new Error('runtime unavailable'));
+
+    await expect(new ProjectsOrchestrationEventService('owner-1', dispatchLane).drain())
+      .resolves.toEqual({ completed: 0, retried: 1, unhandled: 0 });
+    expect(retry).toHaveBeenCalledWith(
+      'transition-1', 'owner-1', 'runtime unavailable', expect.any(Date),
+    );
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationWriters.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationWriters.contract.test.ts
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from '@jest/globals';
+
+function source(relativePath: string): string {
+  return fs.readFileSync(path.resolve(process.cwd(), relativePath), 'utf8');
+}
+
+describe('Projects orchestration writer contract', () => {
+  it('routes dispatcher execution and review transitions through the shared outbox boundary', () => {
+    const dispatch = source('pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts');
+    for (const sourceName of [
+      'task-dispatch-claim',
+      'task-dispatch-finalize',
+      'legacy-review-finalize',
+      'protected-review-finalize',
+      'verification-failure-escalation',
+    ]) {
+      expect(dispatch).toContain(`'${ sourceName }'`);
+    }
+  });
+
+  it('routes blocked planning and durable-wait releases through the same boundary', () => {
+    const planning = source('pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts');
+    const waits = source('pkg/rancher-desktop/agent/database/models/WorkTaskWaitModel.ts');
+    expect(planning).toContain("'planning-run-claim'");
+    expect(waits).toContain("'durable-wait-observation'");
+    expect(waits).toContain("'durable-wait-failure'");
+  });
+
+  it('drains committed events before new dispatcher claims and after settlement', () => {
+    const dispatcher = source('pkg/rancher-desktop/agent/services/TaskDispatcherService.ts');
+    expect(dispatcher.match(/getProjectsOrchestrationEventService\(\)\.drain\(50\)/g)).toHaveLength(2);
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationWriters.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationWriters.contract.test.ts
@@ -18,6 +18,7 @@ describe('Projects orchestration writer contract', () => {
       'verification-failure-escalation',
       'duplicate-review-generation',
       'orphan-execution-recovery',
+      'expired-execution-lease-recovery',
     ]) {
       expect(dispatch).toContain(`'${ sourceName }'`);
     }

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationWriters.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationWriters.contract.test.ts
@@ -36,4 +36,16 @@ describe('Projects orchestration writer contract', () => {
     const dispatcher = source('pkg/rancher-desktop/agent/services/TaskDispatcherService.ts');
     expect(dispatcher.match(/getProjectsOrchestrationEventService\(\)\.drain\(50\)/g)).toHaveLength(2);
   });
+
+  it('routes human-comment wait invalidation, lane archival, and capability recovery through the outbox', () => {
+    const workItems = source('pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts');
+    const lanes = source('pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts');
+    const capabilities = source('pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts');
+
+    expect(workItems).toContain("'human-comment-wait-invalidation'");
+    expect(workItems.slice(workItems.indexOf('static async addComment'))).toContain('appendTaskTransitionEvent(');
+    expect(lanes).toContain("'lane-archive-move'");
+    expect(capabilities).toContain("'capability-recovery-open'");
+    expect(capabilities).toContain("'capability-recovery-resolved'");
+  });
 });

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationWriters.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationWriters.contract.test.ts
@@ -16,6 +16,8 @@ describe('Projects orchestration writer contract', () => {
       'legacy-review-finalize',
       'protected-review-finalize',
       'verification-failure-escalation',
+      'duplicate-review-generation',
+      'orphan-execution-recovery',
     ]) {
       expect(dispatch).toContain(`'${ sourceName }'`);
     }

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
@@ -19,4 +19,9 @@ describe('Projects transition outbox contract', () => {
   it('uses task and generation as its replay identity', () => {
     expect(source).toContain('projects.task.transitioned:${ committed.id }:${ claimed.entry.generation }');
   });
+
+  it('dispatches orchestration only through the durable event service after commit', () => {
+    expect(source).toContain('getProjectsOrchestrationEventService().drain()');
+    expect(source).not.toContain('LaneEntryAutomationService.dispatchEntry(laneEntryId)');
+  });
 });

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from '@jest/globals';
+
+describe('Projects transition outbox contract', () => {
+  const source = fs.readFileSync(path.resolve(
+    process.cwd(), 'pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts',
+  ), 'utf8');
+
+  it('records the transition event inside the task/lane-entry transaction', () => {
+    const transaction = source.slice(source.indexOf('updated = await postgresClient.transaction'));
+    expect(transaction).toContain('claimLaneEntryInTransaction');
+    expect(transaction).toContain('createPostgresProjectsRepositories(client).events.append');
+    expect(transaction).toContain("eventType:      'projects.task.transitioned'");
+    expect(transaction).toContain('claimed.entry.generation');
+  });
+
+  it('uses task and generation as its replay identity', () => {
+    expect(source).toContain('projects.task.transitioned:${ committed.id }:${ claimed.entry.generation }');
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
@@ -7,17 +7,21 @@ describe('Projects transition outbox contract', () => {
   const source = fs.readFileSync(path.resolve(
     process.cwd(), 'pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts',
   ), 'utf8');
+  const appendSource = fs.readFileSync(path.resolve(
+    process.cwd(), 'pkg/rancher-desktop/agent/projects/infrastructure/appendTaskTransitionEvent.ts',
+  ), 'utf8');
 
   it('records the transition event inside the task/lane-entry transaction', () => {
     const transaction = source.slice(source.indexOf('updated = await postgresClient.transaction'));
-    expect(transaction).toContain('claimLaneEntryInTransaction');
-    expect(transaction).toContain('createPostgresProjectsRepositories(client).events.append');
-    expect(transaction).toContain("eventType:      'projects.task.transitioned'");
-    expect(transaction).toContain('claimed.entry.generation');
+    expect(transaction).toContain('appendTaskTransitionEvent(');
+    expect(appendSource).toContain('claimLaneEntryInTransaction');
+    expect(appendSource).toContain('createPostgresProjectsRepositories(client).events.append');
+    expect(appendSource).toContain("eventType:      'projects.task.transitioned'");
+    expect(appendSource).toContain('claimed.entry.generation');
   });
 
   it('uses task and generation as its replay identity', () => {
-    expect(source).toContain('projects.task.transitioned:${ committed.id }:${ claimed.entry.generation }');
+    expect(appendSource).toContain('projects.task.transitioned:${ task.id }:${ claimed.entry.generation }');
   });
 
   it('dispatches orchestration only through the durable event service after commit', () => {

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
@@ -28,4 +28,10 @@ describe('Projects transition outbox contract', () => {
     expect(source).toContain('getProjectsOrchestrationEventService().drain()');
     expect(source).not.toContain('LaneEntryAutomationService.dispatchEntry(laneEntryId)');
   });
+
+  it('commits task creation and its initial lifecycle event atomically', () => {
+    const insert = source.slice(source.indexOf('static async insertTask'), source.indexOf('static async upsertTask'));
+    expect(insert).toContain('postgresClient.transaction(async(client)');
+    expect(insert).toContain("appendTaskTransitionEvent(client, inserted, '', actor");
+  });
 });

--- a/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsRepositories.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsRepositories.ts
@@ -2,6 +2,8 @@ import type {
   EpicSnapshot,
   ProjectSnapshot,
   ProjectsCommentRepository,
+  ProjectsDomainEventRecord,
+  ProjectsDomainEventRepository,
   ProjectsEpicRepository,
   ProjectsProjectRepository,
   ProjectsRepositories,
@@ -111,11 +113,42 @@ class PostgresCommentRepository implements ProjectsCommentRepository {
   }
 }
 
+class PostgresDomainEventRepository implements ProjectsDomainEventRepository {
+  constructor(private readonly client: ProjectsSqlClient) {}
+
+  async append(input: {
+    id:              string;
+    taskId:          string;
+    generation:      number;
+    generationHash?: string | null;
+    eventType:       string;
+    idempotencyKey:  string;
+    payload:         Readonly<Record<string, unknown>>;
+    occurredAt:      Date;
+  }): Promise<ProjectsDomainEventRecord> {
+    const result = await this.client.query<ProjectsDomainEventRecord>(`
+      INSERT INTO work_project_domain_events (
+        id, task_id, generation, generation_hash, event_type,
+        idempotency_key, payload, occurred_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+      ON CONFLICT (idempotency_key) DO UPDATE
+        SET idempotency_key = EXCLUDED.idempotency_key
+      RETURNING *
+    `, [
+      input.id, input.taskId, input.generation, input.generationHash ?? null,
+      input.eventType, input.idempotencyKey, JSON.stringify(input.payload), input.occurredAt.toISOString(),
+    ]);
+    if (!result.rows[0]) throw new Error('Projects domain-event insert returned no row.');
+    return result.rows[0];
+  }
+}
+
 export function createPostgresProjectsRepositories(client: ProjectsSqlClient): ProjectsRepositories {
   return {
     projects: new PostgresProjectRepository(client),
     epics:    new PostgresEpicRepository(client),
     tasks:    new PostgresTaskRepository(client),
     comments: new PostgresCommentRepository(client),
+    events:   new PostgresDomainEventRepository(client),
   };
 }

--- a/pkg/rancher-desktop/agent/projects/infrastructure/ProjectsDomainEventOutbox.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/ProjectsDomainEventOutbox.ts
@@ -1,0 +1,55 @@
+import { postgresClient } from '../../database/PostgresClient';
+
+import type { ProjectsDomainEventRecord } from '../application/ProjectsRepositories';
+
+export class ProjectsDomainEventOutbox {
+  static async claim(owner: string, limit = 25, leaseSeconds = 120): Promise<ProjectsDomainEventRecord[]> {
+    const normalizedOwner = owner.trim();
+    if (!normalizedOwner) throw new Error('Projects outbox lease owner is required.');
+    const boundedLimit = Math.max(1, Math.min(100, limit));
+    const boundedLease = Math.max(15, Math.min(900, leaseSeconds));
+    return postgresClient.transaction(async(client) => {
+      const claimed = await client.query<ProjectsDomainEventRecord>(`
+        WITH candidates AS (
+          SELECT id
+            FROM work_project_domain_events
+           WHERE (status = 'pending' AND available_at <= now())
+              OR (status = 'processing' AND leased_until <= now())
+           ORDER BY available_at ASC, created_at ASC
+           FOR UPDATE SKIP LOCKED
+           LIMIT $1
+        )
+        UPDATE work_project_domain_events event
+           SET status = 'processing', attempts = attempts + 1,
+               lease_owner = $2, leased_until = now() + ($3 * interval '1 second'),
+               updated_at = now(), last_error = NULL
+          FROM candidates
+         WHERE event.id = candidates.id
+        RETURNING event.*
+      `, [boundedLimit, normalizedOwner, boundedLease]);
+      return claimed.rows;
+    });
+  }
+
+  static async complete(id: string, owner: string): Promise<boolean> {
+    const rows = await postgresClient.query<{ id: string }>(`
+      UPDATE work_project_domain_events
+         SET status = 'completed', lease_owner = NULL, leased_until = NULL,
+             completed_at = now(), updated_at = now(), last_error = NULL
+       WHERE id = $1 AND status = 'processing' AND lease_owner = $2
+      RETURNING id
+    `, [id, owner]);
+    return rows.length === 1;
+  }
+
+  static async retry(id: string, owner: string, error: string, availableAt: Date): Promise<boolean> {
+    const rows = await postgresClient.query<{ id: string }>(`
+      UPDATE work_project_domain_events
+         SET status = 'pending', lease_owner = NULL, leased_until = NULL,
+             available_at = $3, updated_at = now(), last_error = $4
+       WHERE id = $1 AND status = 'processing' AND lease_owner = $2
+      RETURNING id
+    `, [id, owner, availableAt.toISOString(), error.slice(0, 2_000)]);
+    return rows.length === 1;
+  }
+}

--- a/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/ProjectsDomainEventOutbox.postgres.test.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/ProjectsDomainEventOutbox.postgres.test.ts
@@ -1,0 +1,94 @@
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { Pool } from 'pg';
+
+import { postgresClient } from '../../../database/PostgresClient';
+import { up as createWorkItems } from '../../../database/migrations/0044_create_work_items_tables';
+import { up as createDomainEventOutbox } from '../../../database/migrations/0086_create_projects_domain_event_outbox';
+import { createPostgresProjectsRepositories } from '../PostgresProjectsRepositories';
+import { ProjectsDomainEventOutbox } from '../ProjectsDomainEventOutbox';
+
+const connectionString = process.env.SULLA_INTEGRATION_POSTGRES_URL;
+const describeWithPostgres = connectionString ? describe : describe.skip;
+
+describeWithPostgres('Projects domain-event outbox (migrated PostgreSQL)', () => {
+  let bootstrapPool: Pool;
+  let pool: Pool;
+  const schema = `projects_outbox_${ randomUUID().replaceAll('-', '') }`;
+  const originalQuery = postgresClient.query;
+  const originalTransaction = postgresClient.transaction;
+
+  beforeAll(async() => {
+    bootstrapPool = new Pool({ connectionString, max: 1 });
+    await bootstrapPool.query(`CREATE SCHEMA "${ schema }"`);
+    pool = new Pool({ connectionString, max: 4, options: `-c search_path=${ schema }` });
+    await pool.query(createWorkItems);
+    await pool.query(createDomainEventOutbox);
+    (postgresClient as any).query = async(text: string, params: unknown[] = []) =>
+      (await pool.query(text, params)).rows;
+    (postgresClient as any).transaction = async(callback: (client: any) => Promise<unknown>) => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        const result = await callback(client);
+        await client.query('COMMIT');
+        return result;
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+      }
+    };
+  });
+
+  afterAll(async() => {
+    (postgresClient as any).query = originalQuery;
+    (postgresClient as any).transaction = originalTransaction;
+    await pool?.end();
+    await bootstrapPool?.query(`DROP SCHEMA IF EXISTS "${ schema }" CASCADE`);
+    await bootstrapPool?.end();
+  });
+
+  beforeEach(async() => {
+    await pool.query('TRUNCATE work_project_domain_events, work_tasks, work_epics, work_projects CASCADE');
+    await pool.query(`
+      INSERT INTO work_projects (id, slug, title) VALUES ('p1', 'p1', 'P1');
+      INSERT INTO work_epics (id, project_id, title) VALUES ('e1', 'p1', 'E1');
+      INSERT INTO work_tasks (id, project_id, epic_id, title, status)
+      VALUES ('t1', 'p1', 'e1', 'T1', 'todo');
+    `);
+  });
+
+  it('reclaims an expired processing lease after a crash and settles by exact owner', async() => {
+    await postgresClient.transaction(async(client) => {
+      await createPostgresProjectsRepositories(client).events.append({
+        id: 'event-1', taskId: 't1', generation: 1,
+        eventType: 'projects.task.transitioned', idempotencyKey: 'transition:t1:1',
+        payload: { fromLane: 'backlog', toLane: 'todo' }, occurredAt: new Date(),
+      });
+    });
+    const first = await ProjectsDomainEventOutbox.claim('owner-a', 1, 15);
+    expect(first).toHaveLength(1);
+    await pool.query(`UPDATE work_project_domain_events SET leased_until = now() - interval '1 second' WHERE id = 'event-1'`);
+    const reclaimed = await ProjectsDomainEventOutbox.claim('owner-b', 1, 15);
+    expect(reclaimed[0]).toMatchObject({ id: 'event-1', lease_owner: 'owner-b', attempts: 2 });
+    await expect(ProjectsDomainEventOutbox.complete('event-1', 'owner-a')).resolves.toBe(false);
+    await expect(ProjectsDomainEventOutbox.complete('event-1', 'owner-b')).resolves.toBe(true);
+  });
+
+  it('rolls back task mutation and event append together', async() => {
+    await expect(postgresClient.transaction(async(client) => {
+      await client.query(`UPDATE work_tasks SET status = 'in_review' WHERE id = 't1'`);
+      await createPostgresProjectsRepositories(client).events.append({
+        id: 'event-rollback', taskId: 't1', generation: 1,
+        eventType: 'projects.task.transitioned', idempotencyKey: 'transition:t1:rollback',
+        payload: {}, occurredAt: new Date(),
+      });
+      throw new Error('abort transition');
+    })).rejects.toThrow('abort transition');
+    expect((await pool.query(`SELECT status FROM work_tasks WHERE id = 't1'`)).rows[0].status).toBe('todo');
+    expect((await pool.query(`SELECT id FROM work_project_domain_events WHERE id = 'event-rollback'`)).rows).toHaveLength(0);
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/ProjectsDomainEventOutbox.postgres.test.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/ProjectsDomainEventOutbox.postgres.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { Pool } from 'pg';
 
 import { postgresClient } from '../../../database/PostgresClient';
@@ -8,6 +8,9 @@ import { up as createWorkItems } from '../../../database/migrations/0044_create_
 import { up as createDomainEventOutbox } from '../../../database/migrations/0086_create_projects_domain_event_outbox';
 import { createPostgresProjectsRepositories } from '../PostgresProjectsRepositories';
 import { ProjectsDomainEventOutbox } from '../ProjectsDomainEventOutbox';
+import { WorkItemsModel } from '../../../database/models/WorkItemsModel';
+import { ProjectsOrchestrationEventService } from '../../application/ProjectsOrchestrationEventService';
+import { TaskLifecycleOrchestrationService } from '../../application/TaskLifecycleOrchestrationService';
 
 const connectionString = process.env.SULLA_INTEGRATION_POSTGRES_URL;
 const describeWithPostgres = connectionString ? describe : describe.skip;
@@ -44,6 +47,7 @@ describeWithPostgres('Projects domain-event outbox (migrated PostgreSQL)', () =>
   });
 
   afterAll(async() => {
+    jest.restoreAllMocks();
     (postgresClient as any).query = originalQuery;
     (postgresClient as any).transaction = originalTransaction;
     await pool?.end();
@@ -90,5 +94,50 @@ describeWithPostgres('Projects domain-event outbox (migrated PostgreSQL)', () =>
     })).rejects.toThrow('abort transition');
     expect((await pool.query(`SELECT status FROM work_tasks WHERE id = 't1'`)).rows[0].status).toBe('todo');
     expect((await pool.query(`SELECT id FROM work_project_domain_events WHERE id = 'event-rollback'`)).rows).toHaveLength(0);
+  });
+
+  it('replays every lifecycle frontier through the runtime dispatcher after restart', async() => {
+    const lifecycle = jest.spyOn(TaskLifecycleOrchestrationService, 'handleCommittedTransition').mockResolvedValue();
+    // Keep the runtime read path real: WorkItemsModel reads through the
+    // disposable migrated pool installed in beforeAll.
+    const cases = [
+      ['in_progress', 'in_review', 'execution-review'],
+      ['in_review', 'todo', 'review-repair'],
+      ['in_review', 'planning', 'review-planning'],
+      ['in_review', 'blocked', 'review-wait'],
+      ['in_review', 'done', 'review-done'],
+      ['blocked', 'planning', 'blocked-planning'],
+      ['blocked', 'in_review', 'blocked-wait-release'],
+    ] as const;
+
+    let generation = 10;
+    for (const [fromLane, toLane, scenario] of cases) {
+      generation++;
+      await pool.query('UPDATE work_tasks SET status = $1 WHERE id = $2', [toLane, 't1']);
+      await postgresClient.transaction(async(client) => {
+        await createPostgresProjectsRepositories(client).events.append({
+          id: `event-${ scenario }`, taskId: 't1', generation,
+          eventType: 'projects.task.transitioned',
+          idempotencyKey: `transition:t1:${ generation }`,
+          payload: { fromLane, toLane, laneAutomated: false, scenario },
+          occurredAt: new Date(),
+        });
+      });
+
+      // A new service instance models process restart: no in-memory queue or
+      // owner state is reused; the committed outbox row is the sole handoff.
+      const restarted = new ProjectsOrchestrationEventService(`restart-owner-${ generation }`, async() => undefined);
+      await expect(restarted.drain(1)).resolves.toEqual({ completed: 1, retried: 0, unhandled: 0 });
+      expect(lifecycle).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: 't1', status: toLane }), fromLane, undefined,
+      );
+      const stored = await pool.query('SELECT status FROM work_project_domain_events WHERE id = $1', [`event-${ scenario }`]);
+      expect(stored.rows[0].status).toBe('completed');
+    }
+
+    expect(lifecycle).toHaveBeenCalledTimes(cases.length);
+    // Guard the test against accidentally replacing the real current-task
+    // lookup with a mocked shortcut.
+    expect(jest.isMockFunction(WorkItemsModel.getTask)).toBe(false);
   });
 });

--- a/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/appendTaskTransitionEvent.test.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/appendTaskTransitionEvent.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { WorkLaneWorkflowBindingModel } from '../../../database/models/WorkLaneWorkflowBindingModel';
+import { appendTaskTransitionEvent } from '../appendTaskTransitionEvent';
+
+describe('appendTaskTransitionEvent', () => {
+  afterEach(() => { jest.restoreAllMocks() });
+
+  it('binds one lane generation and appends one event through the caller transaction', async() => {
+    const entry = { id: 'lane-entry-4', generation: 4, status: 'pending' } as any;
+    const claim = jest.spyOn(WorkLaneWorkflowBindingModel, 'claimLaneEntryInTransaction')
+      .mockResolvedValue({ created: true, entry });
+    const query = jest.fn<any>().mockResolvedValue({ rows: [{ id: 'event-4' }] });
+    const client = { query } as any;
+
+    await appendTaskTransitionEvent(
+      client,
+      { id: 'task-1', status: 'in_review' } as any,
+      'in_progress',
+      'dispatcher',
+      'task-dispatch-finalize',
+    );
+
+    expect(claim).toHaveBeenCalledWith(client, 'task-1', 'in_review', 'dispatcher');
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0]).toContain('INSERT INTO work_project_domain_events');
+    expect(query.mock.calls[0][1]).toEqual(expect.arrayContaining([
+      'projects-event-task-1-4-transition',
+      'projects.task.transitioned:task-1:4',
+      'projects.task.transitioned',
+    ]));
+  });
+
+  it('does nothing when no lane transition occurred', async() => {
+    const claim = jest.spyOn(WorkLaneWorkflowBindingModel, 'claimLaneEntryInTransaction');
+    await appendTaskTransitionEvent(
+      { query: jest.fn() } as any,
+      { id: 'task-1', status: 'todo' } as any,
+      'todo',
+      'dispatcher',
+      'noop',
+    );
+    expect(claim).not.toHaveBeenCalled();
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/appendTaskTransitionEvent.test.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/__tests__/appendTaskTransitionEvent.test.ts
@@ -19,6 +19,7 @@ describe('appendTaskTransitionEvent', () => {
       'in_progress',
       'dispatcher',
       'task-dispatch-finalize',
+      { generationHash: 'artifact-generation-4', metadata: { dispatchId: 'dispatch-4' } },
     );
 
     expect(claim).toHaveBeenCalledWith(client, 'task-1', 'in_review', 'dispatcher');
@@ -28,6 +29,7 @@ describe('appendTaskTransitionEvent', () => {
       'projects-event-task-1-4-transition',
       'projects.task.transitioned:task-1:4',
       'projects.task.transitioned',
+      'artifact-generation-4',
     ]));
   });
 

--- a/pkg/rancher-desktop/agent/projects/infrastructure/appendTaskTransitionEvent.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/appendTaskTransitionEvent.ts
@@ -1,0 +1,40 @@
+import { WorkLaneWorkflowBindingModel } from '../../database/models/WorkLaneWorkflowBindingModel';
+
+import { createPostgresProjectsRepositories } from './PostgresProjectsRepositories';
+
+import type { WorkTaskRecord } from '../../database/models/WorkItemsModel';
+import type { PoolClient } from 'pg';
+
+/**
+ * Claim the exact lane generation and append its orchestration event through
+ * the caller's transaction. Every task-status writer uses this boundary so a
+ * committed transition can never exist without a recoverable handoff.
+ */
+export async function appendTaskTransitionEvent(
+  client: PoolClient,
+  task: WorkTaskRecord,
+  previousStatus: string,
+  actor: string,
+  source: string,
+): Promise<void> {
+  if (task.status === previousStatus) return;
+  const claimed = await WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction(
+    client, task.id, task.status, actor,
+  );
+  await createPostgresProjectsRepositories(client).events.append({
+    id:             `projects-event-${ task.id }-${ claimed.entry.generation }-transition`,
+    taskId:         task.id,
+    generation:     claimed.entry.generation,
+    eventType:      'projects.task.transitioned',
+    idempotencyKey: `projects.task.transitioned:${ task.id }:${ claimed.entry.generation }`,
+    occurredAt:     new Date(),
+    payload:        {
+      actor,
+      source,
+      fromLane:      previousStatus,
+      toLane:        task.status,
+      laneEntryId:   claimed.entry.id,
+      laneAutomated: claimed.entry.status === 'pending',
+    },
+  });
+}

--- a/pkg/rancher-desktop/agent/projects/infrastructure/appendTaskTransitionEvent.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/appendTaskTransitionEvent.ts
@@ -16,6 +16,10 @@ export async function appendTaskTransitionEvent(
   previousStatus: string,
   actor: string,
   source: string,
+  options: {
+    generationHash?: string | null;
+    metadata?:       Readonly<Record<string, unknown>>;
+  } = {},
 ): Promise<void> {
   if (task.status === previousStatus) return;
   const claimed = await WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction(
@@ -25,6 +29,7 @@ export async function appendTaskTransitionEvent(
     id:             `projects-event-${ task.id }-${ claimed.entry.generation }-transition`,
     taskId:         task.id,
     generation:     claimed.entry.generation,
+    generationHash: options.generationHash,
     eventType:      'projects.task.transitioned',
     idempotencyKey: `projects.task.transitioned:${ task.id }:${ claimed.entry.generation }`,
     occurredAt:     new Date(),
@@ -35,6 +40,7 @@ export async function appendTaskTransitionEvent(
       toLane:        task.status,
       laneEntryId:   claimed.entry.id,
       laneAutomated: claimed.entry.status === 'pending',
+      ...options.metadata,
     },
   });
 }

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -141,6 +141,9 @@ export class TaskDispatcherService {
     if (!this.initialized || this.checking) return;
     this.checking = true;
     try {
+      // Complete any committed lifecycle handoffs before claiming more WIP.
+      const { getProjectsOrchestrationEventService } = await import('../projects/application/ProjectsOrchestrationEventService');
+      await getProjectsOrchestrationEventService().drain(50);
       const enabled = await SullaSettingsModel.get('heartbeatEnabled', false);
       if (!enabled) {
         await LifecycleCapabilityModel.report({
@@ -608,6 +611,9 @@ export class TaskDispatcherService {
         .catch(err => console.error(`[TaskDispatcher] Stage-claim release failed for ${ liveStageClaim.id }:`, err));
       this.active.delete(dispatch.id);
       GraphRegistry.delete(dispatch.thread_id);
+      const { getProjectsOrchestrationEventService } = await import('../projects/application/ProjectsOrchestrationEventService');
+      await getProjectsOrchestrationEventService().drain(50)
+        .catch(err => console.error('[TaskDispatcher] Orchestration event drain failed:', err));
       if (this.initialized) {
         this.checkAndDispatch().catch(err => console.error('[TaskDispatcher] Refill check failed:', err));
       }

--- a/pkg/rancher-desktop/main/workItemsEvents.ts
+++ b/pkg/rancher-desktop/main/workItemsEvents.ts
@@ -380,11 +380,11 @@ export function initWorkItemsEvents(): void {
     return true;
   });
 
-  // Lane claims are committed outbox rows. Drain them after handler setup so
-  // a crash between task commit and dispatch cannot silently strand work.
-  import('@pkg/agent/services/LaneEntryAutomationService')
-    .then(({ LaneEntryAutomationService }) => LaneEntryAutomationService.drainRecoverable(50, true))
-    .catch(error => console.warn('[WorkItems] Lane-entry recovery failed:', error));
+  // Domain events are the durable orchestration handoff. Drain them after IPC
+  // setup so a crash after task commit cannot strand a lane transition.
+  import('@pkg/agent/projects/application/ProjectsOrchestrationEventService')
+    .then(({ getProjectsOrchestrationEventService }) => getProjectsOrchestrationEventService().drain(50))
+    .catch(error => console.warn('[WorkItems] Projects orchestration recovery failed:', error));
 }
 
 interface ReorderUpdate {


### PR DESCRIPTION
## Phase 4 status: exact-head review requested

Packaged Sulla Desktop review surface for dHAe Phase 4 at exact head d5fe75b2f.

Implemented:
- ordered additive startup migration 0086_create_projects_domain_event_outbox, registered in the packaged migration registry
- no runtime DDL and no install-local or live database schema edits
- generation-scoped durable outbox with idempotency, lease claim/reclaim, exact-owner settlement, and bounded retry
- task creation/mutation, custody, lane-entry generation, and transition event commit atomically
- lane automation plus planning/dispatcher lifecycle reactions replay through one handler; stale generations are suppressed
- startup recovery and dispatcher drains replay committed events before new WIP and after settlement
- dispatcher, planning, review, repair, durable wait, human-comment invalidation, lane archival, and lifecycle-capability recovery writers emit through the shared boundary
- review and repair events carry lane generation plus exact artifact/review generation hash

Verification:
- real disposable migrated PostgreSQL: 3 tests passed for crash lease reclaim, atomic rollback, and restart runtime replay across execution to review; review to repair, planning, wait, and done; blocked to planning and wait release
- focused contract/model validation: 11 suites and 72 tests passed
- git diff --check passed
- source audit found no work_project_domain_events schema DDL outside migration 0086 and its migration contract test
- full agent TypeScript check attempted but the process exhausted the 2 GB VM heap; aggregate build is not claimed
- legacy WorkItemsModel test suite still contains stale transaction mocks from the merged transaction refactor and is not claimed green

Gate:
- independent exact-head review of d5fe75b2f, then ready and merge under Jonathon merge-train authorization

No live database mutation, rebuild, restart, or runtime activation is claimed.