### PR TITLE
fix(test): import jest from @jest/globals in ArtifactCustodyPolicy.test

### DIFF
--- a/pkg/rancher-desktop/agent/services/__tests__/ArtifactCustodyPolicy.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/ArtifactCustodyPolicy.test.ts
@@ -1,3 +1,5 @@
+import { jest } from '@jest/globals';
+
 import { ArtifactCustodyPolicy } from '../ArtifactCustodyPolicy';
 
 describe('ArtifactCustodyPolicy.validate', () => {
@@ -52,7 +54,8 @@ describe('ArtifactCustodyPolicy.derive', () => {
 
 describe('ArtifactCustodyPolicy.persistWithClient', () => {
   it('defaults work_kind to non_code when custody omits workKind, to satisfy the NOT NULL column', async() => {
-    const query = jest.fn().mockResolvedValue({});
+    const query: any = jest.fn();
+    query.mockResolvedValue({});
     const client = { query } as any;
     await ArtifactCustodyPolicy.persistWithClient(client, 'task-1', 'in_review', { artifactUrl: 'https://a' }, 'sulla');
     expect(query).toHaveBeenCalledWith(


### PR DESCRIPTION
Repairs a test-harness bug I shipped in #751: the new persistWithClient test used the bare jest global, which is undefined under the project's --experimental-vm-modules jest invocation (my pre-merge check ran the wrong invocation). Behavior code unaffected -- 8/9 tests passed even broken. Now imports jest from @jest/globals and types the mock as any, matching the repo's other ESM suites. 9/9 pass under the real runner; eslint clean. Found during the dHAe Phase 8 (a6YV) full Projects test sweep.