### PR TITLE
fix(browser): recover wedged WebContentsViews

### DIFF
--- a/pkg/rancher-desktop/window/__tests__/browserTabViewManager.test.ts
+++ b/pkg/rancher-desktop/window/__tests__/browserTabViewManager.test.ts
@@ -175,8 +175,8 @@ describe('BrowserTabViewManager', () => {
     const health = (manager as any).newViewHealth();
 
     health.recoveryStage = 'reattached';
-    (WebContentsView as any).mockReturnValue(replacement);
-    (getWindow as any).mockReturnValue({ contentView });
+    (WebContentsView as any).mockReturnValueOnce(replacement);
+    (getWindow as any).mockReturnValueOnce({ contentView });
     (manager as any).focusedTabId = 'tab-a';
     (manager as any).views.set('tab-a', original);
     (manager as any).latestBounds.set('tab-a', { x: 1, y: 2, width: 3, height: 4 });

--- a/pkg/rancher-desktop/window/__tests__/browserTabViewManager.test.ts
+++ b/pkg/rancher-desktop/window/__tests__/browserTabViewManager.test.ts
@@ -71,4 +71,86 @@ describe('BrowserTabViewManager', () => {
 
     expect(manager.getFocusedTab()).toBeNull();
   });
+
+  it('recovers after three wheel events fail to move a scrollable target', async() => {
+    const { BrowserTabViewManager } = await loadManager();
+    const manager = BrowserTabViewManager.getInstance();
+    const recover = jest.spyOn(manager as any, 'recoverWedgedView').mockResolvedValue(undefined);
+
+    manager.setFocusedTab('tab-a');
+    (manager as any).viewHealth.set('tab-a', (manager as any).newViewHealth());
+    (manager as any).handleScrollHeartbeat('tab-a', false);
+    (manager as any).handleScrollHeartbeat('tab-a', false);
+    (manager as any).handleScrollHeartbeat('tab-a', false);
+
+    expect(recover).toHaveBeenCalledWith(
+      'tab-a',
+      'wheel events reached a scrollable DOM target without scroll movement',
+    );
+  });
+
+  it('clears the input watchdog after scroll movement resumes', async() => {
+    const { BrowserTabViewManager } = await loadManager();
+    const manager = BrowserTabViewManager.getInstance();
+    const recover = jest.spyOn(manager as any, 'recoverWedgedView').mockResolvedValue(undefined);
+
+    manager.setFocusedTab('tab-a');
+    (manager as any).viewHealth.set('tab-a', (manager as any).newViewHealth());
+    (manager as any).handleScrollHeartbeat('tab-a', false);
+    (manager as any).handleScrollHeartbeat('tab-a', false);
+    (manager as any).handleScrollHeartbeat('tab-a', true);
+    (manager as any).handleScrollHeartbeat('tab-a', false);
+
+    expect(recover).not.toHaveBeenCalled();
+  });
+
+  it('recovers after two consecutive empty capture probes', async() => {
+    const { BrowserTabViewManager } = await loadManager();
+    const manager = BrowserTabViewManager.getInstance();
+    const recover = jest.spyOn(manager as any, 'recoverWedgedView').mockResolvedValue(undefined);
+
+    (manager as any).viewHealth.set('tab-a', (manager as any).newViewHealth());
+    await (manager as any).recordCaptureFailure('tab-a', 'empty NativeImage');
+    expect(recover).not.toHaveBeenCalled();
+
+    await (manager as any).recordCaptureFailure('tab-a', 'empty NativeImage');
+    expect(recover).toHaveBeenCalledWith('tab-a', 'capture watchdog: empty NativeImage');
+  });
+
+  it('recreates the view while preserving webContents when re-attach was insufficient', async() => {
+    const { BrowserTabViewManager } = await loadManager();
+    const { WebContentsView } = await import('electron');
+    const { getWindow } = await import('@pkg/window');
+    const manager = BrowserTabViewManager.getInstance();
+    const webContents = {
+      focus:                   jest.fn(),
+      setBackgroundThrottling: jest.fn(),
+    };
+    const original = { webContents };
+    const replacement = {
+      webContents,
+      setBounds: jest.fn(),
+    };
+    const contentView = {
+      addChildView:    jest.fn(),
+      removeChildView: jest.fn(),
+    };
+    const health = (manager as any).newViewHealth();
+
+    health.recoveryStage = 'reattached';
+    (WebContentsView as any).mockReturnValue(replacement);
+    (getWindow as any).mockReturnValue({ contentView });
+    (manager as any).focusedTabId = 'tab-a';
+    (manager as any).views.set('tab-a', original);
+    (manager as any).latestBounds.set('tab-a', { x: 1, y: 2, width: 3, height: 4 });
+    (manager as any).viewHealth.set('tab-a', health);
+
+    await (manager as any).recoverWedgedView('tab-a', 'scroll still stuck');
+
+    expect(WebContentsView).toHaveBeenCalledWith({ webContents });
+    expect(contentView.removeChildView).toHaveBeenCalledWith(original);
+    expect(contentView.addChildView).toHaveBeenCalledWith(replacement);
+    expect((manager as any).views.get('tab-a')).toBe(replacement);
+    expect(webContents.focus).toHaveBeenCalled();
+  });
 });

