### PR TITLE
fix(dispatcher): do not spread null liveness row

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
@@ -481,7 +481,7 @@ export class WorkConveyorMetricsModel {
   }
 
   private static classifyDispatcherLiveness(row: DispatcherLivenessRecord | null) {
-    if (!row) return { status: 'unknown' as const, ...row };
+    if (!row) return { status: 'unknown' as const };
     const overdue = row.next_expected_tick_at != null && new Date(row.next_expected_tick_at).getTime() < Date.now();
     return {
       ...row,


### PR DESCRIPTION
## Summary

Phase 3 liveness classifier spread a possibly-null `dispatcher_liveness` row:

```ts
if (!row) return { status: 'unknown' as const, ...row };
```

That is a TypeScript/runtime hazard before migration 0091 has run. Return `{ status: 'unknown' }` instead of spreading `null`.

## Scope

One-line classifier fix in `WorkConveyorMetricsModel.classifyDispatcherLiveness`. No dispatcher/recovery path change.

Verified the remote file is the full metrics model (24kB), not a placeholder.

No rebuild, restart, or deploy.
