### PR TITLE
fix: keep human gate monitoring independent from deadlines

### DIFF
--- a/pkg/rancher-desktop/agent/tools/project/__tests__/registerTaskWait.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/registerTaskWait.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { resolveNextCheckAt } from '../register_task_wait';
+
+describe('resolveNextCheckAt', () => {
+  it('keeps an explicit monitor schedule unchanged', () => {
+    expect(resolveNextCheckAt('human_gate', '2026-08-25T20:00:00.000Z', '2026-12-01T00:00:00.000Z'))
+      .toBe('2026-08-25T20:00:00.000Z');
+  });
+
+  it('uses a short monitor cadence instead of the human deadline', () => {
+    const now = Date.parse('2026-08-25T20:00:00.000Z');
+    expect(resolveNextCheckAt('human_gate', undefined, '2027-08-25T20:00:00.000Z', now))
+      .toBe('2026-08-25T20:05:00.000Z');
+  });
+
+  it('leaves waits without a deadline on the database default cadence', () => {
+    expect(resolveNextCheckAt('external_job', undefined, null)).toBeUndefined();
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/project/register_task_wait.ts
+++ b/pkg/rancher-desktop/agent/tools/project/register_task_wait.ts
@@ -5,6 +5,14 @@ import type { WorkTaskWaitKind } from '../../database/models/WorkTaskWaitModel';
 
 const WAIT_KINDS = new Set<WorkTaskWaitKind>(['github_checks', 'human_gate', 'scheduled_time', 'external_job']);
 
+const MONITOR_RECHECK_MS = 5 * 60 * 1000;
+
+export function resolveNextCheckAt(waitKind: WorkTaskWaitKind, nextCheckAt: unknown, dueAt: string | null, now = Date.now()): string | undefined {
+  if (typeof nextCheckAt === 'string' && nextCheckAt.trim()) return nextCheckAt.trim();
+  if (waitKind === 'human_gate' && dueAt) return new Date(now + MONITOR_RECHECK_MS).toISOString();
+  return undefined;
+}
+
 /** Register one deterministic external wait. Duplicate active targets are idempotent. */
 export class RegisterTaskWaitWorker extends BaseTool {
   name = '';
@@ -20,9 +28,9 @@ export class RegisterTaskWaitWorker extends BaseTool {
     }
     try {
       const dueAt = typeof input.due_at === 'string' && input.due_at.trim() ? input.due_at.trim() : null;
-      const nextCheckAt = typeof input.next_check_at === 'string' && input.next_check_at.trim()
-        ? input.next_check_at.trim()
-        : (waitKind === 'human_gate' && dueAt ? dueAt : undefined);
+      // A due date is the human gate's deadline, not its monitor schedule.
+      // Keep the monitor alive on its normal cadence while preserving due_at separately.
+      const nextCheckAt = resolveNextCheckAt(waitKind, input.next_check_at, dueAt);
       const actor = input.actor || 'sulla';
       const registration = await getProjectsApplicationService().registerWait({
         taskId,


### PR DESCRIPTION
Keep human-gate due_at as a deadline, not the monitor next-poll time. Schedule the default monitor check five minutes out so long-lived gates cannot be stranded for months or a year. Add regression coverage for explicit schedules, long deadlines, and deadline-free waits. Verification: git diff --check passed. Jest and ESLint were attempted but did not complete within the VM execution window, so no result is claimed.