### PR TITLE
fix(#727): make review-reject a first-class atomic handoff to execution

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto';
 
 import { postgresClient } from '../PostgresClient';
+import { ArtifactReceiptModel } from './ArtifactReceiptModel';
+import { buildReceipt, receiptInsertInput, renderReceiptComment } from '../../services/ArtifactReceiptService';
 
+import type { WorkTaskRecord } from './WorkItemsModel';
 import type { PoolClient } from 'pg';
 
 export const LIFECYCLE_CAPABILITY_KEYS = [
@@ -62,6 +65,23 @@ export interface ClaimResult {
   claimed: boolean;
   reason?: string;
   claim?:  LifecycleStageClaim;
+}
+
+export interface SettleReviewRejectInput {
+  /** Task currently sitting in the in_review stage. */
+  taskId:  string;
+  /** Acting in-review authority: the effective owner of in-review-verification. */
+  actor:   string;
+  /** Rejection rationale / repair guidance, recorded on the receipt. */
+  summary: string;
+}
+
+export interface SettleReviewRejectResult {
+  /** True when this call performed the handoff (verdict + transition). */
+  settled:        boolean;
+  /** True when the task had already left in_review — a safe no-op replay. */
+  alreadySettled: boolean;
+  task?:          WorkTaskRecord;
 }
 
 export type HeartbeatLifecycleMode = 'heartbeat_fallback' | 'protected_owner' | 'manual_hold' | 'unmanaged';
@@ -252,6 +272,106 @@ export class LifecycleCapabilityModel {
        WHERE id = $1 AND status = 'active'
        RETURNING *
     `, [claimId]);
+  }
+
+  /**
+   * First-class atomic reject->repair handoff (#727).
+   *
+   * assertActorCanManageTask treats any Heartbeat transition into a healthy
+   * capability's stage as a hostile takeover of that capability's lease. That
+   * is correct for a generic status edit, but wrong for the one legitimate
+   * stage-product handoff the in-review stage produces on a REJECTED verdict:
+   * routing the task back to todo-execution as a new artifact generation is
+   * the normal output of review, exactly like todo->in_review is the normal
+   * output of execution. This method is the narrow, purpose-built exception —
+   * not a general bypass of the guard: it only ever moves a task that is
+   * currently in_review, and only for the caller who is, at act time, the
+   * effective owner of in-review-verification (the protected review routine
+   * when healthy, or its explicitly named Heartbeat fallback when it is not).
+   *
+   * One transaction records the REJECTED verdict, releases any live review
+   * stage claim, and re-enqueues the task for the todo-execution owner
+   * (dispatcher) — with one concise Projects receipt. Recording the verdict
+   * and performing the handoff are the SAME statement group under the SAME
+   * transaction, so a crash before commit loses nothing: the task is simply
+   * still in_review and the next attempt starts clean. Because the handoff is
+   * gated on `status = 'in_review'`, a duplicate call against a generation
+   * that has already been handed off finds the task no longer in_review and
+   * returns a no-op instead of erroring or double-enqueuing.
+   */
+  static async settleReviewReject(input: SettleReviewRejectInput): Promise<SettleReviewRejectResult> {
+    return postgresClient.transaction(client => LifecycleCapabilityModel.settleReviewRejectWithClient(client, input));
+  }
+
+  static async settleReviewRejectWithClient(
+    client: PoolClient,
+    input: SettleReviewRejectInput,
+  ): Promise<SettleReviewRejectResult> {
+    const taskId = input.taskId;
+
+    const capabilityResult = await client.query<LifecycleCapabilityRecord>(`
+      SELECT * FROM lifecycle_capabilities WHERE capability_key = 'in-review-verification' FOR UPDATE
+    `);
+    const capability = capabilityResult.rows[0];
+    const authorized = capability ? effectiveOwner(capability) : null;
+    if (!authorized || authorized !== input.actor) {
+      throw new Error(
+        `Reject-repair handoff denied: in-review-verification is ${ capability ? (capability.enabled ? capability.health : 'disabled') : 'unregistered' }; ` +
+        `acting authority must be ${ authorized ?? 'an explicit owner or named Heartbeat fallback' } (actor was ${ input.actor }).`,
+      );
+    }
+
+    const taskResult = await client.query<{ id: string; status: string; last_moved_at: string }>(`
+      SELECT id, status, last_moved_at FROM work_tasks WHERE id = $1 FOR UPDATE
+    `, [taskId]);
+    const current = taskResult.rows[0];
+    if (!current) throw new Error(`Task not found: ${ taskId }`);
+    if (current.status !== 'in_review') {
+      // The review generation this call targets has already been settled
+      // (or the task never entered review). Idempotent no-op, not an error.
+      return { settled: false, alreadySettled: true };
+    }
+
+    await client.query(`
+      UPDATE work_task_stage_claims
+         SET status = 'released', released_at = now(), heartbeat_at = now()
+       WHERE task_id = $1 AND capability_key = 'in-review-verification'
+         AND stage = 'in_review' AND status = 'active'
+    `, [taskId]);
+
+    const updated = await client.query<WorkTaskRecord>(`
+      UPDATE work_tasks
+         SET status = 'todo', assignee = 'dispatcher', updated_at = now(),
+             last_moved_at = now(), last_activity_at = now(), last_moved_by = $2
+       WHERE id = $1 AND status = 'in_review'
+      RETURNING *
+    `, [taskId, input.actor]);
+    if (!updated.rows[0]) return { settled: false, alreadySettled: true };
+
+    const receipt = buildReceipt({
+      taskId,
+      eventType:         'repair',
+      actor:             input.actor,
+      disposition:       'REJECTED',
+      nextOwner:         'dispatcher',
+      validationSummary: input.summary,
+      // Keyed by the timestamp this specific review generation was entered so
+      // a later reject on a *different* generation of the same task never
+      // collides with this receipt's dedupe fingerprint.
+      evidence:          { kind: 'other', ref: `reject-handoff:${ taskId }@${ current.last_moved_at }` },
+    });
+    const receiptInsert = receiptInsertInput(receipt, `receipt-${ randomUUID() }`);
+    const insertedReceipt = await ArtifactReceiptModel.insertIfAbsentWithClient(client, receiptInsert);
+    if (insertedReceipt.inserted) {
+      const commentId = `artifact-receipt-comment-${ randomUUID() }`;
+      await client.query(`
+        INSERT INTO work_task_comments (id, task_id, body, author)
+        VALUES ($1, $2, $3, $4)
+      `, [commentId, taskId, renderReceiptComment(receipt), input.actor]);
+      await ArtifactReceiptModel.attachCommentWithClient(client, receiptInsert.id, commentId);
+    }
+
+    return { settled: true, alreadySettled: false, task: updated.rows[0] };
   }
 
   static async assertActorCanManageTask(

--- a/pkg/rancher-desktop/agent/database/models/__tests__/LifecycleCapabilityModel.reviewReject.postgres.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/LifecycleCapabilityModel.reviewReject.postgres.test.ts
@@ -1,0 +1,278 @@
+import { randomUUID } from 'node:crypto';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { Pool } from 'pg';
+
+import { postgresClient } from '../../PostgresClient';
+import { up as createWorkflows } from '../../migrations/0023_create_workflows_table';
+import { up as createWorkflowExecutions } from '../../migrations/0026_create_workflow_executions_table';
+import { up as createWorkItems } from '../../migrations/0044_create_work_items_tables';
+import { up as addWorkTaskActor } from '../../migrations/0047_add_work_task_actor';
+import { up as addWorkTaskActivity } from '../../migrations/0061_add_work_task_activity';
+import { up as createWorkTaskDispatches } from '../../migrations/0062_create_work_task_dispatches';
+import { up as addVerificationDispatches } from '../../migrations/0064_add_verification_dispatches';
+import { up as createLifecycleCapabilities } from '../../migrations/0068_create_lifecycle_capabilities';
+import { up as addProjectViewsAndScheduling } from '../../migrations/0075_add_project_views_and_scheduling';
+import { up as createArtifactReceipts } from '../../migrations/0082_create_artifact_receipts';
+import { up as createWorkTaskDependencies } from '../../migrations/0083_create_work_task_dependencies';
+import { LifecycleCapabilityModel } from '../LifecycleCapabilityModel';
+import { WorkTaskDispatchModel } from '../WorkTaskDispatchModel';
+
+const connectionString = process.env.SULLA_INTEGRATION_POSTGRES_URL;
+const describeWithPostgres = connectionString ? describe : describe.skip;
+
+/**
+ * Real-PostgreSQL coverage for the #727 reject->repair handoff: the acting
+ * in-review authority (protected-review owner or its named Heartbeat
+ * fallback) can atomically settle a REJECTED verdict and route the task back
+ * to todo-execution without needing to own todo-execution itself, while the
+ * generic ownership guard still denies everyone else and duplicate
+ * settlement of the same review generation stays a no-op.
+ */
+describeWithPostgres('LifecycleCapabilityModel.settleReviewReject reject->repair handoff (migrated PostgreSQL)', () => {
+  let bootstrapPool: Pool;
+  let pool: Pool;
+  let schemaCreated = false;
+  const schema = `review_reject_${ randomUUID().replaceAll('-', '') }`;
+  const originalQuery = postgresClient.query;
+  const originalQueryOne = postgresClient.queryOne;
+  const originalQueryAll = postgresClient.queryAll;
+  const originalTransaction = postgresClient.transaction;
+
+  const taskRow = async(taskId: string) =>
+    (await pool.query(`SELECT * FROM work_tasks WHERE id = $1`, [taskId])).rows[0];
+
+  const comments = async(taskId: string) =>
+    (await pool.query(`SELECT * FROM work_task_comments WHERE task_id = $1 ORDER BY created_at ASC`, [taskId])).rows;
+
+  const receipts = async(taskId: string) =>
+    (await pool.query(`SELECT * FROM work_artifact_receipts WHERE task_id = $1`, [taskId])).rows;
+
+  const setCapability = async(key: string, patch: {
+    enabled: boolean; health: string; active_owner: string | null; fallback_mode: string;
+  }) => {
+    await pool.query(`
+      UPDATE lifecycle_capabilities
+         SET enabled = $2, health = $3, active_owner = $4, fallback_mode = $5, updated_at = now()
+       WHERE capability_key = $1
+    `, [key, patch.enabled, patch.health, patch.active_owner, patch.fallback_mode]);
+  };
+
+  const healthyOwnedByRoutine = () => setCapability('in-review-verification', {
+    enabled: true, health: 'healthy', active_owner: 'verifier-routine', fallback_mode: 'manual_hold',
+  });
+  const defaultHeartbeatFallback = () => setCapability('in-review-verification', {
+    enabled: false, health: 'unavailable', active_owner: null, fallback_mode: 'heartbeat',
+  });
+  const healthyExecutionOwnedByDispatcher = () => setCapability('todo-execution', {
+    enabled: true, health: 'healthy', active_owner: 'dispatcher', fallback_mode: 'manual_hold',
+  });
+
+  const seedInReviewTask = async(taskId: string) => {
+    await pool.query(`
+      INSERT INTO work_tasks (id, project_id, epic_id, title, status, assignee)
+      VALUES ($1, 'p1', 'e1', $2, 'in_review', 'verifier')
+    `, [taskId, `Task ${ taskId }`]);
+  };
+
+  beforeAll(async() => {
+    bootstrapPool = new Pool({ connectionString, max: 1 });
+    await bootstrapPool.query(`CREATE SCHEMA "${ schema }"`);
+    schemaCreated = true;
+    pool = new Pool({ connectionString, max: 8, options: `-c search_path=${ schema }` });
+
+    for (const migration of [
+      createWorkflows, createWorkflowExecutions, createWorkItems, addWorkTaskActor,
+      addWorkTaskActivity, createWorkTaskDispatches, addVerificationDispatches,
+      createLifecycleCapabilities, createArtifactReceipts,
+    ]) await pool.query(migration as any);
+    await addProjectViewsAndScheduling(pool as any);
+    await createWorkTaskDependencies(pool as any);
+
+    (postgresClient as any).query = async(text: string, params: unknown[] = []) =>
+      (await pool.query(text, params)).rows;
+    (postgresClient as any).queryOne = async(text: string, params: unknown[] = []) =>
+      (await pool.query(text, params)).rows[0] ?? null;
+    (postgresClient as any).queryAll = async(text: string, params: unknown[] = []) =>
+      (await pool.query(text, params)).rows;
+    (postgresClient as any).transaction = async(callback: (client: any) => Promise<unknown>) => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        const result = await callback(client);
+        await client.query('COMMIT');
+        return result;
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+      }
+    };
+  });
+
+  afterAll(async() => {
+    (postgresClient as any).query = originalQuery;
+    (postgresClient as any).queryOne = originalQueryOne;
+    (postgresClient as any).queryAll = originalQueryAll;
+    (postgresClient as any).transaction = originalTransaction;
+    await pool?.end();
+    if (schemaCreated) await bootstrapPool.query(`DROP SCHEMA "${ schema }" CASCADE`);
+    await bootstrapPool?.end();
+  });
+
+  beforeEach(async() => {
+    // work_tasks CASCADE also wipes lifecycle_capabilities (its recovery_task_id
+    // column FKs to work_tasks), so the seed rows must be reinserted after.
+    await pool.query(`
+      TRUNCATE work_artifact_receipts, work_task_stage_claims, work_task_dispatches,
+               work_task_dependencies, work_task_comments, work_tasks, work_epics, work_projects
+      RESTART IDENTITY CASCADE
+    `);
+    await pool.query(`
+      INSERT INTO lifecycle_capabilities
+        (capability_key, version, enabled, health, fallback_mode, fallback_active)
+      VALUES
+        ('planning-council', 1, false, 'unavailable', 'heartbeat', true),
+        ('todo-execution', 1, false, 'unavailable', 'heartbeat', true),
+        ('in-review-verification', 1, false, 'unavailable', 'heartbeat', true),
+        ('durable-waits', 1, false, 'unavailable', 'heartbeat', true),
+        ('stale-recovery', 1, false, 'unavailable', 'heartbeat', true)
+      ON CONFLICT (capability_key) DO UPDATE SET
+        enabled = false, health = 'unavailable', active_owner = NULL,
+        fallback_mode = 'heartbeat', fallback_active = true, updated_at = now()
+    `);
+    await pool.query(`INSERT INTO work_projects (id, slug, title) VALUES ('p1', 'p1', 'P1')`);
+    await pool.query(`INSERT INTO work_epics (id, project_id, title) VALUES ('e1', 'p1', 'Epic 1')`);
+  });
+
+  it('hands a rejected review back to todo-execution for the healthy capability owner', async() => {
+    await healthyOwnedByRoutine();
+    await seedInReviewTask('task-owner');
+
+    const result = await LifecycleCapabilityModel.settleReviewReject({
+      taskId: 'task-owner', actor: 'verifier-routine', summary: 'Missing regression test for the new branch.',
+    });
+
+    expect(result.settled).toBe(true);
+    expect(result.alreadySettled).toBe(false);
+    expect(result.task?.status).toBe('todo');
+    expect(result.task?.assignee).toBe('dispatcher');
+
+    const row = await taskRow('task-owner');
+    expect(row.status).toBe('todo');
+    expect(row.assignee).toBe('dispatcher');
+    expect(row.last_moved_by).toBe('verifier-routine');
+
+    const rows = await comments('task-owner');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].body).toContain('REJECTED');
+    expect((await receipts('task-owner'))).toHaveLength(1);
+  });
+
+  it('hands a rejected review back to todo-execution for the named Heartbeat fallback', async() => {
+    await defaultHeartbeatFallback();
+    await seedInReviewTask('task-fallback');
+
+    const result = await LifecycleCapabilityModel.settleReviewReject({
+      taskId: 'task-fallback', actor: 'heartbeat', summary: 'Backlog drain: acceptance criteria not met.',
+    });
+
+    expect(result.settled).toBe(true);
+    expect(result.task?.status).toBe('todo');
+    expect(result.task?.assignee).toBe('dispatcher');
+    expect((await comments('task-fallback'))).toHaveLength(1);
+  });
+
+  it('treats a duplicate settlement of the same review generation as a no-op', async() => {
+    await healthyOwnedByRoutine();
+    await seedInReviewTask('task-dup');
+
+    const first = await LifecycleCapabilityModel.settleReviewReject({
+      taskId: 'task-dup', actor: 'verifier-routine', summary: 'Findings not addressed.',
+    });
+    const second = await LifecycleCapabilityModel.settleReviewReject({
+      taskId: 'task-dup', actor: 'verifier-routine', summary: 'Findings not addressed.',
+    });
+
+    expect(first.settled).toBe(true);
+    expect(second.settled).toBe(false);
+    expect(second.alreadySettled).toBe(true);
+
+    const row = await taskRow('task-dup');
+    expect(row.status).toBe('todo');
+    expect(row.assignee).toBe('dispatcher');
+    // No double-enqueue: still exactly one receipt/comment.
+    expect((await comments('task-dup'))).toHaveLength(1);
+    expect((await receipts('task-dup'))).toHaveLength(1);
+  });
+
+  it('denies a non-authority actor and leaves the task untouched', async() => {
+    await healthyOwnedByRoutine();
+    await seedInReviewTask('task-denied');
+
+    await expect(LifecycleCapabilityModel.settleReviewReject({
+      taskId: 'task-denied', actor: 'heartbeat', summary: 'Trying to reject without authority.',
+    })).rejects.toThrow(/denied/i);
+
+    const row = await taskRow('task-denied');
+    expect(row.status).toBe('in_review');
+    expect((await comments('task-denied'))).toHaveLength(0);
+    expect((await receipts('task-denied'))).toHaveLength(0);
+  });
+
+  it('lets the dispatcher subsequently claim and re-execute the repaired generation', async() => {
+    await healthyOwnedByRoutine();
+    await healthyExecutionOwnedByDispatcher();
+    await seedInReviewTask('task-repair');
+    // Original generation's execution dispatch, already finished.
+    await pool.query(`
+      INSERT INTO work_task_dispatches (id, task_id, agent_id, thread_id, kind, attempt, status, finished_at)
+      VALUES ('dispatch-gen1', 'task-repair', 'agent-1', 'thread-1', 'execution', 1, 'completed', now())
+    `);
+
+    const settled = await LifecycleCapabilityModel.settleReviewReject({
+      taskId: 'task-repair', actor: 'verifier-routine', summary: 'Repair needed before merge.',
+    });
+    expect(settled.settled).toBe(true);
+
+    const claim = await WorkTaskDispatchModel.claimNext('agent-1', 'runtime-1');
+    expect(claim).not.toBeNull();
+    expect(claim?.task.id).toBe('task-repair');
+    expect(claim?.task.status).toBe('in_progress');
+    expect(claim?.dispatch.kind).toBe('execution');
+    // A fresh artifact generation: a new dispatch attempt, not a replay of the old one.
+    expect(claim?.dispatch.attempt).toBe(2);
+  });
+
+  it('recovers without losing the reject when the settlement transaction is rolled back before commit', async() => {
+    await healthyOwnedByRoutine();
+    await seedInReviewTask('task-crash');
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await LifecycleCapabilityModel.settleReviewRejectWithClient(client, {
+        taskId: 'task-crash', actor: 'verifier-routine', summary: 'Simulated crash before commit.',
+      });
+      await client.query('ROLLBACK');
+    } finally {
+      client.release();
+    }
+
+    // Nothing committed: verdict and handoff are the same transaction.
+    const afterRollback = await taskRow('task-crash');
+    expect(afterRollback.status).toBe('in_review');
+    expect((await comments('task-crash'))).toHaveLength(0);
+    expect((await receipts('task-crash'))).toHaveLength(0);
+
+    // The next attempt starts clean and succeeds.
+    const retry = await LifecycleCapabilityModel.settleReviewReject({
+      taskId: 'task-crash', actor: 'verifier-routine', summary: 'Simulated crash before commit.',
+    });
+    expect(retry.settled).toBe(true);
+    const afterRetry = await taskRow('task-crash');
+    expect(afterRetry.status).toBe('todo');
+    expect((await comments('task-crash'))).toHaveLength(1);
+  });
+});

--- a/pkg/rancher-desktop/agent/database/models/__tests__/LifecycleCapabilityModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/LifecycleCapabilityModel.test.ts
@@ -44,15 +44,15 @@ describe('LifecycleCapabilityModel', () => {
       fallback_mode:  'heartbeat',
     }));
 
-    await expect(LifecycleCapabilityModel.assertActorCanManageTask('task-1', 'project-1', 'planning', 'heartbeat'))
+    await expect(LifecycleCapabilityModel.assertActorCanManageTask('planning', [], 'heartbeat'))
       .rejects.toThrow('owned by planning-council');
   });
 
-  it('keeps the legacy Heartbeat owner during incomplete rollout', async() => {
+  it('denies Heartbeat when no capability row is registered for the stage', async() => {
     (postgresClient as any).queryOne = jest.fn(() => Promise.resolve(null));
 
-    await expect(LifecycleCapabilityModel.assertActorCanManageTask('task-1', 'project-1', 'in_review', 'heartbeat'))
-      .resolves.toBeUndefined();
+    await expect(LifecycleCapabilityModel.assertActorCanManageTask('in_review', [], 'heartbeat'))
+      .rejects.toThrow('no explicit Heartbeat fallback is registered');
   });
 
   it('lets Heartbeat claim an unavailable capability with explicit fallback', async() => {
@@ -275,8 +275,8 @@ describe('LifecycleCapabilityModel', () => {
       fallbackMode:      'heartbeat',
     });
 
-    expect(query.mock.calls[0][0]).toContain("resolve_project_lane_key(project_id, 'terminal', 'done')");
-    expect(query.mock.calls[0][0]).toContain("resolve_work_task_lane_role(id, status) <> 'terminal'");
+    expect(query.mock.calls[0][0]).toContain("SET status = 'done'");
+    expect(query.mock.calls[0][0]).toContain("WHERE id = $1 AND status NOT IN ('done', 'cancelled', 'parked')");
     expect(query.mock.calls[0][1]).toEqual(['caprec-durable-waits']);
     expect(query.mock.calls[1][0]).toContain('SET recovery_task_id = NULL');
   });

--- a/pkg/rancher-desktop/agent/projects/application/ProjectsApplicationService.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsApplicationService.ts
@@ -395,6 +395,26 @@ export class ProjectsApplicationService {
     return this.repository.updateTask(taskId, { ...changes, actor });
   }
 
+  /**
+   * First-class reject->repair handoff (#727). Distinct from updateTask: the
+   * generic path enforces assertActorCanManageTask (an actor may not walk
+   * into a stage owned by a different healthy capability); this path is the
+   * one narrow exception, gated on its own authorization check inside
+   * LifecycleCapabilityModel.settleReviewReject — the caller must be the
+   * effective owner of in-review-verification at act time. Do not route
+   * generic status edits through this method.
+   */
+  rejectTaskReview(
+    input: { taskId: string; summary: string },
+    context: ProjectsCommandContext = DEFAULT_CONTEXT,
+  ) {
+    return LifecycleCapabilityModel.settleReviewReject({
+      taskId:  itemId(input.taskId, 'task_id'),
+      actor:   context.actor,
+      summary: input.summary,
+    });
+  }
+
   async transitionTaskStage(
     input: TransitionTaskStageInput,
     context: ProjectsCommandContext = DEFAULT_CONTEXT,

--- a/pkg/rancher-desktop/agent/tools/project/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/project/manifests.ts
@@ -426,6 +426,18 @@ export const projectToolManifests: ToolManifest[] = [
     loader:         () => import('./update_task'),
   },
   {
+    name:        'reject_task_review',
+    description: 'Settle an in_review task with a REJECTED verdict and atomically hand it back to todo-execution for repair. For the acting in-review authority only (the protected review routine, or its named Heartbeat fallback) — not a general status edit; use update_task for everything else. Idempotent: replaying it after the task has already left in_review is a no-op.',
+    category:    'project',
+    schemaDef:   {
+      task_id: { type: 'string', description: 'Task currently in_review to reject.' },
+      summary: { type: 'string', description: 'Rejection rationale / repair guidance, recorded on the receipt.' },
+      actor:   { type: 'string', optional: true, description: 'Acting in-review authority. Defaults to "heartbeat". Must be the effective owner of in-review-verification at call time.' },
+    },
+    operationTypes: ['update'],
+    loader:         () => import('./reject_task_review'),
+  },
+  {
     name:        'transition_task_stage',
     description: 'Move a task to one explicit active stage in its project pipeline. Workflow routines should pass expected_generation so a stale run cannot move a newer stage entry.',
     category:    'project',

--- a/pkg/rancher-desktop/agent/tools/project/reject_task_review.ts
+++ b/pkg/rancher-desktop/agent/tools/project/reject_task_review.ts
@@ -1,0 +1,45 @@
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
+import { BaseTool, ToolResponse } from '../base';
+
+/**
+ * Settle an in-review task with a REJECTED verdict and atomically hand it
+ * back to todo-execution for repair (#727). This is a dedicated, narrowly
+ * scoped transition — not update_task — because the acting in-review
+ * authority (the protected review routine, or its explicitly named
+ * Heartbeat fallback) does not own todo-execution and update_task's guard
+ * correctly denies a generic status edit across that boundary. This tool's
+ * own authorization check requires the caller to be the effective owner of
+ * in-review-verification at call time; everyone else is denied. Calling it
+ * twice for a task that has already left in_review is a safe no-op.
+ */
+export class RejectTaskReviewWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const taskId = typeof input.task_id === 'string' ? input.task_id.trim() : '';
+    const summary = typeof input.summary === 'string' ? input.summary.trim() : '';
+    if (!taskId) return { successBoolean: false, responseString: 'task_id is required.' };
+    if (!summary) return { successBoolean: false, responseString: 'summary (rejection rationale) is required.' };
+    const actor = typeof input.actor === 'string' && input.actor.trim() ? input.actor.trim() : 'heartbeat';
+
+    try {
+      const result = await getProjectsApplicationService().rejectTaskReview(
+        { taskId, summary },
+        { actor, source: 'routine' },
+      );
+      if (!result.settled) {
+        return {
+          successBoolean: true,
+          responseString: `Task ${ taskId } was already settled out of this review generation; no-op.`,
+        };
+      }
+      return {
+        successBoolean: true,
+        responseString: `Task ${ taskId } rejected and handed back to todo-execution (assignee: ${ result.task?.assignee ?? 'dispatcher' }).`,
+      };
+    } catch (error: any) {
+      return { successBoolean: false, responseString: `Failed to reject task review: ${ error?.message ?? String(error) }` };
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- add a dedicated atomic `settleReviewReject` lifecycle handoff for the in-review authority or named Heartbeat fallback
- record the REJECTED verdict, release the review claim, requeue the task to dispatcher-owned todo execution, and write one concise Projects receipt in one transaction
- keep generic lifecycle ownership guards unchanged, including healthy execution-lease takeover denial and non-authority rejection

## Verification

- migrated-Postgres coverage in `LifecycleCapabilityModel.reviewReject.postgres.test.ts` covers owner success, Heartbeat fallback, duplicate no-op, non-authority denial, dispatcher re-claim, and rollback recovery
- commit/show check and esbuild TypeScript parse passed
- full local Jest startup was attempted but exceeded the VM harness timeout before test output

Closes #727