### PR TITLE
fix(dispatcher): reclaim stale dispatch leases on every tick, not just at boot

### DIFF
--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -95,7 +95,6 @@ export class TaskDispatcherService {
   private initialized = false;
   private checking = false;
   private schedulerId: ReturnType<typeof setInterval> | null = null;
-  private recoveredOnStart = false;
   private reclaimedReviewsOnStart = 0;
   private active = new Map<string, AbortService>();
   private lastBackpressure: {
@@ -143,7 +142,6 @@ export class TaskDispatcherService {
 
   destroy(): void {
     this.initialized = false;
-    this.recoveredOnStart = false;
     if (this.schedulerId) {
       clearInterval(this.schedulerId);
       this.schedulerId = null;
@@ -174,11 +172,15 @@ export class TaskDispatcherService {
         return;
       }
 
-      if (!this.recoveredOnStart) {
-        const recovered = await WorkTaskDispatchModel.recoverStale();
-        this.recoveredOnStart = true;
-        if (recovered.length > 0) console.warn(`[TaskDispatcher] Recovered ${ recovered.length } orphaned dispatch(es)`);
-      }
+      // Run on every tick, not just once at boot. recoverStale() only
+      // reclaims dispatches silent past its 45-minute heartbeat threshold,
+      // so it's safe to call continuously -- and it must be, since a
+      // dispatch can go dead mid-process-lifetime (a stuck sub-agent call,
+      // a crashed worker) just as easily as it can from a prior restart.
+      // A one-shot startup-only reclaim leaves those permanently stuck for
+      // the rest of the process's uptime with nothing else watching them.
+      const recovered = await WorkTaskDispatchModel.recoverStale();
+      if (recovered.length > 0) console.warn(`[TaskDispatcher] Recovered ${ recovered.length } stale dispatch(es)`);
 
       await this.checkInProgressRecovery();
       const reviewReady = await this.fillVerificationPool();


### PR DESCRIPTION
## Summary
- Fixes a gap Jonathon flagged directly: dead dispatcher leases were not being reclaimed. Confirmed live at the time of writing: 4 execution dispatches sat `running` for 80+ minutes, well past the existing 45-minute stale threshold, holding all 4 WIP slots (`conveyor_health` reported `backpressureReason: stale_leases_holding_slots`).
- `WorkTaskDispatchModel.recoverStale()` already exists and is correct -- it marks dispatches `stale` once their heartbeat has been silent for 45+ minutes and frees the underlying task back to `todo`/`in_review` for redispatch.
- The bug was in when it gets called: `TaskDispatcherService.checkAndDispatch()` only invoked it when `this.recoveredOnStart` was `false`. That flag flips to `true` after the very first tick and never resets until the process exits, so reclaim only ever ran **once per process lifetime**, to clean up dispatches orphaned by a *previous* crash/restart. A dispatch that goes dead *while the process keeps running* (stuck sub-agent call, unhandled exception in a background continuation, etc.) was never caught for the rest of that process's uptime -- exactly the class of failure surfaced by #769 before it was fixed.

## Fix
- Removed the one-shot `recoveredOnStart` gate (field, its `destroy()` reset, and the conditional) and call `recoverStale()` unconditionally on every `checkAndDispatch` tick (every 60s per `CHECK_INTERVAL_MS`).
- `recoverStale()` is already bounded by its own 45-minute heartbeat threshold, so this does not make reclaim more aggressive -- it only makes it continuous instead of once-per-process. Cheap, mostly-empty query on ticks where nothing is stale.

## Validation
- `git diff --check` passes.
- Small, additive/subtractive diff (9 insertions, 7 deletions, all in one file) -- did not attempt a full Jest run given the memory-pressure OOM this environment hit on the previous PR (#769) for the same file; flagging that honestly rather than claiming a test run that did not happen.
- Traced against the actual live DB state (work_task_dispatches heartbeat ages) and the actual call site before making the change, not guessed.

## Follow-up (not in this PR)
- Might be worth a regression test asserting `checkAndDispatch` reclaims a synthetically-staled dispatch on a tick after the first, once the suite can run without OOM'ing here.
