### PR TITLE
fix(projects): default automatedProjectManagementEnabled to true

### DIFF
--- a/pkg/rancher-desktop/agent/services/ProjectAutomationWipLimits.ts
+++ b/pkg/rancher-desktop/agent/services/ProjectAutomationWipLimits.ts
@@ -78,7 +78,7 @@ async function readRoleLimit(role: WorkLaneSemanticRole): Promise<number | null>
 /** Resolve the effective per-role ceilings from durable settings. */
 export async function resolveWipLimits(): Promise<WipLimits> {
   const out = {} as WipLimits;
-  const enabled = Boolean(await SullaSettingsModel.get('automatedProjectManagementEnabled', false));
+  const enabled = Boolean(await SullaSettingsModel.get('automatedProjectManagementEnabled', true));
   if (!enabled) {
     for (const role of ALL_SEMANTIC_ROLES) out[role] = null;
     return out;

--- a/pkg/rancher-desktop/agent/services/RoutineConcurrencyPolicy.ts
+++ b/pkg/rancher-desktop/agent/services/RoutineConcurrencyPolicy.ts
@@ -15,10 +15,9 @@
  *     transaction-scoped advisory lock, giving an exact, race-free ceiling
  *     across concurrent launches for any protected routine kind.
  *
- * Everything ships dark: when automatedProjectManagementEnabled is false the
- * resolver returns the caller's legacy value and callers skip reservation, so
- * runtime behaviour is unchanged until the human enables the feature in the
- * new settings area.
+ * Enabled by default. When the human explicitly turns automatedProjectManagementEnabled
+ * off, the resolver returns the caller's legacy value and callers skip
+ * reservation, restoring pre-feature unlimited/hardcoded behaviour.
  */
 import { randomUUID } from 'node:crypto';
 import type { PoolClient } from 'pg';
@@ -85,7 +84,7 @@ function clampLimit(value: number, fallback: number): number {
 
 export class RoutineConcurrencyPolicy {
   static async isEnabled(): Promise<boolean> {
-    return Boolean(await SullaSettingsModel.get(MASTER_ENABLED_KEY, false));
+    return Boolean(await SullaSettingsModel.get(MASTER_ENABLED_KEY, true));
   }
 
   /**

--- a/pkg/rancher-desktop/pages/LanguageModelSettings.vue
+++ b/pkg/rancher-desktop/pages/LanguageModelSettings.vue
@@ -81,7 +81,7 @@ export default defineComponent({
       remoteRetryCount:      3, // Number of retries before falling back to local LLM
       remoteTimeoutSeconds:  60, // Remote API timeout limit in seconds
       // Automated Project Management (protected routine concurrency + custody)
-      automatedProjectManagementEnabled: false,
+      automatedProjectManagementEnabled: true,
       routineConcurrencyPlanning:  1,
       routineConcurrencyExecution: 3,
       routineConcurrencyReview:    3,
@@ -232,7 +232,7 @@ export default defineComponent({
     this.heartbeatProvider = await SullaSettingsModel.get('heartbeatProvider', 'default');
     this.subconsciousProvider = await SullaSettingsModel.get('subconsciousProvider', 'default');
     this.heartbeatDelayMinutes = await SullaSettingsModel.get('heartbeatDelayMinutes', 15);
-    this.automatedProjectManagementEnabled = Boolean(await SullaSettingsModel.get('automatedProjectManagementEnabled', false));
+    this.automatedProjectManagementEnabled = Boolean(await SullaSettingsModel.get('automatedProjectManagementEnabled', true));
     this.routineConcurrencyPlanning  = Number(await SullaSettingsModel.get('routineConcurrency_planning', 1));
     this.routineConcurrencyExecution = Number(await SullaSettingsModel.get('routineConcurrency_execution', 3));
     this.routineConcurrencyReview    = Number(await SullaSettingsModel.get('routineConcurrency_review', 3));


### PR DESCRIPTION
Ship enabled instead of dark. Flips the master switch fallback in `RoutineConcurrencyPolicy.isEnabled()`, the WIP-limit resolver in `ProjectAutomationWipLimits.resolveWipLimits()`, and both the component default and `mounted()` re-read fallback in `LanguageModelSettings.vue`.

Scope verified: this key only gates `RoutineConcurrencyPolicy` / `ProjectAutomationWipLimits` inside the legacy `TaskDispatcherService` — no connection to `LaneEntryAutomationService` or lane-workflow bindings.

Effect once live: default per-kind concurrency limits (planning 1, execution 3, review 3, repair 2, dreaming 1, other 2) and per-role WIP ceilings actually enforce instead of legacy unlimited/hardcoded behavior, for anyone who has not explicitly set the setting.

Projects task GgFp.