### PR TITLE
fix(dispatcher): watchdog ticks and recover-safe initialization

### DIFF
--- a/pkg/rancher-desktop/agent/database/PostgresClient.ts
+++ b/pkg/rancher-desktop/agent/database/PostgresClient.ts
@@ -1,5 +1,7 @@
 // PostgresClient.ts — upgraded to pg.Pool + proper shutdown
 
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import { Pool, PoolClient, QueryResult, QueryResultRow } from 'pg';
 
 import { SullaSettingsModel } from './models/SullaSettingsModel';
@@ -8,6 +10,7 @@ export class PostgresClient {
   private pool: Pool | null = null;
   private connected = false;
   private shuttingDown = false;
+  private statementTimeout = new AsyncLocalStorage<number>();
 
   get isShuttingDown(): boolean {
     return this.shuttingDown;
@@ -76,16 +79,35 @@ export class PostgresClient {
     return this.pool!.connect();
   }
 
+  async withStatementTimeout<T>(timeoutMs: number, callback: () => Promise<T>): Promise<T> {
+    const boundedTimeoutMs = Math.max(1, Math.floor(timeoutMs));
+
+    return this.statementTimeout.run(boundedTimeoutMs, callback);
+  }
+
+  private async applyStatementTimeout(client: PoolClient, local: boolean): Promise<boolean> {
+    const timeoutMs = this.statementTimeout.getStore();
+    if (!timeoutMs) return false;
+    await client.query("SELECT set_config('statement_timeout', $1, $2)", [`${ timeoutMs }ms`, local]);
+    return true;
+  }
+
   async queryWithResult<T extends QueryResultRow = any>(text: string, params: any[] = []): Promise<QueryResult<T>> {
     if (this.shuttingDown) {
       return { rows: [], rowCount: 0, command: '', oid: 0, fields: [] } as unknown as QueryResult<T>;
     }
     const client = await this.getClient();
+    let timeoutApplied = false;
     try {
+      timeoutApplied = await this.applyStatementTimeout(client, false);
       const res = await client.query(text, params);
       return res;
     } finally {
-      client.release();
+      try {
+        if (timeoutApplied) await client.query('RESET statement_timeout');
+      } finally {
+        client.release();
+      }
     }
   }
 
@@ -94,11 +116,17 @@ export class PostgresClient {
       return [];
     }
     const client = await this.getClient();
+    let timeoutApplied = false;
     try {
+      timeoutApplied = await this.applyStatementTimeout(client, false);
       const res = await client.query(text, params);
       return res.rows;
     } finally {
-      client.release();
+      try {
+        if (timeoutApplied) await client.query('RESET statement_timeout');
+      } finally {
+        client.release();
+      }
     }
   }
 
@@ -115,6 +143,7 @@ export class PostgresClient {
     const client = await this.getClient();
     try {
       await client.query('BEGIN');
+      await this.applyStatementTimeout(client, true);
       const result = await callback(client);
       await client.query('COMMIT');
       return result;
@@ -155,7 +184,7 @@ export class PostgresClient {
           throw new Error(`PostgreSQL not reachable after ${ maxAttempts } attempts`);
         }
         console.log(`[PostgresClient] waitForReady attempt ${ i }/${ maxAttempts } failed, retrying...`);
-        await new Promise(r => setTimeout(r, intervalMs));
+        await new Promise(resolve => setTimeout(resolve, intervalMs));
       } finally {
         try { await probe?.end() } catch { /* ignore */ }
       }

--- a/pkg/rancher-desktop/agent/database/__tests__/PostgresClient.statement-timeout.test.ts
+++ b/pkg/rancher-desktop/agent/database/__tests__/PostgresClient.statement-timeout.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { PostgresClient } from '../PostgresClient';
+
+describe('PostgresClient statement timeout scope', () => {
+  it('sets and resets a timeout around a direct query', async() => {
+    const poolClient = {
+      query:   jest.fn((sql: string) => Promise.resolve({ rows: sql === 'SELECT 42' ? [{ value: 42 }] : [] })),
+      release: jest.fn(),
+    };
+    const postgres = new PostgresClient();
+
+    jest.spyOn(postgres, 'getClient').mockResolvedValue(poolClient as any);
+    const rows = await postgres.withStatementTimeout(30_000, () => postgres.query<{ value: number }>('SELECT 42'));
+
+    expect(rows).toEqual([{ value: 42 }]);
+    expect(poolClient.query.mock.calls).toEqual([
+      ["SELECT set_config('statement_timeout', $1, $2)", ['30000ms', false]],
+      ['SELECT 42', []],
+      ['RESET statement_timeout'],
+    ]);
+    expect(poolClient.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a transaction-local timeout for transaction callbacks', async() => {
+    const poolClient = {
+      query:   jest.fn(() => Promise.resolve({ rows: [] })),
+      release: jest.fn(),
+    };
+    const postgres = new PostgresClient();
+
+    jest.spyOn(postgres, 'getClient').mockResolvedValue(poolClient as any);
+    await postgres.withStatementTimeout(15_000, () => postgres.transaction(async(client) => {
+      await client.query('SELECT 1');
+    }));
+
+    expect(poolClient.query.mock.calls).toEqual([
+      ['BEGIN'],
+      ["SELECT set_config('statement_timeout', $1, $2)", ['15000ms', true]],
+      ['SELECT 1'],
+      ['COMMIT'],
+    ]);
+    expect(poolClient.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -39,6 +39,8 @@ const DEFAULT_VERIFIER_TIMEOUT_MINUTES = 45;
 const DEFAULT_IN_PROGRESS_STALE_MINUTES = 360;
 const DEFAULT_RECOVERY_BATCH_SIZE = 1;
 const DEFAULT_RECOVERY_RETRY_CEILING = 3;
+const DEFAULT_TICK_TIMEOUT_MS = 5 * 60_000;
+const LINKED_PR_REQUEST_TIMEOUT_MS = 30_000;
 const LEGACY_VERIFIER_TOOLS = [
   'file_search', 'read_file',
   'git_status', 'git_diff', 'git_log', 'git_blame',
@@ -93,9 +95,13 @@ export function getTaskDispatcherService(): TaskDispatcherService {
  */
 export class TaskDispatcherService {
   private initialized = false;
-  private checking = false;
+  private tickGeneration = 0;
+  private activeTickGeneration: number | null = null;
+  private activeTickStartedAt: string | null = null;
+  private tickWedgeCount = 0;
+  private lastTickError: string | null = null;
   private schedulerId: ReturnType<typeof setInterval> | null = null;
-  private reclaimedReviewsOnStart = 0;
+  private reclaimedReviews = 0;
   private active = new Map<string, AbortService>();
   private lastBackpressure: {
     limits:   WipLimits;
@@ -106,19 +112,16 @@ export class TaskDispatcherService {
 
   async initialize(): Promise<void> {
     if (this.initialized) return;
-    this.initialized = true;
 
-    await LifecycleCapabilityModel.recoverPreviousRuntime('todo-execution', RUNTIME_INSTANCE_ID);
-    const recoveredReviewClaims = await LifecycleCapabilityModel.recoverPreviousRuntime(
-      'in-review-verification', RUNTIME_INSTANCE_ID,
-    );
-    this.reclaimedReviewsOnStart = (await WorkTaskDispatchModel.recoverOrphanedVerification(
-      recoveredReviewClaims,
-    )).length;
-    await this.checkAndDispatch();
+    // Arm the scheduler before any recovery or first tick can fail. The
+    // initialized flag is truthful only after the scheduler exists, so a
+    // failed first pass can recover on the next interval instead of bricking
+    // the service behind a one-shot initialization gate.
     this.schedulerId = setInterval(() => {
       this.checkAndDispatch().catch(err => console.error('[TaskDispatcher] Scheduled check failed:', err));
     }, CHECK_INTERVAL_MS);
+    this.initialized = true;
+    await this.checkAndDispatch();
     console.log('[TaskDispatcher] Mechanical dispatcher initialized');
   }
 
@@ -142,6 +145,8 @@ export class TaskDispatcherService {
 
   destroy(): void {
     this.initialized = false;
+    this.activeTickGeneration = null;
+    this.activeTickStartedAt = null;
     if (this.schedulerId) {
       clearInterval(this.schedulerId);
       this.schedulerId = null;
@@ -151,9 +156,61 @@ export class TaskDispatcherService {
   }
 
   private async checkAndDispatch(): Promise<void> {
-    if (!this.initialized || this.checking) return;
-    this.checking = true;
+    if (!this.initialized || this.activeTickGeneration !== null) return;
+    const generation = ++this.tickGeneration;
+    this.activeTickGeneration = generation;
+    this.activeTickStartedAt = new Date().toISOString();
+    this.lastTickError = null;
+    let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
     try {
+      // Read the setting inside the guarded section too: a stalled settings
+      // read is itself a tick-path failure and must release the gate.
+      const tickTimeoutMs = await this.getTickTimeoutMs();
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutTimer = setTimeout(() => reject(new Error(`dispatcher tick ${ generation } exceeded ${ tickTimeoutMs }ms deadline`)), tickTimeoutMs);
+      });
+      await Promise.race([this.runTick(), timeout]);
+    } catch (err) {
+      const timedOut = err instanceof Error && err.message.includes('exceeded') && err.message.includes('deadline');
+      if (timedOut) {
+        this.tickWedgeCount += 1;
+        console.error('[TaskDispatcher] Tick watchdog expired; releasing tick gate', {
+          generation, startedAt: this.activeTickStartedAt, tickTimeoutMs, wedgeCount: this.tickWedgeCount,
+        });
+      } else {
+        this.lastTickError = err instanceof Error ? err.message : String(err);
+        console.error('[TaskDispatcher] Dispatch check failed:', err);
+      }
+      await this.reportTickHealth(timedOut ? 'degraded' : 'degraded', this.lastTickError ?? (timedOut ? 'tick deadline exceeded' : undefined));
+    } finally {
+      if (timeoutTimer) clearTimeout(timeoutTimer);
+      // An expired tick's promise may eventually settle. It must never clear
+      // the gate belonging to a newer generation.
+      if (this.activeTickGeneration === generation) {
+        this.activeTickGeneration = null;
+        this.activeTickStartedAt = null;
+      }
+    }
+  }
+
+  private async getTickTimeoutMs(): Promise<number> {
+    const configured = Number(await Promise.race([
+      SullaSettingsModel.get('taskDispatcherTickTimeoutMs', DEFAULT_TICK_TIMEOUT_MS),
+      new Promise(resolve => setTimeout(() => resolve(DEFAULT_TICK_TIMEOUT_MS), 1000)),
+    ]));
+    return Math.max(1000, configured || DEFAULT_TICK_TIMEOUT_MS);
+  }
+
+  private async runTick(): Promise<void> {
+    try {
+      const recoveredReviewClaims = await LifecycleCapabilityModel.recoverPreviousRuntime(
+        'in-review-verification', RUNTIME_INSTANCE_ID,
+      );
+      this.reclaimedReviews += (await WorkTaskDispatchModel.recoverOrphanedVerification(
+        recoveredReviewClaims,
+      )).length;
+      await LifecycleCapabilityModel.recoverPreviousRuntime('todo-execution', RUNTIME_INSTANCE_ID);
+
       // The dispatcher is an independent system from the conversational Heartbeat
       // agent (Jonathon, 2026-08-25) -- it must not read heartbeatEnabled/heartbeatWindow.
       // Its own master switch is automatedProjectManagementEnabled (RoutineConcurrencyPolicy),
@@ -218,8 +275,9 @@ export class TaskDispatcherService {
         return;
       }
       await this.fillExecutionPool();
+      await this.reportTickHealth('healthy');
     } catch (err) {
-      console.error('[TaskDispatcher] Dispatch check failed:', err);
+      this.lastTickError = err instanceof Error ? err.message : String(err);
       await LifecycleCapabilityModel.report({
         key:               'todo-execution',
         enabled:           true,
@@ -227,11 +285,24 @@ export class TaskDispatcherService {
         owner:             'dispatcher',
         runtimeInstanceId: RUNTIME_INSTANCE_ID,
         fallbackMode:      'heartbeat',
-        error:             err instanceof Error ? err.message : String(err),
+        error:             this.lastTickError,
       }).catch(reportErr => console.error('[TaskDispatcher] Capability report failed:', reportErr));
-    } finally {
-      this.checking = false;
     }
+  }
+
+  private async reportTickHealth(health: 'healthy' | 'degraded', error?: string): Promise<void> {
+    await LifecycleCapabilityModel.report({
+      key: 'todo-execution', enabled: this.initialized, health,
+      owner: this.initialized ? 'dispatcher' : null, runtimeInstanceId: RUNTIME_INSTANCE_ID,
+      fallbackMode: 'heartbeat', error,
+      details: {
+        tickGeneration: this.tickGeneration,
+        activeTickGeneration: this.activeTickGeneration,
+        activeTickStartedAt: this.activeTickStartedAt,
+        tickWedgeCount: this.tickWedgeCount,
+        lastTickError: this.lastTickError,
+      },
+    });
   }
 
   private async checkInProgressRecovery(): Promise<void> {
@@ -291,6 +362,7 @@ export class TaskDispatcherService {
       const octokit = new Octokit({ auth: token.value });
       const { data } = await octokit.pulls.get({
         owner: match[1], repo: match[2], pull_number: Number(match[3]),
+        request: { timeout: LINKED_PR_REQUEST_TIMEOUT_MS },
       });
       return data.state === 'open';
     } catch (err: any) {
@@ -351,7 +423,7 @@ export class TaskDispatcherService {
         owner:             null,
         runtimeInstanceId: RUNTIME_INSTANCE_ID,
         fallbackMode:      'manual_hold',
-        details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviewsOnStart },
+        details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviews },
       });
       return false;
     }
@@ -365,7 +437,7 @@ export class TaskDispatcherService {
         runtimeInstanceId: RUNTIME_INSTANCE_ID,
         fallbackMode:      'manual_hold',
         error:             'Protected review routine, rollout, or default agent is unavailable.',
-        details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviewsOnStart },
+        details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviews },
       });
       return false;
     }
@@ -382,7 +454,7 @@ export class TaskDispatcherService {
       owner:             'dispatcher',
       runtimeInstanceId: RUNTIME_INSTANCE_ID,
       fallbackMode:      'heartbeat',
-      details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviewsOnStart },
+      details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviews },
     });
 
     let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning('verification'));
@@ -418,7 +490,7 @@ export class TaskDispatcherService {
       owner:             'dispatcher',
       runtimeInstanceId: RUNTIME_INSTANCE_ID,
       fallbackMode:      'manual_hold',
-      details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviewsOnStart },
+      details:           { ...(await WorkTaskDispatchModel.verificationPoolStats()), reclaimed: this.reclaimedReviews },
     });
     return true;
   }

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -1,14 +1,16 @@
 import { Octokit } from '@octokit/rest';
 
 import { AbortService } from './AbortService';
-import { resolvePullRequestHead, resolvePullRequestHeads } from './GitHubPullRequestHeadService';
-import { GraphRegistry } from './GraphRegistry';
-import { LifecycleCapabilityModel } from '../database/models/LifecycleCapabilityModel';
-import { getIntegrationService } from './IntegrationService';
-import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
-import { RoutineConcurrencyPolicy } from './RoutineConcurrencyPolicy';
 import { ArtifactCustodyPolicy } from './ArtifactCustodyPolicy';
 import { buildReceipt, renderReceiptComment } from './ArtifactReceiptService';
+import { resolvePullRequestHead, resolvePullRequestHeads } from './GitHubPullRequestHeadService';
+import { GraphRegistry } from './GraphRegistry';
+import { getIntegrationService } from './IntegrationService';
+import { resolveWipLimits, evaluateClaim, type WipLimits, type RoleCounts, type BackpressureDecision } from './ProjectAutomationWipLimits';
+import { RoutineConcurrencyPolicy } from './RoutineConcurrencyPolicy';
+import { postgresClient } from '../database/PostgresClient';
+import { LifecycleCapabilityModel } from '../database/models/LifecycleCapabilityModel';
+import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { WorkItemsModel, type WorkTaskRecord } from '../database/models/WorkItemsModel';
 import {
   WorkTaskDispatchModel,
@@ -19,14 +21,13 @@ import {
   type ReviewDisposition,
   type VerificationVerdict,
 } from '../database/models/WorkTaskDispatchModel';
-import { resolveWipLimits, evaluateClaim, type WipLimits, type RoleCounts, type BackpressureDecision } from './ProjectAutomationWipLimits';
 import { WorkflowModel } from '../database/models/WorkflowModel';
+import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../routines/core/defaultCoreAgent';
 import {
   REVIEW_PROJECT_ARTIFACT_DEFINITION,
   REVIEW_PROJECT_ARTIFACT_ID,
   ARTIFACT_VERIFICATION_ADAPTERS,
 } from '../routines/core/reviewProjectArtifact';
-import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../routines/core/defaultCoreAgent';
 import { extractAgentTurnOutcome } from '../tools/agents/agentTurnOutcome';
 import { toolRegistry } from '../tools/registry';
 import { createPlaybookState } from '../workflow/WorkflowPlaybook';
@@ -40,6 +41,7 @@ const DEFAULT_IN_PROGRESS_STALE_MINUTES = 360;
 const DEFAULT_RECOVERY_BATCH_SIZE = 1;
 const DEFAULT_RECOVERY_RETRY_CEILING = 3;
 const DEFAULT_TICK_TIMEOUT_MS = 5 * 60_000;
+const DEFAULT_TICK_QUERY_TIMEOUT_MS = 30_000;
 const LINKED_PR_REQUEST_TIMEOUT_MS = 30_000;
 const LEGACY_VERIFIER_TOOLS = [
   'file_search', 'read_file',
@@ -162,26 +164,28 @@ export class TaskDispatcherService {
     this.activeTickStartedAt = new Date().toISOString();
     this.lastTickError = null;
     let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+    let tickTimeoutMs = DEFAULT_TICK_TIMEOUT_MS;
+    let healthError: string | null = null;
     try {
       // Read the setting inside the guarded section too: a stalled settings
       // read is itself a tick-path failure and must release the gate.
-      const tickTimeoutMs = await this.getTickTimeoutMs();
-      const timeout = new Promise<never>((_, reject) => {
+      tickTimeoutMs = await this.getTickTimeoutMs();
+      const timeout = new Promise<never>((_resolve, reject) => {
         timeoutTimer = setTimeout(() => reject(new Error(`dispatcher tick ${ generation } exceeded ${ tickTimeoutMs }ms deadline`)), tickTimeoutMs);
       });
-      await Promise.race([this.runTick(), timeout]);
+      await Promise.race([this.runTick(generation), timeout]);
     } catch (err) {
       const timedOut = err instanceof Error && err.message.includes('exceeded') && err.message.includes('deadline');
+      healthError = timedOut ? 'tick deadline exceeded' : err instanceof Error ? err.message : String(err);
+      this.lastTickError = healthError;
       if (timedOut) {
         this.tickWedgeCount += 1;
         console.error('[TaskDispatcher] Tick watchdog expired; releasing tick gate', {
           generation, startedAt: this.activeTickStartedAt, tickTimeoutMs, wedgeCount: this.tickWedgeCount,
         });
       } else {
-        this.lastTickError = err instanceof Error ? err.message : String(err);
         console.error('[TaskDispatcher] Dispatch check failed:', err);
       }
-      await this.reportTickHealth(timedOut ? 'degraded' : 'degraded', this.lastTickError ?? (timedOut ? 'tick deadline exceeded' : undefined));
     } finally {
       if (timeoutTimer) clearTimeout(timeoutTimer);
       // An expired tick's promise may eventually settle. It must never clear
@@ -190,6 +194,12 @@ export class TaskDispatcherService {
         this.activeTickGeneration = null;
         this.activeTickStartedAt = null;
       }
+    }
+    // Capability reporting is also database-backed. Release the tick gate
+    // before awaiting it so a wedged report cannot disable future ticks.
+    if (healthError) {
+      await this.reportTickHealth('degraded', healthError)
+        .catch(reportErr => console.error('[TaskDispatcher] Tick health report failed:', reportErr));
     }
   }
 
@@ -201,15 +211,22 @@ export class TaskDispatcherService {
     return Math.max(1000, configured || DEFAULT_TICK_TIMEOUT_MS);
   }
 
-  private async runTick(): Promise<void> {
+  private async runTick(generation: number): Promise<void> {
+    await postgresClient.withStatementTimeout(
+      DEFAULT_TICK_QUERY_TIMEOUT_MS,
+      () => this.runTickWithStatementTimeout(generation),
+    );
+  }
+
+  private async runTickWithStatementTimeout(generation: number): Promise<void> {
     try {
+      await LifecycleCapabilityModel.recoverPreviousRuntime('todo-execution', RUNTIME_INSTANCE_ID);
       const recoveredReviewClaims = await LifecycleCapabilityModel.recoverPreviousRuntime(
         'in-review-verification', RUNTIME_INSTANCE_ID,
       );
       this.reclaimedReviews += (await WorkTaskDispatchModel.recoverOrphanedVerification(
         recoveredReviewClaims,
       )).length;
-      await LifecycleCapabilityModel.recoverPreviousRuntime('todo-execution', RUNTIME_INSTANCE_ID);
 
       // The dispatcher is an independent system from the conversational Heartbeat
       // agent (Jonathon, 2026-08-25) -- it must not read heartbeatEnabled/heartbeatWindow.
@@ -275,8 +292,13 @@ export class TaskDispatcherService {
         return;
       }
       await this.fillExecutionPool();
-      await this.reportTickHealth('healthy');
+      if (this.activeTickGeneration === generation) {
+        await this.reportTickHealth('healthy');
+      }
     } catch (err) {
+      // A timed-out generation can settle after a newer tick has started. It
+      // must not overwrite the newer generation's diagnostics or health.
+      if (this.activeTickGeneration !== generation) return;
       this.lastTickError = err instanceof Error ? err.message : String(err);
       await LifecycleCapabilityModel.report({
         key:               'todo-execution',
@@ -292,9 +314,13 @@ export class TaskDispatcherService {
 
   private async reportTickHealth(health: 'healthy' | 'degraded', error?: string): Promise<void> {
     await LifecycleCapabilityModel.report({
-      key: 'todo-execution', enabled: this.initialized, health,
-      owner: this.initialized ? 'dispatcher' : null, runtimeInstanceId: RUNTIME_INSTANCE_ID,
-      fallbackMode: 'heartbeat', error,
+      key:               'todo-execution',
+      enabled:           this.initialized,
+      health,
+      owner:             this.initialized ? 'dispatcher' : null,
+      runtimeInstanceId: RUNTIME_INSTANCE_ID,
+      fallbackMode:      'heartbeat',
+      error,
       details: {
         tickGeneration: this.tickGeneration,
         activeTickGeneration: this.activeTickGeneration,
@@ -361,7 +387,9 @@ export class TaskDispatcherService {
       if (!token) return true;
       const octokit = new Octokit({ auth: token.value });
       const { data } = await octokit.pulls.get({
-        owner: match[1], repo: match[2], pull_number: Number(match[3]),
+        owner:   match[1],
+        repo:    match[2],
+        pull_number: Number(match[3]),
         request: { timeout: LINKED_PR_REQUEST_TIMEOUT_MS },
       });
       return data.state === 'open';

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -37,7 +37,11 @@ const workflowFindByIdMock: any = jest.fn(() => Promise.resolve({ attributesSnap
 const findAgentDirMock: any = jest.fn(() => '/agents/sulla-desktop');
 const automationEnabledMock: any = jest.fn(() => Promise.resolve(true));
 const resolveLimitMock: any = jest.fn((_scope: string, configured: number) => Promise.resolve(configured));
+const withStatementTimeoutMock: any = jest.fn((_timeoutMs: number, callback: () => Promise<unknown>) => callback());
 
+jest.unstable_mockModule('../../database/PostgresClient', () => ({
+  postgresClient: { withStatementTimeout: withStatementTimeoutMock },
+}));
 jest.unstable_mockModule('../../database/models/SullaSettingsModel', () => ({
   SullaSettingsModel: { get: settingsGetMock },
 }));
@@ -149,6 +153,7 @@ describe('TaskDispatcherService', () => {
     reportCapabilityMock.mockResolvedValue({});
     releaseStageMock.mockResolvedValue(undefined);
     automationEnabledMock.mockResolvedValue(true);
+    withStatementTimeoutMock.mockImplementation((_timeoutMs: number, callback: () => Promise<unknown>) => callback());
   });
 
   it('activates verification by default', async() => {
@@ -158,6 +163,59 @@ describe('TaskDispatcherService', () => {
     service.destroy();
 
     expect(claimNextReviewMock).toHaveBeenCalled();
+    expect(withStatementTimeoutMock).toHaveBeenCalledWith(30_000, expect.any(Function));
+  });
+
+  it('releases a wedged tick at its deadline and runs the next scheduled tick', async() => {
+    jest.useFakeTimers();
+    try {
+      settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+        if (key === 'taskDispatcherTickTimeoutMs') return Promise.resolve(1_000);
+        if (key === 'taskVerifierOwner') return Promise.resolve('legacy');
+        return Promise.resolve(fallback);
+      });
+      recoverPreviousRuntimeMock
+        .mockImplementationOnce(() => new Promise(() => {}))
+        .mockResolvedValue([]);
+
+      const { TaskDispatcherService } = await import('../TaskDispatcherService');
+      const service = new TaskDispatcherService();
+      const initialized = service.initialize();
+
+      await jest.advanceTimersByTimeAsync(1_000);
+      await initialized;
+      await jest.advanceTimersByTimeAsync(59_000);
+
+      expect(recoverPreviousRuntimeMock.mock.calls.length).toBeGreaterThan(1);
+      expect(countRunningMock).toHaveBeenCalled();
+      expect(reportCapabilityMock).toHaveBeenCalledWith(expect.objectContaining({
+        key:     'todo-execution',
+        details: expect.objectContaining({ tickWedgeCount: 1 }),
+      }));
+      service.destroy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('keeps the scheduler armed when first-pass recovery throws', async() => {
+    jest.useFakeTimers();
+    try {
+      recoverPreviousRuntimeMock
+        .mockRejectedValueOnce(new Error('recovery failed'))
+        .mockResolvedValue([]);
+
+      const { TaskDispatcherService } = await import('../TaskDispatcherService');
+      const service = new TaskDispatcherService();
+      await service.initialize();
+      await jest.advanceTimersByTimeAsync(60_000);
+
+      expect(recoverPreviousRuntimeMock.mock.calls.length).toBeGreaterThan(1);
+      expect(countRunningMock).toHaveBeenCalled();
+      service.destroy();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('reclaims only review tasks whose previous-runtime claims were recovered', async() => {
@@ -172,7 +230,7 @@ describe('TaskDispatcherService', () => {
     expect(recoverOrphanedVerificationMock).toHaveBeenCalledWith(['orphan-review']);
     expect(recoverStaleMock).toHaveBeenCalledWith();
     expect(reportCapabilityMock).toHaveBeenCalledWith(expect.objectContaining({
-      key: 'in-review-verification',
+      key:     'in-review-verification',
       details: expect.objectContaining({ reclaimed: 1 }),
     }));
   });


### PR DESCRIPTION
## Summary

Implements Projects task ZtXn / Phase 2 of the Autonomous Work Conveyor Reliability program.

- Adds a per-tick deadline with generation/start diagnostics and wedge counting.
- Releases the tick gate after deadline while preventing stale generations from clearing newer ticks.
- Arms the scheduler before initialization work and moves runtime claim/orphan recovery into every tick.
- Adds a 30-second timeout to linked pull-request probes.
- Keeps recovery and capability reporting live across the process lifetime.

## Validation

- `git diff --check` passed.
- Focused Jest was attempted but could not complete in this shared checkout because other Jest/TypeScript workers are concurrently active; no assertion result was available.
- No schema changes.

No merge or deploy performed.