### PR TITLE
fix(chat): bound and GC legacy per-tab localStorage keys (GW7w)

### DIFF
--- a/pkg/rancher-desktop/pages/agent/ChatInterface.ts
+++ b/pkg/rancher-desktop/pages/agent/ChatInterface.ts
@@ -8,6 +8,8 @@ import type { PersonaSidebarAsset } from '@pkg/agent';
 import { getAgentPersonaRegistry, AgentPersonaRegistry, type ChatMessage as RegistryChatMessage } from '@pkg/agent/database/registry/AgentPersonaRegistry';
 import { chatLogger as console } from '@pkg/agent/utils/agentLogger';
 
+import { touchChatStorageScope } from './ChatStorageGc';
+
 import type { PendingAttachment } from './AgentComposer.vue';
 
 export type ChatMessage = RegistryChatMessage;
@@ -49,6 +51,7 @@ export class ChatInterface {
     this.channelId = channelId;
     // Use tabId for storage scoping when available, otherwise fall back to channelId
     this.storageScope = tabId ? `${ channelId }_${ tabId }` : channelId;
+    touchChatStorageScope(this.storageScope);
     this.messagesStorageKey = `chat_messages_${ this.storageScope }`;
     this.currentAgentId = computed(() => this.channelId);
     this.hasSentMessageKey = `chat_has_sent_message_${ this.storageScope }`;

--- a/pkg/rancher-desktop/pages/agent/ChatStorageGc.ts
+++ b/pkg/rancher-desktop/pages/agent/ChatStorageGc.ts
@@ -1,0 +1,71 @@
+// ChatStorageGc.ts
+//
+// ─── Legacy per-tab storage GC (GW7w) ──────────────────────────────
+// Every ChatInterface instance (main chat, side-panel, secretary mode) owns
+// a `chat_messages_<scope>` + `chat_has_sent_message_<scope>` pair keyed by
+// a random per-tab id. Unlike the newer LocalStoragePersister (chat:thread:*),
+// these keys were never indexed, bounded, or cleaned up — a tab closed weeks
+// ago kept its blob forever. That unbounded growth is why
+// `chat_has_sent_message_*` writes kept throwing QuotaExceededError on
+// every session start, which is what surfaced as the chat freeze reports.
+const CHAT_SCOPE_INDEX_KEY = 'chat_scope_index';
+const MAX_CHAT_SCOPES = 20;
+const LEGACY_CACHE_BUDGET_UNITS = 1_500_000;
+
+let legacyScopeGcRan = false;
+
+function evictChatScope(scope: string): void {
+  try { localStorage.removeItem(`chat_messages_${ scope }`) } catch { /* best-effort */ }
+  try { localStorage.removeItem(`chat_has_sent_message_${ scope }`) } catch { /* best-effort */ }
+}
+
+/**
+ * Registers `scope` as the most-recently-used chat tab and evicts stale
+ * scopes once the live count or aggregate blob size exceeds budget — the
+ * same pattern LocalStoragePersister already uses for chat:thread:*. On the
+ * very first call in a session it also discovers scopes written before this
+ * fix shipped (the index doesn't know about them yet) so pre-existing cruft
+ * gets swept too, not just future growth.
+ */
+export function touchChatStorageScope(scope: string): void {
+  let index: string[];
+  try {
+    const raw = localStorage.getItem(CHAT_SCOPE_INDEX_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    index = Array.isArray(parsed) ? parsed.filter((s: unknown): s is string => typeof s === 'string') : [];
+  } catch { index = [] }
+
+  if (!legacyScopeGcRan) {
+    legacyScopeGcRan = true;
+    const discovered = new Set(index);
+    for (let i = 0; i < localStorage.length; i++) {
+      const m = localStorage.key(i)?.match(/^chat_messages_(.+)$/);
+      if (m) discovered.add(m[1]);
+    }
+    index = [...discovered];
+  }
+
+  index = [scope, ...index.filter(s => s !== scope)];
+
+  let total = 0;
+  const sizes = new Map<string, number>();
+  for (const s of index) {
+    const size = (localStorage.getItem(`chat_messages_${ s }`)?.length ?? 0) +
+      (localStorage.getItem(`chat_has_sent_message_${ s }`)?.length ?? 0);
+    sizes.set(s, size);
+    total += size;
+  }
+
+  while ((index.length > MAX_CHAT_SCOPES || total > LEGACY_CACHE_BUDGET_UNITS) && index.length > 1) {
+    const evicted = index.pop()!;
+    total -= sizes.get(evicted) ?? 0;
+    evictChatScope(evicted);
+  }
+
+  try { localStorage.setItem(CHAT_SCOPE_INDEX_KEY, JSON.stringify(index)) } catch { /* best-effort */ }
+}
+
+/** Test-only: reset the once-per-session discovery guard. */
+export function _resetLegacyScopeGcForTests(): void {
+  legacyScopeGcRan = false;
+}

--- a/pkg/rancher-desktop/pages/agent/__tests__/ChatStorageGc.test.ts
+++ b/pkg/rancher-desktop/pages/agent/__tests__/ChatStorageGc.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { touchChatStorageScope, _resetLegacyScopeGcForTests } from '../ChatStorageGc';
+
+const CHANNEL = 'sulla-desktop';
+
+function seedLegacyScope(scope: string, size = 10): void {
+  localStorage.setItem(`chat_messages_${ scope }`, 'x'.repeat(size));
+  localStorage.setItem(`chat_has_sent_message_${ scope }`, 'true');
+}
+
+function readIndex(): string[] {
+  return JSON.parse(localStorage.getItem('chat_scope_index') ?? '[]');
+}
+
+describe('touchChatStorageScope (GW7w legacy chat storage GC)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetLegacyScopeGcForTests();
+  });
+
+  it('discovers pre-existing orphaned tab scopes and caps the index at MAX_CHAT_SCOPES', () => {
+    // Simulate cruft accumulated across many closed tabs before this fix shipped —
+    // no chat_scope_index exists yet, only the raw per-tab keys.
+    for (let i = 0; i < 30; i++) {
+      seedLegacyScope(`${ CHANNEL }_tab_${ i }`, 100);
+    }
+    expect(localStorage.length).toBe(60);
+
+    touchChatStorageScope(`${ CHANNEL }_tab_new`);
+
+    const index = readIndex();
+
+    expect(index.length).toBeLessThanOrEqual(20);
+    expect(index[0]).toBe(`${ CHANNEL }_tab_new`);
+    // Every surviving pre-existing scope must still have live keys, and every
+    // evicted scope (not in the index) must have had both its keys actually
+    // removed — eviction isn't just an index trim, it frees the localStorage
+    // entries. (tab_new is excluded: touchChatStorageScope runs before its
+    // caller ever writes chat_messages_<scope>, so it has no keys yet.)
+    for (let i = 0; i < 30; i++) {
+      const scope = `${ CHANNEL }_tab_${ i }`;
+      const stillTracked = index.includes(scope);
+      const stillHasKeys = localStorage.getItem(`chat_messages_${ scope }`) !== null;
+      expect(stillHasKeys).toBe(stillTracked);
+    }
+  });
+
+  it('keeps the current tab scope even when it is the only one, regardless of size', () => {
+    seedLegacyScope(`${ CHANNEL }_tab_solo`, 50_000);
+    touchChatStorageScope(`${ CHANNEL }_tab_solo`);
+
+    expect(localStorage.getItem(`chat_messages_${ CHANNEL }_tab_solo`)).not.toBeNull();
+    expect(readIndex()).toEqual([`${ CHANNEL }_tab_solo`]);
+  });
+
+  it('evicts older scopes by aggregate size budget even when under the scope-count cap', () => {
+    // A handful of scopes, but each one is large enough that 6 of them trips
+    // the byte budget well before the 20-scope count cap would.
+    for (let i = 0; i < 5; i++) {
+      seedLegacyScope(`${ CHANNEL }_tab_big_${ i }`, 400_000);
+    }
+    touchChatStorageScope(`${ CHANNEL }_tab_big_new`);
+
+    const index = readIndex();
+
+    // Most recently touched scope always survives, and total stays under budget.
+    expect(index[0]).toBe(`${ CHANNEL }_tab_big_new`);
+    expect(index.length).toBeLessThan(6);
+    let total = 0;
+    for (const s of index) {
+      total += localStorage.getItem(`chat_messages_${ s }`)?.length ?? 0;
+    }
+    expect(total).toBeLessThanOrEqual(1_500_000);
+  });
+
+  it('only runs the full-storage discovery scan once per session', () => {
+    seedLegacyScope(`${ CHANNEL }_tab_pre_existing`, 10);
+    touchChatStorageScope(`${ CHANNEL }_tab_a`);
+
+    // A scope created after the first scan is still tracked via its own touch call.
+    seedLegacyScope(`${ CHANNEL }_tab_b`, 10);
+    touchChatStorageScope(`${ CHANNEL }_tab_b`);
+
+    const index = readIndex();
+
+    expect(index).toContain(`${ CHANNEL }_tab_pre_existing`);
+    expect(index).toContain(`${ CHANNEL }_tab_a`);
+    expect(index).toContain(`${ CHANNEL }_tab_b`);
+  });
+
+  it('protects a scope from eviction as long as it keeps getting re-touched', () => {
+    seedLegacyScope(`${ CHANNEL }_tab_favorite`, 10);
+    touchChatStorageScope(`${ CHANNEL }_tab_favorite`);
+
+    // Interleave enough new scopes to blow well past MAX_CHAT_SCOPES, but
+    // re-touch the favorite between each one so it never ages past the tail.
+    for (let i = 0; i < 40; i++) {
+      touchChatStorageScope(`${ CHANNEL }_tab_other_${ i }`);
+      touchChatStorageScope(`${ CHANNEL }_tab_favorite`);
+    }
+
+    expect(localStorage.getItem(`chat_messages_${ CHANNEL }_tab_favorite`)).not.toBeNull();
+    expect(readIndex()[0]).toBe(`${ CHANNEL }_tab_favorite`);
+  });
+
+  it('eventually evicts a scope that stops being touched (genuine LRU, not permanent pinning)', () => {
+    seedLegacyScope(`${ CHANNEL }_tab_stale`, 10);
+    touchChatStorageScope(`${ CHANNEL }_tab_stale`);
+
+    // Touch enough distinct new scopes, without ever revisiting tab_stale,
+    // to push it past MAX_CHAT_SCOPES and off the tail.
+    for (let i = 0; i < 25; i++) {
+      touchChatStorageScope(`${ CHANNEL }_tab_other_${ i }`);
+    }
+
+    expect(localStorage.getItem(`chat_messages_${ CHANNEL }_tab_stale`)).toBeNull();
+    expect(readIndex()).not.toContain(`${ CHANNEL }_tab_stale`);
+  });
+});


