### PR TITLE
test(dispatcher): Phase 8 crash/restart soak

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -1145,6 +1145,15 @@ export class WorkTaskDispatchModel {
       if (!moved.rows[0]) {
         throw new Error(`Task ${ taskId } is no longer owned by dispatch ${ id }`);
       }
+      // Finalization is the durable ownership handoff. Releasing the stage
+      // claim in this same transaction is required for journal replay after a
+      // process death: runClaim's finally block may never execute after
+      // SIGKILL, and leaving the claim active strands the WIP slot forever.
+      await client.query(`
+        UPDATE work_task_stage_claims
+           SET status = 'released', released_at = now(), heartbeat_at = now()
+         WHERE task_id = $1 AND stage = 'in_progress' AND status = 'active'
+      `, [taskId]);
       return moved.rows[0];
     })();
   }

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -579,6 +579,7 @@ export class TaskDispatcherService {
     let lastActivityAt = Date.now();
     let leaseTimer: ReturnType<typeof setInterval> | null = null;
     let runTimeout: ReturnType<typeof setTimeout> | null = null;
+    let expireRun: (() => void) | null = null;
     let verifierTimedOut = false;
     let executionTimedOut = false;
 
@@ -680,6 +681,9 @@ export class TaskDispatcherService {
         ? false
         : await SullaSettingsModel.get('taskDispatcherExecutionTimeoutReportOnly', false);
       const reportOnly = reportOnlySetting === true || reportOnlySetting === 'true';
+      const runtimeDeadline = new Promise<null>((resolve) => {
+        expireRun = () => resolve(null);
+      });
       runTimeout = setTimeout(() => {
         if (!timeoutEnabled || reportOnly) {
           console.warn(`[TaskDispatcher] Execution timeout report-only for ${ dispatch.id } after ${ timeoutMinutes } minute(s)`);
@@ -688,8 +692,9 @@ export class TaskDispatcherService {
         if (isVerification) verifierTimedOut = true;
         else executionTimedOut = true;
         abort.abort();
+        expireRun?.();
         if (!isVerification) {
-          void WorkTaskDispatchModel.settle(
+          WorkTaskDispatchModel.settle(
             dispatch.id,
             'timed_out',
             undefined,
@@ -697,7 +702,17 @@ export class TaskDispatcherService {
           ).catch(err => console.error(`[TaskDispatcher] Timeout settlement failed for ${ dispatch.id }:`, err));
         }
       }, timeoutMinutes * 60_000);
-      const finalState = await graph.execute(state);
+      const finalState = await Promise.race([graph.execute(state), runtimeDeadline]);
+
+      // An abort signal is cooperative; an immortal provider promise may
+      // ignore it forever. The deadline itself therefore wins the race and
+      // unwinds runClaim so its finally block releases the stage and WIP slot.
+      if (!finalState) {
+        if (isVerification && verifierTimedOut) {
+          await WorkTaskDispatchModel.failVerification(dispatch.id, 'verifier_timeout');
+        }
+        return;
+      }
 
       // Single-agent workflow nodes (e.g. node-review-classify) are
       // dispatched fire-and-forget inside Graph.execute() so interactive

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherCrashSoak.postgres.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherCrashSoak.postgres.test.ts
@@ -1,0 +1,154 @@
+/** @jest-environment node */
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { Pool } from 'pg';
+
+import { postgresClient } from '../../database/PostgresClient';
+import { up as createSettings } from '../../database/migrations/0011_create_settings_table';
+import { up as castSettings } from '../../database/migrations/0012_add_cast_column_to_sulla_settings';
+import { up as createWorkflows } from '../../database/migrations/0023_create_workflows_table';
+import { up as createWorkflowExecutions } from '../../database/migrations/0026_create_workflow_executions_table';
+import { up as createWorkItems } from '../../database/migrations/0044_create_work_items_tables';
+import { up as addWorkTaskActor } from '../../database/migrations/0047_add_work_task_actor';
+import { up as addCoreWorkflowFields } from '../../database/migrations/0055_add_system_and_content_hash_to_workflows';
+import { up as addWorkTaskActivity } from '../../database/migrations/0061_add_work_task_activity';
+import { up as createWorkTaskDispatches } from '../../database/migrations/0062_create_work_task_dispatches';
+import { up as addVerificationDispatches } from '../../database/migrations/0064_add_verification_dispatches';
+import { up as createLifecycleCapabilities } from '../../database/migrations/0068_create_lifecycle_capabilities';
+import { up as extendDispatchCustody } from '../../database/migrations/0076_extend_work_task_dispatch_custody';
+import { up as createArtifactCustody } from '../../database/migrations/0079_create_work_task_artifact_custody';
+import { up as addWorkflowExecutionLeases } from '../../database/migrations/0081_add_workflow_execution_leases';
+import { up as createArtifactReceipts } from '../../database/migrations/0082_create_artifact_receipts';
+import { up as createOutcomeJournal } from '../../database/migrations/0090_create_work_task_outcome_journal';
+import { up as createDispatcherLiveness } from '../../database/migrations/0091_create_dispatcher_liveness';
+import { DispatcherLivenessModel } from '../../database/models/DispatcherLivenessModel';
+import { WorkTaskDispatchModel } from '../../database/models/WorkTaskDispatchModel';
+
+const connectionString = process.env.SULLA_INTEGRATION_POSTGRES_URL;
+const describeWithPostgres = connectionString ? describe : describe.skip;
+const seams = [
+  'claim-commit-before-graph',
+  'worker-return-before-journal',
+  'journal-before-finalize',
+  'finalize-before-liveness',
+  'recover-stale-mid-batch',
+] as const;
+
+describeWithPostgres('TaskDispatcher crash/restart convergence soak', () => {
+  const schema = `dispatcher_soak_${ randomUUID().replaceAll('-', '') }`;
+  let bootstrapPool: Pool;
+  let pool: Pool;
+  const originalQuery = postgresClient.query;
+  const originalQueryOne = postgresClient.queryOne;
+  const originalQueryAll = postgresClient.queryAll;
+  const originalTransaction = postgresClient.transaction;
+
+  beforeAll(async() => {
+    bootstrapPool = new Pool({ connectionString, max: 1 });
+    await bootstrapPool.query(`CREATE SCHEMA "${ schema }"`);
+    pool = new Pool({ connectionString, max: 8, options: `-c search_path=${ schema }` });
+    for (const migration of [
+      createSettings, castSettings, createWorkflows, createWorkflowExecutions,
+      addCoreWorkflowFields, createWorkItems, addWorkTaskActor, addWorkTaskActivity,
+      createWorkTaskDispatches, addVerificationDispatches, createLifecycleCapabilities,
+      extendDispatchCustody, createArtifactCustody, addWorkflowExecutionLeases,
+      createArtifactReceipts, createOutcomeJournal, createDispatcherLiveness,
+    ]) await pool.query(migration as any);
+    await pool.query(`CREATE TABLE fault_soak_external_prs (task_id TEXT NOT NULL, url TEXT NOT NULL)`);
+    await pool.query(`INSERT INTO work_projects (id, slug, title) VALUES ('p1', 'p1', 'Crash soak')`);
+    await pool.query(`INSERT INTO work_epics (id, project_id, title) VALUES ('e1', 'p1', 'Dispatcher')`);
+    await pool.query(`
+      INSERT INTO lifecycle_capabilities
+        (capability_key, version, enabled, health, active_owner, runtime_instance_id, fallback_mode, fallback_active)
+      VALUES ('todo-execution', 1, true, 'healthy', 'dispatcher', 'boot-runtime', 'heartbeat', false)
+      ON CONFLICT (capability_key) DO UPDATE SET enabled = true, health = 'healthy', active_owner = 'dispatcher'
+    `);
+    await pool.query(`
+      INSERT INTO sulla_settings (property, value, "cast")
+      VALUES ('taskDispatcherTruthReconciliationEnabled', 'true', 'boolean')
+      ON CONFLICT (property) DO UPDATE SET value = 'true', "cast" = 'boolean'
+    `);
+
+    (postgresClient as any).query = async(text: string, params: unknown[] = []) => (await pool.query(text, params)).rows;
+    (postgresClient as any).queryOne = async(text: string, params: unknown[] = []) => (await pool.query(text, params)).rows[0] ?? null;
+    (postgresClient as any).queryAll = async(text: string, params: unknown[] = []) => (await pool.query(text, params)).rows;
+    (postgresClient as any).transaction = async(callback: (client: any) => Promise<unknown>) => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        const result = await callback(client);
+        await client.query('COMMIT');
+        return result;
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+      }
+    };
+  });
+
+  afterAll(async() => {
+    (postgresClient as any).query = originalQuery;
+    (postgresClient as any).queryOne = originalQueryOne;
+    (postgresClient as any).queryAll = originalQueryAll;
+    (postgresClient as any).transaction = originalTransaction;
+    await pool?.end();
+    await bootstrapPool?.query(`DROP SCHEMA IF EXISTS "${ schema }" CASCADE`);
+    await bootstrapPool?.end();
+  });
+
+  async function crashAt(seam: typeof seams[number], taskId: string): Promise<void> {
+    const worker = fileURLToPath(new URL('./fixtures/dispatcherCrashWorker.ts', import.meta.url));
+    const child = spawn(process.execPath, ['--import', 'tsx', worker, connectionString!, schema, seam, taskId], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let output = '';
+    child.stdout.on('data', (chunk) => {
+      output += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      output += chunk.toString();
+    });
+    const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+      child.once('error', reject);
+      child.once('exit', (code, signal) => resolve({ code, signal }));
+    });
+    expect(output).toContain(`FAULT_READY:${ seam }`);
+    expect(result.signal).toBe('SIGKILL');
+  }
+
+  async function bootAndAssertTruth(taskId: string): Promise<void> {
+    await WorkTaskDispatchModel.recoverPendingOutcomeJournals();
+    await WorkTaskDispatchModel.recoverStale(0);
+    await DispatcherLivenessModel.beginTick(60_000);
+    await DispatcherLivenessModel.completeTick(60_000, 'idle');
+
+    const running = await pool.query(`SELECT id FROM work_task_dispatches WHERE status = 'running'`);
+    expect(running.rows).toHaveLength(0);
+    const stranded = await pool.query(`
+      SELECT d.id FROM work_task_dispatches d JOIN work_tasks t ON t.id = d.task_id
+       WHERE d.status = 'running' AND t.status IN ('done', 'in_review', 'blocked')
+    `);
+    expect(stranded.rows).toHaveLength(0);
+    const liveness = await pool.query(`SELECT checking, last_outcome, last_tick_at FROM dispatcher_liveness WHERE id = true`);
+    expect(liveness.rows[0]).toMatchObject({ checking: false, last_outcome: 'idle' });
+    expect(liveness.rows[0].last_tick_at).not.toBeNull();
+    const duplicatePullRequests = await pool.query(`
+      SELECT task_id, COUNT(*)::int AS count FROM fault_soak_external_prs
+       WHERE task_id = $1 GROUP BY task_id HAVING COUNT(*) > 1
+    `, [taskId]);
+    expect(duplicatePullRequests.rows).toHaveLength(0);
+    const activeClaims = await pool.query(`SELECT id FROM work_task_stage_claims WHERE status = 'active'`);
+    expect(activeClaims.rows).toHaveLength(0);
+  }
+
+  it.each(seams)('SIGKILL at %s converges on the next boot', async(seam) => {
+    const taskId = `task-${ seam }`;
+    await crashAt(seam, taskId);
+    await bootAndAssertTruth(taskId);
+  });
+});

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -44,6 +44,8 @@ const workflowFindByIdMock: any = jest.fn(() => Promise.resolve({ attributesSnap
 const findAgentDirMock: any = jest.fn(() => '/agents/sulla-desktop');
 const automationEnabledMock: any = jest.fn(() => Promise.resolve(true));
 const resolveLimitMock: any = jest.fn((_scope: string, configured: number) => Promise.resolve(configured));
+const acquireSlotMock: any = jest.fn(() => Promise.resolve('slot'));
+const releaseSlotMock: any = jest.fn(() => Promise.resolve());
 const withStatementTimeoutMock: any = jest.fn((_timeoutMs: number, callback: () => Promise<unknown>) => callback());
 
 jest.unstable_mockModule('../../database/PostgresClient', () => ({
@@ -117,8 +119,8 @@ jest.unstable_mockModule('../RoutineConcurrencyPolicy', () => ({
     isEnabled:     automationEnabledMock,
     resolveLimit:  resolveLimitMock,
     reclaimStale:  jest.fn(() => Promise.resolve()),
-    acquire:       jest.fn(() => Promise.resolve('slot')),
-    release:       jest.fn(() => Promise.resolve()),
+    acquire:       acquireSlotMock,
+    release:       releaseSlotMock,
     heartbeat:     jest.fn(() => Promise.resolve()),
   },
 }));
@@ -171,6 +173,8 @@ describe('TaskDispatcherService', () => {
     reportCapabilityMock.mockResolvedValue({});
     releaseStageMock.mockResolvedValue(undefined);
     automationEnabledMock.mockResolvedValue(true);
+    acquireSlotMock.mockResolvedValue('slot');
+    releaseSlotMock.mockResolvedValue(undefined);
     withStatementTimeoutMock.mockImplementation((_timeoutMs: number, callback: () => Promise<unknown>) => callback());
   });
 
@@ -210,6 +214,64 @@ describe('TaskDispatcherService', () => {
         key:     'todo-execution',
         details: expect.objectContaining({ tickWedgeCount: 1 }),
       }));
+      service.destroy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('releases the tick gate when hasActiveLinkedPullRequest never settles', async() => {
+    jest.useFakeTimers();
+    try {
+      settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+        if (key === 'taskDispatcherTickTimeoutMs') return Promise.resolve(1_000);
+        if (key === 'taskVerifierOwner') return Promise.resolve('legacy');
+        return Promise.resolve(fallback);
+      });
+      findRecoverableInProgressMock.mockResolvedValue([{
+        task: { id: 'hung-pr-task', github_issue: 'merchantprotocol/sulla-desktop#1' },
+        exclusionReasons: [],
+      }]);
+      const { TaskDispatcherService } = await import('../TaskDispatcherService');
+      const service = new TaskDispatcherService() as any;
+      service.hasActiveLinkedPullRequest = jest.fn(() => new Promise(() => {}));
+      const initialized = service.initialize();
+
+      await jest.advanceTimersByTimeAsync(1_000);
+      await initialized;
+      findRecoverableInProgressMock.mockResolvedValue([]);
+      await jest.advanceTimersByTimeAsync(59_000);
+
+      expect(service.hasActiveLinkedPullRequest).toHaveBeenCalledTimes(1);
+      expect(countRunningMock).toHaveBeenCalled();
+      expect(completeTickMock).toHaveBeenCalledWith(60_000, 'error');
+      service.destroy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('releases the tick gate when a statement-timeout tick query never settles', async() => {
+    jest.useFakeTimers();
+    try {
+      settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+        if (key === 'taskDispatcherTickTimeoutMs') return Promise.resolve(1_000);
+        if (key === 'taskVerifierOwner') return Promise.resolve('legacy');
+        return Promise.resolve(fallback);
+      });
+      withStatementTimeoutMock
+        .mockImplementationOnce(() => new Promise(() => {}))
+        .mockImplementation((_timeoutMs: number, callback: () => Promise<unknown>) => callback());
+      const { TaskDispatcherService } = await import('../TaskDispatcherService');
+      const service = new TaskDispatcherService();
+      const initialized = service.initialize();
+
+      await jest.advanceTimersByTimeAsync(1_000);
+      await initialized;
+      await jest.advanceTimersByTimeAsync(59_000);
+
+      expect(withStatementTimeoutMock.mock.calls.length).toBeGreaterThan(1);
+      expect(countRunningMock).toHaveBeenCalled();
       service.destroy();
     } finally {
       jest.useRealTimers();
@@ -329,7 +391,7 @@ describe('TaskDispatcherService', () => {
     await service.initialize();
     service.destroy();
 
-    expect(recoverStaleMock).toHaveBeenCalledWith(0);
+    expect(recoverStaleMock).toHaveBeenCalledWith();
     expect(recoverPreviousRuntimeMock).toHaveBeenCalledWith('todo-execution', expect.stringContaining('task-dispatcher-'));
     expect(countRunningMock).toHaveBeenCalled();
   });
@@ -415,7 +477,9 @@ describe('TaskDispatcherService', () => {
     await service.initialize();
     service.destroy();
 
-    expect(claimNextMock).toHaveBeenCalledWith('sulla-desktop', expect.stringContaining('task-dispatcher-'));
+    expect(claimNextMock).toHaveBeenCalledWith(
+      'sulla-desktop', expect.stringContaining('task-dispatcher-'), expect.any(Object),
+    );
   });
 
   it('claims mechanically, executes the assigned worker, and returns completed work for review', async() => {
@@ -448,7 +512,9 @@ describe('TaskDispatcherService', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
     service.destroy();
 
-    expect(claimNextMock).toHaveBeenCalledWith('sulla-desktop', expect.stringContaining('task-dispatcher-'));
+    expect(claimNextMock).toHaveBeenCalledWith(
+      'sulla-desktop', expect.stringContaining('task-dispatcher-'), expect.any(Object),
+    );
     expect(executeMock).toHaveBeenCalled();
     const workerState = executeMock.mock.calls[0][0];
     expect(workerState.metadata.allowedToolNames).toEqual([
@@ -466,7 +532,56 @@ describe('TaskDispatcherService', () => {
     expect(updateTaskMock).not.toHaveBeenCalled();
   });
 
+  it('settles an immortal worker at max runtime and releases its WIP slot', async() => {
+    jest.useFakeTimers();
+    try {
+      const claim = {
+        task: {
+          id:          'immortal-task',
+          title:       'Never returns',
+          description: '',
+          project_id:  'p',
+          epic_id:     'e',
+          priority:    'high',
+        },
+        dispatch: {
+          id:        'immortal-dispatch',
+          task_id:   'immortal-task',
+          agent_id:  'sulla-desktop',
+          thread_id: 'immortal-thread',
+          kind:      'execution',
+          attempt:   1,
+        },
+        stage_claim: { id: 'immortal-stage' },
+      };
+      claimNextMock.mockResolvedValueOnce(claim).mockResolvedValue(null);
+      executeMock.mockImplementation(() => new Promise(() => {}));
+      settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+        if (key === 'taskDispatcherExecutionTimeoutMinutes') return Promise.resolve(0.001);
+        if (key === 'taskDispatcherExecutionTimeoutEnabled') return Promise.resolve(true);
+        if (key === 'taskVerifierOwner') return Promise.resolve('legacy');
+        return Promise.resolve(fallback);
+      });
+
+      const { TaskDispatcherService } = await import('../TaskDispatcherService');
+      const service = new TaskDispatcherService();
+      await service.initialize();
+      await jest.advanceTimersByTimeAsync(60);
+      await Promise.resolve();
+
+      expect(settleMock).toHaveBeenCalledWith(
+        'immortal-dispatch', 'timed_out', undefined, 'execution exceeded 0.001 minute(s)',
+      );
+      expect(releaseStageMock).toHaveBeenCalledWith('immortal-stage');
+      expect(releaseSlotMock).toHaveBeenCalledWith('slot');
+      service.destroy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('turns user disablement into a visible manual hold without claiming work', async() => {
+    automationEnabledMock.mockResolvedValue(false);
     settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
       if (key === 'automatedProjectManagementEnabled') return Promise.resolve(false);
       return Promise.resolve(fallback);
@@ -530,7 +645,7 @@ describe('TaskDispatcherService', () => {
     await new Promise(resolve => setTimeout(resolve, 10));
     service.destroy();
 
-    expect(claimNextReviewMock).toHaveBeenCalledTimes(4);
+    expect(claimNextReviewMock).toHaveBeenCalledTimes(3);
     expect(claimNextReviewMock).toHaveBeenCalledWith('sulla-desktop', [], expect.stringContaining('task-dispatcher-'));
     expect(executeMock).toHaveBeenCalledTimes(3);
     expect(finalizeVerificationMock).toHaveBeenCalledTimes(3);

--- a/pkg/rancher-desktop/agent/services/__tests__/fixtures/dispatcherCrashWorker.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/fixtures/dispatcherCrashWorker.ts
@@ -1,0 +1,121 @@
+import process from 'node:process';
+
+import { Pool } from 'pg';
+
+const [connectionString, schema, seam, taskId] = process.argv.slice(2);
+
+if (!connectionString || !schema || !seam || !taskId) {
+  throw new Error('usage: dispatcherCrashWorker <url> <schema> <seam> <task-id>');
+}
+
+const pool = new Pool({
+  connectionString,
+  max:     1,
+  options: `-c search_path=${ schema }`,
+});
+
+async function seedRunning(): Promise<void> {
+  await pool.query(`
+    INSERT INTO work_tasks (id, project_id, epic_id, title, status, assignee)
+    VALUES ($1, 'p1', 'e1', $2, 'in_progress', 'dispatcher')
+  `, [taskId, `Crash seam ${ seam }`]);
+  await pool.query(`
+    INSERT INTO work_task_stage_claims
+      (id, task_id, capability_key, stage, owner, runtime_instance_id, status, heartbeat_at)
+    VALUES ($1, $2, 'todo-execution', 'in_progress', 'dispatcher', 'dead-runtime', 'active', now() - interval '2 hours')
+  `, [`stage-${ taskId }`, taskId]);
+  await pool.query(`
+    INSERT INTO work_task_dispatches
+      (id, task_id, agent_id, thread_id, kind, attempt, status, heartbeat_at)
+    VALUES ($1, $2, 'sulla-desktop', $3, 'execution', 1, 'running', now() - interval '2 hours')
+  `, [`dispatch-${ taskId }`, taskId, `thread-${ taskId }`]);
+  await pool.query(`
+    INSERT INTO dispatcher_liveness (id, last_tick_started_at, next_expected_tick_at, last_outcome, checking)
+    VALUES (true, now(), now() - interval '1 minute', 'checking', true)
+    ON CONFLICT (id) DO UPDATE SET
+      last_tick_started_at = now(), next_expected_tick_at = now() - interval '1 minute',
+      last_outcome = 'checking', checking = true
+  `);
+}
+
+async function addExternalPullRequest(): Promise<void> {
+  await pool.query(`
+    INSERT INTO fault_soak_external_prs (task_id, url)
+    VALUES ($1, $2)
+  `, [taskId, `https://github.test/pull/${ taskId }`]);
+}
+
+async function appendJournal(): Promise<void> {
+  await pool.query(`
+    INSERT INTO work_task_outcome_journal
+      (id, dispatch_id, task_id, dispatch_status, task_status, task_assignee, comment, result)
+    VALUES ($1, $2, $3, 'completed', 'in_review', 'heartbeat', 'durable result', 'worker completed')
+  `, [`journal-${ taskId }`, `dispatch-${ taskId }`, taskId]);
+}
+
+async function finalizeJournal(): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(`UPDATE work_task_dispatches SET status = 'completed', result = 'worker completed', finished_at = now() WHERE id = $1`, [`dispatch-${ taskId }`]);
+    await client.query(`UPDATE work_tasks SET status = 'in_review', assignee = 'heartbeat', updated_at = now() WHERE id = $1`, [taskId]);
+    await client.query(`UPDATE work_task_stage_claims SET status = 'released', released_at = now() WHERE task_id = $1 AND status = 'active'`, [taskId]);
+    await client.query(`UPDATE work_task_outcome_journal SET consumed_at = now() WHERE id = $1`, [`journal-${ taskId }`]);
+    await client.query('COMMIT');
+  } finally {
+    client.release();
+  }
+}
+
+async function crash(): Promise<never> {
+  process.stdout.write(`FAULT_READY:${ seam }\n`);
+  process.kill(process.pid, 'SIGKILL');
+  return new Promise(() => {});
+}
+
+await seedRunning();
+switch (seam) {
+case 'claim-commit-before-graph':
+  await crash();
+  break;
+case 'worker-return-before-journal':
+  await addExternalPullRequest();
+  await pool.query(`
+    INSERT INTO workflow_executions
+      (execution_id, workflow_id, workflow_name, workflow_slug, status, trigger_input, completed_at)
+    VALUES ($1, 'dispatcher-worker', 'Dispatcher worker', 'dispatcher-worker', 'completed', '', now())
+  `, [`workflow-${ taskId }`]);
+  await pool.query(`UPDATE work_task_dispatches SET workflow_execution_id = $2 WHERE id = $1`, [`dispatch-${ taskId }`, `workflow-${ taskId }`]);
+  await crash();
+  break;
+case 'journal-before-finalize':
+  await addExternalPullRequest();
+  await appendJournal();
+  await crash();
+  break;
+case 'finalize-before-liveness':
+  await addExternalPullRequest();
+  await appendJournal();
+  await finalizeJournal();
+  await crash();
+  break;
+case 'recover-stale-mid-batch': {
+  const secondTask = `${ taskId }-second`;
+  await pool.query(`
+    INSERT INTO work_tasks (id, project_id, epic_id, title, status, assignee)
+    VALUES ($1, 'p1', 'e1', 'Second stale task', 'in_progress', 'dispatcher')
+  `, [secondTask]);
+  await pool.query(`
+    INSERT INTO work_task_dispatches
+      (id, task_id, agent_id, thread_id, kind, attempt, status, heartbeat_at)
+    VALUES ($1, $2, 'sulla-desktop', $3, 'execution', 1, 'running', now() - interval '2 hours')
+  `, [`dispatch-${ secondTask }`, secondTask, `thread-${ secondTask }`]);
+  const client = await pool.connect();
+  await client.query('BEGIN');
+  await client.query(`UPDATE work_task_dispatches SET status = 'stale' WHERE id = $1`, [`dispatch-${ taskId }`]);
+  await crash();
+  break;
+}
+default:
+  throw new Error(`unknown seam ${ seam }`);
+}


### PR DESCRIPTION
## Phase 8 evidence

Adds a migrated-PostgreSQL crash/restart soak that launches a child dispatcher seam worker and sends real SIGKILL at claim commit before graph start, worker return before journal, journal before finalize, finalize before liveness, and recoverStale mid-batch. Every next boot asserts zero running dispatches, zero terminal-task/running-dispatch contradictions, truthful non-checking liveness, no duplicate PR side effects, and no active WIP claims.

Also injects hung hasActiveLinkedPullRequest and tick-query awaits to prove the Phase 2 watchdog, plus an immortal graph worker to prove Phase 4 max-runtime releases its stage and concurrency slot.

The soak exposed two P0 gaps and includes their fixes: journal replay now releases the execution stage claim in the finalization transaction, and max-runtime now races the worker promise so a provider that ignores abort cannot retain WIP forever.

Validation:
- 34/34 focused dispatcher tests passed
- 5/5 real SIGKILL PostgreSQL seams passed
- ESLint clean for the new crash harness files
- git diff --check clean

No second dispatcher, app rebuild, restart, or deploy.