### PR TITLE
fix(browser): restore root document wheel scrolling in embedded tabs

### DIFF
--- a/pkg/rancher-desktop/window/__tests__/browserScrollFallback.test.ts
+++ b/pkg/rancher-desktop/window/__tests__/browserScrollFallback.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { shouldFallbackToRootScroll } from '../browserScrollFallback';
+
+const state = (overrides: Partial<Parameters<typeof shouldFallbackToRootScroll>[0]> = {}) => ({
+  hasInnerScrollableTarget: false,
+  rootScrollTop:           0,
+  rootMaxScrollTop:        2_000,
+  deltaY:                  120,
+  defaultPrevented:        false,
+  ...overrides,
+});
+
+describe('shouldFallbackToRootScroll', () => {
+  it('falls back when the document can scroll and native scrolling did not move it', () => {
+    expect(shouldFallbackToRootScroll(state())).toBe(true);
+  });
+
+  it('does not replay a gesture when an inner overflow target can scroll', () => {
+    expect(shouldFallbackToRootScroll(state({ hasInnerScrollableTarget: true }))).toBe(false);
+  });
+
+  it('does not replay gestures at the document edge or after prevention', () => {
+    expect(shouldFallbackToRootScroll(state({ rootScrollTop: 2_000 }))).toBe(false);
+    expect(shouldFallbackToRootScroll(state({ deltaY: -120, rootScrollTop: 0 }))).toBe(false);
+    expect(shouldFallbackToRootScroll(state({ defaultPrevented: true }))).toBe(false);
+  });
+});

--- a/pkg/rancher-desktop/window/browserScrollFallback.ts
+++ b/pkg/rancher-desktop/window/browserScrollFallback.ts
@@ -1,0 +1,23 @@
+export interface RootScrollFallbackState {
+  hasInnerScrollableTarget: boolean;
+  rootScrollTop: number;
+  rootMaxScrollTop: number;
+  deltaY: number;
+  defaultPrevented: boolean;
+}
+
+/**
+ * Returns whether a wheel gesture should be replayed against the document
+ * root after Chromium failed to move it natively.
+ *
+ * Inner overflow nodes are deliberately excluded. Their native scroll path
+ * already works and replaying the gesture at the root would scroll two
+ * surfaces at once.
+ */
+export function shouldFallbackToRootScroll(state: RootScrollFallbackState): boolean {
+  if (state.defaultPrevented || state.hasInnerScrollableTarget || Math.abs(state.deltaY) < 1) return false;
+
+  return state.deltaY > 0
+    ? state.rootScrollTop < state.rootMaxScrollTop - 1
+    : state.rootScrollTop > 1;
+}

--- a/pkg/rancher-desktop/window/browserTabPreload.ts
+++ b/pkg/rancher-desktop/window/browserTabPreload.ts
@@ -25,9 +25,11 @@
 import { ipcRenderer } from 'electron';
 
 import { buildGuestBridgeScript } from '../agent/scripts/injected/GuestBridgePreload';
+import { shouldFallbackToRootScroll } from './browserScrollFallback';
 
 const IPC_CHANNEL = 'browser-tab-view:bridge-event';
 const LOG_PREFIX = '[SULLA_TAB_PRELOAD]';
+const ROOT_SCROLL_FALLBACK_DELAY_MS = 80;
 
 /* ------------------------------------------------------------------ */
 /*  Native scroll-input health                                        */
@@ -74,7 +76,27 @@ window.addEventListener('wheel', (event) => {
   const before = scrollTarget.scrollTop;
 
   requestAnimationFrame(() => setTimeout(() => {
-    if (event.defaultPrevented) return;
+    const root = document.scrollingElement;
+    const rootMaxScrollTop = root ? root.scrollHeight - root.clientHeight : 0;
+    const nativeRootMoved = root && Math.abs(root.scrollTop - before) > 0.5;
+
+    // WebContentsView can deliver trusted wheel events while Chromium's root
+    // scroll node fails to consume them. Replay only that narrow case. Inner
+    // overflow containers are left entirely to Chromium because they already
+    // scroll correctly and should not cause the document to move as well.
+    if (root && scrollTarget === root && !nativeRootMoved && shouldFallbackToRootScroll({
+      hasInnerScrollableTarget: false,
+      rootScrollTop:           root.scrollTop,
+      rootMaxScrollTop,
+      deltaY:                  event.deltaY,
+      defaultPrevented:        event.defaultPrevented,
+    })) {
+      try {
+        window.scrollBy({ top: event.deltaY, left: event.deltaX, behavior: 'instant' });
+      } catch {
+        window.scrollBy(event.deltaX, event.deltaY);
+      }
+    }
 
     try {
       ipcRenderer.send(IPC_CHANNEL, {
@@ -84,7 +106,7 @@ window.addEventListener('wheel', (event) => {
     } catch (err) {
       console.error(`${ LOG_PREFIX } scroll heartbeat failed`, err);
     }
-  }, 80));
+  }, ROOT_SCROLL_FALLBACK_DELAY_MS));
 }, { capture: true, passive: true });
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## What changed

Embedded WebContentsView tabs can receive trusted wheel events while Chromium fails to advance the root document scroll node. This adds a preload fallback that replays the gesture against the document root only when no inner overflow target is eligible and the native root did not move. Inner overflow scrolling remains untouched.

## Validation

- Direct Node strip-types decision test: root fallback=true, inner target=false, edge=false
- Isolated helper TypeScript check passed
- `git diff --check` passed
- Added `browserScrollFallback.test.ts` covering root, inner-container, edge, and prevented cases
- Full focused Jest/ESLint entrypoints were blocked by existing VM resource/workspace hangs; no runtime rebuild or deploy performed

Closes Projects task mGjz when reviewed and merged.