### PR TITLE
fix(projects): let dispatcher reclaim any idle in_progress task regardless of assignee

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -138,7 +138,6 @@ export interface ClaimedDispatch {
 export type InProgressExclusionReason =
   | 'archived'
   | 'epic_closed'
-  | 'human_or_unknown_owner'
   | 'non_autonomous_label'
   | 'live_dispatch'
   | 'active_child'
@@ -148,7 +147,6 @@ export type InProgressExclusionReason =
 
 export interface InProgressClassificationRow extends WorkTaskRecord {
   epic_open:            boolean;
-  autonomous_owner:     boolean;
   autonomous_labels:    boolean;
   has_live_dispatch:    boolean;
   has_active_child:     boolean;
@@ -183,11 +181,21 @@ export interface WorkTaskDispatchFinalization {
 
 const CLOSED_EPIC_STATUSES = ['done', 'cancelled', 'parked', 'blocked'];
 
+/**
+ * Idle in_progress reclaim is ownership-neutral by design (Jonathon
+ * directive 2026-08-25, Projects task 1Nk7): whoever is actively working a
+ * task — human or agent — holds it as assignee exactly like any other
+ * sub-agent assignment. There is no "must already be assignee=dispatcher"
+ * or "must be an autonomous owner" gate here. The only protections against
+ * yanking real work out from under someone are activity-based
+ * (stale_activity / has_live_dispatch / has_active_child /
+ * has_active_agent_job) and the explicit opt-out labels in
+ * NON_AUTONOMOUS_TASK_LABELS (e.g. "human", "gated", "no-auto-dispatch").
+ */
 export function classifyInProgressRow(row: InProgressClassificationRow): InProgressExclusionReason[] {
   const reasons: InProgressExclusionReason[] = [];
   if (row.archived) reasons.push('archived');
   if (!row.epic_open) reasons.push('epic_closed');
-  if (!row.autonomous_owner) reasons.push('human_or_unknown_owner');
   if (!row.autonomous_labels) reasons.push('non_autonomous_label');
   if (row.has_live_dispatch) reasons.push('live_dispatch');
   if (row.has_active_child) reasons.push('active_child');
@@ -590,10 +598,9 @@ export class WorkTaskDispatchModel {
     const rows = await postgresClient.query<InProgressClassificationRow>(`
       SELECT t.*,
              (e.id IS NOT NULL AND e.archived = false AND NOT (e.status = ANY($1::text[]))) AS epic_open,
-             (t.assignee IS NULL OR LOWER(t.assignee) = ANY($2::text[])) AS autonomous_owner,
              NOT EXISTS (
                SELECT 1 FROM unnest(COALESCE(t.labels, '{}')) AS label
-                WHERE LOWER(label) = ANY($3::text[])
+                WHERE LOWER(label) = ANY($2::text[])
              ) AS autonomous_labels,
              EXISTS (
                SELECT 1 FROM work_task_dispatches d
@@ -605,7 +612,7 @@ export class WorkTaskDispatchModel {
                   AND child.archived = false
                   AND child.status NOT IN ('done', 'cancelled', 'parked')
              ) AS has_active_child,
-             (t.last_activity_at <= now() - ($4 * interval '1 minute')) AS stale_activity,
+             (t.last_activity_at <= now() - ($3 * interval '1 minute')) AS stale_activity,
              EXISTS (
                SELECT 1 FROM agent_jobs j
                 WHERE j.status = 'running'
@@ -616,13 +623,12 @@ export class WorkTaskDispatchModel {
         LEFT JOIN work_epics e ON e.id = t.epic_id
        WHERE t.status = 'in_progress'
        ORDER BY t.last_activity_at ASC, t.id ASC
-       LIMIT $5
-    `, [CLOSED_EPIC_STATUSES, AUTONOMOUS_TASK_ASSIGNEES, NON_AUTONOMOUS_TASK_LABELS, staleMinutes, Math.max(1, limit)]);
+       LIMIT $4
+    `, [CLOSED_EPIC_STATUSES, NON_AUTONOMOUS_TASK_LABELS, staleMinutes, Math.max(1, limit)]);
 
     return rows.map((row) => {
       const {
         epic_open: _epicOpen,
-        autonomous_owner: _autonomousOwner,
         autonomous_labels: _autonomousLabels,
         has_live_dispatch: _hasLiveDispatch,
         has_active_child: _hasActiveChild,
@@ -665,10 +671,9 @@ export class WorkTaskDispatchModel {
              AND t.archived = false
              AND e.archived = false
              AND NOT (e.status = ANY($2::text[]))
-             AND (t.assignee IS NULL OR LOWER(t.assignee) = ANY($3::text[]))
              AND NOT EXISTS (
                SELECT 1 FROM unnest(COALESCE(t.labels, '{}')) AS label
-                WHERE LOWER(label) = ANY($4::text[])
+                WHERE LOWER(label) = ANY($3::text[])
              )
              AND NOT EXISTS (
                SELECT 1 FROM work_task_dispatches d
@@ -685,9 +690,9 @@ export class WorkTaskDispatchModel {
                 WHERE j.status = 'running'
                   AND (j.job_id = t.source_ref OR COALESCE(j.results, '[]'::jsonb)::text LIKE '%' || t.id || '%')
              )
-             AND t.last_activity_at = $5::timestamptz
+             AND t.last_activity_at = $4::timestamptz
            FOR UPDATE OF t SKIP LOCKED
-        `, [candidate.task.id, CLOSED_EPIC_STATUSES, AUTONOMOUS_TASK_ASSIGNEES, NON_AUTONOMOUS_TASK_LABELS, candidate.fingerprint]);
+        `, [candidate.task.id, CLOSED_EPIC_STATUSES, NON_AUTONOMOUS_TASK_LABELS, candidate.fingerprint]);
 
         const task = locked.rows[0];
         if (!task) {
@@ -703,10 +708,15 @@ export class WorkTaskDispatchModel {
         const outcome = attemptNumber >= Math.max(1, retryCeiling) ? 'blocked_ceiling' : 'recovered';
         const nextStatus = outcome === 'recovered' ? 'todo' : 'blocked';
         const nextAssignee = outcome === 'recovered' ? TASK_ASSIGNEES.dispatcher : TASK_ASSIGNEES.heartbeat;
+        // Ownership-neutral: prior assignee may be a human, dispatcher, heartbeat, or any
+        // other agent identity. Idle timeout is the only gate — see classifyInProgressRow.
         const reason = outcome === 'recovered'
-          ? 'stale autonomous in_progress task had no live owner or operation'
+          ? 'in_progress task idle past the reclaim threshold with no live owner or operation'
           : `recovery retry ceiling reached (${ retryCeiling })`;
         const auditId = `recovery-${ randomUUID() }`;
+        const idleMinutes = Math.max(0, Math.round(
+          (Date.now() - new Date(task.last_activity_at).getTime()) / 60000,
+        ));
         const undo = `restore status=in_progress, assignee=${ task.assignee ?? 'unassigned' }, and review activity at ${ task.last_activity_at }`;
 
         await client.query(`
@@ -730,7 +740,9 @@ export class WorkTaskDispatchModel {
            WHERE id = $2
         `, [
           `comment-${ randomUUID() }`, task.id,
-          `Orphan recovery attempt ${ attemptNumber }: ${ reason }. Prior owner: ${ task.assignee ?? 'unassigned' }. Prior activity: ${ task.last_activity_at }. Outcome: ${ nextStatus }/${ nextAssignee }. Undo path: ${ undo }.`,
+          `Orphan recovery attempt ${ attemptNumber }: ${ reason }. Prior owner: ${ task.assignee ?? 'unassigned' }. ` +
+          `Idle for ${ idleMinutes } minute(s) (no activity since ${ task.last_activity_at }). ` +
+          `Outcome: ${ nextStatus }/${ nextAssignee }. Undo: ${ undo }.`,
           nextStatus, nextAssignee,
         ]);
         results.push({ taskId: task.id, outcome, attemptNumber });

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts
@@ -479,12 +479,11 @@ describe('WorkTaskDispatchModel', () => {
     expect(query.mock.calls[3][1][2]).toContain('retry ceiling');
   });
 
-  it('classifies the full in-progress safety matrix', () => {
+  it('classifies the full in-progress safety matrix without gating on assignee', () => {
     const eligible = {
       id:                   'task-1',
       archived:             false,
       epic_open:            true,
-      autonomous_owner:     true,
       autonomous_labels:    true,
       has_live_dispatch:    false,
       has_active_child:     false,
@@ -496,16 +495,38 @@ describe('WorkTaskDispatchModel', () => {
       ...eligible,
       archived:             true,
       epic_open:            false,
-      autonomous_owner:     false,
       autonomous_labels:    false,
       has_live_dispatch:    true,
       has_active_child:     true,
       stale_activity:       false,
       has_active_agent_job: true,
     })).toEqual([
-      'archived', 'epic_closed', 'human_or_unknown_owner', 'non_autonomous_label',
+      'archived', 'epic_closed', 'non_autonomous_label',
       'live_dispatch', 'active_child', 'recent_activity', 'active_agent_job',
     ]);
+  });
+
+  it('Jonathon directive 1Nk7: a human- or agent-assigned idle task is eligible for reclaim regardless of assignee', () => {
+    const base = {
+      id:                   'task-human',
+      archived:             false,
+      epic_open:            true,
+      autonomous_labels:    true,
+      has_live_dispatch:    false,
+      has_active_child:     false,
+      has_active_agent_job: false,
+    } as any;
+
+    // Idle (stale_activity = true): reclaimable no matter who currently holds it.
+    for (const assignee of ['human', 'sulla-desktop', 'heartbeat', 'some-other-agent', null]) {
+      expect(classifyInProgressRow({ ...base, assignee, stale_activity: true })).toEqual([]);
+    }
+
+    // Recent activity (stale_activity = false): never reclaimed, regardless of assignee.
+    for (const assignee of ['human', 'sulla-desktop', 'heartbeat', 'some-other-agent', null]) {
+      expect(classifyInProgressRow({ ...base, assignee, stale_activity: false }))
+        .toEqual(['recent_activity']);
+    }
   });
 
   it('uses the configured stale boundary and includes durable operation checks in report-only classification', async() => {
@@ -514,9 +535,10 @@ describe('WorkTaskDispatchModel', () => {
     try {
       await WorkTaskDispatchModel.findRecoverableInProgress(360, 25);
       const [sql, values] = (postgresClient.query as any).mock.calls[0];
-      expect(sql).toContain("last_activity_at <= now() - ($4 * interval '1 minute')");
+      expect(sql).toContain("last_activity_at <= now() - ($3 * interval '1 minute')");
       expect(sql).toContain("j.status = 'running'");
       expect(sql).toContain("d.status = 'running'");
+      expect(sql).not.toContain('autonomous_owner');
       expect(values).toEqual(expect.arrayContaining([360, 25]));
     } finally {
       (postgresClient as any).query = originalQuery;
@@ -533,8 +555,9 @@ describe('WorkTaskDispatchModel', () => {
     await expect(WorkTaskDispatchModel.recoverOrphanedInProgress([candidate], 1, 3))
       .resolves.toEqual([{ taskId: 'task-1', outcome: 'cas_miss' }]);
     expect(query).toHaveBeenCalledTimes(1);
-    expect(query.mock.calls[0][0]).toContain('t.last_activity_at = $5::timestamptz');
+    expect(query.mock.calls[0][0]).toContain('t.last_activity_at = $4::timestamptz');
     expect(query.mock.calls[0][0]).toContain('FOR UPDATE OF t SKIP LOCKED');
+    expect(query.mock.calls[0][0]).not.toContain('autonomous_owner');
   });
 
   it('audits and requeues an orphan, then blocks at the retry ceiling', async() => {
@@ -569,6 +592,42 @@ describe('WorkTaskDispatchModel', () => {
     await expect(WorkTaskDispatchModel.recoverOrphanedInProgress([candidate], 1, 3))
       .resolves.toEqual([{ taskId: 'task-1', outcome: 'blocked_ceiling', attemptNumber: 3 }]);
     expect(ceilingQuery.mock.calls[3][1]).toEqual(expect.arrayContaining(['blocked', 'heartbeat']));
+  });
+
+  it('Jonathon directive 1Nk7: reclaims a human-assigned idle in_progress task and audits prior owner + idle duration + undo path', async() => {
+    const staleActivity = new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString(); // 8h idle
+    const task = {
+      id:               'task-human-1',
+      status:           'in_progress',
+      assignee:         'human',
+      last_activity_at: staleActivity,
+    } as any;
+    const candidate = {
+      task, fingerprint: task.last_activity_at, attemptCount: 0, exclusionReasons: [],
+    } as any;
+
+    const query = (jest.fn() as any)
+      .mockResolvedValueOnce({ rows: [task] })
+      .mockResolvedValueOnce({ rows: [{ count: '0' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.recoverOrphanedInProgress([candidate], 1, 3))
+      .resolves.toEqual([{ taskId: 'task-human-1', outcome: 'recovered', attemptNumber: 1 }]);
+
+    // The locking re-check no longer filters on assignee at all.
+    expect(query.mock.calls[0][0]).not.toContain('autonomous_owner');
+    expect(query.mock.calls[0][0]).not.toMatch(/t\.assignee IS NULL OR LOWER\(t\.assignee\)/);
+
+    const commentSql = query.mock.calls[3][0];
+    const commentParams = query.mock.calls[3][1];
+    expect(commentSql).toContain('INSERT INTO work_task_comments');
+    expect(commentParams).toEqual(expect.arrayContaining(['todo', 'dispatcher']));
+    const commentBody = commentParams[2];
+    expect(commentBody).toContain('Prior owner: human');
+    expect(commentBody).toMatch(/Idle for \d+ minute\(s\)/);
+    expect(commentBody).toContain('Undo:');
   });
 
   it('atomically records protected review evidence and routes REPLAN to the planning council', async() => {


### PR DESCRIPTION
Summary

- Jonathon directive 2026-08-25 (Projects task 1Nk7): a task should not have to be explicitly assignee=dispatcher before the dispatcher can reclaim it. Whoever is actively working a task, human or agent, holds it as assignee exactly like any other sub-agent assignment. Once it sits idle past the configured threshold, the dispatcher should be able to pick it back up.
- WorkTaskDispatchModel already had an ownership-neutral, lease-independent idle recovery path (findRecoverableInProgress / recoverOrphanedInProgress, wired into TaskDispatcherService.checkInProgressRecovery) based on last_activity_at rather than a live work_task_dispatches lease row. However it gated eligibility on an autonomous_owner check requiring assignee to be NULL, heartbeat, or dispatcher, which excluded any task a human or other agent (sulla-desktop, a named worker, etc.) had set to in_progress by hand.
- Removed that gate from classifyInProgressRow, findRecoverableInProgress, and the row-locking re-check in recoverOrphanedInProgress. The remaining protections are unchanged and still apply to every assignee: stale_activity (idle threshold), has_live_dispatch, has_active_child, has_active_agent_job, and the explicit opt-out labels in NON_AUTONOMOUS_TASK_LABELS (human, gated, decision, manual, no-auto-dispatch).
- The idle threshold stays configurable via the existing taskDispatcherInProgressStaleMinutes setting (default 360 minutes, floor 15), read in TaskDispatcherService.checkInProgressRecovery. No new setting was introduced since this one already covers the requirement.
- Recovery audit comments now explicitly state prior owner, idle duration in minutes, and an Undo path, matching this codebase's established audit convention.

Out of scope

- Task SvxE (Heartbeat's own supervisory/manual reclaim reasoning using live agent roster and worktree activity signals) is untouched. That is a distinct, already-scoped fix requiring separate protected-prompt authorization from Jonathon.
- The master enable switch taskDispatcherInProgressRecoveryEnabled still defaults to false (report-only mode). Flipping that to actually activate reclaim in production is a rollout decision left to Jonathon; this PR only fixes the eligibility predicate so that switch does the right thing once enabled.

Test plan

- Focused Jest on the two touched files: node_modules/.bin/jest --runTestsByPath pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchModel.test.ts. Result: 24 of 27 tests pass. The remaining 3 failures (ArtifactCustodyPolicy settings fallback path, insertTask notify path, artifact_sha assertion) are pre-existing on origin/main and reproduce identically before this change (verified via git stash) — unrelated to this diff.
- New regression coverage added: classifyInProgressRow matrix without the ownership gate, an explicit human/agent-assignee-neutral idle-vs-recent-activity matrix, and an end-to-end recoverOrphanedInProgress test for a human-assigned idle task asserting the audit comment records Prior owner, Idle for N minute(s), and Undo.
- Existing dispatcher-leased stale-task regression tests (recoverStale) are untouched and still pass, confirming that code path is unaffected.
- Focused ESLint on both touched files: only pre-existing errors remain (verified identical via git stash comparison); the two new operator-linebreak errors introduced by my edit were fixed.
- git diff --check: clean.
- Full repo-wide tsc/build was not attempted per known VM OOM constraint; focused Jest via ts-jest type-checks the touched files.
- No database migration, no merge, no deploy, no app rebuild/restart performed.

Commit d4f907af242ea7bd14ce6ebaf4064c74e03343da on branch fix/1Nk7-dispatcher-idle-reclaim.