### PR TITLE
fix(chat): prevent stream updates starving the renderer

### DIFF
--- a/pkg/rancher-desktop/pages/chat/messages/ThinkingMessage.vue
+++ b/pkg/rancher-desktop/pages/chat/messages/ThinkingMessage.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue';
+import { computed, onUnmounted, ref, watch } from 'vue';
 
 import { renderMarkdown } from './markdown';
 
@@ -70,6 +70,8 @@ const thinkingLines = computed(() => {
 const startMs = Date.now();
 const elapsed = ref('0.0s');
 let timer: ReturnType<typeof setInterval> | null = null;
+let scrollFrame: number | null = null;
+let scrollTarget: HTMLElement | null = null;
 
 function startTimer() {
   if (timer) return;
@@ -92,16 +94,25 @@ watch(completed, (done) => {
     startTimer();
   }
 }, { immediate: true });
-onUnmounted(stopTimer);
+onUnmounted(() => {
+  stopTimer();
+  if (scrollFrame !== null) cancelAnimationFrame(scrollFrame);
+  scrollFrame = null;
+  scrollTarget = null;
+});
 
 function toggle() {
   if (completed.value) expanded.value = !expanded.value;
 }
 
 function scrollToBottom(el: any) {
-  if (el instanceof HTMLElement) {
-    nextTick(() => { el.scrollTop = el.scrollHeight });
-  }
+  if (!(el instanceof HTMLElement)) return;
+  scrollTarget = el;
+  if (scrollFrame !== null) return;
+  scrollFrame = requestAnimationFrame(() => {
+    scrollFrame = null;
+    if (scrollTarget) scrollTarget.scrollTop = scrollTarget.scrollHeight;
+  });
 }
 </script>
 

--- a/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
+++ b/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
@@ -38,6 +38,11 @@ export interface PersonaAdapterOptions {
 export class PersonaAdapter {
   private ci: ChatInterface;
   private stopWatchers: WatchStopHandle[] = [];
+  // Backend stream deltas can arrive faster than Vue can paint. Coalesce the
+  // deep-watch callbacks into one sync per animation frame so a long thinking
+  // trace cannot monopolize the renderer's microtask queue. Completion/stop
+  // paths call flushSyncMessages() to publish the final state immediately.
+  private syncFrame: number | null = null;
 
   /**
    * Mirrors ChatInterface.hasMessages — true once the user has sent their
@@ -87,7 +92,7 @@ export class PersonaAdapter {
 
     // React to persona.messages growing / items being mutated in place.
     this.stopWatchers.push(
-      watch(() => this.ci.messages.value, () => this.syncMessages(), { deep: true }),
+      watch(() => this.ci.messages.value, () => this.scheduleSyncMessages(), { deep: true }),
     );
 
     // Drive the run-state machine from the backend. Also re-map every
@@ -98,7 +103,7 @@ export class PersonaAdapter {
     this.stopWatchers.push(
       watch(() => this.ci.graphRunning.value, (running) => {
         this.syncRunState(running);
-        this.syncMessages();
+        this.flushSyncMessages();
       }),
     );
 
@@ -230,6 +235,10 @@ export class PersonaAdapter {
   }
 
   dispose(): void {
+    if (this.syncFrame !== null) {
+      cancelAnimationFrame(this.syncFrame);
+      this.syncFrame = null;
+    }
     for (const stop of this.stopWatchers) stop();
     this.stopWatchers = [];
     this.firstSeenAt.clear();
@@ -243,6 +252,22 @@ export class PersonaAdapter {
   }
 
   // ─── Sync backend → controller ─────────────────────────────────────
+  private scheduleSyncMessages(): void {
+    if (this.syncFrame !== null) return;
+    this.syncFrame = requestAnimationFrame(() => {
+      this.syncFrame = null;
+      this.syncMessages();
+    });
+  }
+
+  private flushSyncMessages(): void {
+    if (this.syncFrame !== null) {
+      cancelAnimationFrame(this.syncFrame);
+      this.syncFrame = null;
+    }
+    this.syncMessages();
+  }
+
   private syncMessages(): void {
     const backend = this.ci.messages.value;
     for (const b of backend) {


### PR DESCRIPTION
## What this fixes

When streamed thinking/message deltas arrive faster than the renderer can paint, the deep persona-message watcher synchronously remapped the entire transcript for every delta. The thinking bubble also scheduled an independent nextTick scroll for every update. Together they could starve the renderer until Stop forced the pending state to flush.

This change:
- coalesces backend to controller transcript sync to one animation frame;
- flushes immediately when the run stops or completes;
- frame-throttles thinking-bubble auto-scroll;
- cancels pending frame work on disposal.

## Verification

- ChatController + run-state tests: **20 passed**
- git diff --check: passed
- Full TypeScript check: attempted; the repository check exceeded the VM default heap and then remained non-diagnostic with a 4 GB heap, so it was stopped. No TypeScript diagnostic was emitted.
- Existing targeted ESLint invocation reports substantial pre-existing style violations in PersonaAdapter.ts; this change did not run the autofixer.

Fixes the “chat freezes while thinking, then all messages appear after Stop” symptom.