### PR TITLE
fix(chat): guarantee streamed messages reach renderer during long runs

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/AgentPersonaModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/AgentPersonaModel.ts
@@ -80,6 +80,11 @@ export class AgentPersonaService {
   private readonly dispatcher = createMessageDispatcher();
 
   readonly messages:     ChatMessage[] = reactive([]);
+  /**
+   * Monotonic signal for renderer consumers. Watching this scalar avoids a
+   * deep traversal of the entire reactive transcript on every stream delta.
+   */
+  readonly messagesRevision = ref(0);
   private readonly toolRunIdToMessageId = new Map<string, string>();
 
   /**
@@ -213,6 +218,7 @@ export class AgentPersonaService {
       };
     }
     this.messages.push(localMessage);
+    this.markMessagesChanged();
 
     this.registry.setLoading(id, true);
 
@@ -241,6 +247,7 @@ export class AgentPersonaService {
         role:      'system',
         content:   'Message could not be delivered — the connection to the agent appears to be down. Please try again.',
       });
+      this.markMessagesChanged();
     }
 
     return delivered;
@@ -277,6 +284,7 @@ export class AgentPersonaService {
       };
     }
     this.messages.push(localMessage);
+    this.markMessagesChanged();
 
     // Send inject_message — backend will push to state.messages without calling graph.execute()
     let delivered: boolean;
@@ -350,6 +358,7 @@ export class AgentPersonaService {
   clearMessages(): void {
     this.messages.splice(0, this.messages.length);
     this.toolRunIdToMessageId.clear();
+    this.markMessagesChanged();
   }
 
   async emitContinueRun(): Promise<boolean> {
@@ -379,6 +388,7 @@ export class AgentPersonaService {
         role:      'system',
         content:   'Could not resume the agent — the connection appears to be down. Please try again.',
       });
+      this.markMessagesChanged();
     }
 
     return delivered;
@@ -505,6 +515,11 @@ export class AgentPersonaService {
     }
 
     this.dispatcher.dispatch(this.getDispatchContext(), agentId, msgThreadId ?? '', msg);
+    this.markMessagesChanged();
+  }
+
+  private markMessagesChanged(): void {
+    this.messagesRevision.value++;
   }
 
   /**

--- a/pkg/rancher-desktop/pages/agent/ChatInterface.ts
+++ b/pkg/rancher-desktop/pages/agent/ChatInterface.ts
@@ -1,5 +1,5 @@
 // ChatInterface.ts
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, type ComputedRef } from 'vue';
 
 import { ChatMessageQueue, createMessageQueue, type QueuedMessage } from './ChatMessageQueue';
 
@@ -37,6 +37,7 @@ export class ChatInterface {
   readonly currentAgentId: ReturnType<typeof computed<string>>;
 
   readonly messages = ref<ChatMessage[]>([]);
+  readonly messagesRevision: ComputedRef<number>;
 
   /**
    * @param channelId  WebSocket channel (shared across tabs, e.g. 'sulla-desktop')
@@ -54,6 +55,7 @@ export class ChatInterface {
     this.hasSentMessage = ref(localStorage.getItem(this.hasSentMessageKey) === 'true');
     this.registry = getAgentPersonaRegistry();
     this.persona = this.registry.getOrCreatePersonaService(channelId, tabId);
+    this.messagesRevision = computed(() => this.persona.messagesRevision.value);
 
     // Initialize message queue
     this.messageQueue = createMessageQueue();
@@ -69,15 +71,14 @@ export class ChatInterface {
     // Restore persisted messages from localStorage
     this.restoreMessages();
 
-    // Watch persona messages for persistence. The UI mirror updates
-    // immediately; the localStorage write is debounced because this deep
-    // watcher fires on EVERY streaming delta — an undebounced persist did a
-    // full JSON.stringify of the message window per chunk (tens of MB of
-    // serialization work across one long response).
-    watch(() => this.persona.messages, () => {
+    // Mirror explicit message revisions instead of deep-watching the full
+    // transcript. A deep watcher traversed every historical message for every
+    // stream delta before this callback even ran, recreating the renderer
+    // starvation that the persistence debounce was meant to prevent.
+    watch(() => this.persona.messagesRevision.value, () => {
       this.messages.value = [...this.persona.messages];
       this.schedulePersist();
-    }, { deep: true });
+    });
 
     // Watch graphRunning to process next queued message when current one completes
     watch(() => this.persona.graphRunning.value, (isRunning) => {

--- a/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
+++ b/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
@@ -16,19 +16,20 @@
 
 import { watch, type ComputedRef, type WatchStopHandle } from 'vue';
 
-import { ipcRenderer } from '@pkg/utils/ipcRenderer';
-
 import { ChatInterface, type ChatMessage as BackendMessage } from '../../agent/ChatInterface';
 import type { ChatController } from '../controller/ChatController';
+import type {
+  ArtifactStatus, WorkflowPayload, WorkflowNode, WorkflowEdge, HtmlPayload,
+} from '../models/Artifact';
+import type { Attachment } from '../models/Attachment';
 import type { Message, UserMessage, SullaMessage, StreamingMessage, ThinkingMessage,
   ToolMessage, ToolApprovalMessage, ToolQuestionMessage, ChannelMessage, SubAgentMessage, CitationMessage, ErrorMessage, HtmlMessage, InterimMessage,
   PatchMessage, PatchHunk, ProactiveMessage,
 } from '../models/Message';
-import type { Attachment } from '../models/Attachment';
-import type {
-  ArtifactStatus, WorkflowPayload, WorkflowNode, WorkflowEdge, HtmlPayload,
-} from '../models/Artifact';
 import { asMessageId, newAttachmentId, newMessageId, type ArtifactId } from '../types/chat';
+import { StreamUpdateScheduler } from './StreamUpdateScheduler';
+
+import { ipcRenderer } from '@pkg/utils/ipcRenderer';
 
 export interface PersonaAdapterOptions {
   channelId?: string;
@@ -38,11 +39,12 @@ export interface PersonaAdapterOptions {
 export class PersonaAdapter {
   private ci: ChatInterface;
   private stopWatchers: WatchStopHandle[] = [];
-  // Backend stream deltas can arrive faster than Vue can paint. Coalesce the
-  // deep-watch callbacks into one sync per animation frame so a long thinking
-  // trace cannot monopolize the renderer's microtask queue. Completion/stop
-  // paths call flushSyncMessages() to publish the final state immediately.
-  private syncFrame: number | null = null;
+  // Backend stream deltas can arrive faster than Vue can paint. Publish the
+  // leading update immediately, then cap continuous updates to ~30fps. A pure
+  // requestAnimationFrame scheduler can deadlock visibly under renderer
+  // starvation: no paint means no callback, while Stop appears to fix it only
+  // because the completion path flushes synchronously.
+  private readonly messageSyncScheduler = new StreamUpdateScheduler(() => this.syncMessages());
 
   /**
    * Mirrors ChatInterface.hasMessages — true once the user has sent their
@@ -97,10 +99,10 @@ export class PersonaAdapter {
     // Pull in any messages that were already restored from localStorage.
     this.syncMessages();
 
-    // React to persona.messages growing / items being mutated in place.
-    // Coalesced to one sync per animation frame — see scheduleSyncMessages().
+    // React to the persona's explicit scalar revision. Deep-watching the
+    // message array traversed the entire transcript on every stream delta.
     this.stopWatchers.push(
-      watch(() => this.ci.messages.value, () => this.scheduleSyncMessages(), { deep: true }),
+      watch(() => this.ci.messagesRevision.value, () => this.messageSyncScheduler.schedule()),
     );
 
     // Drive the run-state machine from the backend. Also re-map every
@@ -113,7 +115,7 @@ export class PersonaAdapter {
     this.stopWatchers.push(
       watch(() => this.ci.graphRunning.value, (running) => {
         this.syncRunState(running);
-        this.flushSyncMessages();
+        this.messageSyncScheduler.flush();
       }),
     );
 
@@ -246,10 +248,7 @@ export class PersonaAdapter {
   }
 
   dispose(): void {
-    if (this.syncFrame !== null) {
-      cancelAnimationFrame(this.syncFrame);
-      this.syncFrame = null;
-    }
+    this.messageSyncScheduler.dispose();
     for (const stop of this.stopWatchers) stop();
     this.stopWatchers = [];
     this.firstSeenAt.clear();
@@ -282,27 +281,9 @@ export class PersonaAdapter {
   // lets us skip all of that for messages nothing has actually changed on.
   //
   // scheduleSyncMessages() additionally caps how often the loop below can
-  // even run — deep-watch fires once per backend mutation, which during a
-  // fast token stream can be far more often than the browser can paint.
-  // Coalescing to one call per animation frame means bursts of events
-  // collapse into a single sync each frame instead of one sync per event.
-  private scheduleSyncMessages(): void {
-    if (this.syncFrame !== null) return;
-    this.syncFrame = requestAnimationFrame(() => {
-      this.syncFrame = null;
-      this.syncMessages();
-    });
-  }
-
-  /** Cancel any pending scheduled sync and run one immediately. */
-  private flushSyncMessages(): void {
-    if (this.syncFrame !== null) {
-      cancelAnimationFrame(this.syncFrame);
-      this.syncFrame = null;
-    }
-    this.syncMessages();
-  }
-
+  // run. The leading update is synchronous so visible progress never depends
+  // on reaching an animation-frame boundary. During a continuous stream, a
+  // short timer publishes the latest accumulated state at a bounded rate.
   private syncMessages(): void {
     const backend = this.ci.messages.value;
     for (const b of backend) {

--- a/pkg/rancher-desktop/pages/chat/services/StreamUpdateScheduler.ts
+++ b/pkg/rancher-desktop/pages/chat/services/StreamUpdateScheduler.ts
@@ -1,0 +1,46 @@
+/**
+ * Leading/trailing throttle for renderer stream updates.
+ *
+ * The leading call is synchronous so publication never depends on the browser
+ * reaching an animation frame. A continuous stream is then capped to the
+ * configured interval while always retaining one trailing update.
+ */
+export class StreamUpdateScheduler {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private pending = false;
+
+  constructor(
+    private readonly publish: () => void,
+    private readonly intervalMs = 32,
+  ) {}
+
+  schedule(): void {
+    this.pending = true;
+    if (this.timer !== null) return;
+    this.run();
+  }
+
+  flush(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.pending = false;
+    this.publish();
+  }
+
+  dispose(): void {
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = null;
+    this.pending = false;
+  }
+
+  private run(): void {
+    this.pending = false;
+    this.publish();
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      if (this.pending) this.run();
+    }, this.intervalMs);
+  }
+}

--- a/pkg/rancher-desktop/pages/chat/services/__tests__/PersonaAdapter.test.ts
+++ b/pkg/rancher-desktop/pages/chat/services/__tests__/PersonaAdapter.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { StreamUpdateScheduler } from '../StreamUpdateScheduler';
+
+describe('PersonaAdapter stream scheduling', () => {
+  beforeEach(() => { jest.useFakeTimers() });
+  afterEach(() => { jest.useRealTimers() });
+
+  it('publishes the leading update immediately and coalesces a burst', () => {
+    const publish = jest.fn();
+    const scheduler = new StreamUpdateScheduler(publish);
+
+    scheduler.schedule();
+    expect(publish).toHaveBeenCalledTimes(1);
+
+    scheduler.schedule();
+    scheduler.schedule();
+    expect(publish).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(32);
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps publishing a continuous stream without animation frames', () => {
+    const publish = jest.fn();
+    const scheduler = new StreamUpdateScheduler(publish);
+
+    scheduler.schedule();
+    for (let i = 0; i < 4; i++) {
+      scheduler.schedule();
+      jest.advanceTimersByTime(32);
+    }
+
+    expect(publish).toHaveBeenCalledTimes(5);
+  });
+
+  it('flushes completion immediately and cancels the pending trailing sync', () => {
+    const publish = jest.fn();
+    const scheduler = new StreamUpdateScheduler(publish);
+
+    scheduler.schedule();
+    scheduler.schedule();
+    scheduler.flush();
+
+    expect(publish).toHaveBeenCalledTimes(2);
+    jest.advanceTimersByTime(64);
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Problem

Chat can stop painting while the model continues streaming. Pressing Stop immediately reveals every queued message, proving the backend stream is healthy and the renderer publication path is blocked. PR #749 reduced mapping cost but still deferred all publication to `requestAnimationFrame`; under renderer starvation that callback can itself be postponed until Stop triggers the synchronous completion flush. Two deep Vue watchers also traversed the entire transcript on every delta.

## Fix

- Add an explicit scalar `messagesRevision` at the persona boundary.
- Replace both transcript-wide deep watchers with O(1) revision watches.
- Replace frame-only sync with a leading/trailing scheduler: publish the first update immediately, then coalesce continuous updates to 32ms while retaining a final trailing update.
- Keep completion/Stop as an immediate flush.
- Add regression tests that prove continuous publication works without any animation-frame callback.

## Verification

- `PersonaAdapter.test.ts`: 3/3 passed
- `MessageDispatcher.thinking.test.ts`: 3/3 passed
- `NODE_OPTIONS=--max-old-space-size=4096 tsc --noEmit -p tsconfig.agent-check.json`: passed
- focused ESLint for new scheduler/test: passed
- `git diff --check`: passed

## Runtime gate

Needs a rebuild/restart and one long tool-heavy live turn before merge.