### PR TITLE
feat(dispatcher): add durable queryable tick liveness

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop/node_modules

--- a/pkg/rancher-desktop/agent/database/migrations/0091_create_dispatcher_liveness.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0091_create_dispatcher_liveness.ts
@@ -1,0 +1,17 @@
+/** Durable dispatcher tick liveness, independent of work/task rows. */
+export const up = `
+  CREATE TABLE IF NOT EXISTS dispatcher_liveness (
+    id                         BOOLEAN PRIMARY KEY DEFAULT true CHECK (id = true),
+    last_tick_started_at       TIMESTAMPTZ,
+    last_tick_at               TIMESTAMPTZ,
+    next_expected_tick_at      TIMESTAMPTZ,
+    last_outcome               TEXT NOT NULL DEFAULT 'never',
+    checking                   BOOLEAN NOT NULL DEFAULT false,
+    consecutive_wedge_count    INTEGER NOT NULL DEFAULT 0,
+    wedge_count                INTEGER NOT NULL DEFAULT 0,
+    updated_at                 TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+  INSERT INTO dispatcher_liveness (id) VALUES (true) ON CONFLICT (id) DO NOTHING;
+`;
+
+export const down = `DROP TABLE IF EXISTS dispatcher_liveness;`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0091_create_dispatcher_liveness.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0091_create_dispatcher_liveness.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { down, up } from '../0091_create_dispatcher_liveness';
+
+describe('0091_create_dispatcher_liveness', () => {
+  it('creates one durable dispatcher heartbeat row independent of work items', () => {
+    expect(up).toContain('CREATE TABLE IF NOT EXISTS dispatcher_liveness');
+    expect(up).toContain('last_tick_started_at');
+    expect(up).toContain('next_expected_tick_at');
+    expect(up).toContain('consecutive_wedge_count');
+    expect(up).toContain('ON CONFLICT (id) DO NOTHING');
+    expect(down).toContain('DROP TABLE IF EXISTS dispatcher_liveness');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -77,6 +77,7 @@ import { up as up_0087, down as down_0087 } from './0087_create_project_pipeline
 import { up as up_0088, down as down_0088 } from './0088_add_generation_to_artifact_receipts';
 import { up as up_0089, down as down_0089 } from './0089_create_agent_definitions';
 import { up as up_0090, down as down_0090 } from './0090_create_work_task_outcome_journal';
+import { up as up_0091, down as down_0091 } from './0091_create_dispatcher_liveness';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -155,4 +156,5 @@ export const migrationsRegistry = [
   { name: '0088_add_generation_to_artifact_receipts',                up: up_0088, down: down_0088 },
   { name: '0089_create_agent_definitions',                           up: up_0089, down: down_0089 },
   { name: '0090_create_work_task_outcome_journal',                  up: up_0090, down: down_0090 },
+  { name: '0091_create_dispatcher_liveness',                         up: up_0091, down: down_0091 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/DispatcherLivenessModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/DispatcherLivenessModel.ts
@@ -1,0 +1,63 @@
+import { postgresClient } from '../PostgresClient';
+
+export type DispatcherTickOutcome =
+  | 'never' | 'checking' | 'idle' | 'no-eligible-work'
+  | 'actively-dispatching' | 'disabled' | 'error';
+
+export interface DispatcherLivenessRecord {
+  last_tick_started_at:    string | null;
+  last_tick_at:            string | null;
+  next_expected_tick_at:   string | null;
+  last_outcome:            DispatcherTickOutcome;
+  checking:                boolean;
+  consecutive_wedge_count: number;
+  wedge_count:             number;
+  updated_at:              string;
+}
+
+export class DispatcherLivenessModel {
+  static async beginTick(intervalMs: number): Promise<DispatcherLivenessRecord> {
+    const row = await postgresClient.queryOne<DispatcherLivenessRecord>(`
+      INSERT INTO dispatcher_liveness (
+        id, last_tick_started_at, next_expected_tick_at, last_outcome,
+        checking, consecutive_wedge_count, wedge_count, updated_at
+      ) VALUES (true, now(), now() + ($1 * interval '1 millisecond'), 'checking', true, 0, 0, now())
+      ON CONFLICT (id) DO UPDATE SET
+        last_tick_started_at = now(),
+        next_expected_tick_at = now() + ($1 * interval '1 millisecond'),
+        last_outcome = 'checking',
+        checking = true,
+        consecutive_wedge_count = CASE WHEN dispatcher_liveness.checking
+          OR dispatcher_liveness.next_expected_tick_at < now()
+          THEN dispatcher_liveness.consecutive_wedge_count + 1 ELSE 0 END,
+        wedge_count = dispatcher_liveness.wedge_count + CASE WHEN dispatcher_liveness.checking
+          OR dispatcher_liveness.next_expected_tick_at < now() THEN 1 ELSE 0 END,
+        updated_at = now()
+      RETURNING *
+    `, [intervalMs]);
+    if (!row) throw new Error('Failed to record dispatcher tick start');
+    return row;
+  }
+
+  static async completeTick(intervalMs: number, outcome: DispatcherTickOutcome): Promise<DispatcherLivenessRecord> {
+    const row = await postgresClient.queryOne<DispatcherLivenessRecord>(`
+      UPDATE dispatcher_liveness
+         SET last_tick_at = now(),
+             next_expected_tick_at = now() + ($1 * interval '1 millisecond'),
+             last_outcome = $2,
+             checking = false,
+             consecutive_wedge_count = 0,
+             updated_at = now()
+       WHERE id = true
+       RETURNING *
+    `, [intervalMs, outcome]);
+    if (!row) throw new Error('Failed to record dispatcher tick completion');
+    return row;
+  }
+
+  static async get(): Promise<DispatcherLivenessRecord | null> {
+    return postgresClient.queryOne<DispatcherLivenessRecord>(
+      'SELECT * FROM dispatcher_liveness WHERE id = true',
+    );
+  }
+}

--- a/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
@@ -17,6 +17,7 @@
  * Read-only: no INSERT/UPDATE/DELETE.
  */
 import { postgresClient } from '../PostgresClient';
+import { DispatcherLivenessModel, type DispatcherLivenessRecord } from './DispatcherLivenessModel';
 
 export type SemanticStage =
   | 'backlog' | 'planning' | 'execution' | 'review' | 'blocked' | 'terminal' | 'manual';
@@ -462,12 +463,12 @@ export class WorkConveyorMetricsModel {
 
   /** Aggregate snapshot of every conveyor metric (all queries run concurrently). */
   static async snapshot(opts: ConveyorMetricsOptions = {}) {
-    const [stages, agePercentiles, throughput, verifier, rework, custody, waits, leases, deps, wip, shipments] =
+    const [stages, agePercentiles, throughput, verifier, rework, custody, waits, leases, deps, wip, shipments, dispatcherLiveness] =
       await Promise.all([
         this.stageCounts(opts), this.stageAgePercentiles(opts), this.throughput(opts),
         this.verifierThroughput(opts), this.reworkRate(opts), this.custodyCompleteness(opts),
         this.waitAdoption(opts), this.staleLeases(opts), this.dependencyHeld(opts),
-        this.wipPressure(opts), this.shipments(opts),
+        this.wipPressure(opts), this.shipments(opts), DispatcherLivenessModel.get(),
       ]);
     return {
       metric: 'conveyor_health',
@@ -475,6 +476,20 @@ export class WorkConveyorMetricsModel {
       project_id: pid(opts),
       stages, agePercentiles, throughput, verifier, rework, custody,
       waits, leases, deps, wip, shipments,
+      dispatcherLiveness: this.classifyDispatcherLiveness(dispatcherLiveness),
+    };
+  }
+
+  private static classifyDispatcherLiveness(row: DispatcherLivenessRecord | null) {
+    if (!row) return { status: 'unknown' as const, ...row };
+    const overdue = row.next_expected_tick_at != null && new Date(row.next_expected_tick_at).getTime() < Date.now();
+    return {
+      ...row,
+      status: row.checking || overdue ? 'wedged' as const
+        : row.last_outcome === 'actively-dispatching' ? 'actively-dispatching' as const
+          : row.last_outcome === 'no-eligible-work' ? 'no-eligible-work' as const
+            : row.last_outcome === 'idle' ? 'idle' as const
+              : row.last_outcome,
     };
   }
 }

--- a/pkg/rancher-desktop/agent/database/models/__tests__/DispatcherLivenessModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/DispatcherLivenessModel.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { postgresClient } from '../../PostgresClient';
+import { DispatcherLivenessModel } from '../DispatcherLivenessModel';
+
+describe('DispatcherLivenessModel', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('records a checking tick and carries forward a stale-check wedge', async() => {
+    const queryOne = jest.spyOn(postgresClient, 'queryOne').mockResolvedValue({
+      checking: true, consecutive_wedge_count: 1, wedge_count: 4,
+    } as any);
+    await DispatcherLivenessModel.beginTick(60_000);
+    expect(queryOne.mock.calls[0][0]).toContain("last_outcome = 'checking'");
+    expect(queryOne.mock.calls[0][0]).toContain('dispatcher_liveness.checking');
+    expect(queryOne.mock.calls[0][1]).toEqual([60_000]);
+  });
+
+  it('completes a tick with an explicit outcome and clears the in-flight flag', async() => {
+    const queryOne = jest.spyOn(postgresClient, 'queryOne').mockResolvedValue({
+      checking: false, last_outcome: 'no-eligible-work',
+    } as any);
+    await DispatcherLivenessModel.completeTick(60_000, 'no-eligible-work');
+    expect(queryOne.mock.calls[0][0]).toContain('checking = false');
+    expect(queryOne.mock.calls[0][1]).toEqual([60_000, 'no-eligible-work']);
+  });
+});

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -9,6 +9,7 @@ import { getIntegrationService } from './IntegrationService';
 import { resolveWipLimits, evaluateClaim, type WipLimits, type RoleCounts, type BackpressureDecision } from './ProjectAutomationWipLimits';
 import { RoutineConcurrencyPolicy } from './RoutineConcurrencyPolicy';
 import { postgresClient } from '../database/PostgresClient';
+import { DispatcherLivenessModel, type DispatcherTickOutcome } from '../database/models/DispatcherLivenessModel';
 import { LifecycleCapabilityModel } from '../database/models/LifecycleCapabilityModel';
 import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { WorkItemsModel, type WorkTaskRecord } from '../database/models/WorkItemsModel';
@@ -168,6 +169,9 @@ export class TaskDispatcherService {
     let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
     let tickTimeoutMs = DEFAULT_TICK_TIMEOUT_MS;
     let healthError: string | null = null;
+    let outcome: DispatcherTickOutcome = 'idle';
+    await DispatcherLivenessModel.beginTick(CHECK_INTERVAL_MS).catch(err =>
+      console.error('[TaskDispatcher] Failed to record tick start:', err));
     try {
       // Read the setting inside the guarded section too: a stalled settings
       // read is itself a tick-path failure and must release the gate.
@@ -175,8 +179,9 @@ export class TaskDispatcherService {
       const timeout = new Promise<never>((_resolve, reject) => {
         timeoutTimer = setTimeout(() => reject(new Error(`dispatcher tick ${ generation } exceeded ${ tickTimeoutMs }ms deadline`)), tickTimeoutMs);
       });
-      await Promise.race([this.runTick(generation), timeout]);
+      outcome = await Promise.race([this.runTick(generation), timeout]);
     } catch (err) {
+      outcome = 'error';
       const timedOut = err instanceof Error && err.message.includes('exceeded') && err.message.includes('deadline');
       healthError = timedOut ? 'tick deadline exceeded' : err instanceof Error ? err.message : String(err);
       this.lastTickError = healthError;
@@ -196,6 +201,8 @@ export class TaskDispatcherService {
         this.activeTickGeneration = null;
         this.activeTickStartedAt = null;
       }
+      await DispatcherLivenessModel.completeTick(CHECK_INTERVAL_MS, outcome).catch(err =>
+        console.error('[TaskDispatcher] Failed to record tick completion:', err));
     }
     // Capability reporting is also database-backed. Release the tick gate
     // before awaiting it so a wedged report cannot disable future ticks.
@@ -213,14 +220,15 @@ export class TaskDispatcherService {
     return Math.max(1000, configured || DEFAULT_TICK_TIMEOUT_MS);
   }
 
-  private async runTick(generation: number): Promise<void> {
-    await postgresClient.withStatementTimeout(
+  private async runTick(generation: number): Promise<DispatcherTickOutcome> {
+    return postgresClient.withStatementTimeout(
       DEFAULT_TICK_QUERY_TIMEOUT_MS,
       () => this.runTickWithStatementTimeout(generation),
     );
   }
 
-  private async runTickWithStatementTimeout(generation: number): Promise<void> {
+  private async runTickWithStatementTimeout(generation: number): Promise<DispatcherTickOutcome> {
+    let outcome: DispatcherTickOutcome = 'idle';
     try {
       const reconciledWorkflowExecutions = await WorkflowExecutionModel.reconcileDispatcherOwnedExecutions();
       if (reconciledWorkflowExecutions.length > 0) {
@@ -240,6 +248,7 @@ export class TaskDispatcherService {
       // exposed as "Enable Automation PM Work" on the Project Automation settings tab.
       const enabled = await RoutineConcurrencyPolicy.isEnabled();
       if (!enabled) {
+        outcome = 'disabled';
         await LifecycleCapabilityModel.report({
           key:               'todo-execution',
           enabled:           false,
@@ -249,7 +258,7 @@ export class TaskDispatcherService {
           fallbackMode:      'manual_hold',
           error:             'Automated Project Management is disabled by user setting.',
         });
-        return;
+        return outcome;
       }
 
       // Run on every tick, not just once at boot. recoverStale() only
@@ -267,8 +276,9 @@ export class TaskDispatcherService {
       await this.checkInProgressRecovery();
       const reviewReady = await this.fillVerificationPool();
       if (!reviewReady) {
+        outcome = 'no-eligible-work';
         console.warn('[TaskDispatcher] Protected review is unavailable; holding fresh execution work');
-        return;
+        return outcome;
       }
       // Issue #711: semantic stage-aware WIP limits + downstream-first backpressure.
       // Additive over the #709 review-drain guard below: this only ever holds MORE
@@ -285,29 +295,36 @@ export class TaskDispatcherService {
           at:       new Date().toISOString(),
         };
         if (!wipDecision.allowed) {
+          outcome = 'no-eligible-work';
           console.log(`[TaskDispatcher] Holding fresh execution work: ${ wipDecision.reason }`);
-          return;
+          return outcome;
         }
       } catch (wipErr) {
         // The gate is a safety invariant. If counts/settings cannot be resolved,
         // fail closed and retry on the next scheduled tick.
+        outcome = 'no-eligible-work';
         console.warn('[TaskDispatcher] WIP limit evaluation failed; holding fresh execution:', wipErr);
-        return;
+        return outcome;
       }
       const reviewBacklog = await WorkTaskDispatchModel.countReviewBacklog();
       if (reviewBacklog > 0) {
+        outcome = 'no-eligible-work';
         console.log(`[TaskDispatcher] Holding fresh todo work until ${ reviewBacklog } downstream review item(s) drain`);
-        return;
+        return outcome;
       }
-      await this.fillExecutionPool();
+      const dispatched = await this.fillExecutionPool();
+      outcome = dispatched > 0 ? 'actively-dispatching' : 'no-eligible-work';
       if (this.activeTickGeneration === generation) {
         await this.reportTickHealth('healthy');
       }
+      return outcome;
     } catch (err) {
       // A timed-out generation can settle after a newer tick has started. It
       // must not overwrite the newer generation's diagnostics or health.
-      if (this.activeTickGeneration !== generation) return;
+      if (this.activeTickGeneration !== generation) return 'error';
       this.lastTickError = err instanceof Error ? err.message : String(err);
+      outcome = 'error';
+      console.error('[TaskDispatcher] Dispatch check failed:', err);
       await LifecycleCapabilityModel.report({
         key:               'todo-execution',
         enabled:           true,
@@ -317,6 +334,7 @@ export class TaskDispatcherService {
         fallbackMode:      'heartbeat',
         error:             this.lastTickError,
       }).catch(reportErr => console.error('[TaskDispatcher] Capability report failed:', reportErr));
+      return outcome;
     }
   }
 
@@ -408,7 +426,7 @@ export class TaskDispatcherService {
     }
   }
 
-  private async fillExecutionPool(): Promise<void> {
+  private async fillExecutionPool(): Promise<number> {
     const configured = Number(await SullaSettingsModel.get('taskDispatcherConcurrency', DEFAULT_CONCURRENCY));
     const concurrency = await RoutineConcurrencyPolicy.resolveLimit('execution', configured || DEFAULT_CONCURRENCY);
     const enforceSlots = await RoutineConcurrencyPolicy.isEnabled();
@@ -425,7 +443,8 @@ export class TaskDispatcherService {
       fallbackMode:      'manual_hold',
     });
 
-        let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning('execution'));
+    let freeSlots = Math.max(0, concurrency - await WorkTaskDispatchModel.countRunning('execution'));
+    let dispatched = 0;
     while (freeSlots > 0 && this.initialized) {
       let slot: string | null = null;
       if (enforceSlots) {
@@ -446,7 +465,9 @@ export class TaskDispatcherService {
           if (heldSlot) void RoutineConcurrencyPolicy.release(heldSlot);
         });
       freeSlots -= 1;
+      dispatched += 1;
     }
+    return dispatched;
   }
 
   private async fillVerificationPool(): Promise<boolean> {

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -34,6 +34,8 @@ const graphDeleteMock: any = jest.fn();
 const recoverPreviousRuntimeMock: any = jest.fn(() => Promise.resolve([]));
 const reportCapabilityMock: any = jest.fn(() => Promise.resolve({}));
 const releaseStageMock: any = jest.fn(() => Promise.resolve());
+const beginTickMock: any = jest.fn(() => Promise.resolve({}));
+const completeTickMock: any = jest.fn(() => Promise.resolve({}));
 const resolvePullRequestHeadMock: any = jest.fn();
 const resolvePullRequestHeadsMock: any = jest.fn();
 const bindReviewGenerationMock: any = jest.fn();
@@ -56,6 +58,9 @@ jest.unstable_mockModule('../../database/models/LifecycleCapabilityModel', () =>
     report:                 reportCapabilityMock,
     releaseStage:           releaseStageMock,
   },
+}));
+jest.unstable_mockModule('../../database/models/DispatcherLivenessModel', () => ({
+  DispatcherLivenessModel: { beginTick: beginTickMock, completeTick: completeTickMock },
 }));
 jest.unstable_mockModule('../../database/models/WorkTaskDispatchModel', () => ({
   WorkTaskDispatchModel: {

--- a/pkg/rancher-desktop/agent/tools/project/conveyor_health.ts
+++ b/pkg/rancher-desktop/agent/tools/project/conveyor_health.ts
@@ -44,6 +44,7 @@ export class ConveyorHealthWorker extends BaseTool {
       lines.push(`Dependency-held: ${ snap.deps.dependencyHeld }`);
       lines.push(`WIP: execution=${ snap.wip.activeExecutionWip }/${ snap.wip.wipLimit ?? 'unlimited' } verification=${ snap.wip.activeVerificationWip } backpressure=${ snap.wip.backpressureReason ?? 'none' }`);
       lines.push(`Shipments: independent=${ snap.shipments.independentShipments } integration_train_closures=${ snap.shipments.integrationTrainClosures } missing_evidence=${ snap.shipments.missingEvidence }`);
+      lines.push(`Dispatcher: ${ snap.dispatcherLiveness.status } last_tick=${ snap.dispatcherLiveness.last_tick_at ?? 'never' } next_expected=${ snap.dispatcherLiveness.next_expected_tick_at ?? 'unknown' } wedges=${ snap.dispatcherLiveness.consecutive_wedge_count ?? 0 }`);
       lines.push('');
       lines.push('## Custody completeness by artifact type (structured/legacy/missing/invalid)');
       for (const c of snap.custody) {

--- a/pkg/rancher-desktop/pages/ProjectsHome.vue
+++ b/pkg/rancher-desktop/pages/ProjectsHome.vue
@@ -195,6 +195,7 @@
                 <div class="ph-health-stat"><span>Stale leases</span><b>{{ conveyorHealth.leases.staleLeases }}</b><small>{{ conveyorHealth.leases.activeLeases }} active total</small></div>
                 <div class="ph-health-stat"><span>Dependency held</span><b>{{ conveyorHealth.deps.dependencyHeld }}</b><small>claim-gated tasks</small></div>
                 <div class="ph-health-stat"><span>Shipments</span><b>{{ conveyorHealth.shipments.independentShipments }}</b><small>{{ conveyorHealth.shipments.integrationTrainClosures }} train · {{ conveyorHealth.shipments.missingEvidence }} missing</small></div>
+                <div class="ph-health-stat" :class="{ held: conveyorHealth.dispatcherLiveness.status === 'wedged' }"><span>Dispatcher</span><b>{{ conveyorHealth.dispatcherLiveness.status }}</b><small>last {{ conveyorHealth.dispatcherLiveness.last_tick_at ? new Date(conveyorHealth.dispatcherLiveness.last_tick_at).toLocaleTimeString() : 'never' }} · next {{ conveyorHealth.dispatcherLiveness.next_expected_tick_at ? new Date(conveyorHealth.dispatcherLiveness.next_expected_tick_at).toLocaleTimeString() : 'unknown' }}</small></div>
               </div>
               <div v-if="healthItems.length" class="ph-health-drill">
                 <b>Oldest {{ healthStage }} work</b>


### PR DESCRIPTION
## Summary

Implements Projects task EAsI / Phase 3 of the Autonomous Work Conveyor Reliability epic on current main.

- Adds migration 0091 with a durable singleton dispatcher liveness record, registered after Phase 5 migration 0090.
- Records dispatcher tick start and completion around the Phase 2 watchdog lifecycle, including early-return outcomes.
- Tracks explicit last outcome, next expected tick, checking state, and wedge counters.
- Extends conveyor_health and ProjectsHome with wedged, idle, no-eligible-work, and actively-dispatching status.
- Preserves Phase 4-6 dispatcher runtime, journal, and reconciliation behavior.

## Validation

- git diff --check — passed.
- Migration and DispatcherLivenessModel Jest suites — 3/3 passed.
- Focused TaskDispatcherService watchdog/liveness integration test — passed.
- Full TaskDispatcherService suite retains five pre-existing expectation failures unrelated to this PR.
- Repo-wide tsc exhausted the Node heap at both 2 GB and 4 GB before diagnostics; no pass claimed.

No deploy, rebuild, or restart performed.