### PR TITLE
fix(projects): make artifact custody fully optional, never blocking

### DIFF
--- a/pkg/rancher-desktop/agent/services/ArtifactCustodyPolicy.ts
+++ b/pkg/rancher-desktop/agent/services/ArtifactCustodyPolicy.ts
@@ -1,25 +1,24 @@
 /**
- * ArtifactCustodyPolicy — fail-closed artifact-evidence custody for protected
- * routine finalization.
+ * ArtifactCustodyPolicy — optional, non-blocking evidence metadata for
+ * Projects lifecycle transitions.
  *
- * Coding work must record branch, commit SHA, remote PR URL, PR head SHA,
- * validation evidence, and provenance. Non-code work must record an
- * authoritative artifact id/URL plus evidence and provenance. When the
- * automatedProjectManagementEnforceCustody setting is on, a task cannot cross
- * into in_review or done unless the required custody is present — the
- * transition throws and the caller's transaction rolls back (fail closed).
+ * Projects pipelines are not all software development, so no lifecycle
+ * invariant may assume a coding-shaped evidence trail. Custody is a couple
+ * of generic, OPTIONAL fields a caller may attach when a task enters review
+ * or done: a coding pipeline might fill in branch/PR details, a non-coding
+ * pipeline might record an artifact link and a note. Nothing is required
+ * and no transition is ever blocked for missing or partial custody.
  *
- * Ships dark: enforcement defaults off so existing pipelines keep flowing;
- * the human enables it from the Automated Project Management settings area
- * once routine-side population is in place.
+ * When custody is supplied and well-formed enough to persist, it is written
+ * as an immutable record in the same transaction as the task move, purely
+ * for audit/history — never as a gate.
  */
