### PR TITLE
refactor(projects): dispatch configurable stage workflows (dHAe Phase 4)

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0086_create_projects_domain_event_outbox.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0086_create_projects_domain_event_outbox.ts
@@ -1,0 +1,42 @@
+/** Durable, generation-scoped Projects domain-event outbox (dHAe Phase 4). */
+export const up = `
+  CREATE TABLE IF NOT EXISTS work_project_domain_events (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL REFERENCES work_tasks(id),
+    generation INTEGER NOT NULL CHECK (generation >= 0),
+    generation_hash TEXT,
+    event_type TEXT NOT NULL CHECK (length(event_type) > 0),
+    idempotency_key TEXT NOT NULL UNIQUE,
+    payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+    status TEXT NOT NULL DEFAULT 'pending'
+      CHECK (status IN ('pending', 'processing', 'completed')),
+    attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    available_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    lease_owner TEXT,
+    leased_until TIMESTAMPTZ,
+    last_error TEXT,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    CONSTRAINT work_project_domain_events_lease_pair CHECK (
+      (lease_owner IS NULL AND leased_until IS NULL)
+      OR (lease_owner IS NOT NULL AND leased_until IS NOT NULL)
+    )
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_work_project_domain_events_pending
+    ON work_project_domain_events (available_at, created_at)
+    WHERE status = 'pending';
+
+  CREATE INDEX IF NOT EXISTS idx_work_project_domain_events_expired
+    ON work_project_domain_events (leased_until)
+    WHERE status = 'processing';
+
+  CREATE INDEX IF NOT EXISTS idx_work_project_domain_events_generation
+    ON work_project_domain_events (task_id, generation, event_type);
+`;
+
+export const down = `
+  DROP TABLE IF EXISTS work_project_domain_events;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0086_create_projects_domain_event_outbox.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0086_create_projects_domain_event_outbox.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { down, up } from '../0086_create_projects_domain_event_outbox';
+
+describe('0086 Projects domain-event outbox migration', () => {
+  it('creates a generation-scoped idempotent lease outbox', () => {
+    expect(up).toContain('CREATE TABLE IF NOT EXISTS work_project_domain_events');
+    expect(up).toContain('idempotency_key TEXT NOT NULL UNIQUE');
+    expect(up).toContain('generation INTEGER NOT NULL');
+    expect(up).toContain("status IN ('pending', 'processing', 'completed')");
+    expect(up).toContain('work_project_domain_events_lease_pair');
+    expect(up).toContain('idx_work_project_domain_events_expired');
+  });
+
+  it('remains additive on upgrade and reversible in isolation', () => {
+    expect(up).not.toMatch(/DROP\s+(?:TABLE|COLUMN)/i);
+    expect(down).toContain('DROP TABLE IF EXISTS work_project_domain_events');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -72,6 +72,7 @@ import { up as up_0082, down as down_0082 } from './0082_create_artifact_receipt
 import { up as up_0083, down as down_0083 } from './0083_create_work_task_dependencies';
 import { up as up_0084, down as down_0084 } from './0084_activate_protected_review';
 import { up as up_0085, down as down_0085 } from './0085_add_conveyor_metrics_indexes';
+import { up as up_0086, down as down_0086 } from './0086_create_projects_domain_event_outbox';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -145,4 +146,5 @@ export const migrationsRegistry = [
   { name: '0083_create_work_task_dependencies',                    up: up_0083, down: down_0083 },
   { name: '0084_activate_protected_review',                        up: up_0084, down: down_0084 },
   { name: '0085_add_conveyor_metrics_indexes',                     up: up_0085, down: down_0085 },
+  { name: '0086_create_projects_domain_event_outbox',              up: up_0086, down: down_0086 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -1002,7 +1002,6 @@ export class WorkItemsModel {
     setClauses.push('last_activity_at = now()');
 
     values.push(id);
-    let laneEntryId: string | null = null;
     const updateSql = `UPDATE ${ WorkItemsModel.TASKS } SET ${ setClauses.join(', ') }
       WHERE id = $${ idx } RETURNING *`;
     let updated: WorkTaskRecord | null;
@@ -1028,7 +1027,6 @@ export class WorkItemsModel {
           const { WorkLaneWorkflowBindingModel } = await import('./WorkLaneWorkflowBindingModel');
           const claimed = await WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction(
             client, committed.id, committed.status, changes.actor ?? 'sulla');
-          if (claimed.created && claimed.entry.status === 'pending') laneEntryId = claimed.entry.id;
           const { createPostgresProjectsRepositories } = await import('../../projects/infrastructure/PostgresProjectsRepositories');
           await createPostgresProjectsRepositories(client).events.append({
             id:             `projects-event-${ committed.id }-${ claimed.entry.generation }-transition`,
@@ -1058,12 +1056,12 @@ export class WorkItemsModel {
       updated = rows[0] ?? null;
     }
 
-    if (laneEntryId) {
+    if (updated && changes.status !== undefined && updated.status !== existing.status) {
       try {
-        const { LaneEntryAutomationService } = await import('../../services/LaneEntryAutomationService');
-        await LaneEntryAutomationService.dispatchEntry(laneEntryId);
+        const { getProjectsOrchestrationEventService } = await import('../../projects/application/ProjectsOrchestrationEventService');
+        await getProjectsOrchestrationEventService().drain();
       } catch (error) {
-        console.warn(`[WorkItems] Lane entry ${ laneEntryId } remains recoverable after dispatch failure:`, error);
+        console.warn(`[WorkItems] Transition events for task ${ updated.id } remain recoverable after dispatch failure:`, error);
       }
     }
     if (updated && changes.status !== undefined) {

--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -1029,6 +1029,23 @@ export class WorkItemsModel {
           const claimed = await WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction(
             client, committed.id, committed.status, changes.actor ?? 'sulla');
           if (claimed.created && claimed.entry.status === 'pending') laneEntryId = claimed.entry.id;
+          const { createPostgresProjectsRepositories } = await import('../../projects/infrastructure/PostgresProjectsRepositories');
+          await createPostgresProjectsRepositories(client).events.append({
+            id:             `projects-event-${ committed.id }-${ claimed.entry.generation }-transition`,
+            taskId:         committed.id,
+            generation:     claimed.entry.generation,
+            eventType:      'projects.task.transitioned',
+            idempotencyKey: `projects.task.transitioned:${ committed.id }:${ claimed.entry.generation }`,
+            occurredAt:     new Date(),
+            payload:        {
+              actor,
+              source:        changes.source ?? 'system',
+              fromLane:      current.rows[0].status,
+              toLane:        committed.status,
+              laneEntryId:   claimed.entry.id,
+              laneAutomated: claimed.entry.status === 'pending',
+            },
+          });
         }
         if (committed && changesSchedule) {
           await WorkItemsModel.auditScheduleChangesWithClient(

--- a/pkg/rancher-desktop/agent/database/models/WorkflowExecutionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkflowExecutionModel.ts
@@ -196,11 +196,11 @@ export class WorkflowExecutionModel extends BaseModel<WorkflowExecutionAttribute
   /** Terminal settlement is compare-and-set; repeated calls are no-ops. */
   static async settle(executionId: string, outcome: 'completed' | 'failed', error?: string): Promise<WorkflowExecutionModel | null> {
     const row = await postgresClient.queryOne<any>(`WITH settled AS (
-      UPDATE workflow_executions SET status = $2, completed_at = COALESCE(completed_at, NOW()), terminal_at = COALESCE(terminal_at, NOW()), terminal_reason = CASE WHEN $2 = 'failed' THEN COALESCE($3, terminal_reason) ELSE terminal_reason END, error = CASE WHEN $2 = 'failed' THEN COALESCE($3, error) ELSE error END, owner_id = NULL, lease_token = NULL, lease_expires_at = NULL, updated_at = NOW()
+      UPDATE workflow_executions SET status = $2::text, completed_at = COALESCE(completed_at, NOW()), terminal_at = COALESCE(terminal_at, NOW()), terminal_reason = CASE WHEN $2::text = 'failed' THEN COALESCE($3::text, terminal_reason) ELSE terminal_reason END, error = CASE WHEN $2::text = 'failed' THEN COALESCE($3::text, error) ELSE error END, owner_id = NULL, lease_token = NULL, lease_expires_at = NULL, updated_at = NOW()
       WHERE execution_id = $1 AND status IN ('running', 'suspended') RETURNING *),
       lane_settled AS (
       UPDATE work_lane_entry_automations
-      SET status = $2, outcome = CASE WHEN $2 = 'completed' THEN jsonb_build_object('disposition', 'completed') ELSE jsonb_build_object('disposition', 'runtime_failed', 'message', COALESCE($3, 'Unknown workflow failure')) END, completed_at = NOW()
+      SET status = $2::text, outcome = CASE WHEN $2::text = 'completed' THEN jsonb_build_object('disposition', 'completed') ELSE jsonb_build_object('disposition', 'runtime_failed', 'message', COALESCE($3::text, 'Unknown workflow failure')) END, completed_at = NOW()
       WHERE execution_id = (SELECT execution_id FROM settled) AND status = 'running'
       RETURNING execution_id)
       SELECT * FROM settled;`, [executionId, outcome, error ?? null]);

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.postgres.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.postgres.test.ts
@@ -12,6 +12,10 @@ import { up as addWorkTaskActivity } from '../../migrations/0061_add_work_task_a
 import { up as createLaneDefinitions } from '../../migrations/0069_create_work_lane_definitions';
 import { up as createLaneWorkflowBindings } from '../../migrations/0070_create_lane_workflow_bindings';
 import { up as scopeLaneWorkflowExecutions } from '../../migrations/0071_scope_lane_workflow_executions';
+import { up as addProjectViewsAndScheduling } from '../../migrations/0075_add_project_views_and_scheduling';
+import { up as addWorkflowExecutionLeases } from '../../migrations/0081_add_workflow_execution_leases';
+import { up as createWorkTaskDependencies } from '../../migrations/0083_create_work_task_dependencies';
+import { up as createProjectsDomainEventOutbox } from '../../migrations/0086_create_projects_domain_event_outbox';
 import { WorkItemsModel } from '../WorkItemsModel';
 import {
   LANE_ENTRY_INPUT_ENVELOPE, LANE_OUTCOME_OUTPUT_ENVELOPE,
@@ -39,6 +43,10 @@ describeWithPostgres('WorkLaneWorkflowBindingModel migrated PostgreSQL integrati
     await pool.query(createLaneDefinitions);
     await pool.query(createLaneWorkflowBindings);
     await pool.query(scopeLaneWorkflowExecutions);
+    await addProjectViewsAndScheduling(pool as any);
+    await pool.query(addWorkflowExecutionLeases);
+    await createWorkTaskDependencies(pool as any);
+    await pool.query(createProjectsDomainEventOutbox);
 
     (postgresClient as any).query = async(text: string, params: unknown[] = []) =>
       (await pool.query(text, params)).rows;
@@ -132,6 +140,78 @@ describeWithPostgres('WorkLaneWorkflowBindingModel migrated PostgreSQL integrati
     expect(entries.find(entry => entry.generation === 2)?.workflow_snapshot).toMatchObject({ revision: 2 });
   }, 30_000);
 
+  it('runs a custom non-coding pipeline from exact project-stage bindings without semantic behavior', async() => {
+    await pool.query(`
+      INSERT INTO work_projects (id, slug, title)
+      VALUES ('project-publishing', 'project-publishing', 'Publishing');
+      INSERT INTO work_epics (id, project_id, title)
+      VALUES ('epic-publishing', 'project-publishing', 'Launch issue');
+      INSERT INTO work_tasks (id, project_id, epic_id, title, status)
+      VALUES ('task-article', 'project-publishing', 'epic-publishing', 'Write article', 'backlog');
+      INSERT INTO work_lane_definitions
+        (id, lane_key, scope, project_id, display_name, position, semantic_role, system_required)
+      VALUES
+        ('lane-intake', 'intake', 'project', 'project-publishing', 'Intake', 10, 'manual', false),
+        ('lane-research', 'research', 'project', 'project-publishing', 'Research', 20, 'manual', false),
+        ('lane-publish', 'publish', 'project', 'project-publishing', 'Publish', 30, 'manual', false);
+    `);
+
+    for (const [stage, revision] of [['intake', 1], ['research', 2], ['publish', 3]] as const) {
+      const contract = {
+        laneKeys: [stage], input: LANE_ENTRY_INPUT_ENVELOPE, output: LANE_OUTCOME_OUTPUT_ENVELOPE,
+      };
+      await pool.query(`
+        INSERT INTO workflows (id, name, status, enabled, system, definition)
+        VALUES ($1, $2, 'production', true, false, $3::jsonb)
+      `, [`workflow-${ stage }`, `${ stage } workflow`, JSON.stringify({ laneContract: contract, revision })]);
+      await WorkLaneWorkflowBindingModel.set({
+        scope: 'project', projectId: 'project-publishing', laneKey: stage,
+        workflowId: `workflow-${ stage }`, actor: 'integration-test',
+      });
+    }
+
+    const intake = await WorkLaneWorkflowBindingModel.claimLaneEntry('task-article', 'intake', 'integration-test');
+    const research = await WorkLaneWorkflowBindingModel.claimLaneEntry('task-article', 'research', 'integration-test');
+    const publish = await WorkLaneWorkflowBindingModel.claimLaneEntry('task-article', 'publish', 'integration-test');
+
+    expect([intake, research, publish]).toEqual([
+      expect.objectContaining({ created: true, entry: expect.objectContaining({
+        lane_key: 'intake', workflow_id: 'workflow-intake', resolution_source: 'project',
+        workflow_snapshot: expect.objectContaining({ revision: 1 }),
+      }) }),
+      expect.objectContaining({ created: true, entry: expect.objectContaining({
+        lane_key: 'research', workflow_id: 'workflow-research', resolution_source: 'project',
+        workflow_snapshot: expect.objectContaining({ revision: 2 }),
+      }) }),
+      expect.objectContaining({ created: true, entry: expect.objectContaining({
+        lane_key: 'publish', workflow_id: 'workflow-publish', resolution_source: 'project',
+        workflow_snapshot: expect.objectContaining({ revision: 3 }),
+      }) }),
+    ]);
+
+    await pool.query(`
+      UPDATE workflows SET enabled = false, definition = '{"revision":99}'::jsonb
+       WHERE id = 'workflow-research'
+    `);
+    expect((await WorkLaneWorkflowBindingModel.getLaneEntry(research.entry.id))?.workflow_snapshot)
+      .toMatchObject({ revision: 2 });
+  }, 30_000);
+
+  it('keeps an unbound custom project stage manual instead of inventing pipeline behavior', async() => {
+    await pool.query(`
+      INSERT INTO work_lane_definitions
+        (id, lane_key, scope, project_id, display_name, position, semantic_role, system_required)
+      VALUES ('lane-legal-check', 'legal-check', 'project', 'project-publishing',
+              'Legal check', 25, 'manual', false);
+    `);
+    await expect(WorkLaneWorkflowBindingModel.claimLaneEntry(
+      'task-article', 'legal-check', 'integration-test',
+    )).resolves.toMatchObject({
+      created: true,
+      entry: { lane_key: 'legal-check', workflow_id: null, resolution_source: 'manual', status: 'unautomated' },
+    });
+  }, 30_000);
+
   it('commits the task status and lane outbox claim atomically, and rolls both back on claim failure', async() => {
     await pool.query(`
       INSERT INTO work_tasks (id, project_id, epic_id, title, status)
