### PR TITLE
diag(chat): trace WS chat pipeline end-to-end for GW7w

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/AgentPersonaModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/AgentPersonaModel.ts
@@ -486,6 +486,11 @@ export class AgentPersonaService {
     const msgThreadId = this.extractThreadId(msg);
     const myThreadId = this.state.threadId;
 
+    // TEMP DIAG (GW7w): trace every inbound WS message at the point it
+    // reaches the renderer, before any filtering can drop it. Remove once
+    // the today's-symptom investigation on task GW7w is closed.
+    console.log(`[GW7w-diag] FE-RECV agent=${ agentId } type=${ msg.type } kind=${ (msg.data as any)?.kind ?? '-' } msgThreadId=${ msgThreadId ?? '-' } myThreadId=${ myThreadId ?? '-' } t=${ Date.now() }`);
+
     // Drop messages that don't carry a threadId when we already have an active thread.
     // This prevents stray workflow / backend messages from leaking into the chat.
     if (!msgThreadId && myThreadId) {
@@ -501,21 +506,25 @@ export class AgentPersonaService {
         if (msg.type === 'chat_message' && (msg.data as any)?.kind === 'channel_message') {
           const toThreadId = (msg.data as any)?.toThreadId;
           if (toThreadId && toThreadId !== myThreadId) {
+            console.log(`[GW7w-diag] FE-DROP reason=channel_message-wrong-target toThreadId=${ toThreadId } myThreadId=${ myThreadId }`);
             return; // targeted to a different thread
           }
           // else: toThreadId matches or absent — fall through to dispatch
         } else {
+          console.log(`[GW7w-diag] FE-DROP reason=missing-threadId type=${ msg.type } kind=${ (msg.data as any)?.kind ?? '-' } myThreadId=${ myThreadId }`);
           return;
         }
       }
     }
 
     if (msgThreadId && myThreadId && msgThreadId !== myThreadId) {
+      console.log(`[GW7w-diag] FE-DROP reason=threadId-mismatch msgThreadId=${ msgThreadId } myThreadId=${ myThreadId }`);
       return; // belongs to a different chat tab — ignore
     }
 
     this.dispatcher.dispatch(this.getDispatchContext(), agentId, msgThreadId ?? '', msg);
     this.markMessagesChanged();
+    console.log(`[GW7w-diag] FE-DISPATCHED kind=${ (msg.data as any)?.kind ?? '-' } revision=${ this.messagesRevision.value } messagesLen=${ this.messages.length } t=${ Date.now() }`);
   }
 
   private markMessagesChanged(): void {

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -1624,7 +1624,15 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     const STREAM_THROTTLE_MS = 50;
     const isVoiceMode = controller.getMode() === 'voice';
 
+    let gw7wFirstTokenLogged = false;
     const onToken = (token: string): void => {
+      // TEMP DIAG (GW7w): log the very first token of the turn so we can
+      // tell "the provider never produced output" apart from "output was
+      // produced but never reached the renderer". Remove once GW7w is closed.
+      if (!gw7wFirstTokenLogged) {
+        gw7wFirstTokenLogged = true;
+        console.log(`[GW7w-diag] BE-FIRST-TOKEN threadId=${ state.metadata.threadId ?? '-' } t=${ Date.now() }`);
+      }
       contentBuffer += token;
 
       // Sub-agent inactivity watchdog in PlaybookController reads this —
@@ -1967,6 +1975,10 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     } else {
       state.metadata.hadUserMessages = true;
     }
+    // TEMP DIAG (GW7w): trace every WS chat send from the main process so we
+    // can correlate "sent" here against "FE-RECV" in AgentPersonaModel.ts.
+    // Remove once the today's-symptom investigation on task GW7w is closed.
+    console.log(`[GW7w-diag] BE-SEND connection=${ connectionId } kind=${ kind } contentLen=${ content.length } threadId=${ threadId ?? '-' } sent=${ sent } t=${ Date.now() }`);
 
     // If this agent is running inside a workflow, also emit a node_thinking
     // event so the workflow canvas can display the conversation in a bubble.

--- a/pkg/rancher-desktop/pages/agent/ChatInterface.ts
+++ b/pkg/rancher-desktop/pages/agent/ChatInterface.ts
@@ -75,9 +75,12 @@ export class ChatInterface {
     // transcript. A deep watcher traversed every historical message for every
     // stream delta before this callback even ran, recreating the renderer
     // starvation that the persistence debounce was meant to prevent.
-    watch(() => this.persona.messagesRevision.value, () => {
+    watch(() => this.persona.messagesRevision.value, (rev) => {
       this.messages.value = [...this.persona.messages];
       this.schedulePersist();
+      // TEMP DIAG (GW7w): confirm the ci.messages mirror actually refreshes
+      // on every persona revision bump. Remove once GW7w is closed.
+      console.log(`[GW7w-diag] CI-MIRROR revision=${ rev } mirroredLen=${ this.messages.value.length } t=${ Date.now() }`);
     });
 
     // Watch graphRunning to process next queued message when current one completes

--- a/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
+++ b/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
@@ -102,7 +102,13 @@ export class PersonaAdapter {
     // React to the persona's explicit scalar revision. Deep-watching the
     // message array traversed the entire transcript on every stream delta.
     this.stopWatchers.push(
-      watch(() => this.ci.messagesRevision.value, () => this.messageSyncScheduler.schedule()),
+      watch(() => this.ci.messagesRevision.value, (rev) => {
+        // TEMP DIAG (GW7w): confirm the adapter watcher actually fires on
+        // every ci revision bump and schedules a sync. Remove once GW7w
+        // is closed.
+        console.log(`[GW7w-diag] ADAPTER-SCHEDULE revision=${ rev } t=${ Date.now() }`);
+        this.messageSyncScheduler.schedule();
+      }),
     );
 
     // Drive the run-state machine from the backend. Also re-map every
@@ -286,6 +292,9 @@ export class PersonaAdapter {
   // short timer publishes the latest accumulated state at a bounded rate.
   private syncMessages(): void {
     const backend = this.ci.messages.value;
+    // TEMP DIAG (GW7w): confirm syncMessages actually runs and how many
+    // backend messages it sees each call. Remove once GW7w is closed.
+    console.log(`[GW7w-diag] SYNC-RUN backendLen=${ backend.length } t=${ Date.now() }`);
     for (const b of backend) {
       if (!b?.id) continue;
 
@@ -299,13 +308,16 @@ export class PersonaAdapter {
       if (!mapped) {
         // Track as seen anyway so we don't repeatedly re-process it.
         this.seen.add(b.id);
+        console.log(`[GW7w-diag] SYNC-SKIP id=${ b.id } kind=${ b.kind ?? '-' } reason=null-mapping`);
         continue;
       }
       if (this.seen.has(b.id)) {
         this.controller.updateMessage(mapped.id, mapped as Partial<Message>);
+        console.log(`[GW7w-diag] SYNC-UPDATE id=${ b.id } kind=${ b.kind ?? '-' } contentLen=${ typeof b.content === 'string' ? b.content.length : -1 } t=${ Date.now() }`);
       } else {
         this.seen.add(b.id);
         this.controller.appendMessage(mapped);
+        console.log(`[GW7w-diag] SYNC-APPEND id=${ b.id } kind=${ b.kind ?? '-' } t=${ Date.now() }`);
       }
     }
   }


### PR DESCRIPTION
## Why

Jonathon reported the chat-freeze symptom recurring today and said this looks like more than the render-starvation bug fixed in #753 -- something new. Rather than guess again, add temporary tracing across every hop a chat message crosses so a live repro tells us exactly where it stops.

## What

All additions are console.log only, tagged [GW7w-diag], no behavior change:

- BaseNode.ts (main process): log every WS chat send in wsChatMessage (kind, contentLen, threadId, sent success), and log the very first streamed token of a turn -- separates "provider never produced output" from "output was produced but never reached the renderer".
- AgentPersonaModel.ts (renderer): log every inbound WS message the instant it reaches handleWebSocketMessage, before any filtering -- this is the real "did it reach the FE" checkpoint. Also logs both previously-silent drop paths (missing-threadId, threadId-mismatch) that this function returns early from with zero visibility today, plus the post-dispatch revision bump.
- ChatInterface.ts: log each time the messagesRevision watcher fires and the ci.messages mirror refreshes.
- PersonaAdapter.ts: log each scheduled sync, each syncMessages() run (backend message count seen), and each per-message append/update/skip decision on the way to the controller.

## How to read it

Main-process logs (BE-SEND, BE-FIRST-TOKEN) show up in the Electron main log/terminal; renderer logs (FE-RECV, FE-DROP, FE-DISPATCHED, CI-MIRROR, ADAPTER-SCHEDULE, SYNC-*) show up in devtools console. Grep both for [GW7w-diag] and correlate by timestamp/threadId during a repro. If a thread shows BE-SEND but no matching FE-RECV, the WS transport dropped it. If FE-RECV appears but FE-DISPATCHED doesn't follow, one of the two thread-id filters silently ate it. If FE-DISPATCHED fires but no SYNC-APPEND/SYNC-UPDATE follows, the mapping/coalescing layer is the problem.

This is a diagnostic-only PR -- remove once the underlying issue on task GW7w is identified and fixed.

Projects task: GW7w.