### PR TITLE
fix(subconscious): bound concurrent post-turn writer fan-out

### DIFF
--- a/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
+++ b/pkg/rancher-desktop/agent/middleware/SubconsciousMiddleware.ts
@@ -21,6 +21,7 @@ import { ObservationsModel } from '../database/models/ObservationsModel';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { GraphRegistry, type DigestibleToolResult } from '../services/GraphRegistry';
 import { parseJson } from '../services/JsonParseService';
+import { runThroughWriterGate } from '../services/SubconsciousWriterGate';
 import { sanitizeConversationContext } from '../utils/conversationContext';
 import { formatDateOnly } from '../utils/formatDateOnly';
 
@@ -348,8 +349,14 @@ export function runSubconsciousObservationWriters(
   }
   if (!options.includeObservations || !hasAnalyzableUserMessage(state)) return;
 
+  // Every writer still runs to completion with a model in the loop — the
+  // gate only bounds how many run concurrently PROCESS-WIDE (not just within
+  // this turn), so a burst of conversations completing close together
+  // (PM automation, Heartbeat, multiple chat/mobile sessions) can't fire
+  // dozens of background LLM calls at once and starve the primary turn's
+  // own model call. See SubconsciousWriterGate.ts.
   const launch = (label: string, run: () => Promise<unknown>): void => {
-    Promise.resolve().then(run).catch((error) => {
+    Promise.resolve().then(() => runThroughWriterGate(run)).catch((error) => {
       console.error(`[SubconsciousMiddleware] Post-turn ${ label } failed (fire-and-forget):`, error instanceof Error ? error.message : error);
     });
   };

--- a/pkg/rancher-desktop/agent/services/SubconsciousWriterGate.ts
+++ b/pkg/rancher-desktop/agent/services/SubconsciousWriterGate.ts
@@ -1,0 +1,62 @@
+// SubconsciousWriterGate.ts
+//
+// Process-wide concurrency gate for post-turn subconscious writers.
+//
+// SubconsciousMiddleware.runSubconsciousObservationWriters fires 8
+// fire-and-forget, LLM-calling background agents after EVERY completed
+// conversation (chat, mobile-relay, Heartbeat cycles, PM-automation worker
+// turns all funnel through the same backend process). With no throttle,
+// each conversation's writers fire in parallel with every other concurrent
+// conversation's writers — when several conversations complete close
+// together (PM automation running at concurrency 5, Heartbeat, multiple
+// chat/mobile sessions), the fan-out multiplies unbounded and can saturate
+// the shared LLM provider concurrency or the local Postgres pool, stalling
+// the primary interactive turn's own model call on any channel.
+//
+// This gate does not skip or time-box any writer — every writer still runs
+// to completion with a model in the loop. It only bounds how many run
+// concurrently process-wide, queuing the rest in arrival order.
+const MAX_CONCURRENT_WRITERS = 3;
+
+let active = 0;
+const waiters: (() => void)[] = [];
+
+function acquire(): Promise<void> {
+  if (active < MAX_CONCURRENT_WRITERS) {
+    active++;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    waiters.push(() => {
+      active++;
+      resolve();
+    });
+  });
+}
+
+function release(): void {
+  active--;
+  const next = waiters.shift();
+  if (next) next();
+}
+
+/** Runs `run` once a concurrency slot is free, then releases the slot. */
+export async function runThroughWriterGate<T>(run: () => Promise<T>): Promise<T> {
+  await acquire();
+  try {
+    return await run();
+  } finally {
+    release();
+  }
+}
+
+/** Test-only: reset gate state between test cases. */
+export function _resetWriterGateForTests(): void {
+  active = 0;
+  waiters.length = 0;
+}
+
+/** Test-only: inspect current gate occupancy. */
+export function _writerGateStateForTests(): { active: number; waiting: number } {
+  return { active, waiting: waiters.length };
+}

--- a/pkg/rancher-desktop/agent/services/__tests__/SubconsciousWriterGate.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/SubconsciousWriterGate.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+import { runThroughWriterGate, _resetWriterGateForTests, _writerGateStateForTests } from '../SubconsciousWriterGate';
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolveOuter!: (v: T) => void;
+  const promise = new Promise<T>((resolve) => { resolveOuter = resolve });
+  return { promise, resolve: resolveOuter };
+}
+
+describe('SubconsciousWriterGate', () => {
+  beforeEach(() => {
+    _resetWriterGateForTests();
+  });
+
+  it('runs up to the concurrency cap immediately', async() => {
+    const gates = [deferred<void>(), deferred<void>(), deferred<void>()];
+    const started: number[] = [];
+
+    const runs = gates.map((g, i) => runThroughWriterGate(async() => {
+      started.push(i);
+      await g.promise;
+    }));
+
+    // Let microtasks flush so all three acquire() calls resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(started.sort()).toEqual([0, 1, 2]);
+    expect(_writerGateStateForTests().active).toBe(3);
+
+    gates.forEach(g => g.resolve());
+    await Promise.all(runs);
+  });
+
+  it('queues work beyond the concurrency cap instead of running it immediately', async() => {
+    const gates = Array.from({ length: 5 }, () => deferred<void>());
+    const started: number[] = [];
+
+    const runs = gates.map((g, i) => runThroughWriterGate(async() => {
+      started.push(i);
+      await g.promise;
+    }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Only the first 3 (the cap) should have started; 2 are queued.
+    expect(started.length).toBe(3);
+    expect(_writerGateStateForTests().active).toBe(3);
+    expect(_writerGateStateForTests().waiting).toBe(2);
+
+    // Freeing one slot lets the next queued task start. Give the resolve ->
+    // await g.promise -> finally{release()} -> next() -> acquire() chain
+    // enough microtask ticks to fully unwind.
+    gates[0].resolve();
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(started.length).toBe(4);
+
+    gates.slice(1).forEach(g => g.resolve());
+    await Promise.all(runs);
+    expect(started.length).toBe(5);
+    expect(_writerGateStateForTests()).toEqual({ active: 0, waiting: 0 });
+  });
+
+  it('releases the slot even when the wrapped work throws', async() => {
+    await expect(runThroughWriterGate(() => {
+      throw new Error('writer failed');
+    })).rejects.toThrow('writer failed');
+
+    expect(_writerGateStateForTests()).toEqual({ active: 0, waiting: 0 });
+
+    // The freed slot is usable immediately afterward.
+    let ran = false;
+    await runThroughWriterGate(() => { ran = true; return Promise.resolve() });
+    expect(ran).toBe(true);
+  });
+
+  it('returns the resolved value of the wrapped work', async() => {
+    const result = await runThroughWriterGate(() => Promise.resolve(42));
+    expect(result).toBe(42);
+  });
+});


### PR DESCRIPTION
## What I found
Jonathon reported the chat freeze is happening on Sulla Mobile too, not just desktop -- which rules out desktop-only causes (like #766, the localStorage quota fix) as the shared root cause, since mobile can't share Electron-renderer localStorage.

Both desktop chat and mobile-relay chat route through the exact same backend pipeline: BackendGraphWebSocketService.handleChannelMessage -> dispatchToAgent -> graph.execute, all inside one Electron main process, sharing one 20-connection Postgres pool and one LLM provider account.

SubconsciousMiddleware.runSubconsciousObservationWriters fires 8 fire-and-forget, LLM-calling background writers after EVERY completed conversation on EVERY channel (chat, mobile-relay, Heartbeat cycles, PM-automation worker turns): the general Observation Writer, 7 identity-domain observers (human/agent/business/world/environment/projects/skills), and the Conversation Writer. Dispatch was a bare `Promise.resolve().then(run)` -- zero concurrency cap, zero queue, zero dedup.

PM automation concurrency was just raised to 5 and the dispatcher/Heartbeat decoupling just merged, so more conversations now complete close together -- and each completion detonates 8 more uncapped background LLM calls. `index.log` shows this live: dozens of subconscious conversations completing in tight clusters seconds apart right now. That can saturate the shared LLM provider concurrency or the Postgres pool, stalling an interactive turn's own model call on any channel -- matching the exact symptom (stuck at "calling ai model", desktop AND mobile).

## Fix
Adds `SubconsciousWriterGate.ts`: a small process-wide concurrency gate (cap 3) wrapping the writer dispatch in `SubconsciousMiddleware.ts`. No writer is skipped or time-boxed -- every one still runs to completion with a model in the loop, per Jonathon's standing directive that subconscious agents must never have the model bypassed for latency. This only bounds how many run concurrently PROCESS-WIDE, queuing the rest in arrival order instead of firing everything unbounded across every concurrent conversation.

Scoped narrowly to the post-turn WRITER fan-out only -- the pre-turn RECALL path (which blocks the user-facing reply and is explicitly time-unlimited by design) is untouched.

## Tests
`pkg/rancher-desktop/agent/services/__tests__/SubconsciousWriterGate.test.ts` -- 4 focused unit tests: runs up to the cap immediately, queues beyond the cap and drains in order, releases the slot on throw, returns the wrapped value.

`SubconsciousMiddleware.test.ts` has 5 pre-existing failures unrelated to this change -- confirmed identical (same 5 failing, same 5 passing) on origin/main before this diff via git stash.

## Relationship to #766
Separate, independent fix. #766 addresses a real desktop-only localStorage quota bug found during the same investigation but doesn't explain mobile. This PR addresses the shared backend cause. Both can land independently.

Generated with Sulla Desktop