### PR TITLE
fix(browser): drop leftover cookie-cache listener that broke the webpack build

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -406,32 +406,6 @@ Electron.app.whenReady().then(() => {
   const fixer = new SullaWebRequestFixer(writeSullaWebRequestEvent);
   fixer.attachToSession(session);
 
-  // Capture cookies set by JavaScript (document.cookie) inside iframes.
-  // Apps like Twenty CRM store auth tokens via JS, not HTTP Set-Cookie headers.
-  // This listener persists those cookies into our DB so they survive across
-  // sessions and can be re-injected by SullaWebRequestFixer.
-  session.cookies.on('changed', (_event, cookie, _cause, removed) => {
-    if (removed) return;
-    try {
-      const hostname = cookie.domain?.replace(/^\./, '') || '';
-      const nameValue = `${ cookie.name }=${ cookie.value }`;
-      const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1';
-
-      if (isLocalhost) {
-        // Cookies don't carry port info.  For localhost, broadcast to all known
-        // localhost domain keys so services like Twenty (30207), N8N (30119) etc.
-        // all receive the cookie if it belongs to them.
-        for (const key of fixer.getLocalhostDomainKeys()) {
-          fixer.onJsCookieChanged(key, nameValue);
-        }
-      } else {
-        const port = cookie.secure ? '443' : '80';
-
-        fixer.onJsCookieChanged(`${ hostname }:${ port }`, nameValue);
-      }
-    } catch { /* no-op */ }
-  });
-
   // Grant microphone and screen-capture permissions for audio capture.
   // setPermissionCheckHandler is needed because getDisplayMedia() triggers a
   // synchronous permission *check* before it fires the async request handler.


### PR DESCRIPTION
## Task
Fixes internal Projects task Kw2S (P0, epic VAPS).

`just build` / webpack currently fails on main with three TS2339 errors in `background.ts`:

- `Property 'getLocalhostDomainKeys' does not exist on type 'SullaWebRequestFixer'`
- `Property 'onJsCookieChanged' does not exist on type 'SullaWebRequestFixer'` (two call sites)

## Cause
PR #791 removed the persisted cookie-header cache from `SullaWebRequestFixer` so Chromium Session is authoritative. `background.ts` still had a `session.cookies.on('changed')` listener that called the deleted methods to re-inject JS cookies into that cache.

## Fix
Delete the leftover listener. `SullaWebRequestFixer.attachToSession()` remains; permission and display-media handlers are unchanged. Native Chromium cookie storage already persists `document.cookie` writes.

## Validation
- PASS: `background.ts` no longer references `getLocalhostDomainKeys` / `onJsCookieChanged` / `session.cookies.on`
- PASS: focused `tsc --noEmit --pretty false background.ts` in the isolated worktree
- Focused Jest for `SullaWebRequestFixer.test.ts` is running after this PR is opened
- Full `just build` / packaged app not run from this branch

No merge or deploy.

## Undo
Close this draft PR and delete `fix/Kw2S-background-cookie-listener`. The dirty `sulla-desktop` checkout on `main` still has local `yarn.lock` / `node_modules` noise unrelated to this fix.
