### PR TITLE
fix(projects): allow blocked transitions with dependency holds

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
@@ -18,6 +18,11 @@ export interface LaneContract {
 export const LANE_ENTRY_INPUT_ENVELOPE = 'project.lane-entry.v1';
 export const LANE_OUTCOME_OUTPUT_ENVELOPE = 'project.lane-outcome.v1';
 
+// Dependency holds prevent work from being claimed into forward execution or
+// review lanes. They must not prevent a task from entering a recovery/settled
+// lane such as blocked, planning, or another non-forward state.
+const DEPENDENCY_GATED_LANE_KEYS = new Set(['todo', 'in_progress', 'in_review']);
+
 export interface LaneWorkflowBindingRecord {
   id:            string;
   profile_id:    string;
@@ -421,7 +426,9 @@ export class WorkLaneWorkflowBindingModel {
     actor = 'sulla', profileId = 'default'):
     Promise<{ created: boolean; entry: LaneEntryAutomationRecord }> {
     await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`lane-entry:${ taskId }`]);
-    await WorkTaskDependencyModel.assertClaimable(taskId, client);
+    if (DEPENDENCY_GATED_LANE_KEYS.has(laneKey)) {
+      await WorkTaskDependencyModel.assertClaimable(taskId, client);
+    }
     const prior = await client.query<LaneEntryAutomationRecord>(`
         SELECT * FROM work_lane_entry_automations WHERE task_id = $1 ORDER BY generation DESC LIMIT 1
       `, [taskId]);

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.postgres.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.postgres.test.ts
@@ -12,6 +12,7 @@ import { up as addWorkTaskActivity } from '../../migrations/0061_add_work_task_a
 import { up as createLaneDefinitions } from '../../migrations/0069_create_work_lane_definitions';
 import { up as createLaneWorkflowBindings } from '../../migrations/0070_create_lane_workflow_bindings';
 import { up as scopeLaneWorkflowExecutions } from '../../migrations/0071_scope_lane_workflow_executions';
+import { up as createPlanningRuns } from '../../migrations/0072_create_work_task_planning_runs';
 import { up as addProjectViewsAndScheduling } from '../../migrations/0075_add_project_views_and_scheduling';
 import { up as addWorkflowExecutionLeases } from '../../migrations/0081_add_workflow_execution_leases';
 import { up as createWorkTaskDependencies } from '../../migrations/0083_create_work_task_dependencies';
@@ -43,6 +44,7 @@ describeWithPostgres('WorkLaneWorkflowBindingModel migrated PostgreSQL integrati
     await pool.query(createLaneDefinitions);
     await pool.query(createLaneWorkflowBindings);
     await pool.query(scopeLaneWorkflowExecutions);
+    await pool.query(createPlanningRuns);
     await addProjectViewsAndScheduling(pool as any);
     await pool.query(addWorkflowExecutionLeases);
     await createWorkTaskDependencies(pool as any);
@@ -234,6 +236,28 @@ describeWithPostgres('WorkLaneWorkflowBindingModel migrated PostgreSQL integrati
     })).rejects.toThrow('No active task/lane context');
     expect(await WorkItemsModel.getTask('task-rollback')).toMatchObject({ status: 'backlog' });
     expect(await WorkLaneWorkflowBindingModel.listLaneEntries('task-rollback')).toEqual([]);
