### PR TITLE
Default Concurrent agent limit count to 5

### DIFF
--- a/pkg/rancher-desktop/agent/services/RoutineConcurrencyPolicy.ts
+++ b/pkg/rancher-desktop/agent/services/RoutineConcurrencyPolicy.ts
@@ -55,6 +55,9 @@ export const DEFAULT_ROUTINE_LIMITS: Record<ProtectedRoutineKind, number> = {
 export const MASTER_ENABLED_KEY = 'automatedProjectManagementEnabled';
 export const TOTAL_LIMIT_KEY = 'routineConcurrencyTotalLimit';
 
+/** Default total concurrent-agent limit when the human hasn't set one yet. */
+export const DEFAULT_TOTAL_LIMIT = 5;
+
 /** Advisory-lock key that serialises all slot acquisitions. */
 const SLOT_ADVISORY_LOCK_KEY = 4823710298;
 
@@ -106,7 +109,7 @@ export class RoutineConcurrencyPolicy {
 
   static async resolveTotalLimit(): Promise<number | null> {
     if (!(await this.isEnabled())) return null;
-    const raw = await SullaSettingsModel.get(TOTAL_LIMIT_KEY, null);
+    const raw = await SullaSettingsModel.get(TOTAL_LIMIT_KEY, DEFAULT_TOTAL_LIMIT);
     if (raw === null || raw === undefined || raw === '') return null;
     const value = clampLimit(Number(raw), 0);
     return value > 0 ? value : null;

--- a/pkg/rancher-desktop/agent/services/__tests__/RoutineConcurrencyPolicy.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/RoutineConcurrencyPolicy.test.ts
@@ -10,6 +10,7 @@ jest.mock('../../database/models/SullaSettingsModel', () => ({
 import {
   RoutineConcurrencyPolicy,
   DEFAULT_ROUTINE_LIMITS,
+  DEFAULT_TOTAL_LIMIT,
   MAX_ROUTINE_CONCURRENCY,
   PROTECTED_ROUTINE_KINDS,
   TOTAL_LIMIT_KEY,
@@ -38,9 +39,9 @@ describe('RoutineConcurrencyPolicy.resolveLimit', () => {
     expect(await RoutineConcurrencyPolicy.resolveLimit('review', 9)).toBe(4);
   });
 
-  it('falls back to MAX_ROUTINE_CONCURRENCY when enabled with no total limit set (0 = unlimited)', async() => {
+  it('falls back to DEFAULT_TOTAL_LIMIT when enabled with no total limit set yet', async() => {
     settings({ automatedProjectManagementEnabled: true });
-    expect(await RoutineConcurrencyPolicy.resolveLimit('execution')).toBe(MAX_ROUTINE_CONCURRENCY);
+    expect(await RoutineConcurrencyPolicy.resolveLimit('execution')).toBe(DEFAULT_TOTAL_LIMIT);
   });
 
   it('clamps the total limit to [0, MAX]', async() => {

--- a/pkg/rancher-desktop/pages/LanguageModelSettings.vue
+++ b/pkg/rancher-desktop/pages/LanguageModelSettings.vue
@@ -83,7 +83,7 @@ export default defineComponent({
       remoteTimeoutSeconds:  60, // Remote API timeout limit in seconds
       // Project Automation (single concurrent-agent limit; see Project Automation tab)
       automatedProjectManagementEnabled: true,
-      routineConcurrencyTotalLimit: 0,
+      routineConcurrencyTotalLimit: 5,
       // Heartbeat settings
       heartbeatEnabled:      true,
       heartbeatDelayMinutes: 15,
@@ -221,7 +221,7 @@ export default defineComponent({
     this.subconsciousProvider = await SullaSettingsModel.get('subconsciousProvider', 'default');
     this.heartbeatDelayMinutes = await SullaSettingsModel.get('heartbeatDelayMinutes', 15);
     this.automatedProjectManagementEnabled = Boolean(await SullaSettingsModel.get('automatedProjectManagementEnabled', true));
-    this.routineConcurrencyTotalLimit = Number(await SullaSettingsModel.get('routineConcurrencyTotalLimit', 0));
+    this.routineConcurrencyTotalLimit = Number(await SullaSettingsModel.get('routineConcurrencyTotalLimit', 5));
     this.botName = await SullaSettingsModel.get('botName', 'Sulla');
     this.primaryUserName = await SullaSettingsModel.get('primaryUserName', '');
     // Load provider/model state from ModelProviderService (source of truth)


### PR DESCRIPTION
Defaults the Project Automation "Concurrent agent limit count" setting to 5 instead of unset/0.

Previously, when `automatedProjectManagementEnabled` was on and the human had not yet set `routineConcurrencyTotalLimit`, the resolver treated the unset value as unlimited and fell through to the 32-agent hard ceiling (`MAX_ROUTINE_CONCURRENCY`). New installs (and existing ones that never touched the setting) were silently running at max concurrency.

- `RoutineConcurrencyPolicy.resolveTotalLimit()` now defaults the DB-backed lookup to a new `DEFAULT_TOTAL_LIMIT = 5` instead of `null`.
- `LanguageModelSettings.vue` mirrors the same default of 5 for the data property and the settings-load fallback, so the UI field shows 5 out of the box.
- Updated the existing unit test that asserted the old "unset = MAX_ROUTINE_CONCURRENCY" behavior to assert the new default of 5.

Users can still set it to any value 0-32, and 0 still means unlimited.

## Test plan
- [x] `jest pkg/rancher-desktop/agent/services/__tests__/RoutineConcurrencyPolicy.test.ts` — 48/48 passed
- [ ] Manual: open Language Model Settings -> Project Automation on a fresh profile, confirm the field shows 5