### PR TITLE
fix(subconscious): sync THINKING_TOOLS allowlist with granted subconscious tools

### DIFF
--- a/pkg/rancher-desktop/agent/nodes/SubconsciousAgentNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/SubconsciousAgentNode.ts
@@ -163,10 +163,22 @@ export class SubconsciousAgentNode extends BaseNode {
     }
 
     // Close thinking bubble before tool cards so thinking appears between them.
-    // file_search, read_file, and memory tools render as thinking (not cards), so skip those.
+    // Every tool actually granted to a subconscious agent (GraphRegistry.ts
+    // *_TOOLS lists + conversationReaderPolicy/conversationWriterPolicy)
+    // renders as thinking, not a card — the subconscious is never supposed to
+    // surface visible tool cards in the parent chat. Keep this set in sync
+    // with those grants; a name missing here silently leaks a tool card.
     const THINKING_TOOLS = new Set([
       'file_search', 'read_file',
+      // Observation Writer / Observation Recall
       'add_observational_memory', 'remove_observational_memory',
+      'search_observations', 'list_observations',
+      // Identity Observer (writer) / Identity Observation Recall — all 6 domains
+      'add_identity_observation', 'remove_identity_observation',
+      'search_identity_observations', 'list_identity_observations',
+      // Conversation Reader / Conversation Writer
+      'search_conversation_keywords', 'search_conversation_logs',
+      'upsert_conversation_keywords',
       'vault_list', 'vault_is_enabled', 'search_conversations',
       'recall_index_lookup', 'recall_index_store',
       'search_history', 'github_read_file', 'get_human_presence', 'list_tabs',


### PR DESCRIPTION
## What broke

`THINKING_TOOLS` in `SubconsciousAgentNode.ts` decides which subconscious tool calls render as thinking vs. visible tool cards on the parent chat channel. It was last touched in #587, before the identity-observation domain system (6 domains) and the Conversation Reader/Writer (task drqq, merged 2026-08-24) were built out.

Every tool those newer subconscious agents actually call was missing from the allowlist:
- `search_observations`, `list_observations` (Observation Writer / Observation Recall)
- `add_identity_observation`, `remove_identity_observation`, `search_identity_observations`, `list_identity_observations` (Identity Observer + Identity Recall, x6 domains: human/business/world/agent/environment/projects)
- `search_conversation_keywords`, `search_conversation_logs`, `upsert_conversation_keywords` (Conversation Reader/Writer)

Since nearly every active subconscious agent's first move is a search/list call before writing, this hit almost every subconscious turn - tool calls that should be invisible thinking leaked out as normal tool cards in the chat UI.

## Fix

Added the missing tool names to `THINKING_TOOLS`, grouped by which subconscious agent grants them, with a comment pointing back at `GraphRegistry.ts` tool lists plus `conversationReaderPolicy`/`conversationWriterPolicy` as the source of truth to keep in sync going forward.

## Verification
- eslint on the changed file: clean
- esbuild parse/bundle of the file: passes (full tsc is memory/rebuild-gated in this repo per prior sessions)
- Scoped to exactly one file/one concern; did not touch pre-existing unrelated uncommitted work on main (Knowledge panel removals, ProjectsHome.vue, yarn.lock)

## Not yet verified
- Live UI confirmation that subconscious tool calls now render as thinking again - needs a rebuild and a real turn