### PR TITLE
fix(dispatcher): idempotent journal replay, review scope pair, drainable-only backlog gate

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -205,6 +205,37 @@ interface WorkTaskOutcomeJournalRow {
 
 const CLOSED_EPIC_STATUSES = ['done', 'cancelled', 'parked', 'blocked'];
 
+/** Heartbeat-silence threshold shared by recoverStale() and the drainable-review-backlog surface. */
+const STALE_DISPATCH_MINUTES = 45;
+
+/**
+ * A review-stage task only exerts downstream-first backpressure while it can
+ * actually drain. A single wedged in_review row must never hold the whole
+ * conveyor (Jonathon directive 2026-08-28): a task whose running dispatch has
+ * a dead heartbeat cannot be claimed for review, a task whose latest
+ * verification ended terminal-failed needs planning/human recovery that
+ * holding fresh todo work does nothing to advance, and a dependency-held task
+ * is un-claimable by the review pool. `alias` is a trusted table alias
+ * (e.g. 't', 'downstream'), never user input.
+ */
+function drainableReviewSql(alias: string): string {
+  return `AND NOT EXISTS (
+             SELECT 1 FROM work_task_dispatches zombie
+              WHERE zombie.task_id = ${ alias }.id AND zombie.status = 'running'
+                AND zombie.heartbeat_at < now() - (${ STALE_DISPATCH_MINUTES } * interval '1 minute')
+           )
+           AND COALESCE((
+             SELECT latest_verification.status <> 'failed'
+                    OR latest_verification.failure_reason IS NULL
+                    OR latest_verification.failure_reason NOT LIKE 'terminal:%'
+               FROM work_task_dispatches latest_verification
+              WHERE latest_verification.task_id = ${ alias }.id
+                AND latest_verification.kind = 'verification'
+              ORDER BY latest_verification.started_at DESC LIMIT 1
+           ), true)
+           ${ WorkTaskDependencyModel.claimExclusionSql(`${ alias }.id`) }`;
+}
+
 /**
  * Idle in_progress reclaim is ownership-neutral by design (Jonathon
  * directive 2026-08-25, Projects task 1Nk7): whoever is actively working a
@@ -317,6 +348,7 @@ export class WorkTaskDispatchModel {
                   SELECT 1 FROM unnest(COALESCE(downstream.labels, '{}')) AS downstream_label
                    WHERE LOWER(downstream_label) = ANY($3::text[])
                 )
+                ${ drainableReviewSql('downstream') }
            )
            AND NOT EXISTS (
              SELECT 1 FROM work_tasks child
@@ -540,10 +572,14 @@ export class WorkTaskDispatchModel {
   }
 
   /**
-   * Count autonomous work already at the review stage, including work with an
-   * active verification lease. Any such row is farther down the conveyor than
-   * todo, so the dispatcher uses this as a hard backpressure gate before
-   * claiming fresh execution work.
+   * Count autonomous work already at the review stage that can still drain —
+   * claimable by the review pool or actively held by a live verification
+   * lease. Any such row is farther down the conveyor than todo, so the
+   * dispatcher uses this as a hard backpressure gate before claiming fresh
+   * execution work. Wedged rows (dead-heartbeat running dispatch,
+   * terminal-failed latest verification, dependency-held) are excluded via
+   * drainableReviewSql: holding the whole conveyor does nothing to advance
+   * them, and one stuck task must never starve every execution slot.
    */
   static async countReviewBacklog(): Promise<number> {
     const row = await postgresClient.queryOne<{ count: string }>(`
@@ -562,6 +598,7 @@ export class WorkTaskDispatchModel {
            SELECT 1 FROM unnest(COALESCE(t.labels, '{}')) AS label
             WHERE LOWER(label) = ANY($2::text[])
          )
+         ${ drainableReviewSql('t') }
     `, [CLOSED_EPIC_STATUSES, NON_AUTONOMOUS_TASK_LABELS]);
     return Number(row?.count || 0);
   }
@@ -858,10 +895,22 @@ export class WorkTaskDispatchModel {
         WHERE id = $1 AND kind = 'verification' AND status = 'running'`,
       [id, execution.executionId, execution.reviewerAgentIds]);
       if (dispatchUpdate.rowCount !== 1) throw new Error('review_dispatch_not_live');
+      // workflow_executions_scope_pair_check (migration 0071) requires
+      // scope_task_id and a positive scope_generation together or neither.
+      // Reviews scope to the task's latest lane-entry generation; a task with
+      // no lane entries launches unscoped rather than violating the constraint
+      // and failing every review.
+      const generationRow = await client.query<{ generation: number | null }>(
+        'SELECT MAX(generation)::int AS generation FROM work_lane_entry_automations WHERE task_id = $1',
+        [execution.scopeTaskId],
+      );
+      const scopeGeneration = Number(generationRow.rows[0]?.generation ?? 0);
       await WorkflowExecutionModel.markRunning({
         executionId: execution.executionId, workflowId: execution.workflowId,
         workflowName: execution.workflowName, workflowSlug: execution.workflowSlug,
-        triggerInput: execution.triggerInput, scopeTaskId: execution.scopeTaskId,
+        triggerInput: execution.triggerInput,
+        scopeTaskId: scopeGeneration > 0 ? execution.scopeTaskId : undefined,
+        scopeGeneration: scopeGeneration > 0 ? scopeGeneration : undefined,
         autoRestart: false,
       }, client);
     });
@@ -1017,22 +1066,76 @@ export class WorkTaskDispatchModel {
         await client.query('UPDATE work_task_outcome_journal SET consumed_at = now() WHERE id = $1', [journalId]);
         return null;
       }
-      const task = await this.finalizeWithClient(client, row.dispatch_id, row.task_id, {
-        dispatchStatus: row.dispatch_status,
-        taskStatus: row.task_status,
-        taskAssignee: row.task_assignee,
-        comment: row.comment,
-        result: row.result ?? undefined,
-        error: row.error ?? undefined,
-        evidence: row.evidence ?? undefined,
-        receipt: row.receipt ?? undefined,
-      });
+      // Replay is only strict while the dispatcher still owns the task. If the
+      // task already advanced (the worker, lane automation, or a human landed
+      // the transition before this journal settled), the full finalization
+      // would throw "no longer owned" on every tick forever — leaving the
+      // dispatch running, the journal pending, stale recovery skipping the
+      // lease, and the review-backlog gate holding the whole conveyor. In that
+      // case settle the dispatch bookkeeping and preserve the task's current
+      // state: the journal's task move already happened or was superseded.
+      const custody = await client.query<{ status: string; assignee: string | null }>(
+        'SELECT status, assignee FROM work_tasks WHERE id = $1 FOR UPDATE', [row.task_id],
+      );
+      const dispatcherOwned = custody.rows[0]?.status === 'in_progress' && custody.rows[0]?.assignee === 'dispatcher';
+      const task = dispatcherOwned
+        ? await this.finalizeWithClient(client, row.dispatch_id, row.task_id, {
+          dispatchStatus: row.dispatch_status,
+          taskStatus: row.task_status,
+          taskAssignee: row.task_assignee,
+          comment: row.comment,
+          result: row.result ?? undefined,
+          error: row.error ?? undefined,
+          evidence: row.evidence ?? undefined,
+          receipt: row.receipt ?? undefined,
+        })
+        : await this.settleDispatchPreservingTask(client, row, custody.rows[0] ?? null);
       await client.query(
         'UPDATE work_task_outcome_journal SET consumed_at = now() WHERE id = $1 AND consumed_at IS NULL',
         [journalId],
       );
       return task;
     });
+  }
+
+  /**
+   * Journal replay for a task that already left dispatcher custody: settle the
+   * dispatch row, release any still-active stage claims, and record the
+   * worker's outcome comment — without touching the task's current
+   * status/assignee, which won the race and is treated as authoritative.
+   */
+  private static async settleDispatchPreservingTask(
+    client: PoolClient,
+    journal: WorkTaskOutcomeJournalRow,
+    currentTask: { status: string; assignee: string | null } | null,
+  ): Promise<WorkTaskRecord | null> {
+    await client.query(`
+      UPDATE work_task_dispatches
+         SET status = $2, result = $3, error = $4, heartbeat_at = now(), finished_at = now()
+       WHERE id = $1 AND status = 'running'
+    `, [journal.dispatch_id, journal.dispatch_status, journal.result ?? null, journal.error ?? null]);
+
+    const observed = currentTask
+      ? `${ currentTask.status }/${ currentTask.assignee ?? 'unassigned' }`
+      : 'missing';
+    await client.query(`
+      INSERT INTO work_task_comments (id, task_id, body, author)
+      VALUES ($1, $2, $3, 'dispatcher')
+    `, [
+      `dispatch-comment-${ randomUUID() }`,
+      journal.task_id,
+      `${ journal.comment }\n\n(Outcome journal replay: the task had already advanced to ${ observed }, `
+        + `so the dispatch was settled without moving the task.)`,
+    ]);
+
+    await client.query(`
+      UPDATE work_task_stage_claims
+         SET status = 'released', released_at = now(), heartbeat_at = now()
+       WHERE task_id = $1 AND status = 'active'
+    `, [journal.task_id]);
+
+    const current = await client.query<WorkTaskRecord>('SELECT * FROM work_tasks WHERE id = $1', [journal.task_id]);
+    return current.rows[0] ?? null;
   }
 
   static async recoverPendingOutcomeJournals(): Promise<string[]> {
@@ -1158,7 +1261,7 @@ export class WorkTaskDispatchModel {
     })();
   }
 
-  static async recoverStale(staleMinutes = 45): Promise<string[]> {
+  static async recoverStale(staleMinutes = STALE_DISPATCH_MINUTES): Promise<string[]> {
     return postgresClient.transaction(async(client: PoolClient) => {
       const setting = await client.query<{ enabled: boolean }>(
         `SELECT COALESCE(value::boolean, false) AS enabled

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchJournalReplay.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskDispatchJournalReplay.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+
+import { postgresClient } from '../../PostgresClient';
+import { WorkflowExecutionModel } from '../WorkflowExecutionModel';
+import { WorkTaskDispatchModel } from '../WorkTaskDispatchModel';
+
+const JOURNAL_ROW = {
+  id:              'outcome-1',
+  dispatch_id:     'dispatch-1',
+  task_id:         'task-1',
+  dispatch_status: 'completed',
+  task_status:     'in_review',
+  task_assignee:   'heartbeat',
+  comment:         'WORK_RESULT: shipped',
+  result:          'ok',
+  error:           null,
+  evidence:        null,
+  receipt:         null,
+  consumed_at:     null,
+};
+
+describe('WorkTaskDispatchModel.finalizeOutcomeJournal idempotent replay', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function transactionWith(query: jest.Mock) {
+    jest.spyOn(postgresClient, 'transaction').mockImplementation((callback: any) => callback({ query }));
+  }
+
+  it('settles the dispatch and consumes the journal when the task already advanced', async() => {
+    const query = jest.fn((sql: string) => {
+      if (sql.includes('FROM work_task_outcome_journal WHERE id')) {
+        return Promise.resolve({ rows: [{ ...JOURNAL_ROW }] });
+      }
+      if (sql.includes('FROM work_task_dispatches WHERE id')) {
+        return Promise.resolve({ rows: [{ status: 'running' }] });
+      }
+      if (sql.includes('SELECT status, assignee FROM work_tasks')) {
+        return Promise.resolve({ rows: [{ status: 'in_review', assignee: 'dispatcher' }] });
+      }
+      if (sql.includes('SELECT * FROM work_tasks WHERE id')) {
+        return Promise.resolve({ rows: [{ id: 'task-1', status: 'in_review', assignee: 'dispatcher' }] });
+      }
+      return Promise.resolve({ rows: [], rowCount: 1 });
+    }) as any;
+    transactionWith(query);
+
+    const task = await WorkTaskDispatchModel.finalizeOutcomeJournal('outcome-1');
+    expect(task).toEqual({ id: 'task-1', status: 'in_review', assignee: 'dispatcher' });
+
+    const statements = query.mock.calls.map(call => String(call[0]));
+    // The dispatch settles to the journal's terminal status.
+    expect(statements.some(sql => sql.includes('UPDATE work_task_dispatches') && sql.includes("status = 'running'"))).toBe(true);
+    // The worker's outcome comment still lands with a replay note.
+    const commentCall = query.mock.calls.find(call => String(call[0]).includes('INSERT INTO work_task_comments'));
+    expect(commentCall).toBeDefined();
+    expect(String((commentCall as any)[1][2])).toContain('WORK_RESULT: shipped');
+    expect(String((commentCall as any)[1][2])).toContain('Outcome journal replay');
+    // Stage claims release so the WIP slot is not stranded.
+    expect(statements.some(sql => sql.includes('UPDATE work_task_stage_claims') && sql.includes("status = 'released'"))).toBe(true);
+    // The journal is consumed exactly once.
+    expect(statements.some(sql => sql.includes('UPDATE work_task_outcome_journal SET consumed_at'))).toBe(true);
+    // The task itself is never moved: its current state won the race.
+    expect(statements.some(sql => sql.includes('UPDATE work_tasks') && sql.includes('SET status'))).toBe(false);
+  });
+
+  it('still runs the strict finalization while the dispatcher owns the task', async() => {
+    const query = jest.fn((sql: string) => {
+      if (sql.includes('FROM work_task_outcome_journal WHERE id')) {
+        return Promise.resolve({ rows: [{ ...JOURNAL_ROW, task_status: 'planning', task_assignee: 'dispatcher' }] });
+      }
+      if (sql.includes('SELECT status, assignee FROM work_tasks')) {
+        return Promise.resolve({ rows: [{ status: 'in_progress', assignee: 'dispatcher' }] });
+      }
+      if (sql.includes('FROM work_task_dispatches WHERE id')) {
+        return Promise.resolve({ rows: [{ status: 'running' }] });
+      }
+      if (sql.includes('UPDATE work_tasks') && sql.includes('RETURNING *')) {
+        return Promise.resolve({ rows: [{ id: 'task-1', status: 'planning', assignee: 'dispatcher' }] });
+      }
+      return Promise.resolve({ rows: [], rowCount: 1 });
+    }) as any;
+    transactionWith(query);
+
+    const task = await WorkTaskDispatchModel.finalizeOutcomeJournal('outcome-1');
+    expect(task).toEqual({ id: 'task-1', status: 'planning', assignee: 'dispatcher' });
+
+    const statements = query.mock.calls.map(call => String(call[0]));
+    // Strict path moves the task with the dispatcher-custody guard intact.
+    expect(statements.some(sql => sql.includes('UPDATE work_tasks')
+      && sql.includes("status = 'in_progress' AND assignee = 'dispatcher'"))).toBe(true);
+  });
+});
+
+describe('WorkTaskDispatchModel.recordReviewLaunchWithExecution scope pair', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const LAUNCH = {
+    executionId:  'exec-1',
+    workflowId:   'core-review',
+    workflowName: 'Review Project Artifact',
+    workflowSlug: 'core-review',
+    triggerInput: 'review it',
+    scopeTaskId:  'task-1',
+    reviewerAgentIds: ['sulla-desktop'],
+  };
+
+  function launchWith(generation: number | null) {
+    const query = jest.fn((sql: string) => {
+      if (sql.includes('UPDATE work_task_dispatches')) return Promise.resolve({ rows: [], rowCount: 1 });
+      if (sql.includes('MAX(generation)')) return Promise.resolve({ rows: [{ generation }] });
+      return Promise.resolve({ rows: [], rowCount: 1 });
+    }) as any;
+    jest.spyOn(postgresClient, 'transaction').mockImplementation((callback: any) => callback({ query }));
+    return query;
+  }
+
+  it('passes the paired lane-entry generation so scope_pair_check cannot fire', async() => {
+    const markRunning = jest.spyOn(WorkflowExecutionModel, 'markRunning').mockResolvedValue(undefined as any);
+    launchWith(3);
+
+    await WorkTaskDispatchModel.recordReviewLaunchWithExecution('dispatch-1', LAUNCH);
+
+    expect(markRunning).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeTaskId: 'task-1', scopeGeneration: 3 }),
+      expect.anything(),
+    );
+  });
+
+  it('launches unscoped when the task has no lane-entry generation', async() => {
+    const markRunning = jest.spyOn(WorkflowExecutionModel, 'markRunning').mockResolvedValue(undefined as any);
+    launchWith(null);
+
+    await WorkTaskDispatchModel.recordReviewLaunchWithExecution('dispatch-1', LAUNCH);
+
+    expect(markRunning).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeTaskId: undefined, scopeGeneration: undefined }),
+      expect.anything(),
+    );
+  });
+});
+
+describe('WorkTaskDispatchModel drainable review backlog', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('excludes wedged review rows from the backpressure count', async() => {
+    const queryOne = jest.spyOn(postgresClient, 'queryOne').mockResolvedValue({ count: '1' } as any);
+
+    await expect(WorkTaskDispatchModel.countReviewBacklog()).resolves.toBe(1);
+
+    const [sql] = queryOne.mock.calls[0];
+    // Dead-heartbeat running dispatches cannot drain and must not hold todo work.
+    expect(sql).toContain("zombie.status = 'running'");
+    expect(sql).toContain('zombie.heartbeat_at < now()');
+    // A terminal-failed latest verification needs planning/human recovery, not backpressure.
+    expect(sql).toContain("latest_verification.kind = 'verification'");
+    expect(sql).toContain("NOT LIKE 'terminal:%'");
+    // Dependency-held review rows are un-claimable by the review pool.
+    expect(sql).toContain('wtd.dependent_task_id = t.id');
+  });
+
+  it('mirrors the drainable conditions inside the todo-claim race guard', async() => {
+    const query = jest.fn(() => Promise.resolve({ rows: [] })) as any;
+    jest.spyOn(postgresClient, 'transaction').mockImplementation((callback: any) => callback({ query }));
+
+    await expect(WorkTaskDispatchModel.claimNext('sulla-desktop', 'runtime-1')).resolves.toBeNull();
+
+    const sql = String(query.mock.calls[0][0]);
+    expect(sql).toContain("downstream.status = 'in_review'");
+    expect(sql).toContain('zombie.task_id = downstream.id');
+    expect(sql).toContain('latest_verification.task_id = downstream.id');
+    expect(sql).toContain('wtd.dependent_task_id = downstream.id');
+  });
+});