+  }, 30_000);
+
+  it('settles a dependency-held planning council when moving the task to blocked', async() => {
+    await pool.query(`
+      INSERT INTO work_tasks (id, project_id, epic_id, title, status)
+      VALUES
+        ('task-dependency-held', 'project-1', 'epic-1', 'Dependency-held task', 'planning'),
+        ('task-dependency-prerequisite', 'project-1', 'epic-1', 'Dependency prerequisite', 'planning');
+      INSERT INTO work_task_planning_runs (id, task_id, workflow_id, trigger_status, trigger_actor)
+      VALUES ('planning-dependency-held', 'task-dependency-held', 'workflow-1', 'planning', 'planning-council');
+    `);
+    await WorkItemsModel.setTaskDependency(
+      'task-dependency-held', 'task-dependency-prerequisite', 'planning-council',
+    );
+
+    await expect(WorkItemsModel.updateTask('task-dependency-held', {
+      status: 'blocked', actor: 'planning-council',
+    })).resolves.toMatchObject({ status: 'blocked' });
+    expect(await WorkItemsModel.getTask('task-dependency-held')).toMatchObject({ status: 'blocked' });
+    expect((await pool.query(
+      'SELECT status FROM work_task_planning_runs WHERE id = $1', ['planning-dependency-held'],
+    )).rows[0]).toMatchObject({ status: 'blocked' });
   }, 30_000);
 
   it('allows two tasks on one workflow while rejecting duplicate active task-generation scope', async() => {

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
 import { postgresClient } from '../../PostgresClient';
+import { WorkTaskDependencyModel } from '../WorkTaskDependencyModel';
 import {
   LANE_ENTRY_INPUT_ENVELOPE, LANE_OUTCOME_OUTPUT_ENVELOPE,
   WorkLaneWorkflowBindingModel,
@@ -112,5 +113,23 @@ describe('WorkLaneWorkflowBindingModel', () => {
     expect(result).toEqual({ created: false, entry: expect.objectContaining({ generation: 4 }) });
     expect(client.query.mock.calls[0][0]).toContain('pg_advisory_xact_lock');
     expect(client.query).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not let an unresolved dependency block entry into blocked', async() => {
+    const assertClaimable = jest.spyOn(WorkTaskDependencyModel, 'assertClaimable')
+      .mockRejectedValue(new Error('dependency hold'));
+    const client = {
+      query: (jest.fn() as any)
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ project_id: 'project-1', epic_id: null, semantic_role: 'blocked', system_required: true }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ id: 'entry-2', task_id: 'task-1', generation: 5, lane_key: 'blocked' }] }),
+    };
+    (postgresClient as any).transaction = jest.fn((callback: any) => callback(client));
+
+    await expect(WorkLaneWorkflowBindingModel.claimLaneEntry('task-1', 'blocked'))
+      .resolves.toMatchObject({ created: true, entry: { lane_key: 'blocked' } });
+    expect(assertClaimable).not.toHaveBeenCalled();
   });
 });

--- a/pkg/rancher-desktop/agent/tools/project/__tests__/taskDependencyTools.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/taskDependencyTools.test.ts
@@ -35,6 +35,7 @@ describe('task dependency tools', () => {
     createDependency.mockResolvedValue({ id: 'dep-1', dependent_task_id: 'a', depends_on_task_id: 'b', relation_type: 'requires' });
     const res = await call(new CreateTaskDependencyWorker(), { dependent_task_id: 'a', depends_on_task_id: 'b' });
     expect(res.successBoolean).toBe(true);
+    expect(res.responseString).toContain('Task a depends on prerequisite b');
     expect(createDependency).toHaveBeenCalledWith(expect.objectContaining({ dependentTaskId: 'a', dependsOnTaskId: 'b', relationType: 'requires' }), expect.any(Object));
   });
 

--- a/pkg/rancher-desktop/agent/tools/project/create_task_dependency.ts
+++ b/pkg/rancher-desktop/agent/tools/project/create_task_dependency.ts
@@ -30,7 +30,7 @@ export class CreateTaskDependencyWorker extends BaseTool {
       }, { actor, source: 'tool' });
       return {
         successBoolean: true,
-        responseString: `Dependency ${ dep.id }: task ${ dep.dependent_task_id } ${ dep.relation_type } ${ dep.depends_on_task_id }. The dependent cannot be claimed until the prerequisite is done.`,
+        responseString: `Dependency ${ dep.id }: task ${ dep.dependent_task_id } ${ dep.relation_type } ${ dep.depends_on_task_id }. Task ${ dep.dependent_task_id } depends on prerequisite ${ dep.depends_on_task_id } and cannot be claimed until it is done.`,
       };
     } catch (err: any) {
       return { successBoolean: false, responseString: `Failed to create task dependency: ${ err?.message ?? String(err) }` };


### PR DESCRIPTION
## Summary

- gate dependency claims only for forward execution/review lanes
- allow dependency-held planning tasks to transition to blocked so council settlement can run
- correct `create_task_dependency` direction wording
- add unit coverage and a migrated-Postgres regression for council settlement

## Validation

- `node --experimental-vm-modules node_modules/.bin/jest pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.postgres.test.ts pkg/rancher-desktop/agent/tools/project/__tests__/taskDependencyTools.test.ts --runInBand` -> 2 passed suites, 14 passed tests, 1 integration suite skipped because `SULLA_INTEGRATION_POSTGRES_URL` is unset
- `git diff --check` -> passed
- `npm run lint:typescript:nofix` -> environment killed the repo-wide lint process with SIGKILL before diagnostics

Closes Projects task 26O2. Ready for human review; do not merge or deploy automatically.