### PR TITLE
feat: add database-backed agent definitions

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0089_create_agent_definitions.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0089_create_agent_definitions.ts
@@ -1,0 +1,38 @@
+/** Canonical database storage for marketplace-backed agent definitions.
+ *
+ * Runtime agent resolution reads this table. The legacy
+ * ~/sulla/resources/agents/<slug>/ bundle remains an import/export format only.
+ */
+export const up = `
+  CREATE TABLE IF NOT EXISTS agent_definitions (
+    id                    TEXT PRIMARY KEY,
+    slug                  TEXT NOT NULL UNIQUE,
+    name                  TEXT NOT NULL,
+    description           TEXT NOT NULL DEFAULT '',
+    system_prompt         TEXT NOT NULL DEFAULT '',
+    soul_content          TEXT NOT NULL DEFAULT '',
+    allowed_tools         TEXT[] NOT NULL DEFAULT '{}',
+    skill_refs            TEXT[] NOT NULL DEFAULT '{}',
+    routine_refs          TEXT[] NOT NULL DEFAULT '{}',
+    model_priority        JSONB NOT NULL DEFAULT '[]'::jsonb,
+    version               TEXT,
+    status                TEXT NOT NULL DEFAULT 'draft'
+                          CHECK (status IN ('draft', 'production', 'archive')),
+    enabled               BOOLEAN NOT NULL DEFAULT true,
+    source_template_slug  TEXT,
+    content_hash          TEXT,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT agent_definitions_model_priority_array
+      CHECK (jsonb_typeof(model_priority) = 'array')
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_agent_definitions_status
+    ON agent_definitions (status);
+  CREATE INDEX IF NOT EXISTS idx_agent_definitions_enabled
+    ON agent_definitions (enabled);
+`;
+
+export const down = `
+  DROP TABLE IF EXISTS agent_definitions CASCADE;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0089_create_agent_definitions.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0089_create_agent_definitions.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { down, up } from '../0089_create_agent_definitions';
+
+describe('0089 create agent definitions migration', () => {
+  it('stores the runtime definition fields and marketplace lifecycle state', () => {
+    expect(up).toContain('CREATE TABLE IF NOT EXISTS agent_definitions');
+    expect(up).toContain('system_prompt');
+    expect(up).toContain('soul_content');
+    expect(up).toContain('allowed_tools         TEXT[]');
+    expect(up).toContain('skill_refs            TEXT[]');
+    expect(up).toContain('routine_refs          TEXT[]');
+    expect(up).toContain('model_priority        JSONB');
+    expect(up).toContain("CHECK (status IN ('draft', 'production', 'archive'))");
+    expect(up).toContain('jsonb_typeof(model_priority) = \'array\'');
+  });
+
+  it('is reversible and does not seed agent data', () => {
+    expect(up).not.toContain('INSERT INTO');
+    expect(down).toContain('DROP TABLE IF EXISTS agent_definitions');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -75,6 +75,7 @@ import { up as up_0085, down as down_0085 } from './0085_add_conveyor_metrics_in
 import { up as up_0086, down as down_0086 } from './0086_create_projects_domain_event_outbox';
 import { up as up_0087, down as down_0087 } from './0087_create_project_pipeline_templates';
 import { up as up_0088, down as down_0088 } from './0088_add_generation_to_artifact_receipts';
+import { up as up_0089, down as down_0089 } from './0089_create_agent_definitions';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -151,4 +152,5 @@ export const migrationsRegistry = [
   { name: '0086_create_projects_domain_event_outbox',              up: up_0086, down: down_0086 },
   { name: '0087_create_project_pipeline_templates',                 up: up_0087, down: down_0087 },
   { name: '0088_add_generation_to_artifact_receipts',                up: up_0088, down: down_0088 },
+  { name: '0089_create_agent_definitions',                           up: up_0089, down: down_0089 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/AgentDefinitionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/AgentDefinitionModel.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from 'node:crypto';
+
+import { postgresClient } from '../PostgresClient';
+
+export type AgentDefinitionStatus = 'draft' | 'production' | 'archive';
+
+export interface ModelPriorityEntry {
+  provider: string;
+  model:    string;
+}
+
+export interface AgentDefinition {
+  id:                   string;
+  slug:                 string;
+  name:                 string;
+  description:          string;
+  system_prompt:        string;
+  soul_content:         string;
+  allowed_tools:        string[];
+  skill_refs:           string[];
+  routine_refs:         string[];
+  model_priority:       ModelPriorityEntry[];
+  version:              string | null;
+  status:               AgentDefinitionStatus;
+  enabled:              boolean;
+  source_template_slug: string | null;
+  content_hash:         string | null;
+  created_at:           string;
+  updated_at:           string;
+}
+
+export interface AgentDefinitionInput {
+  slug:                string;
+  name:                string;
+  description?:       string;
+  systemPrompt?:      string;
+  soulContent?:        string;
+  allowedTools?:      string[];
+  skillRefs?:         string[];
+  routineRefs?:       string[];
+  modelPriority?:     ModelPriorityEntry[];
+  version?:            string | null;
+  status?:             AgentDefinitionStatus;
+  enabled?:            boolean;
+  sourceTemplateSlug?: string | null;
+  contentHash?:        string | null;
+}
+
+export interface AgentDefinitionPatch {
+  name?:               string;
+  description?:        string;
+  systemPrompt?:       string;
+  soulContent?:         string;
+  allowedTools?:       string[];
+  skillRefs?:           string[];
+  routineRefs?:        string[];
+  modelPriority?:      ModelPriorityEntry[];
+  version?:             string | null;
+  status?:              AgentDefinitionStatus;
+  enabled?:             boolean;
+  sourceTemplateSlug?: string | null;
+  contentHash?:        string | null;
+}
+
+function toStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(item => String(item).trim()).filter(Boolean) : [];
+}
+
+function toModelPriority(value: unknown): ModelPriorityEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.map(entry => ({
+    provider: String(entry?.provider ?? '').trim(),
+    model:    String(entry?.model ?? '').trim(),
+  })).filter(entry => entry.provider && entry.model);
+}
+
+function toIso(value: unknown): string {
+  return value instanceof Date ? value.toISOString() : String(value ?? '');
+}
+
+function rowToDefinition(row: any): AgentDefinition {
+  return {
+    id:                   String(row.id),
+    slug:                 String(row.slug),
+    name:                 String(row.name),
+    description:          String(row.description ?? ''),
+    system_prompt:        String(row.system_prompt ?? ''),
+    soul_content:         String(row.soul_content ?? ''),
+    allowed_tools:        toStringArray(row.allowed_tools),
+    skill_refs:           toStringArray(row.skill_refs),
+    routine_refs:         toStringArray(row.routine_refs),
+    model_priority:       toModelPriority(row.model_priority),
+    version:              row.version == null ? null : String(row.version),
+    status:               row.status as AgentDefinitionStatus,
+    enabled:              row.enabled !== false,
+    source_template_slug: row.source_template_slug == null ? null : String(row.source_template_slug),
+    content_hash:         row.content_hash == null ? null : String(row.content_hash),
+    created_at:           toIso(row.created_at),
+    updated_at:           toIso(row.updated_at),
+  };
+}
+
+function required(value: string, field: string): string {
+  const normalized = String(value ?? '').trim();
+  if (!normalized) throw new Error(`${ field } is required.`);
+  return normalized;
+}
+
+function validateModelPriority(entries: ModelPriorityEntry[] = []): ModelPriorityEntry[] {
+  return entries.map(entry => ({
+    provider: required(entry.provider, 'model_priority.provider'),
+    model:    required(entry.model, 'model_priority.model'),
+  }));
+}
+
+export class AgentDefinitionModel {
+  static async get(id: string): Promise<AgentDefinition | null> {
+    const row = await postgresClient.queryOne('SELECT * FROM agent_definitions WHERE id = $1 LIMIT 1', [id]);
+    return row ? rowToDefinition(row) : null;
+  }
+
+  static async findBySlug(slug: string): Promise<AgentDefinition | null> {
+    const row = await postgresClient.queryOne('SELECT * FROM agent_definitions WHERE slug = $1 LIMIT 1', [slug]);
+    return row ? rowToDefinition(row) : null;
+  }
+
+  static async list(status?: AgentDefinitionStatus): Promise<AgentDefinition[]> {
+    const rows = status
+      ? await postgresClient.query('SELECT * FROM agent_definitions WHERE status = $1 ORDER BY name ASC, slug ASC', [status])
+      : await postgresClient.query('SELECT * FROM agent_definitions ORDER BY name ASC, slug ASC', []);
+    return rows.map(rowToDefinition);
+  }
+
+  static async create(input: AgentDefinitionInput): Promise<AgentDefinition> {
+    const slug = required(input.slug, 'slug');
+    const name = required(input.name, 'name');
+    const row = await postgresClient.queryOne(`
+      INSERT INTO agent_definitions (
+        id, slug, name, description, system_prompt, soul_content,
+        allowed_tools, skill_refs, routine_refs, model_priority,
+        version, status, enabled, source_template_slug, content_hash
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11,$12,$13,$14,$15)
+      RETURNING *
+    `, [
+      `agent-${ randomUUID() }`, slug, name, input.description ?? '', input.systemPrompt ?? '', input.soulContent ?? '',
+      toStringArray(input.allowedTools), toStringArray(input.skillRefs), toStringArray(input.routineRefs),
+      JSON.stringify(validateModelPriority(input.modelPriority)), input.version ?? null,
+      input.status ?? 'draft', input.enabled !== false, input.sourceTemplateSlug ?? null, input.contentHash ?? null,
+    ]);
+    if (!row) throw new Error(`Failed to create agent definition ${ slug }.`);
+    return rowToDefinition(row);
+  }
+
+  static async update(id: string, patch: AgentDefinitionPatch): Promise<AgentDefinition | null> {
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    const add = (column: string, value: unknown, cast = '') => {
+      sets.push(`${ column } = $${ params.length + 1 }${ cast }`);
+      params.push(value);
+    };
+    if (patch.name !== undefined) add('name', required(patch.name, 'name'));
+    if (patch.description !== undefined) add('description', patch.description);
+    if (patch.systemPrompt !== undefined) add('system_prompt', patch.systemPrompt);
+    if (patch.soulContent !== undefined) add('soul_content', patch.soulContent);
+    if (patch.allowedTools !== undefined) add('allowed_tools', toStringArray(patch.allowedTools));
+    if (patch.skillRefs !== undefined) add('skill_refs', toStringArray(patch.skillRefs));
+    if (patch.routineRefs !== undefined) add('routine_refs', toStringArray(patch.routineRefs));
+    if (patch.modelPriority !== undefined) add('model_priority', JSON.stringify(validateModelPriority(patch.modelPriority)), '::jsonb');
+    if (patch.version !== undefined) add('version', patch.version);
+    if (patch.status !== undefined) add('status', patch.status);
+    if (patch.enabled !== undefined) add('enabled', patch.enabled);
+    if (patch.sourceTemplateSlug !== undefined) add('source_template_slug', patch.sourceTemplateSlug);
+    if (patch.contentHash !== undefined) add('content_hash', patch.contentHash);
+    if (sets.length === 0) return AgentDefinitionModel.get(id);
+    sets.push('updated_at = now()');
+    params.push(id);
+    const row = await postgresClient.queryOne(`UPDATE agent_definitions SET ${ sets.join(', ') } WHERE id = $${ params.length } RETURNING *`, params);
+    return row ? rowToDefinition(row) : null;
+  }
+
+  static async setStatus(id: string, status: AgentDefinitionStatus): Promise<AgentDefinition | null> {
+    return AgentDefinitionModel.update(id, { status });
+  }
+
+  static async delete(id: string): Promise<boolean> {
+    const row = await postgresClient.queryOne('DELETE FROM agent_definitions WHERE id = $1 RETURNING id', [id]);
+    return !!row;
+  }
+}

--- a/pkg/rancher-desktop/agent/index.ts
+++ b/pkg/rancher-desktop/agent/index.ts
@@ -19,6 +19,15 @@ export type { MarketplaceEntry, InstalledExtension } from './services/ExtensionS
 
 // Models
 export { AgentPersonaService } from './database/models/AgentPersonaModel';
+export { AgentDefinitionModel } from './database/models/AgentDefinitionModel';
+export type {
+  AgentDefinition,
+  AgentDefinitionInput,
+  AgentDefinitionPatch,
+  AgentDefinitionStatus,
+  ModelPriorityEntry,
+} from './database/models/AgentDefinitionModel';
+export { AgentDefinitionService, agentDefinitionService } from './services/AgentDefinitionService';
 export type {
   PersonaTemplateId,
   PersonaStatus,

--- a/pkg/rancher-desktop/agent/services/AgentDefinitionService.ts
+++ b/pkg/rancher-desktop/agent/services/AgentDefinitionService.ts
@@ -1,0 +1,20 @@
+import {
+  AgentDefinitionModel,
+  type AgentDefinition,
+  type AgentDefinitionInput,
+  type AgentDefinitionPatch,
+  type AgentDefinitionStatus,
+} from '../database/models/AgentDefinitionModel';
+
+/** Runtime-facing facade for database-backed agent definitions. */
+export class AgentDefinitionService {
+  get(id: string): Promise<AgentDefinition | null> { return AgentDefinitionModel.get(id) }
+  findBySlug(slug: string): Promise<AgentDefinition | null> { return AgentDefinitionModel.findBySlug(slug) }
+  list(status?: AgentDefinitionStatus): Promise<AgentDefinition[]> { return AgentDefinitionModel.list(status) }
+  create(input: AgentDefinitionInput): Promise<AgentDefinition> { return AgentDefinitionModel.create(input) }
+  update(id: string, patch: AgentDefinitionPatch): Promise<AgentDefinition | null> { return AgentDefinitionModel.update(id, patch) }
+  setStatus(id: string, status: AgentDefinitionStatus): Promise<AgentDefinition | null> { return AgentDefinitionModel.setStatus(id, status) }
+  delete(id: string): Promise<boolean> { return AgentDefinitionModel.delete(id) }
+}
+
+export const agentDefinitionService = new AgentDefinitionService();


### PR DESCRIPTION
## Summary
- add migration 0089 for canonical `agent_definitions` storage
- add CRUD model with normalized tool/skill/routine refs and ordered provider/model priority
- add runtime service facade and public exports
- keep filesystem agent bundles as import/export only; no UI or runtime filesystem changes

## Validation
- `node --experimental-vm-modules node_modules/jest/bin/jest.js pkg/rancher-desktop/agent/database/migrations/__tests__/0089_create_agent_definitions.test.ts pkg/rancher-desktop/agent/database/migrations/__tests__/registry.test.ts --runInBand` — 2 suites, 3 tests passed
- targeted ESLint — 0 errors, 11 interface-alignment warnings
- `git diff --check` — passed
- broad `tsconfig.agent-check.json` remains blocked by pre-existing unrelated repository errors (missing historical migration imports, test signature drift, optional Discord typings, and other baseline failures)