### PR DESCRIPTION
Fixes the 36-hour conveyor deadlock diagnosed 2026-08-28 (task 26O2) and the systemic defect Jonathon called out: **one stuck task must never block the whole dispatcher.**

## Root causes fixed

**1. Journal replay threw forever once a task advanced (Fix A — the 26O2 wedge)**
`finalizeOutcomeJournal()` replayed the full finalization, whose task move requires `status='in_progress' AND assignee='dispatcher'`. Task 26O2 had already reached `in_review`, so every tick threw *no longer owned*, rolled back, and left the dispatch `running` + journal unconsumed — which also made `recoverStale()` skip the lease. Replay now checks custody first: if the dispatcher no longer owns the task, it settles the dispatch to the journal's terminal status, releases active stage claims, records the worker's outcome comment with a replay note, and preserves the task's current state.

**2. Every protected review crashed on launch (Fix B)**
`recordReviewLaunchWithExecution()` inserted `workflow_executions.scope_task_id` without `scope_generation`, violating migration 0071's `scope_pair_check` — 9/9 review dispatches failed instantly on 8/27 (Supb, 7F3T, qxFB). Reviews now scope to the task's latest `work_lane_entry_automations.generation`, or launch unscoped when the task has no lane entries.

**3. Backpressure counted un-drainable review rows (Fix C)**
`countReviewBacklog()` and `claimNext()`'s downstream race guard held ALL fresh todo work while any autonomous task sat in review — even one that could never drain. Both surfaces now share `drainableReviewSql()`, which excludes: dead-heartbeat running dispatches (45-min threshold shared with `recoverStale`), tasks whose latest verification ended `terminal:*`, and dependency-held tasks. A wedged review row no longer starves execution slots; live reviews still exert full downstream-first backpressure.

## Verification
- New suite `WorkTaskDispatchJournalReplay.test.ts` (6 tests): replay-preserves-task, strict-path-when-owned, scope pair present/absent, drainable exclusions in both SQL surfaces. **8/8 pass** together with the existing backpressure suite.
- Adjacent `WorkTaskDispatchModel`/`TaskDispatcherService` suites show 34 failures that are **byte-identical on pristine origin/main** under the same runner config — pre-existing, not regressions.
- Focused Jest ran transpile-only (`isolatedModules`, node env) because full ts-jest + tsc are OOM-killed in the Lima VM (~1.6 GB free); esbuild parse of the touched file passes.

## After merge
Requires the usual rebuild/restart to go live. On the first tick with this code: the 26O2 journal settles, its zombie dispatch completes, the review backlog gate unblocks, and the six dispatcher-assigned todo tasks (esgc, wPif, mGjz, f0eV, n7K5, OxgT) become claimable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)