### PR TITLE
fix(chat): remove verbose stream diagnostics

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/AgentPersonaModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/AgentPersonaModel.ts
@@ -486,11 +486,6 @@ export class AgentPersonaService {
     const msgThreadId = this.extractThreadId(msg);
     const myThreadId = this.state.threadId;
 
-    // TEMP DIAG (GW7w): trace every inbound WS message at the point it
-    // reaches the renderer, before any filtering can drop it. Remove once
-    // the today's-symptom investigation on task GW7w is closed.
-    console.log(`[GW7w-diag] FE-RECV agent=${ agentId } type=${ msg.type } kind=${ (msg.data as any)?.kind ?? '-' } msgThreadId=${ msgThreadId ?? '-' } myThreadId=${ myThreadId ?? '-' } t=${ Date.now() }`);
-
     // Drop messages that don't carry a threadId when we already have an active thread.
     // This prevents stray workflow / backend messages from leaking into the chat.
     if (!msgThreadId && myThreadId) {
@@ -506,25 +501,21 @@ export class AgentPersonaService {
         if (msg.type === 'chat_message' && (msg.data as any)?.kind === 'channel_message') {
           const toThreadId = (msg.data as any)?.toThreadId;
           if (toThreadId && toThreadId !== myThreadId) {
-            console.log(`[GW7w-diag] FE-DROP reason=channel_message-wrong-target toThreadId=${ toThreadId } myThreadId=${ myThreadId }`);
             return; // targeted to a different thread
           }
           // else: toThreadId matches or absent — fall through to dispatch
         } else {
-          console.log(`[GW7w-diag] FE-DROP reason=missing-threadId type=${ msg.type } kind=${ (msg.data as any)?.kind ?? '-' } myThreadId=${ myThreadId }`);
           return;
         }
       }
     }
 
     if (msgThreadId && myThreadId && msgThreadId !== myThreadId) {
-      console.log(`[GW7w-diag] FE-DROP reason=threadId-mismatch msgThreadId=${ msgThreadId } myThreadId=${ myThreadId }`);
       return; // belongs to a different chat tab — ignore
     }
 
     this.dispatcher.dispatch(this.getDispatchContext(), agentId, msgThreadId ?? '', msg);
     this.markMessagesChanged();
-    console.log(`[GW7w-diag] FE-DISPATCHED kind=${ (msg.data as any)?.kind ?? '-' } revision=${ this.messagesRevision.value } messagesLen=${ this.messages.length } t=${ Date.now() }`);
   }
 
   private markMessagesChanged(): void {

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -1624,15 +1624,7 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     const STREAM_THROTTLE_MS = 50;
     const isVoiceMode = controller.getMode() === 'voice';
 
-    let gw7wFirstTokenLogged = false;
     const onToken = (token: string): void => {
-      // TEMP DIAG (GW7w): log the very first token of the turn so we can
-      // tell "the provider never produced output" apart from "output was
-      // produced but never reached the renderer". Remove once GW7w is closed.
-      if (!gw7wFirstTokenLogged) {
-        gw7wFirstTokenLogged = true;
-        console.log(`[GW7w-diag] BE-FIRST-TOKEN threadId=${ state.metadata.threadId ?? '-' } t=${ Date.now() }`);
-      }
       contentBuffer += token;
 
       // Sub-agent inactivity watchdog in PlaybookController reads this —
@@ -1975,11 +1967,6 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     } else {
       state.metadata.hadUserMessages = true;
     }
-    // TEMP DIAG (GW7w): trace every WS chat send from the main process so we
-    // can correlate "sent" here against "FE-RECV" in AgentPersonaModel.ts.
-    // Remove once the today's-symptom investigation on task GW7w is closed.
-    console.log(`[GW7w-diag] BE-SEND connection=${ connectionId } kind=${ kind } contentLen=${ content.length } threadId=${ threadId ?? '-' } sent=${ sent } t=${ Date.now() }`);
-
     // If this agent is running inside a workflow, also emit a node_thinking
     // event so the workflow canvas can display the conversation in a bubble.
     // Subconscious subagents set `workflowThinkingLabel` so the frontend

--- a/pkg/rancher-desktop/pages/agent/ChatInterface.ts
+++ b/pkg/rancher-desktop/pages/agent/ChatInterface.ts
@@ -75,12 +75,9 @@ export class ChatInterface {
     // transcript. A deep watcher traversed every historical message for every
     // stream delta before this callback even ran, recreating the renderer
     // starvation that the persistence debounce was meant to prevent.
-    watch(() => this.persona.messagesRevision.value, (rev) => {
+    watch(() => this.persona.messagesRevision.value, () => {
       this.messages.value = [...this.persona.messages];
       this.schedulePersist();
-      // TEMP DIAG (GW7w): confirm the ci.messages mirror actually refreshes
-      // on every persona revision bump. Remove once GW7w is closed.
-      console.log(`[GW7w-diag] CI-MIRROR revision=${ rev } mirroredLen=${ this.messages.value.length } t=${ Date.now() }`);
     });
 
     // Watch graphRunning to process next queued message when current one completes

--- a/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
+++ b/pkg/rancher-desktop/pages/chat/services/PersonaAdapter.ts
@@ -102,13 +102,7 @@ export class PersonaAdapter {
     // React to the persona's explicit scalar revision. Deep-watching the
     // message array traversed the entire transcript on every stream delta.
     this.stopWatchers.push(
-      watch(() => this.ci.messagesRevision.value, (rev) => {
-        // TEMP DIAG (GW7w): confirm the adapter watcher actually fires on
-        // every ci revision bump and schedules a sync. Remove once GW7w
-        // is closed.
-        console.log(`[GW7w-diag] ADAPTER-SCHEDULE revision=${ rev } t=${ Date.now() }`);
-        this.messageSyncScheduler.schedule();
-      }),
+      watch(() => this.ci.messagesRevision.value, () => this.messageSyncScheduler.schedule()),
     );
 
     // Drive the run-state machine from the backend. Also re-map every
@@ -292,9 +286,6 @@ export class PersonaAdapter {
   // short timer publishes the latest accumulated state at a bounded rate.
   private syncMessages(): void {
     const backend = this.ci.messages.value;
-    // TEMP DIAG (GW7w): confirm syncMessages actually runs and how many
-    // backend messages it sees each call. Remove once GW7w is closed.
-    console.log(`[GW7w-diag] SYNC-RUN backendLen=${ backend.length } t=${ Date.now() }`);
     for (const b of backend) {
       if (!b?.id) continue;
 
@@ -308,16 +299,13 @@ export class PersonaAdapter {
       if (!mapped) {
         // Track as seen anyway so we don't repeatedly re-process it.
         this.seen.add(b.id);
-        console.log(`[GW7w-diag] SYNC-SKIP id=${ b.id } kind=${ b.kind ?? '-' } reason=null-mapping`);
         continue;
       }
       if (this.seen.has(b.id)) {
         this.controller.updateMessage(mapped.id, mapped as Partial<Message>);
-        console.log(`[GW7w-diag] SYNC-UPDATE id=${ b.id } kind=${ b.kind ?? '-' } contentLen=${ typeof b.content === 'string' ? b.content.length : -1 } t=${ Date.now() }`);
       } else {
         this.seen.add(b.id);
         this.controller.appendMessage(mapped);
-        console.log(`[GW7w-diag] SYNC-APPEND id=${ b.id } kind=${ b.kind ?? '-' } t=${ Date.now() }`);
       }
     }
   }


### PR DESCRIPTION
## Summary
- remove temporary GW7w console probes from the chat streaming hot path
- preserve the existing revision-based sync and throttled renderer updates

The diagnostic commit logged every inbound/outbound stream event, revision mirror, adapter schedule, and sync operation. Those synchronous console writes can starve the renderer during long responses and recreate the reported freeze.

## Verification
- `PersonaAdapter.test.ts`: 3/3 tests passed
- `git diff --check`: passed
- repo-wide ESLint remains blocked by pre-existing baseline errors in untouched files; see local verification output

No merge or deploy included.