### PR TITLE
fix(projects): recover migrations and health query

### DIFF
--- a/pkg/rancher-desktop/agent/database/DatabaseManager.ts
+++ b/pkg/rancher-desktop/agent/database/DatabaseManager.ts
@@ -28,7 +28,8 @@ export function getDatabaseManager(): DatabaseManager {
 
 export class DatabaseManager {
   private initialized = false;
-  private pollingInterval: NodeJS.Timeout | null = null;
+  private initializationPromise: Promise<void> | null = null;
+  private pollingInterval:       NodeJS.Timeout | null = null;
   private isPolling = false;
 
   /**
@@ -38,14 +39,23 @@ export class DatabaseManager {
    */
   async initialize(): Promise<void> {
     if (this.initialized) return;
+    if (this.initializationPromise) return this.initializationPromise;
 
+    this.initializationPromise = this.initializeOnce();
+    try {
+      await this.initializationPromise;
+    } finally {
+      this.initializationPromise = null;
+    }
+  }
+
+  private async initializeOnce(): Promise<void> {
     console.log('[DB] Connecting to PostgreSQL...');
 
     // Use the shared singleton — lifecycle manager already verified the host port is reachable
     await postgresClient.initialize();
     await postgresClient.query('SELECT 1');
     console.log('[DB] Connection healthy');
-    this.initialized = true;
 
     await this.runMigrations();
 
@@ -110,6 +120,7 @@ export class DatabaseManager {
       console.warn('[DB] ProjectRegistry warm initialization failed:', error);
     }
 
+    this.initialized = true;
     console.log('[DB] Database fully initialized');
   }
 

--- a/pkg/rancher-desktop/agent/database/__tests__/DatabaseManager.test.ts
+++ b/pkg/rancher-desktop/agent/database/__tests__/DatabaseManager.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { DatabaseManager } from '../DatabaseManager';
+import { postgresClient } from '../PostgresClient';
+
+describe('DatabaseManager initialization', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('retries after migration failure instead of poisoning the singleton as initialized', async() => {
+    const initialize = jest.spyOn(postgresClient, 'initialize').mockResolvedValue(undefined);
+    const query = jest.spyOn(postgresClient, 'query').mockImplementation(((sql: string) => {
+      if (sql.includes('SELECT name FROM sulla_migrations')) {
+        return Promise.reject(new Error('migration read failed'));
+      }
+      return Promise.resolve([]);
+    }) as any);
+    const manager = new DatabaseManager();
+
+    await expect(manager.initialize()).rejects.toThrow('migration read failed');
+    await expect(manager.initialize()).rejects.toThrow('migration read failed');
+
+    expect(initialize).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls.filter(([sql]) => sql === 'SELECT 1')).toHaveLength(2);
+  });
+});

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -573,7 +573,7 @@ export class WorkTaskDispatchModel {
            SELECT 1 FROM unnest(COALESCE(t.labels, '{}')) AS label
             WHERE LOWER(label) = ANY($2::text[])
          )
