### PR TITLE
fix(chat): scope desktop stops to thread ownership

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/AgentPersonaModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/AgentPersonaModel.ts
@@ -395,15 +395,15 @@ export class AgentPersonaService {
   }
 
   async emitStopSignal(agentId: string): Promise<boolean> {
-    console.log('[AgentPersonaModel] Emitting stop signal for agent:', agentId, 'thread:', this.state.threadId);
+    console.log('[AgentPersonaModel] Emitting stop signal for agent:', agentId, 'tab:', this.tabId, 'thread:', this.state.threadId);
     let sent: boolean;
     try {
-      // Send the threadId so the backend stops only THIS tab's run, not
-      // every active run on the channel. Backend falls back to channel-wide
-      // stop when threadId is missing (older clients).
+      // Send both ownership identifiers so the backend and logs can prove
+      // which tab/thread requested the stop. The backend rejects unscoped
+      // stops rather than treating the shared channel as run ownership.
       sent = await this.wsService.send(agentId, {
         type:      'stop_run',
-        data:      { threadId: this.state.threadId },
+        data:      { threadId: this.state.threadId, tabId: this.tabId },
         timestamp: Date.now(),
       });
     } catch {

--- a/pkg/rancher-desktop/agent/services/BackendGraphWebSocketService.ts
+++ b/pkg/rancher-desktop/agent/services/BackendGraphWebSocketService.ts
@@ -193,19 +193,19 @@ export class BackendGraphWebSocketService {
     }
 
     if (msg.type === 'stop_run') {
-      // Stop a specific thread when the frontend supplies one (current chat
-      // tab); otherwise stop every active run on the channel as a fallback
-      // for older clients.
       const data = typeof msg.data === 'string' ? {} : (msg.data as any);
-      const stopThreadId = typeof data?.threadId === 'string' ? data.threadId : '';
-      if (stopThreadId) {
-        this.activeAborts.get(this.abortKey(channelId, stopThreadId))?.abort();
-      } else {
-        const prefix = `${ channelId }|`;
-        for (const [k, abort] of this.activeAborts) {
-          if (k.startsWith(prefix)) abort.abort();
-        }
+      const stopThreadId = typeof data?.threadId === 'string' ? data.threadId.trim() : '';
+      const stopTabId = typeof data?.tabId === 'string' ? data.tabId.trim() : '';
+      console.log(`[BackendGraphWS:stop_run] channelId=${ channelId }, tabId=${ stopTabId || '(none)' }, threadId=${ stopThreadId || '(none)' }`);
+
+      // A WebSocket channel is shared by every desktop chat tab. It is not a
+      // run-ownership boundary, so missing/stale client identity must fail
+      // closed. A stale thread id simply finds no active abort handle.
+      if (!stopThreadId) {
+        console.warn(`[BackendGraphWS:stop_run] ignored unscoped stop for channelId=${ channelId }, tabId=${ stopTabId || '(none)' }`);
+        return;
       }
+      this.activeAborts.get(this.abortKey(channelId, stopThreadId))?.abort();
       return;
     }
 

--- a/pkg/rancher-desktop/agent/services/FrontendGraphWebSocketService.ts
+++ b/pkg/rancher-desktop/agent/services/FrontendGraphWebSocketService.ts
@@ -19,7 +19,7 @@ export class FrontendGraphWebSocketService {
   private readonly wsService = getWebSocketClientService();
   private channelId:   string;
   private unsubscribe: (() => void) | null = null;
-  private activeAbort: AbortService | null = null;
+  private activeAborts = new Map<string, AbortService>();
 
   constructor(private readonly deps: FrontendGraphWebSocketDeps, channelId?: string) {
     this.channelId = channelId || DEFAULT_CHANNEL_ID;
@@ -38,10 +38,7 @@ export class FrontendGraphWebSocketService {
       this.unsubscribe();
       this.unsubscribe = null;
     }
-    if (this.activeAbort) {
-      this.activeAbort.abort();
-      this.activeAbort = null;
-    }
+    this.abortAllRuns();
     await this.deregisterAgent().catch(() => {});
 
     // Switch and re-initialize
@@ -54,10 +51,7 @@ export class FrontendGraphWebSocketService {
       this.unsubscribe();
       this.unsubscribe = null;
     }
-    if (this.activeAbort) {
-      this.activeAbort.abort();
-      this.activeAbort = null;
-    }
+    this.abortAllRuns();
 
     // Frontend is only available while the app window is open.
     // Remove it from the active agents registry on teardown.
@@ -111,13 +105,15 @@ export class FrontendGraphWebSocketService {
     });
 
     if (msg.type === 'stop_run') {
-      console.log(`[FrontendGraph:stop_run] received — activeAbort=${ !!this.activeAbort }, channel=${ this.channelId }`);
-      if (this.activeAbort) {
-        this.activeAbort.abort();
-        console.log('[FrontendGraph:stop_run] abort() called successfully');
-      } else {
-        console.warn('[FrontendGraph:stop_run] No activeAbort controller — graph may have already finished');
+      const data = typeof msg.data === 'string' ? {} : (msg.data as any);
+      const threadId = typeof data?.threadId === 'string' ? data.threadId.trim() : '';
+      const tabId = typeof data?.tabId === 'string' ? data.tabId.trim() : '';
+      console.log(`[FrontendGraph:stop_run] channelId=${ this.channelId }, tabId=${ tabId || '(none)' }, threadId=${ threadId || '(none)' }`);
+      if (!threadId) {
+        console.warn(`[FrontendGraph:stop_run] ignored unscoped stop for channelId=${ this.channelId }, tabId=${ tabId || '(none)' }`);
+        return;
       }
+      this.activeAborts.get(threadId)?.abort();
       return;
     }
 
@@ -174,18 +170,19 @@ export class FrontendGraphWebSocketService {
     }
 
     // Create a fresh AbortService for this run and wire it into state.
-    // Set state first so stop_run can't race between activeAbort and state.
-    if (this.activeAbort) {
+    // Set state first so stop_run can't race between activeAborts and state.
+    const prior = this.activeAborts.get(threadId);
+    if (prior) {
       try {
-        this.activeAbort.abort();
+        prior.abort();
       } catch {
         // already aborted
       }
     }
     const abort = new AbortService();
     state.metadata.options.abort = abort;
-    this.activeAbort = abort;
-    const isCurrentRun = () => this.activeAbort === abort;
+    this.activeAborts.set(threadId, abort);
+    const isCurrentRun = () => this.activeAborts.get(threadId) === abort;
 
     // Always refresh model context from current settings so existing threads
     // follow the currently selected frontend model/provider.
@@ -269,7 +266,7 @@ export class FrontendGraphWebSocketService {
       state.metadata.iterations = 0;
       (state.metadata as any).agentLoopCount = 0;
       if (isCurrentRun()) {
-        this.activeAbort = null;
+        this.activeAborts.delete(threadId);
       }
 
       // Persist thread state so it survives page reloads
@@ -293,18 +290,19 @@ export class FrontendGraphWebSocketService {
     const { graph, state } = existing as { graph: any; state: AgentGraphState };
 
     // Create a fresh AbortService for this run.
-    // Set state first so stop_run can't race between activeAbort and state.
-    if (this.activeAbort) {
+    // Set state first so stop_run can't race between activeAborts and state.
+    const prior = this.activeAborts.get(threadId);
+    if (prior) {
       try {
-        this.activeAbort.abort();
+        prior.abort();
       } catch {
         // already aborted
       }
     }
     const abort = new AbortService();
     state.metadata.options.abort = abort;
-    this.activeAbort = abort;
-    const isCurrentRun = () => this.activeAbort === abort;
+    this.activeAborts.set(threadId, abort);
+    const isCurrentRun = () => this.activeAborts.get(threadId) === abort;
 
     try {
       // Reset loop counters so the graph can run another full set of cycles
@@ -332,7 +330,7 @@ export class FrontendGraphWebSocketService {
       state.metadata.iterations = 0;
       (state.metadata as any).agentLoopCount = 0;
       if (isCurrentRun()) {
-        this.activeAbort = null;
+        this.activeAborts.delete(threadId);
       }
 
       // Persist thread state so it survives page reloads
@@ -346,6 +344,13 @@ export class FrontendGraphWebSocketService {
       data:      { role: 'assistant', content, thread_id: threadId ?? this.deps.currentThreadId.value },
       timestamp: Date.now(),
     });
+  }
+
+  private abortAllRuns(): void {
+    for (const abort of this.activeAborts.values()) {
+      abort.abort();
+    }
+    this.activeAborts.clear();
   }
 
   private emitSystemMessage(content: string, threadId?: string): void {

--- a/pkg/rancher-desktop/agent/services/__tests__/BackendGraphWebSocketService.abortRace.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/BackendGraphWebSocketService.abortRace.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import type { AbortService } from '../AbortService';
 
@@ -25,6 +25,19 @@ const state: any = {
   metadata: { options: {} },
   messages: [],
 };
+const statesByThread = new Map<string, any>();
+let messageSequence = 0;
+
+function stateForThread(threadId: string): any {
+  let threadState = statesByThread.get(threadId);
+  if (!threadState) {
+    threadState = threadId === 'thread-1'
+      ? state
+      : { metadata: { options: {}, threadId }, messages: [] };
+    statesByThread.set(threadId, threadState);
+  }
+  return threadState;
+}
 
 jest.unstable_mockModule('../WebSocketClientService', () => ({
   getWebSocketClientService: jest.fn(() => ({
@@ -44,15 +57,15 @@ jest.unstable_mockModule('../SchedulerService', () => ({
 
 jest.unstable_mockModule('../GraphRegistry', () => ({
   GraphRegistry: {
-    getOrCreateAgentGraph: jest.fn(() => Promise.resolve({
+    getOrCreateAgentGraph: jest.fn((_agentId: string, threadId: string) => Promise.resolve({
       graph: { execute: executeMock },
-      state,
+      state: stateForThread(threadId),
     })),
     delete: jest.fn(),
   },
   getAgentIdForTrigger: jest.fn(() => Promise.resolve('sulla-desktop')),
   nextThreadId:         jest.fn(() => 'thread-generated'),
-  nextMessageId:        jest.fn(() => `msg-${ state.messages.length + 1 }`),
+  nextMessageId:        jest.fn(() => `msg-${ ++messageSequence }`),
 }));
 
 jest.unstable_mockModule('../ActiveAgentsRegistry', () => ({
@@ -68,6 +81,15 @@ jest.unstable_mockModule('../../utils/sullaPaths', () => ({
 }));
 
 describe('BackendGraphWebSocketService interruption ownership', () => {
+  beforeEach(() => {
+    executeMock.mockReset();
+    sendMock.mockReset();
+    statesByThread.clear();
+    state.metadata = { options: {} };
+    state.messages = [];
+    messageSequence = 0;
+  });
+
   it('does not let an aborted superseded run delete the newer run abort handle', async() => {
     const { BackendGraphWebSocketService } = await import('../BackendGraphWebSocketService');
     const svc: any = new BackendGraphWebSocketService();
@@ -123,5 +145,75 @@ describe('BackendGraphWebSocketService interruption ownership', () => {
 
     expect(secondAbort?.aborted).toBe(true);
     expect(svc.activeAborts.has('sulla-desktop|thread-1')).toBe(false);
+  });
+
+  it('keeps two simultaneous chat threads independent and ignores unscoped stops', async() => {
+    const { BackendGraphWebSocketService } = await import('../BackendGraphWebSocketService');
+    const svc: any = new BackendGraphWebSocketService();
+    const threadAStarted = deferred<AbortService>();
+    const threadBStarted = deferred<AbortService>();
+    const threadAMayFinish = deferred();
+    const threadBMayFinish = deferred();
+
+    executeMock.mockImplementation(async(runState: any) => {
+      const threadId = runState.metadata.threadId as string;
+      const abort = runState.metadata.options.abort as AbortService;
+      const started = threadId === 'thread-a' ? threadAStarted : threadBStarted;
+      const mayFinish = threadId === 'thread-a' ? threadAMayFinish : threadBMayFinish;
+      started.resolve(abort);
+
+      await Promise.race([
+        mayFinish.promise,
+        new Promise<void>((resolve) => abort.signal.addEventListener('abort', () => resolve(), { once: true })),
+      ]);
+      if (abort.aborted) throw new DOMException('Operation aborted', 'AbortError');
+    });
+
+    const runA = svc.dispatchToAgent('sulla-desktop', 'sulla-desktop', 'chat A', 'thread-a');
+    const abortA = await threadAStarted.promise;
+    const runB = svc.dispatchToAgent('sulla-desktop', 'sulla-desktop', 'chat B', 'thread-b');
+    const abortB = await threadBStarted.promise;
+
+    expect(abortA.aborted).toBe(false);
+    expect(abortB.aborted).toBe(false);
+    expect(svc.activeAborts.get('sulla-desktop|thread-a')).toBe(abortA);
+    expect(svc.activeAborts.get('sulla-desktop|thread-b')).toBe(abortB);
+
+    // A malformed/legacy stop must not use the shared channel as ownership.
+    await svc.handleChannelMessage('sulla-desktop', 'sulla-desktop', {
+      type:      'stop_run',
+      data:      { tabId: 'tab-b' },
+      timestamp: Date.now(),
+    });
+    expect(abortA.aborted).toBe(false);
+    expect(abortB.aborted).toBe(false);
+
+    await svc.handleChannelMessage('sulla-desktop', 'sulla-desktop', {
+      type:      'stop_run',
+      data:      { tabId: 'stale-tab', threadId: 'stale-thread' },
+      timestamp: Date.now(),
+    });
+    expect(abortA.aborted).toBe(false);
+    expect(abortB.aborted).toBe(false);
+
+    // An explicit stop from chat B terminates only chat B; chat A keeps running.
+    await svc.handleChannelMessage('sulla-desktop', 'sulla-desktop', {
+      type:      'stop_run',
+      data:      { tabId: 'tab-b', threadId: 'thread-b' },
+      timestamp: Date.now(),
+    });
+    await runB;
+
+    expect(abortB.aborted).toBe(true);
+    expect(abortA.aborted).toBe(false);
+    expect(svc.activeAborts.has('sulla-desktop|thread-b')).toBe(false);
+    expect(svc.activeAborts.get('sulla-desktop|thread-a')).toBe(abortA);
+
+    threadAMayFinish.resolve();
+    await runA;
+    expect(svc.activeAborts.has('sulla-desktop|thread-a')).toBe(false);
+
+    // Keep the unused completion deferred explicit so this test cannot leak.
+    threadBMayFinish.resolve();
   });
 });

--- a/pkg/rancher-desktop/pages/BrowserTabChat.vue
+++ b/pkg/rancher-desktop/pages/BrowserTabChat.vue
@@ -733,9 +733,9 @@ watch(
 
 onUnmounted(() => {
   // voice cleanup is handled automatically by useVoiceSession's onUnmounted
-  if (graphRunning.value) {
-    chatController.stop();
-  }
+  // Do not stop the graph here. A tab can unmount during mode switches or
+  // teardown while another same-channel chat is active; only the explicit
+  // Stop control owns cancellation for this tab/thread.
   chatController.dispose();
   modelSelector.dispose();
 });

--- a/pkg/rancher-desktop/pages/agent/ChatInterface.ts
+++ b/pkg/rancher-desktop/pages/agent/ChatInterface.ts
@@ -28,6 +28,7 @@ export class ChatInterface {
   private readonly persona:            AgentPersonaService;
   private readonly registry:           AgentPersonaRegistry;
   private readonly channelId:          string;
+  private readonly tabId?:             string;
   /** Unique key for this tab's localStorage — scoped by tabId when provided */
   private readonly storageScope:       string;
   private readonly messagesStorageKey: string;
@@ -49,6 +50,7 @@ export class ChatInterface {
    */
   constructor(channelId: string = DEFAULT_CHANNEL, tabId?: string) {
     this.channelId = channelId;
+    this.tabId = tabId;
     // Use tabId for storage scoping when available, otherwise fall back to channelId
     this.storageScope = tabId ? `${ channelId }_${ tabId }` : channelId;
     touchChatStorageScope(this.storageScope);
@@ -241,8 +243,16 @@ export class ChatInterface {
   }
 
   stop(): void {
-    console.log(`[ChatInterface:stop] channelId=${ this.channelId }, graphRunning was ${ this.persona.graphRunning.value }`);
-    this.persona.emitStopSignal(this.channelId);
+    const threadId = this.persona.getThreadId();
+    console.log(`[ChatInterface:stop] channelId=${ this.channelId }, tabId=${ this.tabId ?? '(none)' }, threadId=${ threadId ?? '(none)' }, graphRunning was ${ this.persona.graphRunning.value }`);
+    if (threadId) {
+      this.persona.emitStopSignal(this.channelId);
+    } else {
+      // Never emit an unscoped stop. Multiple tabs intentionally share one
+      // channel, so a missing thread id must fail closed instead of risking a
+      // channel-wide abort in an older backend.
+      console.warn(`[ChatInterface:stop] ignored unscoped stop for channelId=${ this.channelId }, tabId=${ this.tabId ?? '(none)' }`);
+    }
     this.persona.graphRunning.value = false;
     // Clear the queue when stopping
     this.messageQueue.clear();


### PR DESCRIPTION
## What changed

- make desktop stop requests carry both `tabId` and `threadId`
- ignore missing or stale thread ownership instead of falling back to channel-wide abort
- keep active abort controllers keyed per thread in both graph executors
- remove the legacy tab-unmount auto-stop so only the explicit Stop control cancels a run
- log channel, tab, and thread ownership on stop
- add a regression for two simultaneous `sulla-desktop` chats

## Verification

- focused Jest: 1 suite, 2 tests, 20 assertions passed
- scoped ESLint: backend service, frontend service, regression test passed
- legacy `BrowserTabChat.vue` ESLint passed
- `git diff --check` passed
- repo-wide `tsc --noEmit` attempted; Node exhausted its 4 GB heap without emitting TypeScript diagnostics

## Scope

This fixes Projects task n57e only. It does not address GW7w (Claude Code stream delivery/Stop-flush behavior).

No merge, deploy, or desktop rebuild performed.