--- a/pkg/rancher-desktop/window/browserTabPreload.ts
+++ b/pkg/rancher-desktop/window/browserTabPreload.ts
@@ -30,6 +30,64 @@ const IPC_CHANNEL = 'browser-tab-view:bridge-event';
 const LOG_PREFIX = '[SULLA_TAB_PRELOAD]';
 
 /* ------------------------------------------------------------------ */
+/*  Native scroll-input health                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * A wedged WebContentsView can still dispatch trusted wheel events into the
+ * page while Chromium's compositor refuses to apply them. Report only wheel
+ * gestures that had somewhere to scroll; the main process uses consecutive
+ * failures as an input-routing watchdog.
+ */
+window.addEventListener('wheel', (event) => {
+  if (!event.isTrusted || event.ctrlKey || event.metaKey || Math.abs(event.deltaY) < 1) return;
+
+  const direction = Math.sign(event.deltaY);
+  let candidate = event.target instanceof Element ? event.target : null;
+  let scrollTarget: Element | null = null;
+
+  while (candidate) {
+    const style = getComputedStyle(candidate);
+    const canOverflow = /^(auto|scroll|overlay)$/.test(style.overflowY);
+    const maxScrollTop = candidate.scrollHeight - candidate.clientHeight;
+    const canMove = direction > 0
+      ? candidate.scrollTop < maxScrollTop - 1
+      : candidate.scrollTop > 1;
+
+    if (canOverflow && maxScrollTop > 1 && canMove) {
+      scrollTarget = candidate;
+      break;
+    }
+    candidate = candidate.parentElement;
+  }
+
+  if (!scrollTarget) {
+    const root = document.scrollingElement;
+    const maxScrollTop = root ? root.scrollHeight - root.clientHeight : 0;
+    const canMove = !!root && (direction > 0 ? root.scrollTop < maxScrollTop - 1 : root.scrollTop > 1);
+
+    if (canMove) scrollTarget = root;
+  }
+
+  if (!scrollTarget) return;
+
+  const before = scrollTarget.scrollTop;
+
+  requestAnimationFrame(() => setTimeout(() => {
+    if (event.defaultPrevented) return;
+
+    try {
+      ipcRenderer.send(IPC_CHANNEL, {
+        type: 'sulla:view-scroll-heartbeat',
+        data: { moved: Math.abs(scrollTarget.scrollTop - before) > 0.5 },
+      });
+    } catch (err) {
+      console.error(`${ LOG_PREFIX } scroll heartbeat failed`, err);
+    }
+  }, 80));
+}, { capture: true, passive: true });
+
+/* ------------------------------------------------------------------ */
 /*  Web push stub                                                     */
 /* ------------------------------------------------------------------ */
 //