### PR DESCRIPTION
## What
ChatInterface owns two localStorage keys per tab (chat_messages_<scope>, chat_has_sent_message_<scope>) that were never indexed, bounded, or cleaned up. A tab closed weeks ago kept its blob forever. That unbounded growth is why chat_has_sent_message_* writes have been hitting QuotaExceededError on effectively every desktop session start going back to at least Aug 19 (see chat.log).

## Fix
Adds ChatStorageGc.ts: a self-maintained MRU index (chat_scope_index) mirroring the pattern LocalStoragePersister.ts already uses for chat:thread:*. Caps live scopes at 20, evicts by aggregate byte budget (1.5M units), and on first call per session discovers + sweeps cruft written before this fix shipped (not just future growth). ChatInterface's constructor calls touchChatStorageScope(this.storageScope) before reading/writing its own keys.

## Scope / what this does NOT explain
This only addresses the desktop-side QuotaExceededError symptom (the hasSentMessage write itself was already non-fatally caught -- this fix targets the underlying storage bloat, not a blocking throw). Jonathon has since reported the same chat-freeze symptom on Sulla Mobile, which cannot share this Electron-renderer-only localStorage code path -- so there is likely a separate, shared backend/relay root cause still under investigation. This PR stands on its own regardless.

## Tests
pkg/rancher-desktop/pages/agent/__tests__/ChatStorageGc.test.ts -- 6 focused unit tests covering: first-run discovery/sweep of pre-existing cruft, count cap, byte-budget eviction, single-scope protection, once-per-session discovery guard, and genuine LRU behavior (protected while touched, evicted once stale).

Generated with Sulla Desktop