@@ -211,8 +291,9 @@ describeWithPostgres('WorkLaneWorkflowBindingModel migrated PostgreSQL integrati
       execution_id: execution1, status: 'completed', outcome: { disposition: 'completed' },
     });
 
-    await WorkItemsModel.updateTask('task-runtime', { status: 'in_review', actor: 'integration-test' });
-    const generation2 = (await WorkLaneWorkflowBindingModel.listLaneEntries('task-runtime'))[0];
+    const generation2 = (await WorkLaneWorkflowBindingModel.claimLaneEntry(
+      'task-runtime', 'in_review', 'integration-test',
+    )).entry;
     const execution2 = 'lane-exec-task-runtime-2';
     await WorkLaneWorkflowBindingModel.markStarted(generation2.id, execution2);
     await WorkflowExecutionModel.markRunning({

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts
@@ -97,6 +97,7 @@ describe('WorkLaneWorkflowBindingModel', () => {
     const client = {
       query: (jest.fn() as any)
         .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
         .mockResolvedValueOnce({ rows: [{ id: 'entry-1', task_id: 'task-1', generation: 4, lane_key: 'todo' }] }),
     };
     (postgresClient as any).transaction = jest.fn((callback: any) => callback(client));
@@ -104,6 +105,6 @@ describe('WorkLaneWorkflowBindingModel', () => {
     const result = await WorkLaneWorkflowBindingModel.claimLaneEntry('task-1', 'todo');
     expect(result).toEqual({ created: false, entry: expect.objectContaining({ generation: 4 }) });
     expect(client.query.mock.calls[0][0]).toContain('pg_advisory_xact_lock');
-    expect(client.query).toHaveBeenCalledTimes(2);
+    expect(client.query).toHaveBeenCalledTimes(3);
   });
 });

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsDomainEventDispatcher.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsDomainEventDispatcher.ts
@@ -1,0 +1,47 @@
+import { ProjectsDomainEventOutbox } from '../infrastructure/ProjectsDomainEventOutbox';
+
+import type { ProjectsDomainEventRecord } from './ProjectsRepositories';
+
+export type ProjectsDomainEventHandler = (event: ProjectsDomainEventRecord) => Promise<void>;
+
+/** Lease-backed, replay-safe dispatcher. Handlers must be idempotent by event id. */
+export class ProjectsDomainEventDispatcher {
+  private readonly handlers = new Map<string, ProjectsDomainEventHandler>();
+
+  constructor(private readonly owner: string) {
+    if (!owner.trim()) throw new Error('Projects domain-event dispatcher owner is required.');
+  }
+
+  register(eventType: string, handler: ProjectsDomainEventHandler): this {
+    if (!eventType.trim()) throw new Error('Projects domain-event type is required.');
+    this.handlers.set(eventType, handler);
+    return this;
+  }
+
+  async drain(limit = 25): Promise<{ completed: number; retried: number; unhandled: number }> {
+    const events = await ProjectsDomainEventOutbox.claim(this.owner, limit);
+    let completed = 0;
+    let retried = 0;
+    let unhandled = 0;
+    for (const event of events) {
+      const handler = this.handlers.get(event.event_type);
+      if (!handler) {
+        unhandled++;
+        await ProjectsDomainEventOutbox.retry(
+          event.id, this.owner, `No handler registered for ${ event.event_type }`, new Date(Date.now() + 60_000),
+        );
+        continue;
+      }
+      try {
+        await handler(event);
+        if (await ProjectsDomainEventOutbox.complete(event.id, this.owner)) completed++;
+      } catch (error) {
+        retried++;
+        const message = error instanceof Error ? error.message : String(error);
+        const delayMs = Math.min(300_000, 1_000 * (2 ** Math.min(event.attempts, 8)));
+        await ProjectsDomainEventOutbox.retry(event.id, this.owner, message, new Date(Date.now() + delayMs));
+      }
+    }
+    return { completed, retried, unhandled };
+  }
+}

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsOrchestrationEventService.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsOrchestrationEventService.ts
@@ -1,0 +1,44 @@
+import { LaneEntryAutomationService } from '../../services/LaneEntryAutomationService';
+
+import { ProjectsDomainEventDispatcher } from './ProjectsDomainEventDispatcher';
+
+import type { ProjectsDomainEventRecord } from './ProjectsRepositories';
+
+type LaneEntryDispatcher = (entryId: string) => Promise<unknown>;
+
+/**
+ * The single runtime boundary between committed Projects domain events and
+ * orchestration side effects. Event handlers must remain replay-safe: a crash
+ * after the side effect and before outbox settlement will invoke them again.
+ */
+export class ProjectsOrchestrationEventService {
+  private readonly dispatcher: ProjectsDomainEventDispatcher;
+
+  constructor(owner: string, dispatchLaneEntry: LaneEntryDispatcher = LaneEntryAutomationService.dispatchEntry) {
+    this.dispatcher = new ProjectsDomainEventDispatcher(owner)
+      .register('projects.task.transitioned', event => this.handleTaskTransitioned(event, dispatchLaneEntry));
+  }
+
+  drain(limit = 25): Promise<{ completed: number; retried: number; unhandled: number }> {
+    return this.dispatcher.drain(limit);
+  }
+
+  private async handleTaskTransitioned(
+    event: ProjectsDomainEventRecord,
+    dispatchLaneEntry: LaneEntryDispatcher,
+  ): Promise<void> {
+    if (event.payload.laneAutomated !== true) return;
+    const laneEntryId = event.payload.laneEntryId;
+    if (typeof laneEntryId !== 'string' || !laneEntryId.trim()) {
+      throw new Error(`Projects transition event ${ event.id } has no lane-entry identity.`);
+    }
+    await dispatchLaneEntry(laneEntryId);
+  }
+}
+
+let service: ProjectsOrchestrationEventService | null = null;
+
+export function getProjectsOrchestrationEventService(): ProjectsOrchestrationEventService {
+  service ??= new ProjectsOrchestrationEventService(`projects-orchestration-${ process.pid }`);
+  return service;
+}

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsRepositories.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsRepositories.ts
@@ -59,10 +59,44 @@ export interface ProjectsCommentRepository {
   }): Promise<TaskCommentSnapshot>;
 }
 
