### PR TITLE
fix(agent): remove built-in profile directory dependency

### DIFF
--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -18,6 +18,7 @@ import { resolveAgentIdentity } from '../utils/agentIdentity';
 import { sanitizeConversationContext } from '../utils/conversationContext';
 import { stripProtocolTags, stripProtocolTagsStreaming } from '../utils/stripProtocolTags';
 import { resolveSullaProjectsDir, resolveSullaSkillsDir, resolveSullaAgentsDir, resolveSullaCodebaseDir, findAgentDir, resolveSullaHomeDir, resolveSullaDocsDir } from '../utils/sullaPaths';
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../routines/core/defaultCoreAgent';
 
 import type { BaseThreadState, NodeResult } from './Graph';
 import type { StreamContext } from '../controllers/Extractor';
@@ -613,14 +614,16 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     const templateVars = await getTemplateVariables();
     templateVars['{{agent_name}}'] = agentMeta?.name || agentId || templateVars['{{botName}}'];
     templateVars['{{agent_id}}'] = agentId;
-    templateVars['{{agent_dir}}'] = findAgentDir(agentId) || path.join(resolveSullaAgentsDir(), agentId);
+    templateVars['{{agent_dir}}'] = agentId === DEFAULT_CORE_ROUTINE_AGENT_ID
+      ? ''
+      : findAgentDir(agentId) || path.join(resolveSullaAgentsDir(), agentId);
 
     // Load agent-specific .md files and split into section overrides vs generic prompt
     let agentSectionOverrides = new Map<string, string>();
     let excludeSections = new Set<string>();
     let agentConfig: AgentConfig | null = agentMeta || null;
 
