### PR TITLE
fix(dispatcher): route claimNext through lane-entry-workflow claim

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -361,8 +361,38 @@ export class WorkTaskDispatchModel {
       if (!updated.rows[0]) {
         throw new Error(`Atomic dispatch lost task ${ task.id } before execution handoff`);
       }
+      const committed = updated.rows[0];
 
-      return { dispatch: inserted.rows[0], task: updated.rows[0], stage_claim: stageClaim.claim };
+      // Mirror WorkItemsModel.updateTask's status-transition side effects.
+      // Without this, mechanical execution dispatch was a second write path
+      // that bypassed the lane-entry-workflow claim entirely: no project
+      // pipeline workflow bound to the entered lane was ever resolved or
+      // attached, and no work_project_domain_events row was appended, so the
+      // Projects activity/audit trail silently missed every dispatcher-driven
+      // todo -> in_progress transition.
+      const { WorkLaneWorkflowBindingModel } = await import('./WorkLaneWorkflowBindingModel');
+      const laneEntry = await WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction(
+        client, committed.id, committed.status, TASK_ASSIGNEES.dispatcher,
+      );
+      const { createPostgresProjectsRepositories } = await import('../../projects/infrastructure/PostgresProjectsRepositories');
+      await createPostgresProjectsRepositories(client).events.append({
+        id:             `projects-event-${ committed.id }-${ laneEntry.entry.generation }-transition`,
+        taskId:         committed.id,
+        generation:     laneEntry.entry.generation,
+        eventType:      'projects.task.transitioned',
+        idempotencyKey: `projects.task.transitioned:${ committed.id }:${ laneEntry.entry.generation }`,
+        occurredAt:     new Date(),
+        payload:        {
+          actor:         TASK_ASSIGNEES.dispatcher,
+          source:        'dispatcher',
+          fromLane:      task.status,
+          toLane:        committed.status,
+          laneEntryId:   laneEntry.entry.id,
+          laneAutomated: laneEntry.entry.status === 'pending',
+        },
+      });
+
+      return { dispatch: inserted.rows[0], task: committed, stage_claim: stageClaim.claim };
     });
   }
 


### PR DESCRIPTION
## Summary
- Item 3 from the dispatcher stall audit (kTJ1 investigation, comment RV49): `WorkTaskDispatchModel.claimNext()` -- the path that claims a `todo` task for mechanical execution -- flips `work_tasks.status` from `todo` to `in_progress` via a raw SQL `UPDATE`, bypassing the same lane-entry-workflow claim (`WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction`) and `work_project_domain_events` append that `WorkItemsModel.updateTask` performs for every other status transition.
- Effect: mechanically-dispatched execution tasks never resolve or attach a workflow bound to the entered lane (they just get the generic `buildWorkerPrompt()` message), and never emit a `projects.task.transitioned` domain event -- a second, independent write path outside the Projects application facade. This is the same class of legacy-direct-write bypass Phase 7/dHAe strangles out elsewhere in the codebase. It was diagnosed in the kTJ1 investigation thread on 2026-08-25 but never turned into a fix.

## Fix
- Inside `claimNext()`'s existing transaction, immediately after the `work_tasks` status UPDATE commits, call `WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction(client, task.id, 'in_progress', TASK_ASSIGNEES.dispatcher)` and append a `projects.task.transitioned` event via `createPostgresProjectsRepositories(client).events.append(...)`.
- This exactly mirrors the block `WorkItemsModel.updateTask` already runs on every status-changing update (same event shape, same lane-entry claim call) -- no new mechanism introduced.
- Verified live: no project currently has a workflow binding on the `in_progress` lane (`sulla project/list_lane_workflow_bindings` shows bindings only on `todo`, `planning`, `in_review`, `blocked`), so this has no visible behavior change today. It closes the audit/consistency gap immediately and makes an execution-stage workflow binding actually take effect the moment one is configured, instead of being silently ignored.
- Scoped to this one call site -- `claimNextReview` (the review-claim path) already goes through the core-routine/playbook path and is untouched.

## Validation
- `git diff --check` passes.
- Small, additive diff (32 insertions, 2 deletions, one file).
- Could not run the Jest suite in this environment -- the `jest` binary is not present in this worktree's `node_modules/.bin` (partial/incomplete install), consistent with the test-tooling limitations already flagged honestly on #769 and #770 for this same directory. Verified correctness by direct line-by-line comparison against the working, already-shipped sibling pattern in `WorkItemsModel.updateTask` (same event shape, same lane-entry-claim call, same transaction placement) rather than by a passing test run.

## Follow-up (not in this PR)
- Attaching the resolved workflow as the dispatched worker's `activeWorkflow` (so an execution-stage binding doesn't just get recorded but actually drives the worker via a playbook, the way `fillReviewPool` already does for review) is a separate, larger behavioral change and is intentionally not included here -- there is no live binding to exercise it against yet.
- Would benefit from a regression test asserting `claimNext` creates a `work_lane_entry_automations` row and a `work_project_domain_events` row, once the suite can run in this environment.
