### PR TITLE
fix(db): quote reserved cast column in migration 0084

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0084_activate_protected_review.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0084_activate_protected_review.ts
@@ -3,12 +3,12 @@ export const up = `
   ALTER TABLE lifecycle_capabilities
     ADD COLUMN IF NOT EXISTS details JSONB NOT NULL DEFAULT '{}'::jsonb;
 
-  INSERT INTO sulla_settings (property, value, cast) VALUES
+  INSERT INTO sulla_settings (property, value, "cast") VALUES
     ('taskVerifierEnabled', 'true', 'boolean'),
     ('taskVerifierOwner', 'core-routine', 'string'),
     ('taskReviewCoreRoutineEnabled', 'true', 'boolean')
   ON CONFLICT (property) DO UPDATE
-    SET value = EXCLUDED.value, cast = EXCLUDED.cast
+    SET value = EXCLUDED.value, "cast" = EXCLUDED."cast"
     WHERE (sulla_settings.property = 'taskVerifierEnabled' AND sulla_settings.value = 'false')
        OR (sulla_settings.property = 'taskVerifierOwner' AND sulla_settings.value = 'legacy')
        OR (sulla_settings.property = 'taskReviewCoreRoutineEnabled' AND sulla_settings.value = 'false');


### PR DESCRIPTION
CAST is a reserved word in Postgres. Migration `0084_activate_protected_review.ts` referenced the `sulla_settings` `cast` column unquoted in its `INSERT` and `ON CONFLICT` `UPDATE`, which throws `syntax error at or near "cast"` on every startup migration run — confirmed in `sulla.log` on both of today's restarts (10:17:55Z, 20:58:13Z). Because 0084 fails, the whole migration chain behind it (0085-0088, including `work_project_domain_events` from Phase 4) has never applied on this or any other restart.

Fix quotes `"cast"` in both spots, matching how migration 0012 originally created the column. Verified the corrected statement plans cleanly against the live schema via `EXPLAIN` (no rows touched, no data mutated).