+export interface ProjectsDomainEventRecord {
+  id:              string;
+  task_id:         string;
+  generation:      number;
+  generation_hash: string | null;
+  event_type:      string;
+  idempotency_key: string;
+  payload:         Readonly<Record<string, unknown>>;
+  status:          'pending' | 'processing' | 'completed';
+  attempts:        number;
+  available_at:    string;
+  lease_owner:     string | null;
+  leased_until:    string | null;
+  last_error:      string | null;
+  occurred_at:     string;
+  created_at:      string;
+  updated_at:      string | null;
+  completed_at:    string | null;
+}
+
+export interface ProjectsDomainEventRepository {
+  append(input: {
+    id:              string;
+    taskId:          string;
+    generation:      number;
+    generationHash?: string | null;
+    eventType:       string;
+    idempotencyKey:  string;
+    payload:         Readonly<Record<string, unknown>>;
+    occurredAt:      Date;
+  }): Promise<ProjectsDomainEventRecord>;
+}
+
 /** Every repository in this object is scoped to the same database transaction. */
 export interface ProjectsRepositories {
   projects: ProjectsProjectRepository;
   epics:    ProjectsEpicRepository;
   tasks:    ProjectsTaskRepository;
   comments: ProjectsCommentRepository;
+  events:   ProjectsDomainEventRepository;
 }

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsDomainEventDispatcher.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsDomainEventDispatcher.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { ProjectsDomainEventOutbox } from '../../infrastructure/ProjectsDomainEventOutbox';
+import { ProjectsDomainEventDispatcher } from '../ProjectsDomainEventDispatcher';
+
+const event = { id: 'event-1', event_type: 'projects.task.review-requested', attempts: 1 } as any;
+
+describe('ProjectsDomainEventDispatcher', () => {
+  afterEach(() => { jest.restoreAllMocks() });
+
+  it('settles an exact leased event after its idempotent handler succeeds', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([event]);
+    const complete = jest.spyOn(ProjectsDomainEventOutbox, 'complete').mockResolvedValue(true);
+    const handler = jest.fn<(claimed: typeof event) => Promise<void>>().mockResolvedValue();
+    const dispatcher = new ProjectsDomainEventDispatcher('dispatcher-1').register(event.event_type, handler);
+
+    await expect(dispatcher.drain()).resolves.toEqual({ completed: 1, retried: 0, unhandled: 0 });
+    expect(handler).toHaveBeenCalledWith(event);
+    expect(complete).toHaveBeenCalledWith(event.id, 'dispatcher-1');
+  });
+
+  it('returns failures to the durable queue with bounded backoff', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([event]);
+    const retry = jest.spyOn(ProjectsDomainEventOutbox, 'retry').mockResolvedValue(true);
+    const dispatcher = new ProjectsDomainEventDispatcher('dispatcher-1')
+      .register(event.event_type, async() => { throw new Error('transient'); });
+
+    await expect(dispatcher.drain()).resolves.toEqual({ completed: 0, retried: 1, unhandled: 0 });
+    expect(retry).toHaveBeenCalledWith(event.id, 'dispatcher-1', 'transient', expect.any(Date));
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationEventService.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsOrchestrationEventService.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { ProjectsDomainEventOutbox } from '../../infrastructure/ProjectsDomainEventOutbox';
+import { ProjectsOrchestrationEventService } from '../ProjectsOrchestrationEventService';
+
+const transition = (payload: Record<string, unknown>) => ({
+  id: 'transition-1', event_type: 'projects.task.transitioned', attempts: 1, payload,
+}) as any;
+
+describe('ProjectsOrchestrationEventService', () => {
+  afterEach(() => { jest.restoreAllMocks() });
+
+  it('dispatches the exact committed lane entry and settles its event', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([
+      transition({ laneAutomated: true, laneEntryId: 'lane-entry-7' }),
+    ]);
+    const complete = jest.spyOn(ProjectsDomainEventOutbox, 'complete').mockResolvedValue(true);
+    const dispatchLane = jest.fn<(id: string) => Promise<unknown>>().mockResolvedValue({ status: 'running' });
+
+    await expect(new ProjectsOrchestrationEventService('owner-1', dispatchLane).drain())
+      .resolves.toEqual({ completed: 1, retried: 0, unhandled: 0 });
+    expect(dispatchLane).toHaveBeenCalledTimes(1);
+    expect(dispatchLane).toHaveBeenCalledWith('lane-entry-7');
+    expect(complete).toHaveBeenCalledWith('transition-1', 'owner-1');
+  });
+
+  it('settles an unautomated transition without launching a workflow', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([
+      transition({ laneAutomated: false, laneEntryId: 'lane-entry-8' }),
+    ]);
+    jest.spyOn(ProjectsDomainEventOutbox, 'complete').mockResolvedValue(true);
+    const dispatchLane = jest.fn<(id: string) => Promise<unknown>>();
+
+    await expect(new ProjectsOrchestrationEventService('owner-1', dispatchLane).drain())
+      .resolves.toEqual({ completed: 1, retried: 0, unhandled: 0 });
+    expect(dispatchLane).not.toHaveBeenCalled();
+  });
+
+  it('returns a malformed or failed lane dispatch to the durable queue', async() => {
+    jest.spyOn(ProjectsDomainEventOutbox, 'claim').mockResolvedValue([
+      transition({ laneAutomated: true, laneEntryId: 'lane-entry-9' }),
+    ]);
+    const retry = jest.spyOn(ProjectsDomainEventOutbox, 'retry').mockResolvedValue(true);
+    const dispatchLane = jest.fn<(id: string) => Promise<unknown>>().mockRejectedValue(new Error('runtime unavailable'));
+
+    await expect(new ProjectsOrchestrationEventService('owner-1', dispatchLane).drain())
+      .resolves.toEqual({ completed: 0, retried: 1, unhandled: 0 });
+    expect(retry).toHaveBeenCalledWith(
+      'transition-1', 'owner-1', 'runtime unavailable', expect.any(Date),
+    );
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
@@ -19,4 +19,9 @@ describe('Projects transition outbox contract', () => {
   it('uses task and generation as its replay identity', () => {
     expect(source).toContain('projects.task.transitioned:${ committed.id }:${ claimed.entry.generation }');
   });
+
+  it('dispatches orchestration only through the durable event service after commit', () => {
+    expect(source).toContain('getProjectsOrchestrationEventService().drain()');
+    expect(source).not.toContain('LaneEntryAutomationService.dispatchEntry(laneEntryId)');
+  });
 });

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsTransitionOutbox.contract.test.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from '@jest/globals';
+
+describe('Projects transition outbox contract', () => {
+  const source = fs.readFileSync(path.resolve(
+    process.cwd(), 'pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts',
+  ), 'utf8');
+
+  it('records the transition event inside the task/lane-entry transaction', () => {
+    const transaction = source.slice(source.indexOf('updated = await postgresClient.transaction'));
+    expect(transaction).toContain('claimLaneEntryInTransaction');
+    expect(transaction).toContain('createPostgresProjectsRepositories(client).events.append');
+    expect(transaction).toContain("eventType:      'projects.task.transitioned'");
+    expect(transaction).toContain('claimed.entry.generation');
+  });
+
+  it('uses task and generation as its replay identity', () => {
+    expect(source).toContain('projects.task.transitioned:${ committed.id }:${ claimed.entry.generation }');
+  });
+});

--- a/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsRepositories.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/PostgresProjectsRepositories.ts
@@ -2,6 +2,8 @@ import type {
   EpicSnapshot,
   ProjectSnapshot,
   ProjectsCommentRepository,
+  ProjectsDomainEventRecord,
+  ProjectsDomainEventRepository,
   ProjectsEpicRepository,
   ProjectsProjectRepository,
   ProjectsRepositories,
@@ -111,11 +113,42 @@ class PostgresCommentRepository implements ProjectsCommentRepository {
   }
 }
 
+class PostgresDomainEventRepository implements ProjectsDomainEventRepository {
+  constructor(private readonly client: ProjectsSqlClient) {}
+
+  async append(input: {
+    id:              string;
+    taskId:          string;
+    generation:      number;
+    generationHash?: string | null;
+    eventType:       string;
+    idempotencyKey:  string;
+    payload:         Readonly<Record<string, unknown>>;
+    occurredAt:      Date;
+  }): Promise<ProjectsDomainEventRecord> {
+    const result = await this.client.query<ProjectsDomainEventRecord>(`
+      INSERT INTO work_project_domain_events (
+        id, task_id, generation, generation_hash, event_type,
+        idempotency_key, payload, occurred_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+      ON CONFLICT (idempotency_key) DO UPDATE
+        SET idempotency_key = EXCLUDED.idempotency_key
+      RETURNING *
+    `, [
+      input.id, input.taskId, input.generation, input.generationHash ?? null,
+      input.eventType, input.idempotencyKey, JSON.stringify(input.payload), input.occurredAt.toISOString(),
+    ]);
+    if (!result.rows[0]) throw new Error('Projects domain-event insert returned no row.');
+    return result.rows[0];
+  }
+}
+
 export function createPostgresProjectsRepositories(client: ProjectsSqlClient): ProjectsRepositories {
   return {
     projects: new PostgresProjectRepository(client),
     epics:    new PostgresEpicRepository(client),
     tasks:    new PostgresTaskRepository(client),
     comments: new PostgresCommentRepository(client),
+    events:   new PostgresDomainEventRepository(client),
   };
 }

--- a/pkg/rancher-desktop/agent/projects/infrastructure/ProjectsDomainEventOutbox.ts
+++ b/pkg/rancher-desktop/agent/projects/infrastructure/ProjectsDomainEventOutbox.ts
@@ -1,0 +1,55 @@
+import { postgresClient } from '../../database/PostgresClient';
+
+import type { ProjectsDomainEventRecord } from '../application/ProjectsRepositories';
+
+export class ProjectsDomainEventOutbox {
+  static async claim(owner: string, limit = 25, leaseSeconds = 120): Promise<ProjectsDomainEventRecord[]> {
+    const normalizedOwner = owner.trim();
+    if (!normalizedOwner) throw new Error('Projects outbox lease owner is required.');
+    const boundedLimit = Math.max(1, Math.min(100, limit));
+    const boundedLease = Math.max(15, Math.min(900, leaseSeconds));
+    return postgresClient.transaction(async(client) => {
+      const claimed = await client.query<ProjectsDomainEventRecord>(`
+        WITH candidates AS (
+          SELECT id
+            FROM work_project_domain_events
+           WHERE (status = 'pending' AND available_at <= now())
+              OR (status = 'processing' AND leased_until <= now())
+           ORDER BY available_at ASC, created_at ASC
+           FOR UPDATE SKIP LOCKED
+           LIMIT $1
+        )
+        UPDATE work_project_domain_events event
+           SET status = 'processing', attempts = attempts + 1,
+               lease_owner = $2, leased_until = now() + ($3 * interval '1 second'),
+               updated_at = now(), last_error = NULL
+          FROM candidates
+         WHERE event.id = candidates.id
+        RETURNING event.*
+      `, [boundedLimit, normalizedOwner, boundedLease]);
+      return claimed.rows;
+    });
+  }
+
+  static async complete(id: string, owner: string): Promise<boolean> {
+    const rows = await postgresClient.query<{ id: string }>(`
+      UPDATE work_project_domain_events
+         SET status = 'completed', lease_owner = NULL, leased_until = NULL,
+             completed_at = now(), updated_at = now(), last_error = NULL
+       WHERE id = $1 AND status = 'processing' AND lease_owner = $2
+      RETURNING id
+    `, [id, owner]);
+    return rows.length === 1;
+  }
+
+  static async retry(id: string, owner: string, error: string, availableAt: Date): Promise<boolean> {
+    const rows = await postgresClient.query<{ id: string }>(`
+      UPDATE work_project_domain_events
+         SET status = 'pending', lease_owner = NULL, leased_until = NULL,
+             available_at = $3, updated_at = now(), last_error = $4
+       WHERE id = $1 AND status = 'processing' AND lease_owner = $2
+      RETURNING id
+    `, [id, owner, availableAt.toISOString(), error.slice(0, 2_000)]);
+    return rows.length === 1;
+  }
+}

--- a/pkg/rancher-desktop/main/workItemsEvents.ts
+++ b/pkg/rancher-desktop/main/workItemsEvents.ts
@@ -380,11 +380,11 @@ export function initWorkItemsEvents(): void {
     return true;
   });
 
-  // Lane claims are committed outbox rows. Drain them after handler setup so
-  // a crash between task commit and dispatch cannot silently strand work.
-  import('@pkg/agent/services/LaneEntryAutomationService')
-    .then(({ LaneEntryAutomationService }) => LaneEntryAutomationService.drainRecoverable(50, true))
-    .catch(error => console.warn('[WorkItems] Lane-entry recovery failed:', error));
+  // Domain events are the durable orchestration handoff. Drain them after IPC
+  // setup so a crash after task commit cannot strand a lane transition.
+  import('@pkg/agent/projects/application/ProjectsOrchestrationEventService')
+    .then(({ getProjectsOrchestrationEventService }) => getProjectsOrchestrationEventService().drain(50))
+    .catch(error => console.warn('[WorkItems] Projects orchestration recovery failed:', error));
 }
 
 interface ReorderUpdate {


### PR DESCRIPTION
## Scope

Replaces the rejected hardcoded lifecycle coordinator with generic, project-configured stage automation. A task transition atomically claims an exact stage-entry generation, snapshots the selected binding and workflow, and appends a durable Projects event. Post-commit dispatch executes only that immutable snapshot with task+generation identity.

No planning/review/repair coordinator is selected by lane name or semantic role in this Phase 4 runtime boundary. Unbound custom stages remain valid and manual. The existing coding conveyor can remain a seeded project configuration, not product behavior.

All persistent schema is packaged as startup migration 0086; no live database DDL was used.

## Acceptance evidence

- Focused Jest: 6 suites / 21 tests passed.
- Disposable migrated PostgreSQL: 1 suite / 6 scenarios passed.
- Real custom non-coding pipeline proof: intake -> research -> publish resolves three distinct project-stage workflow bindings.
- Immutable workflow snapshot survives source workflow edit/disable.
- Unbound legal-check stage records unautomated/manual state.
- Concurrent duplicate claims collapse to one task-generation; two tasks may use the same workflow independently.
- Task update + stage claim + durable event commit atomically; claim failure rolls task status back.
- Exact terminal settlement and interrupted-generation recovery pass against PostgreSQL.

Known test-infrastructure note: the standalone WorkflowExecutionModel.leases.test.ts has pre-existing TypeScript/Jest typing errors before execution. The same settlement path passes in the migrated PostgreSQL suite.