### PR TITLE
fix(dispatcher): full record shape for unknown liveness state

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkConveyorMetricsModel.ts
@@ -481,7 +481,19 @@ export class WorkConveyorMetricsModel {
   }
 
   private static classifyDispatcherLiveness(row: DispatcherLivenessRecord | null) {
-    if (!row) return { status: 'unknown' as const };
+    if (!row) {
+      return {
+        status: 'unknown' as const,
+        last_tick_started_at: null,
+        last_tick_at: null,
+        next_expected_tick_at: null,
+        last_outcome: 'never' as const,
+        checking: false,
+        consecutive_wedge_count: 0,
+        wedge_count: 0,
+        updated_at: null,
+      };
+    }
     const overdue = row.next_expected_tick_at != null && new Date(row.next_expected_tick_at).getTime() < Date.now();
     return {
       ...row,


### PR DESCRIPTION
## Summary

Follow-up to the null-spread fix: the `unknown` branch returned only `{ status }`, so `conveyor_health.ts` failed webpack with TS2339 — `last_tick_at`, `next_expected_tick_at`, and `consecutive_wedge_count` do not exist on that union member (the exact 3 errors from Jonathon's local build).

The unknown branch now returns every `DispatcherLivenessRecord` field as null/false/0, so both union branches have the same shape and the existing `??` fallbacks in `conveyor_health.ts` and the Projects UI keep working.

## Scope

Only `classifyDispatcherLiveness` in `WorkConveyorMetricsModel`. No dispatcher or recovery path change. No rebuild, restart, or deploy performed here.
