### PR TITLE
fix(claude-code): resume stdout on warm-pool adoption — Claude turns freeze until Stop

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -92,6 +92,13 @@ interface PrewarmRecord {
   closed:        boolean;
   busy:          boolean;
   reapTimer:     ReturnType<typeof setTimeout> | null;
+  /**
+   * Output the process wrote while nobody was listening (booting prewarm, or
+   * parked between warm turns), drained at claim time. Replayed through the
+   * adopting turn's line processor so a buffered system/init line still
+   * delivers its session id. See claimPrewarm.
+   */
+  pendingStdout?: string;
 }
 
 export class ClaudeCodeService extends BaseLanguageModel {
@@ -361,6 +368,29 @@ export class ClaudeCodeService extends BaseLanguageModel {
     if (rec.closed || rec.model !== model) {
       this.killPrewarmRecord(rec);                       // dead or model mismatch
       return null;
+    }
+
+    // Drain anything the process wrote while unclaimed. A prewarm that sat
+    // past the CLI's stdin-wait can emit an empty `result` (observed as an
+    // instant "claude produced no output" failure on the adopting turn) —
+    // a process that already resulted with no prompt is useless, so decline
+    // it and let the caller cold-spawn. Anything else (system/init) is kept
+    // for replay so the adopting turn still sees the session id.
+    let drained = '';
+    try {
+      let chunk: Buffer | string | null;
+      while ((chunk = rec.proc.stdout.read()) !== null) drained += chunk.toString('utf-8');
+    } catch { /* stream already ended — closed flag handling covers it */ }
+    if (drained) {
+      const staleResult = drained.split('\n').some((line) => {
+        try { return JSON.parse(line.trim())?.type === 'result'; } catch { return false; }
+      });
+      if (staleResult) {
+        log.warn(`[ClaudeCodeService] claimPrewarm: discarding pooled proc for convId=${ convId } — stale result buffered while unclaimed`);
+        this.killPrewarmRecord(rec);
+        return null;
+      }
+      rec.pendingStdout = drained;
     }
     return rec;
   }
@@ -1390,6 +1420,25 @@ This is a hard rule, not a suggestion: catalog and docs first, improvise last.
         }
       };
       proc.stderr.on('data', onStderrData);
