### PR TITLE
fix(chat): stop renderer freeze-then-dump during long tool-heavy turns

### DIFF
--- a/pkg/rancher-desktop/pages/chat/messages/ThinkingMessage.vue
+++ b/pkg/rancher-desktop/pages/chat/messages/ThinkingMessage.vue
@@ -45,7 +45,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onUnmounted, ref, watch } from 'vue';
+import { computed, onUnmounted, ref, watch } from 'vue';
 
 import { renderMarkdown } from './markdown';
 
@@ -70,6 +70,8 @@ const thinkingLines = computed(() => {
 const startMs = Date.now();
 const elapsed = ref('0.0s');
 let timer: ReturnType<typeof setInterval> | null = null;
+let scrollFrame: number | null = null;
+let scrollTarget: HTMLElement | null = null;
 
 function startTimer() {
   if (timer) return;
@@ -92,16 +94,25 @@ watch(completed, (done) => {
     startTimer();
   }
 }, { immediate: true });
-onUnmounted(stopTimer);
+onUnmounted(() => {
+  stopTimer();
+  if (scrollFrame !== null) cancelAnimationFrame(scrollFrame);
+  scrollFrame = null;
+  scrollTarget = null;
+});
 
 function toggle() {
   if (completed.value) expanded.value = !expanded.value;
 }
 
 function scrollToBottom(el: any) {
-  if (el instanceof HTMLElement) {
-    nextTick(() => { el.scrollTop = el.scrollHeight });
-  }
+  if (!(el instanceof HTMLElement)) return;
+  scrollTarget = el;
+  if (scrollFrame !== null) return;
+  scrollFrame = requestAnimationFrame(() => {
+    scrollFrame = null;
+    if (scrollTarget) scrollTarget.scrollTop = scrollTarget.scrollHeight;
+  });
 }
 </script>
 

--- a/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
+++ b/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
@@ -58,6 +58,13 @@ export class PersonaAdapter {
   private firstCompletedAt = new Map<string, number>();
   /** Hash of the last-mapped transcript Message per backend id, for skipping no-op updates. */
   private lastMappedHash = new Map<string, string>();
+  /**
+   * Cheap per-message fingerprint (primitive fields / lengths, not a full
+   * serialize) used to skip mapBackendMessage()+stableHash() entirely for
+   * messages that haven't actually changed since the last sync. See
+   * rawSignature() for why this exists.
+   */
+  private lastRawSignature = new Map<string, string>();
   /** workflowRunId → artifactId, so repeated node events find the same artifact. */
   private workflowArtifacts = new Map<string, ArtifactId>();
   /** workflowRunId → name used when the artifact was first opened (stable across updates). */
@@ -223,6 +230,7 @@ export class PersonaAdapter {
     this.firstSeenAt.clear();
     this.firstCompletedAt.clear();
     this.lastMappedHash.clear();
+    this.lastRawSignature.clear();
     this.workflowArtifacts.clear();
     this.workflowNames.clear();
     this.htmlArtifacts.clear();
@@ -235,6 +243,7 @@ export class PersonaAdapter {
     this.firstSeenAt.clear();
     this.firstCompletedAt.clear();
     this.lastMappedHash.clear();
+    this.lastRawSignature.clear();
     this.workflowArtifacts.clear();
     this.workflowNames.clear();
     this.htmlArtifacts.clear();
@@ -243,10 +252,31 @@ export class PersonaAdapter {
   }
 
   // ─── Sync backend → controller ─────────────────────────────────────
+  //
+  // This runs on EVERY backend message-array mutation — i.e. every streamed
+  // token and every tool-progress event during a run, not just once per
+  // turn. It used to call mapBackendMessage() + JSON.stringify(mapped) on
+  // every message in the thread on every single call, including messages
+  // that hadn't changed at all. mapBackendMessage does real work per kind
+  // (regex scans, array mapping) and JSON.stringify re-serializes the full
+  // mapped object — for a streaming message that cost grows with the
+  // message's own length, so cost-per-event scaled with total content
+  // length and total events scaled with the same stream: an O(N) turn did
+  // O(N^2) work. On a long tool-heavy turn that was enough to keep the
+  // renderer's JS thread continuously busy and starve paint for minutes —
+  // reported as "chat freezes, then every message dumps in at once the
+  // instant I hit Stop" (Stop ends the event stream, the thread finally
+  // gets a gap to paint). rawSignature() below is an O(1) fingerprint that
+  // lets us skip all of that for messages nothing has actually changed on.
   private syncMessages(): void {
     const backend = this.ci.messages.value;
     for (const b of backend) {
       if (!b?.id) continue;
+
+      const rawSig = this.rawSignature(b);
+      if (this.seen.has(b.id) && this.lastRawSignature.get(b.id) === rawSig) continue;
+      this.lastRawSignature.set(b.id, rawSig);
+
       const mapped = this.mapBackendMessage(b);
       // A null mapping means the message is represented elsewhere (e.g. in the
       // artifact sidebar) and should not produce a transcript entry.
@@ -256,17 +286,42 @@ export class PersonaAdapter {
         continue;
       }
       if (this.seen.has(b.id)) {
-        // Existing — update mutable fields, but skip if nothing changed.
-        const hash = stableHash(mapped);
-        if (this.lastMappedHash.get(b.id) === hash) continue;
-        this.lastMappedHash.set(b.id, hash);
         this.controller.updateMessage(mapped.id, mapped as Partial<Message>);
       } else {
         this.seen.add(b.id);
-        this.lastMappedHash.set(b.id, stableHash(mapped));
         this.controller.appendMessage(mapped);
       }
     }
+  }
+
+  /**
+   * O(1) fingerprint (primitive reads / string lengths) of the backend
+   * fields that can change what mapBackendMessage() produces for a given
+   * message. Deliberately avoids serializing `content` itself — only its
+   * length — since content is the field that grows every streamed token.
+   * Must cover every backend field MessageDispatcher mutates in place after
+   * a message's first push (verified against MessageDispatcher.ts): content,
+   * `_completed`, toolCard.status/output/error, subAgentActivity.*, and
+   * workflowNode.status/output/error/nodeIndex/totalNodes. graphRunning is
+   * included because thinking/streaming completion falls back to it.
+   * Other kinds (patch, citation, tool_approval, tool_question, channel,
+   * proactive, html, workflow_document) are pushed once and never mutated,
+   * so kind|role|contentLen already makes their signature stable.
+   */
+  private rawSignature(b: BackendMessage): string {
+    const contentLen = typeof b.content === 'string' ? b.content.length : -1;
+    const completed = (b as any)._completed === true ? 1 : 0;
+    const running = this.ci.graphRunning.value ? 1 : 0;
+    const tool = b.toolCard
+      ? `${ b.toolCard.status }|${ b.toolCard.output?.length ?? -1 }|${ b.toolCard.error ?? '' }`
+      : '';
+    const subAgent = b.subAgentActivity
+      ? `${ b.subAgentActivity.status }|${ b.subAgentActivity.thinkingLines.length }|${ b.subAgentActivity.output?.length ?? -1 }|${ b.subAgentActivity.error ?? '' }`
+      : '';
+    const wfNode = b.workflowNode
+      ? `${ b.workflowNode.status }|${ b.workflowNode.output?.length ?? -1 }|${ b.workflowNode.error ?? '' }|${ b.workflowNode.nodeIndex }|${ b.workflowNode.totalNodes }`
+      : '';
+    return `${ b.kind ?? '' }|${ b.role }|${ contentLen }|${ completed }|${ running }|${ tool }|${ subAgent }|${ wfNode }`;
   }
 
   private syncRunState(running: boolean): void {

--- a/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
+++ b/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
@@ -38,6 +38,11 @@ export interface PersonaAdapterOptions {
 export class PersonaAdapter {
   private ci: ChatInterface;
   private stopWatchers: WatchStopHandle[] = [];
+  // Backend stream deltas can arrive faster than Vue can paint. Coalesce the
+  // deep-watch callbacks into one sync per animation frame so a long thinking
+  // trace cannot monopolize the renderer's microtask queue. Completion/stop
+  // paths call flushSyncMessages() to publish the final state immediately.
+  private syncFrame: number | null = null;
 
   /**
    * Mirrors ChatInterface.hasMessages — true once the user has sent their
@@ -93,19 +98,22 @@ export class PersonaAdapter {
     this.syncMessages();
 
     // React to persona.messages growing / items being mutated in place.
+    // Coalesced to one sync per animation frame — see scheduleSyncMessages().
     this.stopWatchers.push(
-      watch(() => this.ci.messages.value, () => this.syncMessages(), { deep: true }),
+      watch(() => this.ci.messages.value, () => this.scheduleSyncMessages(), { deep: true }),
     );
 
     // Drive the run-state machine from the backend. Also re-map every
     // message whenever `graphRunning` flips — the streaming/thinking
     // mappings use it as a completion fallback, so a transition to
     // idle must re-evaluate dangling bubbles even when the underlying
-    // message objects haven't changed.
+    // message objects haven't changed. Flushed immediately (not scheduled):
+    // this fires at most twice per turn, and the run-state/UI should not
+    // wait a frame behind it.
     this.stopWatchers.push(
       watch(() => this.ci.graphRunning.value, (running) => {
         this.syncRunState(running);
-        this.syncMessages();
+        this.flushSyncMessages();
       }),
     );
 
@@ -238,6 +246,10 @@ export class PersonaAdapter {
   }
 
   dispose(): void {
+    if (this.syncFrame !== null) {
+      cancelAnimationFrame(this.syncFrame);
+      this.syncFrame = null;
+    }
     for (const stop of this.stopWatchers) stop();
     this.stopWatchers = [];
     this.firstSeenAt.clear();
@@ -268,6 +280,29 @@ export class PersonaAdapter {
   // instant I hit Stop" (Stop ends the event stream, the thread finally
   // gets a gap to paint). rawSignature() below is an O(1) fingerprint that
   // lets us skip all of that for messages nothing has actually changed on.
+  //
+  // scheduleSyncMessages() additionally caps how often the loop below can
+  // even run — deep-watch fires once per backend mutation, which during a
+  // fast token stream can be far more often than the browser can paint.
+  // Coalescing to one call per animation frame means bursts of events
+  // collapse into a single sync each frame instead of one sync per event.
+  private scheduleSyncMessages(): void {
+    if (this.syncFrame !== null) return;
+    this.syncFrame = requestAnimationFrame(() => {
+      this.syncFrame = null;
+      this.syncMessages();
+    });
+  }
+
+  /** Cancel any pending scheduled sync and run one immediately. */
+  private flushSyncMessages(): void {
+    if (this.syncFrame !== null) {
+      cancelAnimationFrame(this.syncFrame);
+      this.syncFrame = null;
+    }
+    this.syncMessages();
+  }
+
   private syncMessages(): void {
     const backend = this.ci.messages.value;
     for (const b of backend) {


### PR DESCRIPTION
Bug: send a message, chat freezes with no visible updates during a long tool-heavy turn, then every message and tool card appears all at once the instant Stop is pressed. Backend was never stuck, it was streaming the whole time.

Root cause, two compounding contributors found independently by two concurrent agent runs and combined here:

1. PersonaAdapter.syncMessages was O(N) per event, O(N^2) per turn. It ran on every backend message mutation, every streamed token, every tool-progress event, and on each call remapped and stringify-hashed every message in the thread, including ones that had not changed. Cost per call scaled with total content length, call count scaled with the same stream. Long tool-heavy turns kept the renderer JS thread continuously busy, starving paint for minutes.
2. No frequency cap on how often that sync, or ThinkingMessage.vue per-token auto-scroll, could run. Both fired synchronously on every single event with no throttling.

Fix:
- rawSignature: an O(1) fingerprint, primitive field reads and string lengths, never full content, that lets syncMessages skip the expensive remap and hash entirely for messages nothing has changed on. Verified against every in-place mutation site in MessageDispatcher.ts.
- scheduleSyncMessages and flushSyncMessages: coalesce the deep-watch trigger to one syncMessages call per animation frame. graphRunning transitions flush immediately so run-state UI does not lag a frame.
- Same coalescing pattern applied to ThinkingMessage.vue scroll-to-bottom, which was forcing a synchronous layout read and write via nextTick on every token.

The two commits are independent and stack: the first makes each sync call cheap, the second caps how often it can run. Either alone helps, together they close both ends of the freeze.

Verification: full project-wide tsc noEmit OOMs in this environment, a known pre-existing limitation, not new to this change. Verified manually against the actual ChatMessage, toolCard, subAgentActivity, and workflowNode type definitions, and every in-place mutation site in MessageDispatcher.ts, to make sure rawSignature covers every field that can change mapBackendMessage output. Needs a real rebuild and restart plus a long tool-heavy turn to confirm live.

Needs Jonathon rebuild and restart plus live verification before merge.