### PR TITLE
fix(projects): route PlanningCouncilService through the application facade

### DIFF
--- a/pkg/rancher-desktop/agent/services/PlanningCouncilService.ts
+++ b/pkg/rancher-desktop/agent/services/PlanningCouncilService.ts
@@ -6,6 +6,7 @@ import {
 } from '../database/models/WorkTaskPlanningRunModel';
 import { WorkflowModel } from '../database/models/WorkflowModel';
 import { recordReceipt } from './ArtifactReceiptService';
+import { getProjectsApplicationService } from '../projects/application/ProjectsApplicationService';
 
 const MAX_DESCRIPTION_CHARS = 12_000;
 const MAX_CONTEXT_DESCRIPTION_CHARS = 4_000;
@@ -103,7 +104,7 @@ export class PlanningCouncilService {
       artifacts: [{ type: 'planning_run', canonicalRef: run.id }],
       evidence: { kind: 'workflow_execution', ref: executionId },
     });
-    await WorkItemsModel.updateTask(task.id, {
+    await getProjectsApplicationService().updateTask(task.id, {
       status:   'blocked',
       assignee: 'heartbeat',
       actor:    'planning-council',
@@ -160,7 +161,7 @@ export class PlanningCouncilService {
         author:  'planning-council',
         body:    `Planning council launch failed (run ${ claim.run.id }): ${ bounded(message, 1_000) }`,
       });
-      await WorkItemsModel.updateTask(claim.task.id, {
+      await getProjectsApplicationService().updateTask(claim.task.id, {
         status:   'blocked',
         assignee: 'heartbeat',
         actor:    'planning-council',

--- a/pkg/rancher-desktop/agent/services/__tests__/PlanningCouncilService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/PlanningCouncilService.test.ts
@@ -5,7 +5,7 @@ const getProjectMock: any = jest.fn();
 const getEpicMock: any = jest.fn();
 const listCommentsMock: any = jest.fn();
 const addCommentMock: any = jest.fn();
-const updateTaskMock: any = jest.fn();
+const applicationUpdateTaskMock: any = jest.fn();
 const claimMock: any = jest.fn();
 const attachExecutionMock: any = jest.fn();
 const settleForTaskMock: any = jest.fn();
@@ -23,8 +23,11 @@ jest.unstable_mockModule('../../database/models/WorkItemsModel', () => ({
     getEpic:      getEpicMock,
     listComments: listCommentsMock,
     addComment:   addCommentMock,
-    updateTask:   updateTaskMock,
   },
+}));
+
+jest.unstable_mockModule('../../projects/application/ProjectsApplicationService', () => ({
+  getProjectsApplicationService: () => ({ updateTask: applicationUpdateTaskMock }),
 }));
 
 jest.unstable_mockModule('../../database/models/WorkTaskPlanningRunModel', () => ({
@@ -109,6 +112,17 @@ describe('PlanningCouncilService', () => {
     }));
   });
 
+  it('routes the task back to blocked through the application facade when launch throws', async() => {
+    executeRoutineMock.mockRejectedValue(new Error('routine engine unavailable'));
+    const PlanningCouncilService = await service();
+    await PlanningCouncilService.handleTaskStatusTransition({ ...task, status: 'blocked' }, 'in_progress', 'worker');
+
+    expect(settleForTaskMock).toHaveBeenCalledWith('task-1', 'failed', expect.stringContaining('routine engine unavailable'));
+    expect(applicationUpdateTaskMock).toHaveBeenCalledWith('task-1', {
+      status: 'blocked', assignee: 'heartbeat', actor: 'planning-council',
+    });
+  });
+
   it('does nothing when the human disabled the locked routine', async() => {
     findWorkflowMock.mockResolvedValue({
       attributes: { system: true, status: 'production', enabled: false },
@@ -170,7 +184,7 @@ describe('PlanningCouncilService', () => {
       'failed',
       expect.stringContaining('without persisting a final plan'),
     );
-    expect(updateTaskMock).toHaveBeenCalledWith('task-1', {
+    expect(applicationUpdateTaskMock).toHaveBeenCalledWith('task-1', {
       status: 'blocked', assignee: 'heartbeat', actor: 'planning-council',
     });
   });


### PR DESCRIPTION
dHAe Phase 7 (strangler removal) slice: closes the one remaining production bypass of ProjectsApplicationService found by re-running the Phase 0 characterization methodology (git grep for direct WorkItemsModel.updateTask/insertTask callers outside the model and the application service itself).

Found: PlanningCouncilService.ts had two call sites still calling WorkItemsModel.updateTask() directly (the workflow-finished failure path and the claim-and-launch failure path), bypassing the shared command boundary Phase 3 (R0SG) was supposed to make the only mutation path.

Fix: both now call getProjectsApplicationService().updateTask() with identical arguments -- no behavior change, just closes the bypass.

Verification: focused Jest via the project's own --experimental-vm-modules jest invocation (this suite mocks ESM-style with jest.unstable_mockModule) -- 7/7 pass, including a new test covering the previously-untested claim-and-launch failure path. Confirmed zero new lint errors by diffing eslint output against unmodified origin/main on both touched files. git diff --check clean.

Tracked on Projects task GNbs under the dHAe OOP-refactor epic.