-    if (agentId) {
+    if (agentId && agentId !== DEFAULT_CORE_ROUTINE_AGENT_ID) {
       const agentData = await loadAgentPromptData(agentId);
       if (agentData) {
         agentSectionOverrides = agentData.sectionOverrides;
@@ -967,6 +970,7 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
   protected async shouldInjectObservationsForAgent(state: BaseThreadState): Promise<boolean> {
     const agentId = resolveAgentIdentity(state.metadata);
     if (!agentId) return true;
+    if (agentId === DEFAULT_CORE_ROUTINE_AGENT_ID) return true;
 
     try {
       const agentDir = findAgentDir(agentId);

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -17,6 +17,7 @@ import { CONVERSATION_READER_TOOLS } from '../utils/conversationReaderPolicy';
 import { CONVERSATION_WRITER_TOOLS } from '../utils/conversationWriterPolicy';
 import { buildObserverTranscriptMessage } from '../utils/observerTranscript';
 import { resolveSullaAgentsDir, resolveAllAgentsDirs, findAgentDir } from '../utils/sullaPaths';
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../routines/core/defaultCoreAgent';
 
 export { buildObserverTranscriptMessage } from '../utils/observerTranscript';
 export { CONVERSATION_READER_TOOLS } from '../utils/conversationReaderPolicy';
@@ -1637,11 +1638,10 @@ export async function getAgentIdForTrigger(triggerType: string): Promise<string>
 
   const assigned = triggerMap[triggerType];
   if (assigned) {
-    const agentDir = findAgentDir(assigned);
-    const exists = !!agentDir;
-    console.log(`[GraphRegistry] getAgentIdForTrigger() — trigger "${ triggerType }" mapped to "${ assigned }", dir exists=${ exists }`);
-    // Return the mapped ID whether or not the dir exists — buildAgentState
-    // gracefully handles missing agent dirs (runs with default prompts/tools).
+    // Built-in identities are code/DB-backed. Do not probe the optional
+    // profile directory while resolving a trigger; a deleted override must
+    // not affect production dispatch or review-pool boot.
+    console.log(`[GraphRegistry] getAgentIdForTrigger() — trigger "${ triggerType }" mapped to "${ assigned }"`);
     return assigned;
   }
 
@@ -1849,6 +1849,13 @@ async function loadAgentConfig(agentId: string): Promise<AgentGraphState['metada
   console.log(`[GraphRegistry] loadAgentConfig() — agentId="${ agentId }"`);
   if (!agentId) {
     console.log(`[GraphRegistry] loadAgentConfig() — empty agentId, returning undefined`);
+    return undefined;
+  }
+
+  // The default Sulla Desktop identity is defined by shipped code and
+  // database-backed prompt sections. Its profile directory is optional user
+  // override state, never a prerequisite for graph construction.
+  if (agentId === DEFAULT_CORE_ROUTINE_AGENT_ID) {
     return undefined;
   }
 

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -7,6 +7,7 @@ const verificationPoolStatsMock: any = jest.fn(() => Promise.resolve({ backlog: 
 const findRecoverableInProgressMock: any = jest.fn(() => Promise.resolve([]));
 const recoverOrphanedInProgressMock: any = jest.fn(() => Promise.resolve([]));
 const countRunningMock: any = jest.fn(() => Promise.resolve(0));
+const countByRoleMock: any = jest.fn(() => Promise.resolve({ execution: 0, verification: 0, planning: 0 }));
 const countReviewBacklogMock: any = jest.fn(() => Promise.resolve(0));
 const claimNextMock: any = jest.fn(() => Promise.resolve(null));
 const claimNextReviewMock: any = jest.fn(() => Promise.resolve(null));
@@ -34,6 +35,8 @@ const bindReviewGenerationMock: any = jest.fn();
 const generationHashMock: any = jest.fn(() => 'f'.repeat(64));
 const workflowFindByIdMock: any = jest.fn(() => Promise.resolve({ attributesSnapshot: { enabled: true } }));
 const findAgentDirMock: any = jest.fn(() => '/agents/sulla-desktop');
+const automationEnabledMock: any = jest.fn(() => Promise.resolve(true));
+const resolveLimitMock: any = jest.fn((_scope: string, configured: number) => Promise.resolve(configured));
 
 jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
   SullaSettingsModel: { get: settingsGetMock },
@@ -53,6 +56,7 @@ jest.unstable_mockModule('../../database/models/WorkTaskDispatchModel', () => ({
     findRecoverableInProgress: findRecoverableInProgressMock,
     recoverOrphanedInProgress: recoverOrphanedInProgressMock,
     countRunning:            countRunningMock,
+    countByRole:             countByRoleMock,
     countReviewBacklog:      countReviewBacklogMock,
     claimNext:               claimNextMock,
     claimNextReview:         claimNextReviewMock,
@@ -87,6 +91,16 @@ jest.unstable_mockModule('../GraphRegistry', () => ({
     delete:                graphDeleteMock,
   },
 }));
+jest.unstable_mockModule('../RoutineConcurrencyPolicy', () => ({
+  RoutineConcurrencyPolicy: {
+    isEnabled:     automationEnabledMock,
+    resolveLimit:  resolveLimitMock,
+    reclaimStale:  jest.fn(() => Promise.resolve()),
+    acquire:       jest.fn(() => Promise.resolve('slot')),
+    release:       jest.fn(() => Promise.resolve()),
+    heartbeat:     jest.fn(() => Promise.resolve()),
+  },
+}));
 jest.unstable_mockModule('../GitHubPullRequestHeadService', () => ({
   resolvePullRequestHead:  resolvePullRequestHeadMock,
   resolvePullRequestHeads: resolvePullRequestHeadsMock,
@@ -111,6 +125,7 @@ describe('TaskDispatcherService', () => {
     findRecoverableInProgressMock.mockResolvedValue([]);
     recoverOrphanedInProgressMock.mockResolvedValue([]);
     countRunningMock.mockResolvedValue(0);
+    countByRoleMock.mockResolvedValue({ execution: 0, verification: 0, planning: 0 });
     countReviewBacklogMock.mockResolvedValue(0);
     claimNextMock.mockResolvedValue(null);
     claimNextReviewMock.mockResolvedValue(null);
@@ -133,6 +148,7 @@ describe('TaskDispatcherService', () => {
     recoverPreviousRuntimeMock.mockResolvedValue([]);
     reportCapabilityMock.mockResolvedValue({});
     releaseStageMock.mockResolvedValue(undefined);
+    automationEnabledMock.mockResolvedValue(true);
   });
 
   it('activates verification by default', async() => {
@@ -193,6 +209,7 @@ describe('TaskDispatcherService', () => {
     await service.initialize();
     service.destroy();
     expect(claimNextReviewMock).toHaveBeenCalled();
+    expect(findAgentDirMock).not.toHaveBeenCalled();
     expect(reportCapabilityMock).toHaveBeenCalledWith(expect.objectContaining({
       key: 'in-review-verification', health: 'healthy',
     }));


### PR DESCRIPTION
Closes Projects task HBFz.

Treat built-in sulla-desktop identity as code/DB-backed during trigger and graph resolution. Skip optional profile-directory probes for the built-in identity in GraphRegistry and BaseNode while preserving filesystem-backed overrides for custom agents. Strengthen dispatcher/review-pool boot regression with the profile resolver absent.

Validation: focused TaskDispatcherService directory-absent regression PASS; git diff --check PASS. Full TypeScript lint wrapper attempted but the existing repository lint process was SIGKILLed by the VM.