-import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 
 export type CustodyWorkKind = 'code' | 'non_code';
 export type CustodyTransition = 'in_review' | 'done';
 
 export interface ArtifactCustody {
-  workKind:     CustodyWorkKind;
+  workKind?:    CustodyWorkKind;
   branch?:      string | null;
   commitSha?:   string | null;
   prUrl?:       string | null;
@@ -31,63 +30,23 @@ export interface ArtifactCustody {
   evidence?:    unknown;
 }
 
-export const CUSTODY_ENFORCEMENT_KEY = 'automatedProjectManagementEnforceCustody';
-
-export class ArtifactCustodyError extends Error {
-  readonly code = 'artifact_custody_missing';
-  readonly transition: CustodyTransition;
-  readonly missing: string[];
-
-  constructor(transition: CustodyTransition, missing: string[]) {
-    super(`Artifact custody incomplete for ${ transition } transition; missing: ${ missing.join(', ') || 'workKind' }`);
-    this.name = 'ArtifactCustodyError';
-    this.transition = transition;
-    this.missing = missing;
-  }
-}
-
-function present(value: unknown): boolean {
-  if (value === null || value === undefined) return false;
-  if (typeof value === 'string') return value.trim().length > 0;
-  if (Array.isArray(value)) return value.length > 0;
-  if (typeof value === 'object') return Object.keys(value as Record<string, unknown>).length > 0;
-  return true;
-}
-
 export class ArtifactCustodyPolicy {
-  static async isEnforced(): Promise<boolean> {
-    // This is a lifecycle invariant, not an operator preference. Keep reading
-    // the retired key for downgrade compatibility, but never permit it to
-    // disable the gate.
-    await SullaSettingsModel.get(CUSTODY_ENFORCEMENT_KEY, true);
-    return true;
-  }
-
-  /** Pure fail-closed validation. Never touches settings. */
+  /**
+   * Structural sanity check only — never a completeness requirement.
+   * Absent custody is fine. Present custody just has to be a plain object
+   * so downstream field access can't blow up on a malformed payload.
+   */
   static validate(custody: ArtifactCustody | null | undefined): { ok: boolean; missing: string[] } {
-    if (!custody || (custody.workKind !== 'code' && custody.workKind !== 'non_code')) {
-      return { ok: false, missing: ['workKind'] };
-    }
-    const missing: string[] = [];
-    if (custody.workKind === 'code') {
-      if (!present(custody.branch))     missing.push('branch');
-      if (!present(custody.commitSha))  missing.push('commitSha');
-      if (!present(custody.prUrl))      missing.push('prUrl');
-      if (!present(custody.prHeadSha))  missing.push('prHeadSha');
-      if (!present(custody.validation)) missing.push('validation');
-      if (!present(custody.provenance)) missing.push('provenance');
-    } else {
-      if (!present(custody.artifactId) && !present(custody.artifactUrl)) missing.push('artifactId|artifactUrl');
-      if (!present(custody.evidence))   missing.push('evidence');
-      if (!present(custody.provenance)) missing.push('provenance');
-    }
-    return { ok: missing.length === 0, missing };
+    if (custody === null || custody === undefined) return { ok: true, missing: [] };
+    if (typeof custody !== 'object' || Array.isArray(custody)) return { ok: false, missing: ['custody'] };
+    return { ok: true, missing: [] };
   }
 
   /**
    * Best-effort derivation of a custody record from the looser evidence fields
-   * older callers already populate, so the gate can validate existing work
-   * without a caller rewrite. An explicit `custody` object always wins.
+   * older callers already populate. Purely descriptive — an explicit
+   * `custody` object always wins, and returning null just means no evidence
+   * metadata gets attached, not that anything is blocked.
    */
   static derive(source: Record<string, unknown> | null | undefined): ArtifactCustody | null {
     if (!source) return null;
@@ -121,13 +80,16 @@ export class ArtifactCustodyPolicy {
     return null;
   }
 
+  /**
+   * Never throws. Custody is optional metadata, not a gate — kept as a
+   * method (rather than deleted from call sites) so existing callers don't
+   * need to change; it simply no longer does anything blocking.
+   */
   static async assertForTransition(
-    transition: CustodyTransition,
-    custody: ArtifactCustody | null | undefined,
+    _transition: CustodyTransition,
+    _custody: ArtifactCustody | null | undefined,
   ): Promise<void> {
-    if (!(await this.isEnforced())) return;
-    const { ok, missing } = this.validate(custody);
-    if (!ok) throw new ArtifactCustodyError(transition, missing);
+    // Intentionally a no-op: no pipeline is required to supply custody.
   }
 
   static async persistWithClient(
@@ -138,10 +100,13 @@ export class ArtifactCustodyPolicy {
     actor: string,
   ): Promise<void> {
     const { randomUUID } = await import('node:crypto');
+    // work_task_artifact_custody.work_kind is NOT NULL; default to the
+    // generic bucket when a caller attaches custody without picking one.
+    const workKind = custody.workKind ?? 'non_code';
     await client.query(`
       INSERT INTO work_task_artifact_custody
         (id, task_id, transition, work_kind, custody, created_by)
       VALUES ($1, $2, $3, $4, $5::jsonb, $6)
-    `, [`custody-${ randomUUID() }`, taskId, transition, custody.workKind, JSON.stringify(custody), actor]);
+    `, [`custody-${ randomUUID() }`, taskId, transition, workKind, JSON.stringify(custody), actor]);
   }
 }

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -708,7 +708,7 @@ export class TaskDispatcherService {
     const dispatchStatus = malformed ? 'failed' : status;
     const concise = parsed?.summary ?? summary.slice(0, 1_500);
     const comment = malformed
-      ? `Dispatch ${ dispatch.id } stopped before review: structured artifact custody was missing or malformed.`
+      ? `Dispatch ${ dispatch.id } stopped before review: no parseable work result was found.`
       : `Dispatch ${ dispatch.id } ${ status } via ${ dispatch.agent_id }: ${ concise }`;
     const receipt = buildReceipt({
       taskId:     task.id,
@@ -718,7 +718,7 @@ export class TaskDispatcherService {
       disposition: malformed ? 'custody_rejected' : status,
       nextOwner:  taskStatus === 'in_review' ? 'review' : taskStatus,
       validationSummary: concise,
-      artifacts: parsed ? [parsed.custody.workKind === 'code' ? {
+      artifacts: parsed?.custody ? [parsed.custody.workKind === 'code' ? {
         type:         'pull_request',
         canonicalRef: parsed.custody.prUrl ?? undefined,
         url:          parsed.custody.prUrl ?? undefined,
@@ -739,7 +739,7 @@ export class TaskDispatcherService {
         receipt,
         result: status === 'failed' ? undefined : summary,
         error:  status === 'failed' || malformed ? concise : undefined,
-        evidence: parsed ? {
+        evidence: parsed?.custody ? {
           artifactType:     parsed.custody.workKind === 'code' ? 'code_pull_request' : 'non_code_artifact',
           artifactLocation: parsed.custody.branch ?? parsed.custody.artifactId ?? undefined,
           artifactUrl:      parsed.custody.prUrl ?? parsed.custody.artifactUrl ?? undefined,
@@ -754,14 +754,16 @@ export class TaskDispatcherService {
     }
   }
 
-  private parseWorkResult(output: string): { summary: string; custody: import('./ArtifactCustodyPolicy').ArtifactCustody } | null {
+  private parseWorkResult(output: string): { summary: string; custody?: import('./ArtifactCustodyPolicy').ArtifactCustody } | null {
     const matches = [...output.matchAll(/<WORK_RESULT>([\s\S]*?)<\/WORK_RESULT>/g)];
     if (matches.length !== 1) return null;
     try {
       const parsed = JSON.parse(matches[0][1].trim());
       if (typeof parsed?.summary !== 'string' || !parsed.summary.trim()) return null;
+      // Custody is optional — a worker may omit it entirely. Only reject the
+      // whole result when custody is present but structurally malformed.
       const custody = parsed.custody;
-      if (!ArtifactCustodyPolicy.validate(custody).ok) return null;
+      if (custody !== undefined && !ArtifactCustodyPolicy.validate(custody).ok) return null;
       return { summary: parsed.summary.trim().slice(0, 1_500), custody };
     } catch {
       return null;

--- a/pkg/rancher-desktop/agent/services/__tests__/ArtifactCustodyPolicy.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/ArtifactCustodyPolicy.test.ts
@@ -1,50 +1,36 @@
-const settingsGet = jest.fn();
-
-jest.mock('../../database/models/SullaSettingsModel', () => ({
-  SullaSettingsModel: { get: (...args: any[]) => settingsGet(...args) },
-}));
-
-import { ArtifactCustodyPolicy, ArtifactCustodyError } from '../ArtifactCustodyPolicy';
+import { ArtifactCustodyPolicy } from '../ArtifactCustodyPolicy';
 
 describe('ArtifactCustodyPolicy.validate', () => {
-  it('rejects missing custody', () => {
-    expect(ArtifactCustodyPolicy.validate(null).ok).toBe(false);
-    expect(ArtifactCustodyPolicy.validate(undefined).missing).toContain('workKind');
+  it('accepts missing custody — it is optional', () => {
+    expect(ArtifactCustodyPolicy.validate(null).ok).toBe(true);
+    expect(ArtifactCustodyPolicy.validate(undefined).ok).toBe(true);
   });
 
-  it('requires the full code custody set', () => {
+  it('accepts a partial code-shaped custody object without requiring every field', () => {
     const result = ArtifactCustodyPolicy.validate({ workKind: 'code', branch: 'b', commitSha: 'c' } as any);
-    expect(result.ok).toBe(false);
-    expect(result.missing).toEqual(expect.arrayContaining(['prUrl', 'prHeadSha', 'validation', 'provenance']));
-  });
-
-  it('accepts complete code custody', () => {
-    const result = ArtifactCustodyPolicy.validate({
-      workKind: 'code', branch: 'feat/x', commitSha: 'abc', prUrl: 'https://pr', prHeadSha: 'def',
-      validation: { tests: 'pass' }, provenance: { agent: 'a' },
-    });
     expect(result.ok).toBe(true);
+    expect(result.missing).toEqual([]);
   });
 
-  it('requires artifact id/url plus evidence and provenance for non_code', () => {
-    expect(ArtifactCustodyPolicy.validate({ workKind: 'non_code' } as any).ok).toBe(false);
-    expect(ArtifactCustodyPolicy.validate({
-      workKind: 'non_code', artifactUrl: 'https://a', evidence: { x: 1 }, provenance: { a: 1 },
-    }).ok).toBe(true);
+  it('accepts a bare non_code custody object with no other fields', () => {
+    expect(ArtifactCustodyPolicy.validate({ workKind: 'non_code' } as any).ok).toBe(true);
+  });
+
+  it('accepts custody with no workKind at all — a couple of generic optional fields is enough', () => {
+    expect(ArtifactCustodyPolicy.validate({ artifactUrl: 'https://a' } as any).ok).toBe(true);
+  });
+
+  it('rejects a structurally malformed custody payload (not an object)', () => {
+    expect(ArtifactCustodyPolicy.validate('nonsense' as any).ok).toBe(false);
+    expect(ArtifactCustodyPolicy.validate(['a', 'b'] as any).ok).toBe(false);
   });
 });
 
 describe('ArtifactCustodyPolicy.assertForTransition', () => {
-  beforeEach(() => settingsGet.mockReset());
-
-  it('cannot be disabled by the retired preference', async() => {
-    settingsGet.mockResolvedValue(false);
-    await expect(ArtifactCustodyPolicy.assertForTransition('in_review', null)).rejects.toBeInstanceOf(ArtifactCustodyError);
-  });
-
-  it('throws when enforced and custody is missing', async() => {
-    settingsGet.mockResolvedValue(true);
-    await expect(ArtifactCustodyPolicy.assertForTransition('done', null)).rejects.toBeInstanceOf(ArtifactCustodyError);
+  it('never throws — custody is optional, not a gate', async() => {
+    await expect(ArtifactCustodyPolicy.assertForTransition('in_review', null)).resolves.toBeUndefined();
+    await expect(ArtifactCustodyPolicy.assertForTransition('done', undefined)).resolves.toBeUndefined();
+    await expect(ArtifactCustodyPolicy.assertForTransition('done', { workKind: 'code' })).resolves.toBeUndefined();
   });
 });
 
@@ -56,5 +42,22 @@ describe('ArtifactCustodyPolicy.derive', () => {
     expect(custody?.workKind).toBe('code');
     expect(custody?.prUrl).toBe('https://pr');
     expect(custody?.commitSha).toBe('c1');
+  });
+
+  it('returns null when there is nothing to derive from', () => {
+    expect(ArtifactCustodyPolicy.derive(null)).toBeNull();
+    expect(ArtifactCustodyPolicy.derive({})).toBeNull();
+  });
+});
+
+describe('ArtifactCustodyPolicy.persistWithClient', () => {
+  it('defaults work_kind to non_code when custody omits workKind, to satisfy the NOT NULL column', async() => {
+    const query = jest.fn().mockResolvedValue({});
+    const client = { query } as any;
+    await ArtifactCustodyPolicy.persistWithClient(client, 'task-1', 'in_review', { artifactUrl: 'https://a' }, 'sulla');
+    expect(query).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining(['task-1', 'in_review', 'non_code']),
+    );
   });
 });


### PR DESCRIPTION
Reverses a prior P0 decision (task wd2j / PR #718) per Jonathon's direct correction: not every Projects pipeline is software development, so no lifecycle transition may require a coding-shaped evidence object.

**What was wrong:**
- `ArtifactCustodyPolicy.assertForTransition` fail-closed on *any* project's task entering a lane with `semantic_role: 'review'`/`'terminal'` (called from `WorkItemsModel`, `WorkTaskDispatchModel`, and `ProjectsApplicationService.updateTask`) — not scoped to Sulla Desktop's own dev pipeline.
- `isEnforced()` read a settings key but then ignored it and hardcoded `return true` — the gate could never be disabled even if a project wanted to.
- Even the `non_code` branch still mandated 3 fields (`artifactId|artifactUrl`, `evidence`, `provenance`) nobody asked for on a simple task board.

**Fix:**
- `workKind` and every custody field are now optional. `validate()` only rejects structurally malformed payloads (not an object), never missing fields.
- `assertForTransition()` is now a no-op — custody can never block a transition.
- `persistWithClient()` defaults `work_kind` to `'non_code'` when a caller attaches custody without picking one (DB column is `NOT NULL`).
- `TaskDispatcherService.parseWorkResult` no longer treats a missing custody block as malformed output that forces a task back to `planning` — only a present-but-garbage payload is rejected.

**Verification:**
- Focused Jest: `ArtifactCustodyPolicy`, `ProjectsApplicationService`, `WorkTaskDispatchModel`, `WorkItemsModel` — zero regressions vs unmodified `origin/main`. One pre-existing failure (assertion that missing custody throws) now correctly passes under the new contract. Two unrelated pre-existing failures (documented on task MBJx: `insertTask` row-shape mismatch, `artifact_sha` SQL assertion drift) are untouched.
- Lint: diffed eslint output before/after on both touched files — zero new errors or warnings.
- `git diff --check` clean.

Tracked on Projects task `wQyd` under the `dHAe` OOP-refactor epic. Draft — not merged.