### PR TITLE
fix(dispatcher): carry a specific reason on malformed protected-review output

### DIFF
--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -68,6 +68,13 @@ interface ParsedProtectedReview extends Omit<ProtectedReviewEvidence, 'workflowE
   disposition: ReviewDisposition;
 }
 
+interface ProtectedReviewParseResult {
+  value:  ParsedProtectedReview | null;
+  // Short machine-readable cause of a null value, so repeat malformed-output
+  // failures on a task carry an actionable reason instead of one opaque string.
+  reason: string | null;
+}
+
 type VerificationOwner = 'core-routine' | 'legacy';
 
 let taskDispatcherServiceInstance: TaskDispatcherService | null = null;
@@ -545,9 +552,9 @@ export class TaskDispatcherService {
         if (verifierTimedOut) {
           await WorkTaskDispatchModel.failVerification(dispatch.id, 'verifier_timeout');
         } else if (verificationOwner === 'core-routine') {
-          const parsed = this.parseProtectedReview(finalState.metadata?.lastCompletedWorkflow);
+          const { value: parsed, reason: parseFailureReason } = this.parseProtectedReview(finalState.metadata?.lastCompletedWorkflow);
           if (!parsed) {
-            await WorkTaskDispatchModel.failVerification(dispatch.id, 'malformed_protected_review_output');
+            await WorkTaskDispatchModel.failVerification(dispatch.id, `malformed_protected_review_output:${ parseFailureReason }`);
           } else {
             const currentArtifacts = await this.resolveReviewArtifacts(task, comments, dispatch.origin_evidence);
             const currentGenerationHash = WorkTaskDispatchModel.reviewGenerationHash(currentArtifacts);
@@ -671,53 +678,84 @@ export class TaskDispatcherService {
     }
   }
 
-  private parseProtectedReview(completed: any): ParsedProtectedReview | null {
-    if (completed?.outcome !== 'completed' || completed.workflowId !== REVIEW_PROJECT_ARTIFACT_ID) return null;
+  private parseProtectedReview(completed: any): ProtectedReviewParseResult {
+    if (completed?.outcome !== 'completed' || completed.workflowId !== REVIEW_PROJECT_ARTIFACT_ID) {
+      return { value: null, reason: 'workflow_did_not_complete' };
+    }
     const synthesis = completed.nodeResults?.find((node: any) => node.nodeId === 'node-review-synthesize');
     const parsed = this.parseJsonObject(synthesis?.result);
-    if (!parsed || !['PASS', 'REPAIRABLE', 'REPLAN', 'EXTERNAL_WAIT', 'BLOCKED'].includes(parsed.disposition)) return null;
-    if (typeof parsed.artifactType !== 'string' || !parsed.artifactType.trim()) return null;
-    if (typeof parsed.generationHash !== 'string' || !/^[a-f0-9]{64}$/i.test(parsed.generationHash)) return null;
+    if (!parsed || !['PASS', 'REPAIRABLE', 'REPLAN', 'EXTERNAL_WAIT', 'BLOCKED'].includes(parsed.disposition)) {
+      return { value: null, reason: 'missing_or_invalid_disposition' };
+    }
+    if (typeof parsed.artifactType !== 'string' || !parsed.artifactType.trim()) {
+      return { value: null, reason: 'invalid_artifact_type' };
+    }
+    if (typeof parsed.generationHash !== 'string' || !/^[a-f0-9]{64}$/i.test(parsed.generationHash)) {
+      return { value: null, reason: 'invalid_generation_hash' };
+    }
     const artifactTypes = Array.isArray(parsed.artifactTypes) ? parsed.artifactTypes : [];
     const allowedTypes = new Set(Object.keys(ARTIFACT_VERIFICATION_ADAPTERS));
-    if (artifactTypes.length === 0 || artifactTypes.some((value: unknown) => typeof value !== 'string' || !allowedTypes.has(value))) return null;
-    if (!Array.isArray(parsed.artifacts) || parsed.artifacts.length === 0) return null;
+    if (artifactTypes.length === 0 || artifactTypes.some((value: unknown) => typeof value !== 'string' || !allowedTypes.has(value))) {
+      return { value: null, reason: 'invalid_artifact_types_list' };
+    }
+    if (!Array.isArray(parsed.artifacts) || parsed.artifacts.length === 0) {
+      return { value: null, reason: 'empty_artifacts_list' };
+    }
     const artifacts = parsed.artifacts.filter((artifact: any) => artifact && typeof artifact === 'object');
     if (artifacts.length !== parsed.artifacts.length || artifacts.some((artifact: any) =>
       !allowedTypes.has(artifact.type) || typeof artifact.canonicalRef !== 'string' ||
       typeof artifact.adapter !== 'string' || typeof artifact.code !== 'boolean' ||
       artifact.adapter !== ARTIFACT_VERIFICATION_ADAPTERS[artifact.type as ReviewArtifactType].adapter ||
-      typeof artifact.hash !== 'string' || !/^[a-f0-9]{40,64}$/i.test(artifact.hash))) return null;
-    if (typeof parsed.artifactRef !== 'string' || !parsed.artifactRef.trim()) return null;
-    if (typeof parsed.artifactHash !== 'string' || !/^[a-f0-9]{40,64}$/i.test(parsed.artifactHash)) return null;
-    if (typeof parsed.summary !== 'string' || !parsed.summary.trim()) return null;
-    if (!Array.isArray(parsed.checks) || !Array.isArray(parsed.findings)) return null;
+      typeof artifact.hash !== 'string' || !/^[a-f0-9]{40,64}$/i.test(artifact.hash))) {
+      return { value: null, reason: 'invalid_artifacts_shape' };
+    }
+    if (typeof parsed.artifactRef !== 'string' || !parsed.artifactRef.trim()) {
+      return { value: null, reason: 'invalid_artifact_ref' };
+    }
+    if (typeof parsed.artifactHash !== 'string' || !/^[a-f0-9]{40,64}$/i.test(parsed.artifactHash)) {
+      return { value: null, reason: 'invalid_artifact_hash' };
+    }
+    if (typeof parsed.summary !== 'string' || !parsed.summary.trim()) {
+      return { value: null, reason: 'missing_summary' };
+    }
+    if (!Array.isArray(parsed.checks) || !Array.isArray(parsed.findings)) {
+      return { value: null, reason: 'invalid_checks_or_findings' };
+    }
     if (parsed.disposition === 'EXTERNAL_WAIT') {
       const wait = parsed.wait;
-      if (!wait || !['github_checks', 'human_gate', 'scheduled_time', 'external_job'].includes(wait.kind)) return null;
-      if (typeof wait.targetKey !== 'string' || !wait.targetKey.trim()) return null;
-      if (!wait.target || typeof wait.target !== 'object' || Array.isArray(wait.target)) return null;
+      if (!wait || !['github_checks', 'human_gate', 'scheduled_time', 'external_job'].includes(wait.kind)) {
+        return { value: null, reason: 'invalid_external_wait_kind' };
+      }
+      if (typeof wait.targetKey !== 'string' || !wait.targetKey.trim()) {
+        return { value: null, reason: 'invalid_external_wait_target_key' };
+      }
+      if (!wait.target || typeof wait.target !== 'object' || Array.isArray(wait.target)) {
+        return { value: null, reason: 'invalid_external_wait_target' };
+      }
     }
     return {
-      disposition:    parsed.disposition,
-      generationHash: parsed.generationHash.toLowerCase(),
-      artifactTypes:  artifactTypes as ReviewArtifactType[],
-      artifacts:      artifacts.map((artifact: any) => ({
-        type:         artifact.type,
-        canonicalRef: artifact.canonicalRef.trim(),
-        url:          typeof artifact.url === 'string' ? artifact.url.trim() : null,
-        hash:         artifact.hash.toLowerCase(),
-        adapter:      artifact.adapter.trim(),
-        code:         artifact.code,
-      })),
-      artifactType: parsed.artifactType.trim(),
-      artifactRef:  parsed.artifactRef.trim(),
-      artifactUrl:  typeof parsed.artifactUrl === 'string' ? parsed.artifactUrl.trim() : null,
-      artifactHash: parsed.artifactHash.toLowerCase(),
-      summary:      parsed.summary.trim().slice(0, 8_000),
-      checks:       parsed.checks,
-      findings:     parsed.findings,
-      wait:         parsed.wait ?? null,
+      value: {
+        disposition:    parsed.disposition,
+        generationHash: parsed.generationHash.toLowerCase(),
+        artifactTypes:  artifactTypes as ReviewArtifactType[],
+        artifacts:      artifacts.map((artifact: any) => ({
+          type:         artifact.type,
+          canonicalRef: artifact.canonicalRef.trim(),
+          url:          typeof artifact.url === 'string' ? artifact.url.trim() : null,
+          hash:         artifact.hash.toLowerCase(),
+          adapter:      artifact.adapter.trim(),
+          code:         artifact.code,
+        })),
+        artifactType: parsed.artifactType.trim(),
+        artifactRef:  parsed.artifactRef.trim(),
+        artifactUrl:  typeof parsed.artifactUrl === 'string' ? parsed.artifactUrl.trim() : null,
+        artifactHash: parsed.artifactHash.toLowerCase(),
+        summary:      parsed.summary.trim().slice(0, 8_000),
+        checks:       parsed.checks,
+        findings:     parsed.findings,
+        wait:         parsed.wait ?? null,
+      },
+      reason: null,
     };
   }
 

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -612,7 +612,7 @@ describe('TaskDispatcherService', () => {
   it('parses a mixed code and non-code generation with structural adapters', async() => {
     const { TaskDispatcherService } = await import('../TaskDispatcherService');
     const service = new TaskDispatcherService() as any;
-    const parsed = service.parseProtectedReview({
+    const { value: parsed, reason } = service.parseProtectedReview({
       workflowId:  'core-routine-review-project-artifact',
       executionId: 'wfp-mixed',
       outcome:     'completed',
@@ -636,9 +636,28 @@ describe('TaskDispatcherService', () => {
         }),
       }],
     });
+    expect(reason).toBeNull();
     expect(parsed.artifactTypes).toEqual(['code_pr', 'documentation']);
     expect(parsed.artifacts).toHaveLength(2);
     expect(parsed.artifacts[1].adapter).toBe('document-read');
+  });
+
+  it.each([
+    [{ outcome: 'completed', workflowId: 'wrong-workflow' }, 'workflow_did_not_complete'],
+    [{
+      outcome: 'completed', workflowId: 'core-routine-review-project-artifact',
+      nodeResults: [{ nodeId: 'node-review-synthesize', result: JSON.stringify({ disposition: 'NOPE' }) }],
+    }, 'missing_or_invalid_disposition'],
+    [{
+      outcome: 'completed', workflowId: 'core-routine-review-project-artifact',
+      nodeResults: [{ nodeId: 'node-review-synthesize', result: JSON.stringify({ disposition: 'PASS' }) }],
+    }, 'invalid_artifact_type'],
+  ] as const)('reports a specific reason for malformed protected-review output %#', async(completed, expectedReason) => {
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService() as any;
+    const { value, reason } = service.parseProtectedReview(completed);
+    expect(value).toBeNull();
+    expect(reason).toBe(expectedReason);
   });
 
   it('rejects malformed verifier output without changing the task to blocked', async() => {


### PR DESCRIPTION
## Why

The protected-review verifier has been failing tasks with a single opaque reason string `malformed_protected_review_output` whenever `parseProtectedReview()` rejects the synthesis output. There are 15+ distinct validation branches (missing synthesis node, invalid disposition, bad hash format, empty artifacts list, etc.) all collapsed into that one string, so when a task fails repeatedly (e.g. task XfKV hit 3 consecutive equivalent failures and escalated to REPLAN) there was no way to tell which check actually failed without re-running it live.

## What changed

- parseProtectedReview() now returns { value, reason } instead of a bare ParsedProtectedReview | null.
- Each failing validation branch returns a short machine-readable reason (e.g. invalid_generation_hash, missing_summary, empty_artifacts_list, invalid_external_wait_kind).
- The one call site in TaskDispatcherService threads the reason into the failVerification call: malformed_protected_review_output:<reason> instead of the bare constant.
- Updated the existing direct unit test for the new return shape and added 3 new cases covering distinct failure reasons.

## Not in scope

This does not fix whatever is causing the review workflow to produce malformed output in the first place -- it makes the cause visible. Next occurrence will show exactly which check failed instead of requiring a live re-run to guess.

## Verification

tsc --noEmit clean on this file. Focused Jest run for this suite was inconclusive in my sandbox (first attempt picked up duplicate test files from unrelated nested worktrees; scoped re-run did not finish before this was pushed, per direct instruction not to hold the PR on tests) -- flagging for CI / human verification rather than claiming a green run.