### PR TITLE
feat(dispatcher): durable outcome journal and idempotent settlement

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0090_create_work_task_outcome_journal.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0090_create_work_task_outcome_journal.ts
@@ -1,0 +1,32 @@
+/**
+ * Durable execution outcome outbox. A worker result is recorded before the
+ * dispatcher attempts to settle the dispatch/task pair, so a process death
+ * cannot turn a completed worker run into a lease expiry.
+ */
+export const up = `
+  CREATE TABLE IF NOT EXISTS work_task_outcome_journal (
+    id               TEXT PRIMARY KEY,
+    dispatch_id      TEXT NOT NULL REFERENCES work_task_dispatches(id) ON DELETE CASCADE,
+    task_id          TEXT NOT NULL REFERENCES work_tasks(id) ON DELETE CASCADE,
+    dispatch_status  TEXT NOT NULL,
+    task_status      TEXT NOT NULL,
+    task_assignee    TEXT NOT NULL,
+    comment          TEXT NOT NULL,
+    result           TEXT,
+    error            TEXT,
+    evidence         JSONB,
+    receipt          JSONB,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    consumed_at      TIMESTAMPTZ,
+    UNIQUE (dispatch_id)
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_work_task_outcome_journal_pending
+    ON work_task_outcome_journal (created_at)
+    WHERE consumed_at IS NULL;
+`;
+
+export const down = `
+  DROP INDEX IF EXISTS idx_work_task_outcome_journal_pending;
+  DROP TABLE IF EXISTS work_task_outcome_journal;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0090_create_work_task_outcome_journal.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0090_create_work_task_outcome_journal.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { down, up } from '../0090_create_work_task_outcome_journal';
+
+describe('0090 create work task outcome journal migration', () => {
+  it('creates an append-only per-dispatch outbox with a pending index', () => {
+    expect(up).toContain('work_task_outcome_journal');
+    expect(up).toContain('UNIQUE (dispatch_id)');
+    expect(up).toContain('consumed_at');
+    expect(up).toContain('idx_work_task_outcome_journal_pending');
+  });
+
+  it('is reversible', () => {
+    expect(down).toContain('DROP TABLE IF EXISTS work_task_outcome_journal');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -76,6 +76,7 @@ import { up as up_0086, down as down_0086 } from './0086_create_projects_domain_
 import { up as up_0087, down as down_0087 } from './0087_create_project_pipeline_templates';
 import { up as up_0088, down as down_0088 } from './0088_add_generation_to_artifact_receipts';
 import { up as up_0089, down as down_0089 } from './0089_create_agent_definitions';
+import { up as up_0090, down as down_0090 } from './0090_create_work_task_outcome_journal';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -153,4 +154,5 @@ export const migrationsRegistry = [
   { name: '0087_create_project_pipeline_templates',                 up: up_0087, down: down_0087 },
   { name: '0088_add_generation_to_artifact_receipts',                up: up_0088, down: down_0088 },
   { name: '0089_create_agent_definitions',                           up: up_0089, down: down_0089 },
+  { name: '0090_create_work_task_outcome_journal',                  up: up_0090, down: down_0090 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -179,6 +179,21 @@ export interface WorkTaskDispatchFinalization {
   receipt?:       ArtifactReceipt;
 }
 
+interface WorkTaskOutcomeJournalRow {
+  id: string;
+  dispatch_id: string;
+  task_id: string;
+  dispatch_status: Exclude<WorkTaskDispatchStatus, 'running' | 'stale'>;
+  task_status: 'in_review' | 'planning' | 'blocked';
+  task_assignee: 'heartbeat' | 'dispatcher';
+  comment: string;
+  result: string | null;
+  error: string | null;
+  evidence: WorkTaskDispatchEvidence | null;
+  receipt: ArtifactReceipt | null;
+  consumed_at: string | null;
+}
+
 const CLOSED_EPIC_STATUSES = ['done', 'cancelled', 'parked', 'blocked'];
 
 /**
@@ -924,13 +939,105 @@ export class WorkTaskDispatchModel {
    * unit. A crash cannot leave a terminal dispatch attached to an in-progress
    * task (or move the task without retaining the evidence that justified it).
    */
+  static async appendOutcomeJournal(
+    id: string,
+    taskId: string,
+    finalization: WorkTaskDispatchFinalization,
+  ): Promise<string> {
+    const journalId = `outcome-${ randomUUID() }`;
+    const inserted = await postgresClient.query<{ id: string }>(`
+      INSERT INTO work_task_outcome_journal
+        (id, dispatch_id, task_id, dispatch_status, task_status, task_assignee,
+         comment, result, error, evidence, receipt)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11::jsonb)
+      ON CONFLICT (dispatch_id) DO NOTHING
+      RETURNING id
+    `, [
+      journalId, id, taskId, finalization.dispatchStatus, finalization.taskStatus,
+      finalization.taskAssignee, finalization.comment, finalization.result ?? null,
+      finalization.error ?? null,
+      finalization.evidence === undefined ? null : JSON.stringify(finalization.evidence),
+      finalization.receipt === undefined ? null : JSON.stringify(finalization.receipt),
+    ]);
+    if (inserted[0]) return inserted[0].id;
+    const existing = await postgresClient.query<{ id: string }>(
+      'SELECT id FROM work_task_outcome_journal WHERE dispatch_id = $1', [id],
+    );
+    if (!existing[0]) throw new Error(`Outcome journal insert disappeared for dispatch ${ id }`);
+    return existing[0].id;
+  }
+
+  static async finalizeOutcomeJournal(journalId: string): Promise<WorkTaskRecord | null> {
+    return postgresClient.transaction(async(client: PoolClient) => {
+      const journal = await client.query<WorkTaskOutcomeJournalRow>(`
+        SELECT * FROM work_task_outcome_journal WHERE id = $1 FOR UPDATE
+      `, [journalId]);
+      const row = journal.rows[0];
+      if (!row) throw new Error(`Outcome journal ${ journalId } was not found`);
+      if (row.consumed_at) return null;
+      const dispatch = await client.query<{ status: WorkTaskDispatchStatus }>(
+        'SELECT status FROM work_task_dispatches WHERE id = $1 FOR UPDATE', [row.dispatch_id],
+      );
+      if (dispatch.rows[0]?.status !== 'running') {
+        await client.query('UPDATE work_task_outcome_journal SET consumed_at = now() WHERE id = $1', [journalId]);
+        return null;
+      }
+      const task = await this.finalizeWithClient(client, row.dispatch_id, row.task_id, {
+        dispatchStatus: row.dispatch_status,
+        taskStatus: row.task_status,
+        taskAssignee: row.task_assignee,
+        comment: row.comment,
+        result: row.result ?? undefined,
+        error: row.error ?? undefined,
+        evidence: row.evidence ?? undefined,
+        receipt: row.receipt ?? undefined,
+      });
+      await client.query(
+        'UPDATE work_task_outcome_journal SET consumed_at = now() WHERE id = $1 AND consumed_at IS NULL',
+        [journalId],
+      );
+      return task;
+    });
+  }
+
+  static async recoverPendingOutcomeJournals(): Promise<string[]> {
+    const pending = await postgresClient.query<{ id: string }>(`
+      SELECT id FROM work_task_outcome_journal
+       WHERE consumed_at IS NULL ORDER BY created_at ASC
+    `);
+    const settled: string[] = [];
+    for (const row of pending) {
+      try {
+        await this.finalizeOutcomeJournal(row.id);
+        settled.push(row.id);
+      } catch (err) {
+        console.warn(`[WorkTaskDispatchModel] Outcome journal ${ row.id } remains pending:`, err);
+      }
+    }
+    return settled;
+  }
+
   static async finalize(id: string, taskId: string, finalization: WorkTaskDispatchFinalization): Promise<WorkTaskRecord> {
     const evidence = finalization.evidence ?? {};
     const custody = ArtifactCustodyPolicy.derive(evidence as unknown as Record<string, unknown>);
     if (finalization.taskStatus === 'in_review') {
       await ArtifactCustodyPolicy.assertForTransition('in_review', custody);
     }
-    return postgresClient.transaction(async(client: PoolClient) => {
+    return postgresClient.transaction(async(client: PoolClient) => this.finalizeWithClient(client, id, taskId, finalization));
+  }
+
+  private static async finalizeWithClient(
+    client: PoolClient,
+    id: string,
+    taskId: string,
+    finalization: WorkTaskDispatchFinalization,
+  ): Promise<WorkTaskRecord> {
+    return (async() => {
+      const evidence = finalization.evidence ?? {};
+      const custody = ArtifactCustodyPolicy.derive(evidence as unknown as Record<string, unknown>);
+      if (finalization.taskStatus === 'in_review') {
+        await ArtifactCustodyPolicy.assertForTransition('in_review', custody);
+      }
       const locked = await client.query<{ status: WorkTaskDispatchStatus }>(
         'SELECT status FROM work_task_dispatches WHERE id = $1 AND task_id = $2 FOR UPDATE',
         [id, taskId],
@@ -1004,7 +1111,7 @@ export class WorkTaskDispatchModel {
         throw new Error(`Task ${ taskId } is no longer owned by dispatch ${ id }`);
       }
       return moved.rows[0];
-    });
+    })();
   }
 
   static async recoverStale(staleMinutes = 45): Promise<string[]> {
@@ -1015,7 +1122,12 @@ export class WorkTaskDispatchModel {
                error = 'dispatcher lease expired or app restarted',
                failure_reason = 'lease_expired',
                finished_at = now()
-         WHERE status = 'running'
+        WHERE status = 'running'
+           AND NOT EXISTS (
+             SELECT 1 FROM work_task_outcome_journal j
+              WHERE j.dispatch_id = work_task_dispatches.id
+                AND j.consumed_at IS NULL
+           )
            AND heartbeat_at < now() - ($1 * interval '1 minute')
         RETURNING id, task_id, kind
       `, [staleMinutes]);

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -179,6 +179,8 @@ export class TaskDispatcherService {
       // a crashed worker) just as easily as it can from a prior restart.
       // A one-shot startup-only reclaim leaves those permanently stuck for
       // the rest of the process's uptime with nothing else watching them.
+      const journaled = await WorkTaskDispatchModel.recoverPendingOutcomeJournals();
+      if (journaled.length > 0) console.log(`[TaskDispatcher] Settled ${ journaled.length } journaled outcome(s)`);
       const recovered = await WorkTaskDispatchModel.recoverStale();
       if (recovered.length > 0) console.warn(`[TaskDispatcher] Recovered ${ recovered.length } stale dispatch(es)`);
 
@@ -837,7 +839,7 @@ export class TaskDispatcherService {
       evidence: { kind: 'dispatch', ref: dispatch.id },
     });
     try {
-      await WorkTaskDispatchModel.finalize(dispatch.id, task.id, {
+      const journalId = await WorkTaskDispatchModel.appendOutcomeJournal(dispatch.id, task.id, {
         dispatchStatus,
         taskStatus,
         taskAssignee: taskStatus === 'planning' ? 'dispatcher' : 'heartbeat',
@@ -855,8 +857,9 @@ export class TaskDispatcherService {
           custody:          parsed.custody,
         } : undefined,
       });
+      await WorkTaskDispatchModel.finalizeOutcomeJournal(journalId);
     } catch (err) {
-      console.error(`[TaskDispatcher] Could not atomically finalize ${ dispatch.id }:`, err);
+      console.error(`[TaskDispatcher] Could not journal/finalize ${ dispatch.id }:`, err);
     }
   }
 

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -13,6 +13,9 @@ const claimNextMock: any = jest.fn(() => Promise.resolve(null));
 const claimNextReviewMock: any = jest.fn(() => Promise.resolve(null));
 const settleMock: any = jest.fn(() => Promise.resolve());
 const finalizeMock: any = jest.fn(() => Promise.resolve());
+const appendOutcomeJournalMock: any = jest.fn(() => Promise.resolve('journal-1'));
+const finalizeOutcomeJournalMock: any = jest.fn(() => Promise.resolve());
+const recoverPendingOutcomeJournalsMock: any = jest.fn(() => Promise.resolve([]));
 const finalizeVerificationMock: any = jest.fn(() => Promise.resolve('APPROVE'));
 const finalizeProtectedReviewMock: any = jest.fn(() => Promise.resolve('PASS'));
 const recordReviewLaunchMock: any = jest.fn(() => Promise.resolve());
@@ -62,6 +65,9 @@ jest.unstable_mockModule('../../database/models/WorkTaskDispatchModel', () => ({
     claimNextReview:         claimNextReviewMock,
     settle:                  settleMock,
     finalize:                finalizeMock,
+    appendOutcomeJournal:    appendOutcomeJournalMock,
+    finalizeOutcomeJournal:  finalizeOutcomeJournalMock,
+    recoverPendingOutcomeJournals: recoverPendingOutcomeJournalsMock,
     finalizeVerification:    finalizeVerificationMock,
     finalizeProtectedReview: finalizeProtectedReviewMock,
     recordReviewLaunch:      recordReviewLaunchMock,
@@ -120,6 +126,7 @@ describe('TaskDispatcherService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     recoverStaleMock.mockResolvedValue([]);
+    recoverPendingOutcomeJournalsMock.mockResolvedValue([]);
     recoverOrphanedVerificationMock.mockResolvedValue([]);
     verificationPoolStatsMock.mockResolvedValue({ backlog: 0, active: 0, suppressedDuplicates: 0, failures: 0 });
     findRecoverableInProgressMock.mockResolvedValue([]);
@@ -381,10 +388,11 @@ describe('TaskDispatcherService', () => {
     expect(workerState.llmTools.map((tool: any) => tool.function.name)).toEqual([
       'browse_tools', 'exec', 'read_file', 'write_file',
     ]);
-    expect(finalizeMock).toHaveBeenCalledWith('dispatch-1', 'task-1', expect.objectContaining({
+    expect(appendOutcomeJournalMock).toHaveBeenCalledWith('dispatch-1', 'task-1', expect.objectContaining({
       dispatchStatus: 'completed', taskStatus: 'in_review', taskAssignee: 'heartbeat',
       evidence: expect.objectContaining({ custody: expect.objectContaining({ workKind: 'code' }) }),
     }));
+    expect(finalizeOutcomeJournalMock).toHaveBeenCalledWith('journal-1');
     expect(releaseStageMock).toHaveBeenCalledWith('stage-claim-1');
     expect(updateTaskMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- add an append-only per-dispatch outcome journal before execution settlement
- consume journal entries transactionally and idempotently
- drain pending journal entries before stale recovery and exclude them from lease expiry

## Validation
- TypeScript compilation: `node_modules/.bin/tsc --noEmit --pretty false --incremental false`
- Migration tests: 2 suites, 3 tests passed
- `git diff --check` passed
- Existing dispatcher suite has five baseline expectation mismatches against current origin/main behavior; no journal-specific failure was observed.

No merge or deploy performed.