### PR TITLE
fix(chat): flush Claude CLI stream-json output

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -270,7 +270,12 @@ export class ClaudeCodeService extends BaseLanguageModel {
     if (p.existingSession) claudeArgs.push('--resume', shq(p.existingSession));
     if (p.mcpConfigPath) claudeArgs.push('--mcp-config', shq(p.mcpConfigPath));
 
-    const innerCmd = `${ envAssignments.join(' ') } exec ${ claudeArgs.join(' ') }`;
+    // Claude Code emits newline-delimited JSON, but its stdout is connected
+    // to the limactl/SSH pipe rather than a terminal. Force the child stream
+    // to flush each complete line so stream-json events reach Sulla while the
+    // turn is running instead of arriving in a burst when the process exits
+    // (which made Stop appear to "unfreeze" the chat).
+    const innerCmd = `${ envAssignments.join(' ') } exec stdbuf -oL -eL ${ claudeArgs.join(' ') }`;
     return ['shell', '0', '--', 'sh', '-c', innerCmd];
   }
 


### PR DESCRIPTION
## Root cause

Claude Code is launched through a non-TTY limactl/SSH pipe. Its stream-json NDJSON can remain buffered until process teardown, which is why Stop makes previously generated messages appear in a burst. The renderer scheduler fix in #753 cannot resolve this provider-specific upstream buffering.

## Fix

Run the Claude CLI under stdbuf -oL -eL so complete NDJSON lines flush while the turn is active. This applies to both cold and prewarmed Claude spawns through the shared launch builder.

## Validation

- git diff --check passed.
- Targeted TypeScript/build validation is pending because this checkout has no installed node_modules.
- Requires rebuild/restart and a long Claude CLI turn without pressing Stop for runtime confirmation.