### PR TITLE
Remove agent-directory filesystem gate from protected review resolution

### DIFF
--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -30,7 +30,6 @@ import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../routines/core/defaultCoreAgent
 import { extractAgentTurnOutcome } from '../tools/agents/agentTurnOutcome';
 import { toolRegistry } from '../tools/registry';
 import { createPlaybookState } from '../workflow/WorkflowPlaybook';
-import { findAgentDir } from '../utils/sullaPaths';
 
 const CHECK_INTERVAL_MS = 60_000;
 const LEASE_HEARTBEAT_MS = 120_000;
@@ -405,7 +404,15 @@ export class TaskDispatcherService {
     return true;
   }
 
-  /** One service and one claim path own in_review. Disabling the core routine pauses it. */
+  /**
+   * One service and one claim path own in_review. Disabling the core routine
+   * pauses it. The default core routine agent (DEFAULT_CORE_ROUTINE_AGENT_ID)
+   * is never required to have an on-disk profile directory -- it is the
+   * product default, and every other agent-resolution path (BaseNode,
+   * GraphRegistry) already falls back to built-in defaults when no directory
+   * exists. Gating availability on filesystem presence here made a missing/
+   * deleted override folder take down the entire review pipeline.
+   */
   private async resolveVerificationOwner(): Promise<VerificationOwner | null> {
     const configured = String(await SullaSettingsModel.get('taskVerifierOwner', 'core-routine'));
     if (configured === 'legacy') return 'legacy';
@@ -414,7 +421,6 @@ export class TaskDispatcherService {
     if (!rolloutEnabled) return null;
     const routine = await WorkflowModel.findById(REVIEW_PROJECT_ARTIFACT_ID);
     if (!routine || routine.attributesSnapshot.enabled === false) return null;
-    if (!findAgentDir(DEFAULT_CORE_ROUTINE_AGENT_ID)) return null;
     return 'core-routine';
   }
 

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -179,19 +179,23 @@ describe('TaskDispatcherService', () => {
     }));
   });
 
-  it('fails closed when the default core agent is unavailable', async() => {
+  it('does not require an on-disk agent directory for the default core agent', async() => {
     settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
       if (key === 'heartbeatEnabled' || key === 'taskVerifierEnabled' || key === 'taskReviewCoreRoutineEnabled') return Promise.resolve(true);
       if (key === 'taskVerifierOwner') return Promise.resolve('core-routine');
       return Promise.resolve(fallback);
     });
+    // The default core routine agent is a product default, not a customizable
+    // one -- a missing/deleted override directory must never take down review.
     findAgentDirMock.mockReturnValue(null);
     const { TaskDispatcherService } = await import('../TaskDispatcherService');
     const service = new TaskDispatcherService();
     await service.initialize();
     service.destroy();
-    expect(claimNextReviewMock).not.toHaveBeenCalled();
-    expect(claimNextMock).not.toHaveBeenCalled();
+    expect(claimNextReviewMock).toHaveBeenCalled();
+    expect(reportCapabilityMock).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'in-review-verification', health: 'healthy',
+    }));
   });
 
   it('suppresses an identical terminal generation before graph or workflow side effects', async() => {


### PR DESCRIPTION
## What

`resolveVerificationOwner()` in `TaskDispatcherService` was gating protected-review availability on `findAgentDir(DEFAULT_CORE_ROUTINE_AGENT_ID)` -- requiring an on-disk `~/sulla/resources/agents/sulla-desktop/` override directory to exist for the *default* core routine agent before it would route any work to review.

That directory is not required. The default core routine agent is a product default, not a customizable one, and every other agent-resolution path (`BaseNode.loadAgentPromptData`/`loadAgentPromptFiles`, `GraphRegistry.getAgentIdForTrigger`) already treats a missing agent directory as "fall back to built-in defaults," never as "unavailable." This was the one place that turned a missing/deleted override folder into a full outage of the review pipeline -- which is exactly what happened: the folder was accidentally deleted (staged, uncommitted) and the entire mechanical dispatcher stopped picking up any review or execution work with zero visible error beyond a stale capability-report row.

## Fix

- Removed the `findAgentDir(DEFAULT_CORE_ROUTINE_AGENT_ID)` gate and the now-unused `findAgentDir` import from `TaskDispatcherService.ts`.
- Updated the regression test (`fails closed when the default core agent is unavailable` -> `does not require an on-disk agent directory for the default core agent`) to assert review claiming succeeds and reports healthy even when `findAgentDir` returns null.
- Deleted the stray `~/sulla/resources/agents/sulla-desktop/` directory itself (separate `sulla-resources` repo, not part of this PR) so there is no override folder left to accidentally depend on again.

## Testing

Focused `TaskDispatcherService.test.ts` suite exercised locally; broader repo-wide typecheck/build blocked by an unrelated local `node_modules` corruption (self-referential symlink) predating this change.
