### PR TITLE
fix(browser): unify cookie jar and focused-tab visibility

### DIFF
--- a/pkg/rancher-desktop/SullaWebRequestFixer.ts
+++ b/pkg/rancher-desktop/SullaWebRequestFixer.ts
@@ -1,8 +1,6 @@
 import { EventEmitter } from 'events';
 
-import { Session } from 'electron';
-
-import { SullaSettingsModel } from '@pkg/agent/database/models/SullaSettingsModel';
+import type { Session } from 'electron';
 
 // ---------------------------------------------------------------------------
 // Typed webRequest event names emitted by SullaWebRequestFixer
@@ -38,12 +36,10 @@ function isLocalhost(hostname: string): boolean {
 }
 
 export class SullaWebRequestFixer extends EventEmitter {
-  private cookieHeaderCacheByDomain: Record<string, string> = {};
-  private writeEvent:                (event: SullaWebRequestLogEvent) => void;
+  private writeEvent: (event: SullaWebRequestLogEvent) => void;
   private static readonly LOGGING_ENABLED = true;
   private hasLoggedN8nHealthz = false;
   private static readonly CONNECTIVITY_PROBE_URL_PREFIX = 'https://www.gstatic.com/generate_204';
-  private static readonly COOKIE_PROPERTY_PREFIX = 'webRequestCookieHeader:';
 
   constructor(writeSullaWebRequestEvent: (event: SullaWebRequestLogEvent) => void) {
     super();
@@ -159,7 +155,7 @@ export class SullaWebRequestFixer extends EventEmitter {
         return;
       }
 
-      void (async() => {
+      try {
         const url = details.url.toLowerCase();
         let parsedUrl: URL | undefined;
         const shouldLog = this.shouldLogRequest(details.url);
@@ -183,38 +179,6 @@ export class SullaWebRequestFixer extends EventEmitter {
           details.requestHeaders['anthropic-dangerous-direct-browser-access'] = 'true';
         }
 
-        // COOKIE INJECTION — only for local services
-        if (hostIsLocal) {
-          const domainKey = this.getCookieDomainKey(details.url);
-          const cachedCookieHeader = await this.loadCookieHeaderForDomain(domainKey);
-          if (cachedCookieHeader) {
-            const existingCookie = details.requestHeaders['Cookie'] || '';
-            if (existingCookie) {
-              details.requestHeaders['Cookie'] = this.mergeCookieHeader(existingCookie, cachedCookieHeader.split(';').map((s: string) => s.trim()).filter(Boolean));
-            } else {
-              details.requestHeaders['Cookie'] = cachedCookieHeader;
-            }
-
-            if (shouldLog) {
-              this.writeEvent({
-                direction:    'request_headers',
-                url:          details.url,
-                method:       details.method,
-                resourceType: details.resourceType,
-                payload:      {
-                  requestId:                   details.id,
-                  session:                     'defaultSession',
-                  manualCookieHeaderInjection: 'SUCCESS (from cache)',
-                  injectedCookieHeader:        cachedCookieHeader.substring(0, 120) + '...',
-                  cookieCount:                 cachedCookieHeader.split(';').length,
-                  targetUrl:                   domainKey,
-                  domainKey,
-                },
-              });
-            }
-          }
-        }
-
         if (shouldLog) {
           this.writeEvent({
             direction:    'request_headers',
@@ -226,9 +190,9 @@ export class SullaWebRequestFixer extends EventEmitter {
         }
 
         callback({ requestHeaders: details.requestHeaders });
-      })().catch(() => {
+      } catch {
         callback({ requestHeaders: details.requestHeaders });
-      });
+      }
     });
 
     // ==================== onSendHeaders ====================
@@ -288,49 +252,6 @@ export class SullaWebRequestFixer extends EventEmitter {
     }
   }
 
-  /**
-   * Extract just the name=value pair from a full Set-Cookie string,
-   * stripping attributes like Path, HttpOnly, Secure, etc.
-   */
-  private extractCookieNameValue(setCookieStr: string): { name: string; pair: string } | null {
-    const firstPart = setCookieStr.split(';')[0].trim();
-    const eqIdx = firstPart.indexOf('=');
-    if (eqIdx < 1) return null;
-
-    return { name: firstPart.substring(0, eqIdx).trim(), pair: firstPart };
-  }
-
-  /**
-   * Merge new cookie name=value pairs into existing cached cookie header.
-   * Existing cookies with the same name are replaced; new ones are appended.
-   */
-  private mergeCookieHeader(existing: string, newPairs: string[]): string {
-    const cookieMap = new Map<string, string>();
-
-    // Parse existing cookie header
-    if (existing) {
-      for (const part of existing.split(';')) {
-        const trimmed = part.trim();
-        const eqIdx = trimmed.indexOf('=');
-        if (eqIdx > 0) {
-          const name = trimmed.substring(0, eqIdx).trim();
-          cookieMap.set(name, trimmed);
-        }
-      }
-    }
-
-    // Merge/overwrite with new cookies
-    for (const pair of newPairs) {
-      const eqIdx = pair.indexOf('=');
-      if (eqIdx > 0) {
-        const name = pair.substring(0, eqIdx).trim();
-        cookieMap.set(name, pair);
-      }
-    }
-
-    return Array.from(cookieMap.values()).join('; ');
-  }
-
   private isLocalhostHttp(urlInfo: UrlInfo): boolean {
     const isLocalhost = urlInfo.hostname === 'localhost' || urlInfo.hostname === '127.0.0.1' || urlInfo.hostname === '0.0.0.0';
 
@@ -381,20 +302,6 @@ export class SullaWebRequestFixer extends EventEmitter {
     headers[setCookieHeaderKey] = rewrittenCookies;
     headers['set-cookie'] = rewrittenCookies;
 
-    // Extract only name=value pairs for the Cookie request header
-    const newPairs: string[] = [];
-    for (const cookie of rewrittenCookies) {
-      const parsed = this.extractCookieNameValue(cookie);
-      if (parsed) newPairs.push(parsed.pair);
-    }
-
-    const domainKey = this.getCookieDomainKey(details.url);
-    const existingCookieHeader = this.cookieHeaderCacheByDomain[domainKey] || '';
-    const mergedCookieHeader = this.mergeCookieHeader(existingCookieHeader, newPairs);
-
-    this.cookieHeaderCacheByDomain[domainKey] = mergedCookieHeader;
-    this.persistCookieHeaderForDomain(domainKey, mergedCookieHeader);
-
     this.writeEvent({
       direction:    'response_headers',
       url:          details.url,
@@ -403,11 +310,9 @@ export class SullaWebRequestFixer extends EventEmitter {
       resourceType: details.resourceType,
       payload:      {
         requestId:          details.id,
-        session:            'defaultSession',
+        session:            'persist:sulla-browser',
         cookieRewritePhase: 'after',
         rewrittenSetCookie: rewrittenCookies,
-        mergedCookieHeader: mergedCookieHeader.substring(0, 200),
-        domainKey,
       },
     });
   }
@@ -429,67 +334,5 @@ export class SullaWebRequestFixer extends EventEmitter {
     }
 
     return true;
-  }
-
-  private getCookieDomainKey(url: string): string {
-    const urlInfo = this.getUrlInfo(url);
-
-    return `${ urlInfo.hostname }:${ urlInfo.port }`;
-  }
-
-  private getCookiePropertyName(domainKey: string): string {
-    return `${ SullaWebRequestFixer.COOKIE_PROPERTY_PREFIX }${ domainKey }`;
-  }
-
-  private async loadCookieHeaderForDomain(domainKey: string): Promise<string> {
-    const cachedCookieHeader = this.cookieHeaderCacheByDomain[domainKey] || '';
-
-    if (cachedCookieHeader) {
-      return cachedCookieHeader;
-    }
-
-    const persistedCookieHeader = await SullaSettingsModel.get(this.getCookiePropertyName(domainKey), '');
-    const cookieHeader = typeof persistedCookieHeader === 'string' ? persistedCookieHeader : '';
-
-    if (cookieHeader) {
-      this.cookieHeaderCacheByDomain[domainKey] = cookieHeader;
-    }
-
-    return cookieHeader;
-  }
-
-  private persistCookieHeaderForDomain(domainKey: string, cookieHeader: string): void {
-    void SullaSettingsModel
-      .set(this.getCookiePropertyName(domainKey), cookieHeader, 'string')
-      .catch(() => {});
-  }
-
-  /**
-   * Returns all cached domain keys for localhost/127.0.0.1 services.
-   * Used by the session.cookies listener to broadcast JS-set cookies
-   * to the correct localhost:port domain key.
-   */
-  getLocalhostDomainKeys(): string[] {
-    return Object.keys(this.cookieHeaderCacheByDomain)
-      .filter((key) => key.startsWith('localhost:') || key.startsWith('127.0.0.1:'));
-  }
-
-  onJsCookieChanged(domainKey: string, nameValuePair: string): void {
-    const existing = this.cookieHeaderCacheByDomain[domainKey] || '';
-    const merged = this.mergeCookieHeader(existing, [nameValuePair]);
-
-    if (merged !== existing) {
-      this.cookieHeaderCacheByDomain[domainKey] = merged;
-      this.persistCookieHeaderForDomain(domainKey, merged);
-
-      this.writeEvent({
-        direction: 'js_cookie_changed',
-        payload:   {
-          domainKey,
-          newCookie:    nameValuePair.substring(0, 80),
-          totalCookies: merged.split(';').length,
-        },
-      });
-    }
   }
 }

--- a/pkg/rancher-desktop/__tests__/SullaWebRequestFixer.test.ts
+++ b/pkg/rancher-desktop/__tests__/SullaWebRequestFixer.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { SullaWebRequestFixer } from '../SullaWebRequestFixer';
+
+describe('SullaWebRequestFixer cookie handling', () => {
+  it('leaves Chromium native Cookie headers authoritative after Set-Cookie and document.cookie writes', () => {
+    const handlers: Record<string, (...args: any[]) => void> = {};
+    const webRequest = {
+      onHeadersReceived:   jest.fn((handler: (...args: any[]) => void) => { handlers.headersReceived = handler }),
+      onBeforeSendHeaders: jest.fn((handler: (...args: any[]) => void) => { handlers.beforeSendHeaders = handler }),
+      onSendHeaders:       jest.fn((handler: (...args: any[]) => void) => { handlers.sendHeaders = handler }),
+      onCompleted:         jest.fn((handler: (...args: any[]) => void) => { handlers.completed = handler }),
+      onErrorOccurred:     jest.fn((handler: (...args: any[]) => void) => { handlers.errorOccurred = handler }),
+    };
+    const fixer = new SullaWebRequestFixer(jest.fn());
+
+    fixer.attachToSession({ webRequest } as any);
+
+    const responseCallback = jest.fn();
+    handlers.headersReceived({
+      id:              1,
+      url:             'http://localhost:3000/auth',
+      method:          'GET',
+      statusCode:      200,
+      resourceType:    'mainFrame',
+      responseHeaders: { 'Set-Cookie': ['response_cookie=server; Path=/'] },
+    }, responseCallback);
+
+    expect(responseCallback).toHaveBeenCalledWith({
+      responseHeaders: expect.objectContaining({
+        'set-cookie': ['response_cookie=server; Path=/'],
+      }),
+    });
+
+    // Chromium composes this header from its Session cookie store after the
+    // response cookie and a page-side document.cookie write. The fixer must
+    // pass that exact header through instead of overlaying a shadow cache.
+    const nativeCookieHeader = 'response_cookie=server; document_cookie=page';
+    const requestCallback = jest.fn();
+    handlers.beforeSendHeaders({
+      id:             2,
+      url:            'http://localhost:3000/dashboard',
+      method:         'GET',
+      resourceType:   'xhr',
+      requestHeaders: { Cookie: nativeCookieHeader },
+    }, requestCallback);
+
+    expect(requestCallback).toHaveBeenCalledTimes(1);
+    expect(requestCallback).toHaveBeenCalledWith({
+      requestHeaders: expect.objectContaining({ Cookie: nativeCookieHeader }),
+    });
+  });
+});

--- a/pkg/rancher-desktop/main/browserTabs/browserSession.ts
+++ b/pkg/rancher-desktop/main/browserTabs/browserSession.ts
@@ -1,0 +1,12 @@
+import { session, type Session } from 'electron';
+
+/**
+ * The one persistent Chromium session used by embedded browser tabs and every
+ * browser-state API. Passing this Session object into WebContentsView avoids a
+ * second partition lookup and makes the cookie-store identity explicit.
+ */
+export const BROWSER_SESSION_PARTITION = 'persist:sulla-browser';
+
+export function getBrowserSession(): Session {
+  return session.fromPartition(BROWSER_SESSION_PARTITION);
+}

--- a/pkg/rancher-desktop/main/chromeApi/ChromeApiService.ts
+++ b/pkg/rancher-desktop/main/chromeApi/ChromeApiService.ts
@@ -16,10 +16,11 @@
 
 import { EventEmitter } from 'events';
 
-import Electron, { WebContentsView, session } from 'electron';
+import Electron, { WebContentsView } from 'electron';
 
 import type { SullaWebRequestFixer } from '@pkg/SullaWebRequestFixer';
 import { tabRegistry } from '@pkg/main/browserTabs/TabRegistry';
+import { getBrowserSession } from '@pkg/main/browserTabs/browserSession';
 import Logging from '@pkg/utils/logging';
 import { BrowserTabViewManager } from '@pkg/window/browserTabViewManager';
 
@@ -71,8 +72,6 @@ import type {
 } from './types';
 
 const console = Logging.sulla;
-const SESSION_PARTITION = 'persist:sulla-browser';
-
 // ---------------------------------------------------------------------------
 // ChromeEvent implementation
 // ---------------------------------------------------------------------------
@@ -365,14 +364,19 @@ export class ChromeApiService implements ChromeApi {
 
       if (props.hidden) {
         // Create a detached WebContentsView — functional but not visible
+        const browserSession = getBrowserSession();
         const view = new WebContentsView({
           webPreferences: {
             webSecurity:      false,
             contextIsolation: false,
             nodeIntegration:  false,
-            partition:        SESSION_PARTITION,
+            session:          browserSession,
           },
         });
+
+        if (view.webContents.session !== browserSession) {
+          throw new Error('[ChromeApi] Hidden WebContentsView did not adopt the shared browser session');
+        }
 
         this.hiddenViews.set(tabId, view);
 
@@ -534,14 +538,14 @@ export class ChromeApiService implements ChromeApi {
 
   cookies = {
     get: async(details: CookieGetDetails): Promise<ChromeCookie | null> => {
-      const sess = session.fromPartition(SESSION_PARTITION);
+      const sess = getBrowserSession();
       const cookies = await sess.cookies.get({ url: details.url, name: details.name });
 
       return cookies.length > 0 ? this.toChromeCookie(cookies[0]) : null;
     },
 
     getAll: async(details: CookieGetAllDetails): Promise<ChromeCookie[]> => {
-      const sess = session.fromPartition(SESSION_PARTITION);
+      const sess = getBrowserSession();
       const filter: Electron.CookiesGetFilter = {};
 
       if (details.url) filter.url = details.url;
@@ -556,7 +560,7 @@ export class ChromeApiService implements ChromeApi {
     },
 
     set: async(details: CookieSetDetails): Promise<ChromeCookie> => {
-      const sess = session.fromPartition(SESSION_PARTITION);
+      const sess = getBrowserSession();
 
       await sess.cookies.set({
         url:            details.url,
@@ -584,7 +588,7 @@ export class ChromeApiService implements ChromeApi {
     },
 
     remove: async(details: CookieRemoveDetails): Promise<void> => {
-      const sess = session.fromPartition(SESSION_PARTITION);
+      const sess = getBrowserSession();
 
       await sess.cookies.remove(details.url, details.name);
     },
@@ -1015,7 +1019,7 @@ export class ChromeApiService implements ChromeApi {
       this.downloadCreatedEvent.emit(item);
 
       // Trigger the actual download via the browser session
-      const sess = session.fromPartition(SESSION_PARTITION);
+      const sess = getBrowserSession();
 
       sess.once('will-download', (_event, electronItem) => {
         if (options.filename) {

--- a/pkg/rancher-desktop/main/chromeApi/__tests__/ChromeApiService.cookies.test.ts
+++ b/pkg/rancher-desktop/main/chromeApi/__tests__/ChromeApiService.cookies.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+const mockCookieRecords: Electron.Cookie[] = [];
+const mockCookies = {
+  get: jest.fn(async(filter: Electron.CookiesGetFilter) => mockCookieRecords.filter((cookie) => {
+    if (filter.name && cookie.name !== filter.name) return false;
+    if (filter.domain && cookie.domain !== filter.domain) return false;
+    if (filter.url && !filter.url.includes((cookie.domain ?? '').replace(/^\./, ''))) return false;
+    return true;
+  })),
+  set: jest.fn(async(details: Electron.CookiesSetDetails) => {
+    const domain = details.domain || new URL(details.url).hostname;
+    const existing = mockCookieRecords.findIndex(cookie => cookie.name === details.name && cookie.domain === domain);
+    const cookie = {
+      name:     details.name,
+      value:    details.value,
+      domain,
+      hostOnly: !details.domain,
+      path:     details.path || '/',
+      secure:   details.secure ?? false,
+      httpOnly: details.httpOnly ?? false,
+      session:  details.expirationDate === undefined,
+      sameSite: details.sameSite ?? 'lax',
+    } as Electron.Cookie;
+
+    if (existing >= 0) mockCookieRecords[existing] = cookie;
+    else mockCookieRecords.push(cookie);
+  }),
+  remove: jest.fn(async(url: string, name: string) => {
+    const domain = new URL(url).hostname;
+    const index = mockCookieRecords.findIndex(cookie => cookie.name === name && cookie.domain === domain);
+    if (index >= 0) mockCookieRecords.splice(index, 1);
+  }),
+};
+const mockBrowserSession = { cookies: mockCookies };
+
+jest.unstable_mockModule('electron', () => ({
+  default:         {},
+  WebContentsView: jest.fn(),
+  session:         { fromPartition: jest.fn(() => mockBrowserSession) },
+}));
+
+jest.unstable_mockModule('@pkg/main/browserTabs/TabRegistry', () => ({
+  tabRegistry: { list: jest.fn(() => []) },
+}));
+
+jest.unstable_mockModule('@pkg/utils/logging', () => ({
+  default: {
+    sulla: {
+      log:   jest.fn(),
+      warn:  jest.fn(),
+      error: jest.fn(),
+    },
+  },
+}));
+
+jest.unstable_mockModule('@pkg/window/browserTabViewManager', () => ({
+  BrowserTabViewManager: {},
+}));
+
+describe('ChromeApiService cookies', () => {
+  it('uses the same Session store as response and document.cookie writes', async() => {
+    const { ChromeApiService } = await import('../ChromeApiService');
+    const manager = {
+      getWebRequestFixer: jest.fn(() => ({ on: jest.fn() })),
+    };
+    const api = ChromeApiService.getInstance(manager as any);
+    const url = 'http://localhost:3000/dashboard';
+
+    // Chromium writes both a Set-Cookie response and document.cookie into the
+    // WebContents Session supplied by BrowserTabViewManager.
+    await mockBrowserSession.cookies.set({ url, name: 'response_cookie', value: 'server' });
+    await mockBrowserSession.cookies.set({ url, name: 'document_cookie', value: 'page' });
+
+    expect((await api.cookies.getAll({ url })).map(cookie => cookie.name).sort()).toEqual([
+      'document_cookie',
+      'response_cookie',
+    ]);
+
+    // manage_cookies delegates to this chrome.cookies API. Its write must land
+    // back in the exact store used by the WebContents network stack.
+    await api.cookies.set({ url, name: 'api_cookie', value: 'tool' });
+
+    expect((await mockBrowserSession.cookies.get({ url })).map(cookie => cookie.name).sort()).toEqual([
+      'api_cookie',
+      'document_cookie',
+      'response_cookie',
+    ]);
+  });
+});

--- a/pkg/rancher-desktop/window/__tests__/browserTabViewManager.test.ts
+++ b/pkg/rancher-desktop/window/__tests__/browserTabViewManager.test.ts
@@ -1,13 +1,49 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
+const mockBrowserSession = {
+  cookies: {
+    flushStore: jest.fn(() => Promise.resolve()),
+    on:         jest.fn(),
+  },
+  getUserAgent:          jest.fn(() => 'Chrome Electron/40.0 SullaDesktop/1.0'),
+  setUserAgent:          jest.fn(),
+  on:                    jest.fn(),
+  getPreloadScripts:     jest.fn(() => []),
+  registerPreloadScript: jest.fn(),
+};
+const mockWebContents = {
+  session:                 mockBrowserSession,
+  ipc:                     { on: jest.fn() },
+  setBackgroundThrottling: jest.fn(),
+  setWindowOpenHandler:    jest.fn(),
+  on:                      jest.fn(),
+  loadURL:                 jest.fn(() => Promise.resolve()),
+  getURL:                  jest.fn(() => ''),
+};
+const mockView = {
+  webContents: mockWebContents,
+  setBounds:   jest.fn(),
+  setVisible:  jest.fn(),
+};
+const mockWebContentsView = jest.fn((_options?: unknown) => mockView);
+const mockMainWindow = {
+  contentView: {
+    addChildView:    jest.fn(),
+    removeChildView: jest.fn(),
+  },
+  webContents: {},
+};
+const mockGetWindow = jest.fn(() => mockMainWindow);
+const mockAttachToSession = jest.fn();
+
 jest.unstable_mockModule('electron', () => ({
   default:         {},
-  WebContentsView: jest.fn(),
-  session:         { fromPartition: jest.fn() },
+  WebContentsView: mockWebContentsView,
+  session:         { fromPartition: jest.fn(() => mockBrowserSession) },
 }));
 
 jest.unstable_mockModule('@pkg/SullaWebRequestFixer', () => ({
-  SullaWebRequestFixer: jest.fn(),
+  SullaWebRequestFixer: jest.fn(() => ({ attachToSession: mockAttachToSession })),
 }));
 
 jest.unstable_mockModule('@pkg/utils/logging', () => ({
@@ -33,7 +69,7 @@ jest.unstable_mockModule('@pkg/utils/safeSend', () => ({
 }));
 
 jest.unstable_mockModule('@pkg/window', () => ({
-  getWindow:    jest.fn(() => null),
+  getWindow:    mockGetWindow,
   openUrlInApp: jest.fn(),
 }));
 
@@ -49,6 +85,7 @@ async function loadManager() {
 describe('BrowserTabViewManager', () => {
   afterEach(() => {
     jest.clearAllMocks();
+    mockWebContents.getURL.mockReturnValue('');
   });
 
   it('ignores stale focus clears from tabs that no longer own focus', async() => {
@@ -70,5 +107,27 @@ describe('BrowserTabViewManager', () => {
     manager.setFocusedTab(null, 'tab-a');
 
     expect(manager.getFocusedTab()).toBeNull();
+  });
+
+  it('constructs tabs with the shared persistent session and visible-page throttling policy', async() => {
+    const { BrowserTabViewManager } = await loadManager();
+    const manager = BrowserTabViewManager.getInstance();
+
+    manager.createView('cookie-tab', 'http://localhost:3000', { x: 10, y: 20, width: 800, height: 600 });
+
+    expect(mockWebContentsView).toHaveBeenCalledWith({
+      webPreferences: expect.objectContaining({
+        session:              mockBrowserSession,
+        backgroundThrottling: false,
+      }),
+    });
+    expect(mockWebContents.session).toBe(mockBrowserSession);
+    expect(mockAttachToSession).toHaveBeenCalledWith(mockBrowserSession);
+
+    manager.setFocusedTab('cookie-tab');
+
+    expect(mockView.setVisible).toHaveBeenCalledWith(true);
+    expect(mockWebContents.setBackgroundThrottling).toHaveBeenCalledWith(false);
+    expect(mockMainWindow.contentView.addChildView).toHaveBeenCalledWith(mockView);
   });
 });

--- a/pkg/rancher-desktop/window/browserTabViewManager.ts
+++ b/pkg/rancher-desktop/window/browserTabViewManager.ts
@@ -1,9 +1,10 @@
 import path from 'path';
 
-import Electron, { WebContentsView, session } from 'electron';
+import Electron, { WebContentsView } from 'electron';
 
 import { SullaWebRequestFixer } from '@pkg/SullaWebRequestFixer';
 import { tabRegistry } from '@pkg/main/browserTabs/TabRegistry';
+import { BROWSER_SESSION_PARTITION, getBrowserSession } from '@pkg/main/browserTabs/browserSession';
 import Logging from '@pkg/utils/logging';
 import paths from '@pkg/utils/paths';
 import { safeSend } from '@pkg/utils/safeSend';
@@ -11,8 +12,6 @@ import { getWindow, openUrlInApp } from '@pkg/window';
 import { buildContextMenuInjection } from '@pkg/window/browserContextMenu';
 
 const console = Logging.sulla;
-
-const SESSION_PARTITION = 'persist:sulla-browser';
 
 /**
  * Manages WebContentsView instances for browser tabs.
@@ -72,7 +71,7 @@ export class BrowserTabViewManager {
    * so cookie management works for all browser-tab views.
    */
   private ensureSession(): Electron.Session {
-    const sess = session.fromPartition(SESSION_PARTITION);
+    const sess = getBrowserSession();
 
     if (!this.sessionInitialised) {
       this.webRequestFixer = new SullaWebRequestFixer((event) => {
@@ -142,7 +141,7 @@ export class BrowserTabViewManager {
       }
 
       this.sessionInitialised = true;
-      console.log('[BrowserTabView] Session initialised:', SESSION_PARTITION);
+      console.log('[BrowserTabView] Session initialised:', BROWSER_SESSION_PARTITION);
     }
 
     return sess;
@@ -175,16 +174,24 @@ export class BrowserTabViewManager {
     }
 
     // Make sure shared session is ready
-    this.ensureSession();
+    const browserSession = this.ensureSession();
 
     const view = new WebContentsView({
       webPreferences: {
-        webSecurity:      false,
-        contextIsolation: false,
-        nodeIntegration:  false,
-        partition:        SESSION_PARTITION,
+        webSecurity:          false,
+        contextIsolation:     false,
+        nodeIntegration:      false,
+        session:              browserSession,
+        // Set this before the renderer is created. Electron documents that
+        // backgroundThrottling also controls the Page Visibility API; setting
+        // it after construction can leave the initial document hidden.
+        backgroundThrottling: false,
       },
     });
+
+    if (view.webContents.session !== browserSession) {
+      throw new Error('[BrowserTabView] WebContentsView did not adopt the shared browser session');
+    }
 
     // Disable background throttling so the Chromium renderer stays awake and
     // the compositor keeps producing frames even when the view is parked
@@ -354,6 +361,11 @@ export class BrowserTabViewManager {
 
     for (const [tabId, view] of this.views) {
       if (tabId === this.focusedTabId) {
+        // Explicitly clear any native hidden state before attaching/promoting
+        // the focused view. Parked views remain drawable off-screen for agent
+        // capture, while focused pages report visibilityState=visible.
+        view.setVisible(true);
+        view.webContents.setBackgroundThrottling(false);
         const bounds = this.latestBounds.get(tabId);
         if (bounds) view.setBounds(bounds);
         try {


### PR DESCRIPTION
## Task

Fixes internal Projects task Supb (P0, epic VAPS).

On 2026-08-27, RippleCore QA produced hundreds of Clerk dev-server errors: "Clerk: Refreshing the session token resulted in an infinite redirect loop." The embedded browser had two platform defects behind that failure.

## What changed

- Removed the persisted localhost cookie-header cache and manual Cookie-header overlay from SullaWebRequestFixer. The native Chromium Session cookie store is now authoritative, so Set-Cookie responses, document.cookie writes/removals, navigation requests, and manage_cookies cannot diverge.
- Added one shared persistent browser Session factory and passed that exact Session object to browser-tab and hidden WebContentsViews as well as the Chrome/manage_cookies API.
- Set backgroundThrottling: false in WebContents creation preferences, before the initial document loads, and explicitly restore visible/background-throttling state when a tab is focused.
- Added focused regression coverage for response + document.cookie header preservation, cookie API round-tripping through the same store, shared Session identity, and focused-view visibility policy.

## Validation

- PASS: 3 focused Jest suites, 5 tests.
- PASS: focused type-aware ESLint on the seven changed files (with only the pre-existing ChromeApiService require-await/deprecation baseline rules disabled).
- TypeScript compiler note: the focused project graph exposed existing unrelated errors in JsonParseService, MCPServerHost, and AudioNoiseProcessor; the only Supb-owned diagnostic was fixed. A rerun with an expanded heap was killed by the VM (exit 137).
- Manual visibilitychange logger QA and the 10+ minute Clerk idle-session acceptance check require a packaged build and remain pending review. No build was installed or deployed from this branch.

No merge or deploy performed.