-       GROUP BY semantic_role
+       GROUP BY 1
     `, [CLOSED_EPIC_STATUSES, NON_AUTONOMOUS_TASK_LABELS]);
 
     const totals: Partial<Record<WorkLaneSemanticRole, number>> = {};

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchCountByRole.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchCountByRole.test.ts
@@ -1,45 +1,63 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
 import { WorkTaskDispatchModel } from '../WorkTaskDispatchModel';
+
 import type { WipLimits } from '../../../services/ProjectAutomationWipLimits';
 
 const unlimited: WipLimits = {
-  backlog: null, planning: null, execution: null, review: null,
-  blocked: null, terminal: null, manual: null,
+  backlog:   null,
+  planning:  null,
+  execution: null,
+  review:    null,
+  blocked:   null,
+  terminal:  null,
+  manual:    null,
 };
 
 describe('WorkTaskDispatchModel.countByRole (issue #711)', () => {
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-  it('aggregates autonomous work by resolved semantic role, honouring custom lanes', async () => {
-    const query = jest.fn().mockResolvedValue({ rows: [
-      { semantic_role: 'review', count: '5' },
-      { semantic_role: 'execution', count: '5' },
-    ] });
+  it('aggregates autonomous work by resolved semantic role, honouring custom lanes', async() => {
+    const query = jest.fn<(text: string, params?: unknown[]) => Promise<any>>().mockResolvedValue({
+      rows: [
+        { semantic_role: 'review', count: '5' },
+        { semantic_role: 'execution', count: '5' },
+      ],
+    });
 
     const counts = await WorkTaskDispatchModel.countByRoleWithClient({ query } as any);
 
     expect(counts.review).toBe(5);    // 2 in_review + 3 custom qa_gate
     expect(counts.execution).toBe(5); // 1 in_progress + 4 todo
-    const sql = query.mock.calls[0][0] as string;
+    const sql = query.mock.calls[0][0];
     expect(sql).toContain("scope = 'project'");
-    expect(sql).toContain('GROUP BY semantic_role');
+    // Both lateral lane lookups expose a semantic_role input column. PostgreSQL
+    // resolves GROUP BY names against inputs before select aliases, so grouping
+    // by the alias is ambiguous in the real database. The ordinal targets the
+    // resolved COALESCE expression unambiguously.
+    expect(sql).toContain('GROUP BY 1');
+    expect(sql).not.toContain('GROUP BY semantic_role');
     expect(sql).toContain("LOWER(t.assignee) IN ('heartbeat', 'dispatcher', 'verifier')");
     expect(sql).toContain('NOT (p.status = ANY($1::text[]))');
   });
 
-  it('falls back to the default status role map when no lane matches', async () => {
-    const query = jest.fn().mockResolvedValue({ rows: [
-      { semantic_role: 'blocked', count: '2' },
-      { semantic_role: 'planning', count: '1' },
-    ] });
+  it('falls back to the default status role map when no lane matches', async() => {
+    const query = jest.fn<(text: string, params?: unknown[]) => Promise<any>>().mockResolvedValue({
+      rows: [
+        { semantic_role: 'blocked', count: '2' },
+        { semantic_role: 'planning', count: '1' },
+      ],
+    });
 
     const counts = await WorkTaskDispatchModel.countByRoleWithClient({ query } as any);
     expect(counts.blocked).toBe(2);
     expect(counts.planning).toBe(1);
   });
 
-  it('serializes WIP evaluation and rejects a saturated claim before selecting a task', async () => {
-    const query = jest.fn()
+  it('serializes WIP evaluation and rejects a saturated claim before selecting a task', async() => {
+    const query = jest.fn<(text: string, params?: unknown[]) => Promise<any>>()
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ semantic_role: 'execution', count: '3' }] });
     const { postgresClient } = await import('../../PostgresClient');
@@ -53,7 +71,7 @@ describe('WorkTaskDispatchModel.countByRole (issue #711)', () => {
 
     expect(query).toHaveBeenCalledTimes(2);
     expect(query.mock.calls[0][0]).toContain('pg_advisory_xact_lock');
-    expect(query.mock.calls[1][0]).toContain('GROUP BY semantic_role');
-    expect(query.mock.calls.some(([sql]: [string]) => sql.includes('FOR UPDATE OF t SKIP LOCKED'))).toBe(false);
+    expect(query.mock.calls[1][0]).toContain('GROUP BY 1');
+    expect(query.mock.calls.some(([sql]) => sql.includes('FOR UPDATE OF t SKIP LOCKED'))).toBe(false);
   });
 });


### PR DESCRIPTION
Projects could load the basic board while the automation-health path failed in two places after the OOP rollout. DatabaseManager marked itself initialized before migrations completed, so one transient migration failure permanently skipped the remaining migration registry for that process. The semantic WIP count query also grouped by an alias that collided with both lateral lane inputs.

This moves the initialized flag to the end of successful bootstrap, shares concurrent initialization attempts while preserving retries after failure, and groups the resolved semantic role by select ordinal.

Verified:
- 3 focused suites, 5 tests passed
- touched DatabaseManager and test files pass ESLint
- git diff --check clean
- patched automationStatus succeeds against the current live database

The live install is currently migrated only through 0077; a rebuilt/restarted app with this patch will retry and apply the packaged 0078-0087 migrations.