### PR TITLE
fix(dispatcher): await review workflow completion before releasing dispatch

### DIFF
--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -544,6 +544,25 @@ export class TaskDispatcherService {
         }, timeoutMinutes * 60_000)
         : null;
       const finalState = await graph.execute(state);
+
+      // Single-agent workflow nodes (e.g. node-review-classify) are
+      // dispatched fire-and-forget inside Graph.execute() so interactive
+      // callers (live chat, PlanningCouncilService) can stay responsive
+      // while a background sub-agent call runs and reconnects later via
+      // PlaybookController.triggerPlaybookContinuation. This dispatcher
+      // call has nothing else to do until the review workflow actually
+      // finishes, so wait here for the SAME in-process completion instead
+      // of treating graph.execute()'s premature return as terminal --
+      // otherwise the finally block below deletes the GraphRegistry entry
+      // the background completion needs to reconnect into, and the
+      // workflow orphans (kTJ1: malformed_protected_review_output).
+      if (isVerification && verificationOwner === 'core-routine' && !finalState.metadata?.lastCompletedWorkflow) {
+        const executionId = state.metadata?.activeWorkflow?.executionId;
+        if (executionId) {
+          await this.awaitReviewWorkflowSettlement(executionId, () => verifierTimedOut);
+        }
+      }
+
       if (verifierTimeout) clearTimeout(verifierTimeout);
       const outcome = extractAgentTurnOutcome(finalState);
       const summary = outcome.text.slice(0, 8_000);
@@ -644,6 +663,28 @@ export class TaskDispatcherService {
         this.checkAndDispatch().catch(err => console.error('[TaskDispatcher] Refill check failed:', err));
       }
     }
+  }
+
+  /**
+   * Poll the durable execution record for a dispatcher-driven review
+   * workflow until PlaybookController.releaseWorkflow() has settled it
+   * (WorkflowExecutionModel.settle), or the verifier timeout fires. This
+   * intentionally does not introduce a new drain/poll service -- it only
+   * bridges the one call site (runClaim) that needs a synchronous result
+   * out of Graph.execute()'s fire-and-forget single-agent node dispatch.
+   * The existing pending-completion / continuation machinery is untouched
+   * and already works correctly once given the chance to reconnect.
+   */
+  private async awaitReviewWorkflowSettlement(executionId: string, timedOut: () => boolean): Promise<void> {
+    const { WorkflowExecutionModel } = await import('../database/models/WorkflowExecutionModel');
+    const pollIntervalMs = 1500;
+    while (!timedOut()) {
+      const execution = await WorkflowExecutionModel.find(executionId).catch(() => null);
+      const status = execution?.attributes?.status;
+      if (status === 'completed' || status === 'failed' || status === 'suspended') return;
+      await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+    }
+    console.warn(`[TaskDispatcher] awaitReviewWorkflowSettlement: execution ${ executionId } did not settle before verifier timeout`);
   }
 
   private parseVerification(output: string): ParsedVerification | null {


### PR DESCRIPTION
## Summary
- Fixes the root cause found while investigating why the review workflow (`core-routine-review-project-artifact`) never completes for mechanically dispatched tasks (kTJ1 and others), even though PR #705 and #763 already fixed the separate worker-tool-access bug.
- `TaskDispatcherService.runClaim()` awaited `graph.execute(state)` and treated its return as terminal, but single-agent workflow nodes (e.g. `node-review-classify`) are dispatched fire-and-forget inside `PlaybookController` so interactive callers (live chat, PlanningCouncilService) stay responsive while the sub-agent finishes in the background and reconnects via `triggerPlaybookContinuation`.
- For dispatcher-driven review workflows there is no interactive caller to reconnect to: `runClaim`'s `finally` block deleted the `GraphRegistry` entry immediately after the premature `graph.execute()` return, orphaning the in-flight sub-agent call. The completion still gets written correctly (confirmed via `workflow_pending_completions` -- one stuck row even contained a fully valid, well-formed reviewer verdict), but nothing was left to consume it, so the workflow exhausted its recovery-attempt ceiling and the dispatcher reported `malformed_protected_review_output:workflow_did_not_complete`.
- Root cause was confirmed via direct DB inspection: `node-review-classify` had a 0/33 completion drain rate over 6 days while every other agent-node type (`core-routine-plan-project-task`, `core-routine-dream-about-human`) drained 100%. It traced to `runClaim`'s await-then-delete pattern racing the non-blocking sub-agent dispatch -- not the node's config or prompt.

## Fix (scoped, per direction)
- After `graph.execute()` returns for a core-routine verification dispatch, if the workflow has not already completed synchronously, wait (bounded by the existing verifier timeout) for `WorkflowExecutionModel` to show the execution settled -- the same durable signal `PlaybookController.releaseWorkflow()` already writes once the existing pending-completion/continuation machinery is given the chance to finish.
- No new drain/poll service is introduced. This only bridges the one call site that needs a synchronous result out of an async engine.
- Scoped strictly to `TaskDispatcherService.runClaim()`'s core-routine review path. Interactive chat and `PlanningCouncilService`'s non-blocking fan-out (used by the working Plan workflow) are untouched.

## Validation
- `git diff --check` passes.
- Focused Jest run (`TaskDispatcherService.test.ts`) was attempted but killed by memory pressure (exit 137) in this environment -- consistent with prior PRs against this file reporting the same repo-wide/heavy-suite OOM issue. Not independently re-verified with a passing test run; flagging honestly rather than claiming green.
- Change is small and additive (41 lines, one modified call site + one new private helper), reviewed manually against the actual root-cause code path (`PlaybookController.executeSubAgentWithRetry`, `Graph.execute`, `PlaybookController.releaseWorkflow`) read directly from source.

## Follow-up (not in this PR)
- Would benefit from a regression test that reproduces the race (dispatch a review, assert the workflow settles before `runClaim` returns) once the test suite can run without OOM'ing in this environment.
