### PR TITLE
fix(projects): PM review follow-ups -- lane-entry crash recovery, honest worker prompt, binding archival

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkItemsModel.ts
@@ -1338,6 +1338,16 @@ export class WorkItemsModel {
           WHERE id = $1`,
         [id],
       );
+      // Project- and epic-scoped lane workflow bindings die with the project,
+      // so an archived project stops appearing in active-binding listings.
+      await postgresClient.query(
+        `UPDATE work_lane_workflow_bindings
+            SET active = false, archived = true, archived_at = now(), updated_at = now()
+          WHERE archived = false
+            AND (   (scope = 'project' AND project_id = $1)
+                 OR (scope = 'epic' AND epic_id IN (SELECT id FROM ${ WorkItemsModel.EPICS } WHERE project_id = $1)))`,
+        [id],
+      );
       return true;
     }
 
@@ -1357,6 +1367,12 @@ export class WorkItemsModel {
       await postgresClient.query(
         `UPDATE ${ WorkItemsModel.EPICS } SET archived = true, updated_at = now()
           WHERE id = $1`,
+        [id],
+      );
+      await postgresClient.query(
+        `UPDATE work_lane_workflow_bindings
+            SET active = false, archived = true, archived_at = now(), updated_at = now()
+          WHERE scope = 'epic' AND epic_id = $1 AND archived = false`,
         [id],
       );
       return true;

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -784,10 +784,10 @@ ${ task.description || '(no description)' }
 
 Execute the task autonomously to the reversible edge. Inspect the real state first. For code work, use an isolated worktree/feature branch, verify the change, commit it, push it through the Sulla GitHub tools, and open a draft PR. Do not merge, deploy, spend money, send external communications, or perform destructive shared-system actions. If a truly irreversible dependency remains, return BLOCKED with the exact requirement; reversible uncertainty is yours to decide.
 
-Completed work MUST end with exactly one machine block. Code custody requires the exact remote PR head and validation/provenance; non-code custody requires an immutable authoritative artifact and evidence:
-<WORK_RESULT>{"summary":"concise receipt","custody":{"workKind":"code","branch":"feat/example","commitSha":"FULL_SHA","prUrl":"https://github.com/owner/repo/pull/123","prHeadSha":"FULL_SHA","validation":{"tests":"exact commands and outcomes"},"provenance":{"agentId":"${ workerAgentId }","dispatchId":"${ dispatchId }"}}}</WORK_RESULT>
+Completed work MUST end with exactly one machine block containing at least a summary:
+<WORK_RESULT>{"summary":"concise receipt"}</WORK_RESULT>
 
-Use workKind "non_code" with artifactId or artifactUrl, evidence, and provenance for non-code work. Missing or malformed custody is structurally rejected and the task will not enter review.`;
+Custody/evidence metadata is OPTIONAL — attach it when it strengthens the receipt, in whatever shape fits the work. For code work include what you have of branch, commitSha, prUrl, prHeadSha, validation, and provenance, e.g. "custody":{"workKind":"code","branch":"feat/example","commitSha":"FULL_SHA","prUrl":"https://github.com/owner/repo/pull/123","prHeadSha":"FULL_SHA","validation":{"tests":"exact commands and outcomes"},"provenance":{"agentId":"${ workerAgentId }","dispatchId":"${ dispatchId }"}}. For non-code work, "workKind":"non_code" with an artifactId or artifactUrl and evidence is plenty. Omitting custody never blocks the task from entering review; only a missing/duplicate WORK_RESULT block or a structurally malformed custody payload is rejected.`;
   }
 
   private buildVerifierPrompt(task: WorkTaskRecord, dispatchId: string, comments: { author: string | null; body: string }[]): string {

--- a/pkg/rancher-desktop/main/workItemsEvents.ts
+++ b/pkg/rancher-desktop/main/workItemsEvents.ts
@@ -431,6 +431,22 @@ export function initWorkItemsEvents(): void {
   import('@pkg/agent/projects/application/ProjectsOrchestrationEventService')
     .then(({ getProjectsOrchestrationEventService }) => getProjectsOrchestrationEventService().drain(50))
     .catch(error => console.warn('[WorkItems] Projects orchestration recovery failed:', error));
+
+  // The domain-event drain only recovers transitions that never dispatched.
+  // A lane workflow that dies MID-RUN leaves its lane entry stuck in
+  // 'running' with the outbox already settled — drainRecoverable is the only
+  // path that resumes those. includeInterrupted=true force-fails executions
+  // still marked running/suspended, which is only safe at startup when this
+  // fresh process cannot have live runs; the periodic sweep passes false so
+  // it never kills an actively-running workflow, while still recovering
+  // pending entries, vanished executions, and settled-but-unrecorded runs.
+  const sweepLaneEntries = (includeInterrupted: boolean) => {
+    import('@pkg/agent/services/LaneEntryAutomationService')
+      .then(({ LaneEntryAutomationService }) => LaneEntryAutomationService.drainRecoverable(50, includeInterrupted))
+      .catch(error => console.warn('[WorkItems] Lane-entry automation recovery failed:', error));
+  };
+  sweepLaneEntries(true);
+  setInterval(() => sweepLaneEntries(false), 5 * 60_000);
 }
 
 interface ReorderUpdate {


### PR DESCRIPTION
Three defects from the 2026-08-25 full PM-system review (Projects task TmhN), all verified against source and the live app before fixing.

1. HIGH -- LaneEntryAutomationService.drainRecoverable had zero production callers (grep-verified), so a lane workflow that died mid-run left its lane entry stuck in running forever and the stage stalled silently. Now swept in workItemsEvents at startup with includeInterrupted=true (safe: a fresh process has no live runs) and every 5 minutes with includeInterrupted=false -- resetInterruptedExecution force-fails any running/suspended execution with no liveness check, so the periodic sweep must never pass true or it would kill actively-running workflows.

2. MEDIUM -- buildWorkerPrompt still claimed missing custody is structurally rejected and the task will not enter review, which #751 made false. Prompt now requires only the WORK_RESULT summary block and describes custody as optional evidence.

3. LOW -- Archiving a project now archives its project- and epic-scoped lane workflow bindings (and archiving an epic archives its epic-scoped bindings). Live-observed: disposable project qtbT left 4 active bindings behind today.

Verification so far: TypeScript parse clean on all three files; git diff --check clean. Focused Jest is pending -- node_modules in every checkout is currently being churned by the concurrent rebuild session. Tests will be run and posted here before merge. Draft until then.