+
+      // Replay output drained while the process sat unclaimed (see
+      // claimPrewarm) so a buffered system/init line still delivers its
+      // session id and "tools connected" signal to THIS turn.
+      if (adopted?.pendingStdout) {
+        const pending = adopted.pendingStdout;
+        adopted.pendingStdout = undefined;
+        onStdoutData(Buffer.from(pending, 'utf-8'));
+      }
+
+      // Adopted processes need an explicit resume: finishWarmTurn parks the
+      // proc with stdout/stderr paused, and attaching a 'data' listener does
+      // NOT restart a stream that was explicitly paused. Without this, a
+      // re-adopted warm proc runs the whole turn with its output pipe frozen —
+      // nothing streams to the UI until the process is killed, at which point
+      // every buffered event floods through at once. Harmless on fresh spawns
+      // (resume on an already-flowing stream is a no-op).
+      proc.stdout.resume();
+      proc.stderr.resume();
 
       const onProcError = (err: Error) => {
         stopHeartbeat();

--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/ClaudeCodeService.claimPrewarm.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/ClaudeCodeService.claimPrewarm.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+// ClaudeCodeService's real imports drag in the Electron main-process world
+// (MCP host, redis, logging, paths), which this suite never exercises —
+// claimPrewarm only touches the in-memory pool. Stub them so the suite
+// stays lightweight enough for constrained environments.
+jest.mock('@pkg/main/MCPServerHost', () => ({ getMCPServerHost: jest.fn() }));
+jest.mock('../../database/RedisClient', () => ({
+  redisClient: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+}));
+jest.mock('@pkg/utils/logging', () => {
+  const noopLog = { log: () => {}, warn: () => {}, error: () => {}, info: () => {}, debug: () => {} };
+
+  return { __esModule: true, default: new Proxy({}, { get: () => noopLog }) };
+});
+jest.mock('@pkg/utils/paths', () => ({
+  __esModule: true,
+  default:    { limactl: '/dev/null', lima: '/dev/null', sullaHome: '/tmp', sullaConfig: '/tmp' },
+}));
+
+import { ClaudeCodeService } from '../ClaudeCodeService';
+
+/**
+ * Regression tests for warm-pool adoption. A parked/prewarmed process can
+ * have output buffered while nobody was listening:
+ *   - a prewarm that idled past the CLI's stdin wait emits an empty `result`,
+ *     which used to instantly fail the adopting turn with "claude produced
+ *     no output";
+ *   - a buffered system/init line must survive adoption so the turn still
+ *     captures its session id.
+ */
+
+function makeRecord(bufferedLines: string[]) {
+  const chunks: (string | null)[] = bufferedLines.length ? [bufferedLines.join('\n')] : [];
+  const proc = {
+    stdout: { read: jest.fn(() => chunks.shift() ?? null) },
+    kill:   jest.fn(),
+  };
+
+  return {
+    proc,
+    mcpSession:    null,
+    mcpConfigPath: null,
+    model:         'claude-code',
+    createdAt:     Date.now(),
+    closed:        false,
+    busy:          false,
+    reapTimer:     null,
+  };
+}
+
+function claim(service: ClaudeCodeService, convId: string, record: ReturnType<typeof makeRecord>) {
+  (service as any).prewarmed.set(convId, record);
+
+  return (service as any).claimPrewarm(convId, 'claude-code');
+}
+
+describe('ClaudeCodeService.claimPrewarm', () => {
+  it('declines a pooled process that buffered a stale result while unclaimed', () => {
+    const service = new ClaudeCodeService();
+    const record = makeRecord([
+      JSON.stringify({ type: 'result', is_error: false, result: '' }),
+    ]);
+
+    const claimed = claim(service, 'conv-stale', record);
+
+    expect(claimed).toBeNull();
+    expect(record.proc.kill).toHaveBeenCalled();
+  });
+
+  it('keeps buffered non-result output for replay into the adopting turn', () => {
+    const service = new ClaudeCodeService();
+    const initLine = JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-1' });
+    const record = makeRecord([initLine, '']);
+
+    const claimed = claim(service, 'conv-init', record);
+
+    expect(claimed).not.toBeNull();
+    expect(claimed.pendingStdout).toContain('sess-1');
+    expect(record.proc.kill).not.toHaveBeenCalled();
+  });
+
+  it('returns a clean record untouched when nothing was buffered', () => {
+    const service = new ClaudeCodeService();
+    const record = makeRecord([]);
+
+    const claimed = claim(service, 'conv-clean', record);
+
+    expect(claimed).not.toBeNull();
+    expect(claimed.pendingStdout).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Root cause (verified in production logs)

Claude Code is the only provider whose replies stop reaching the chat interface until Stop is pressed. The freeze is the warm pool:

1. `finishWarmTurn()` parks a process between turns with an **explicit** `proc.stdout.pause()`.
2. The next turn adopts the parked proc and only attaches a new `'data'` listener. Per Node's documented semantics, attaching a `'data'` listener does **not** restart a stream that was explicitly paused.
3. The entire turn therefore runs with its output pipe frozen — no text deltas, no tool events, no result. Killing the process (Stop button, or the 15-min stall watchdog) destroys the stream and floods every buffered event through at once, which is exactly the observed "press Stop and the whole transcript dumps" behavior.

**Log evidence (8/27–8/28):**
- Thread `i1lkpq` 19:33:55Z turn: 5 minutes of total silence, then 25 Bash tool events + the final message land within 10 ms of the Stop press at 19:38:53.428Z (`warm turn ok: 3011 chars` at .443).
- Every frozen turn adopted a parked proc (no `prewarm` line between park and run); every streaming turn ran on a fresh spawn/prewarm — 100% correlation across ~10 sampled turns.
- Each mystery mid-run event burst matches a `[ChatInterface:stop]` press (21:08:46→21:08 burst, 21:37:44→21:37, 21:54:01→21:54) or the 15-minute stall watchdog (20:04 turn → 20:20 burst).
- Fresh prewarms work because their streams were never explicitly paused (never-flowed streams DO auto-start on `'data'` attach) — which is why the bug is intermittent and only hits back-to-back turns within the 5-min warm reap window.
- Isolated repro confirms the semantics: a child stdout paused explicitly delivers 0 events after a `'data'` listener attaches, and flows immediately after `resume()`.

## Second bug fixed (seen 8/28 19:44:26Z)
A prewarmed proc that sat unclaimed ~57s emitted an empty `result` (CLI stdin-wait giving up). The buffered stale result was delivered the instant the turn adopted the proc and settled it immediately: `warm turn failed, evicting proc: claude produced no output` 1 ms after `runClaude` start.

## Fix
- **Adoption resumes the stream:** after attaching its stdout/stderr listeners, `runClaude` calls `resume()` on both (no-op for fresh spawns).
- **Stale-output drain at claim:** `claimPrewarm` reads whatever the proc wrote while unclaimed. If a stale `result` is buffered, the proc is declined + killed and the turn cold-spawns instead of failing. Benign buffered lines (`system/init`) are replayed into the adopting turn so the session id still lands. The replay cannot re-trigger the settle path because result-bearing procs never reach it.

## Validation
- Full Jest is OOM-killed in this VM (known constraint), so the service was bundled via esbuild with heavy deps stubbed and the three `claimPrewarm` scenarios executed against the real code: stale-result declined+killed, init preserved for replay, clean record untouched — **all pass**.
- Node paused-stream semantics repro script: `turn1 flowing: true / adopted-without-resume events: 0 / after-resume events: >0`.
- `git diff --check` clean; both changed files parse clean under esbuild.
- A Jest suite (`ClaudeCodeService.claimPrewarm.test.ts`) is included for CI, with the heavy Electron-world imports mocked.

Runtime verification still needed after rebuild: two back-to-back Claude turns in one chat within 5 minutes — the second turn should now stream live instead of freezing until Stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)