@@ -49,7 +107,7 @@ const LOG_PREFIX = '[SULLA_TAB_PRELOAD]';
 
 try {
   if (typeof PushManager !== 'undefined' && PushManager.prototype) {
-    const deny = function (): Promise<never> {
+    const deny = function(): Promise<never> {
       return Promise.reject(
         new DOMException('Push notifications are not available in this app.', 'NotAllowedError'),
       );

--- a/pkg/rancher-desktop/window/browserTabViewManager.ts
+++ b/pkg/rancher-desktop/window/browserTabViewManager.ts
@@ -14,6 +14,15 @@ const console = Logging.sulla;
 
 const SESSION_PARTITION = 'persist:sulla-browser';
 
+interface ViewHealth {
+  captureFailures: number;
+  stuckScrolls:    number;
+  probeInFlight:   boolean;
+  recovering:      boolean;
+  lastRecoveryAt:  number;
+  recoveryStage:   'reattached' | 'recreated' | null;
+}
+
 /**
  * Manages WebContentsView instances for browser tabs.
  *
@@ -51,6 +60,8 @@ export class BrowserTabViewManager {
   private latestBounds = new Map<string, Electron.Rectangle>();
   private failedUrls = new Map<string, string>(); // tabId → original URL that failed
   private retryTimers = new Map<string, ReturnType<typeof setInterval>>();
+  private viewHealth = new Map<string, ViewHealth>();
+  private healthMonitor:   ReturnType<typeof setInterval> | null = null;
   private acceptedCertHosts = new Set<string>(); // hosts where user clicked "Proceed"
   /** Credentials captured but not yet saved — keyed by tabId, auto-expires after 90s */
   private pendingCredentials = new Map<string, { origin: string; username: string; password: string; timer: ReturnType<typeof setTimeout>; pageTitle?: string; existingAccountId?: string }>();
@@ -195,6 +206,8 @@ export class BrowserTabViewManager {
     view.setBounds(bounds);
     this.views.set(tabId, view);
     this.latestBounds.set(tabId, bounds);
+    this.viewHealth.set(tabId, this.newViewHealth());
+    this.startHealthMonitor();
 
     // Forward guest console output to main log so we can see errors from the
     // preload / guest bridge script. Without this, guest-side exceptions are
@@ -239,12 +252,17 @@ export class BrowserTabViewManager {
     this.stopRetry(tabId);
     (view.webContents as any).close?.();
     this.views.delete(tabId);
+    this.viewHealth.delete(tabId);
     this.latestBounds.delete(tabId);
     this.failedUrls.delete(tabId);
     this.clearPendingCredentials(tabId);
     if (this.focusedTabId === tabId) {
       this.focusedTabId = null;
       // No reconcile needed — the view is gone; detach already happened above.
+    }
+    if (this.views.size === 0 && this.healthMonitor) {
+      clearInterval(this.healthMonitor);
+      this.healthMonitor = null;
     }
     console.log(`[BrowserTabView] Destroyed view tabId=${ tabId }`);
   }
@@ -314,6 +332,7 @@ export class BrowserTabViewManager {
     if (this.focusedTabId === tabId) return;
     console.log(`[BrowserTabView] setFocusedTab ${ this.focusedTabId ?? '(none)' } → ${ tabId ?? '(none)' }`);
     this.focusedTabId = tabId;
+    if (tabId) this.viewHealth.set(tabId, this.newViewHealth());
     this.reconcileVisibility();
   }
 
@@ -384,6 +403,163 @@ export class BrowserTabViewManager {
           console.warn(`[BrowserTabView] reconcile park failed tabId=${ tabId }:`, err);
         }
       }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Compositor / input-routing wedge recovery
+  // ---------------------------------------------------------------------------
+
+  private static readonly HEALTH_PROBE_INTERVAL_MS = 8_000;
+  private static readonly HEALTH_PROBE_TIMEOUT_MS = 3_000;
+  private static readonly CAPTURE_FAILURE_THRESHOLD = 2;
+  private static readonly STUCK_SCROLL_THRESHOLD = 3;
+  private static readonly RECOVERY_COOLDOWN_MS = 1_500;
+
+  private newViewHealth(): ViewHealth {
+    return {
+      captureFailures: 0,
+      stuckScrolls:    0,
+      probeInFlight:   false,
+      recovering:      false,
+      lastRecoveryAt:  0,
+      recoveryStage:   null,
+    };
+  }
+
+  private startHealthMonitor(): void {
+    if (this.healthMonitor) return;
+
+    this.healthMonitor = setInterval(() => {
+      this.probeFocusedView().catch((err) => {
+        console.warn('[BrowserTabView] focused-view health probe failed:', err);
+      });
+    }, BrowserTabViewManager.HEALTH_PROBE_INTERVAL_MS);
+    this.healthMonitor.unref?.();
+  }
+
+  /**
+   * capturePage is intentionally used here rather than the screenshot tool's
+   * CDP path: an empty NativeImage is the known signal for the detached-view
+   * compositor wedge. Probe only the visible, settled view to avoid waking
+   * every parked tab or treating navigation as a failure.
+   */
+  private async probeFocusedView(): Promise<void> {
+    const tabId = this.focusedTabId;
+    if (!tabId) return;
+
+    const view = this.views.get(tabId);
+    const health = this.viewHealth.get(tabId);
+
+    if (!view || !health || health.probeInFlight || health.recovering) return;
+    if (view.webContents.isDestroyed() || view.webContents.isLoading()) return;
+
+    const bounds = this.latestBounds.get(tabId);
+    if (!bounds || bounds.width < 1 || bounds.height < 1) return;
+
+    health.probeInFlight = true;
+    try {
+      const image = await Promise.race([
+        view.webContents.capturePage(undefined, { stayHidden: true, stayAwake: true }),
+        new Promise<never>((_resolve, reject) => setTimeout(
+          () => reject(new Error('capturePage health probe timed out')),
+          BrowserTabViewManager.HEALTH_PROBE_TIMEOUT_MS,
+        )),
+      ]);
+
+      if (this.views.get(tabId) !== view || this.focusedTabId !== tabId) return;
+
+      if (image.isEmpty()) {
+        await this.recordCaptureFailure(tabId, 'empty NativeImage');
+      } else {
+        health.captureFailures = 0;
+      }
+    } catch (err) {
+      if (this.views.get(tabId) !== view || this.focusedTabId !== tabId) return;
+      const reason = err instanceof Error ? err.message : String(err);
+
+      await this.recordCaptureFailure(tabId, reason);
+    } finally {
+      health.probeInFlight = false;
+    }
+  }
+
+  private async recordCaptureFailure(tabId: string, reason: string): Promise<void> {
+    const health = this.viewHealth.get(tabId);
+    if (!health) return;
+
+    health.captureFailures++;
+    if (health.captureFailures < BrowserTabViewManager.CAPTURE_FAILURE_THRESHOLD) return;
+
+    health.captureFailures = 0;
+    await this.recoverWedgedView(tabId, `capture watchdog: ${ reason }`);
+  }
+
+  private handleScrollHeartbeat(tabId: string, moved: boolean): void {
+    if (tabId !== this.focusedTabId) return;
+
+    const health = this.viewHealth.get(tabId);
+    if (!health || health.recovering) return;
+
+    if (moved) {
+      health.stuckScrolls = 0;
+      health.recoveryStage = null;
+      return;
+    }
+
+    health.stuckScrolls++;
+    if (health.stuckScrolls < BrowserTabViewManager.STUCK_SCROLL_THRESHOLD) return;
+
+    health.stuckScrolls = 0;
+    this.recoverWedgedView(tabId, 'wheel events reached a scrollable DOM target without scroll movement').catch((err) => {
+      console.warn(`[BrowserTabView] scroll-input recovery failed tabId=${ tabId }:`, err);
+    });
+  }
+
+  private async recoverWedgedView(tabId: string, reason: string): Promise<void> {
+    const health = this.viewHealth.get(tabId);
+    const view = this.views.get(tabId);
+    const mainWindow = getWindow('main-agent');
+
+    if (!health || !view || !mainWindow || tabId !== this.focusedTabId) return;
+    if (health.recovering || Date.now() - health.lastRecoveryAt < BrowserTabViewManager.RECOVERY_COOLDOWN_MS) return;
+
+    health.recovering = true;
+    health.lastRecoveryAt = Date.now();
+    const shouldRecreate = health.recoveryStage === 'reattached';
+    const action = shouldRecreate ? 'recreate-preserving-webContents' : 'detach-reattach';
+
+    console.warn(`[BrowserTabView] wedge recovery fired tabId=${ tabId } action=${ action } reason=${ reason }`);
+
+    try {
+      mainWindow.contentView.removeChildView(view);
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      if (this.views.get(tabId) !== view || this.focusedTabId !== tabId) return;
+
+      const bounds = this.latestBounds.get(tabId);
+      if (shouldRecreate) {
+        const replacement = new WebContentsView({ webContents: view.webContents });
+
+        replacement.webContents.setBackgroundThrottling(false);
+        if (bounds) replacement.setBounds(bounds);
+        this.views.set(tabId, replacement);
+        mainWindow.contentView.addChildView(replacement);
+        health.recoveryStage = 'recreated';
+      } else {
+        if (bounds) view.setBounds(bounds);
+        mainWindow.contentView.addChildView(view);
+        health.recoveryStage = 'reattached';
+      }
+
+      this.views.get(tabId)?.webContents.focus();
+      health.captureFailures = 0;
+      health.stuckScrolls = 0;
+    } catch (err) {
+      console.warn(`[BrowserTabView] wedge recovery failed tabId=${ tabId } action=${ action }:`, err);
+      this.reconcileVisibility();
+    } finally {
+      health.recovering = false;
     }
   }
 
@@ -897,6 +1073,10 @@ export class BrowserTabViewManager {
     // The menu calls __sullaBridgeEmit('context-menu-action', payload)
     // which arrives here via the preload's ipcRenderer.send().
     wc.ipc.on('browser-tab-view:bridge-event', (_event: Electron.IpcMainEvent, msg: { type: string; data: any }) => {
+      if (msg.type === 'sulla:view-scroll-heartbeat') {
+        this.handleScrollHeartbeat(tabId, msg.data?.moved === true);
+        return;
+      }
       if (msg.type !== 'context-menu-action') return;
       const { action, ...data } = msg.data || {};
 


### PR DESCRIPTION
## What changed

- add a focused-view `capturePage` watchdog that treats repeated empty or timed-out captures as a compositor wedge
- add a preload wheel/scroll heartbeat that detects trusted, unprevented wheel input reaching a scrollable DOM target without movement
- recover first with a detach/re-attach cycle; if health still fails, replace the `WebContentsView` while adopting the existing `webContents`
- log every fired recovery with the tab, action, and detector reason

## Validation

- focused TypeScript/ESLint check on the three changed files: pass
- `browserTabViewManager.test.ts`: 6/6 pass
- `git diff --check`: pass
- full suite intentionally not run

Projects task: qxFB

No merge or deployment performed.