### PR TITLE
fix(chat): bound provider context and compact tool results

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/BaseLanguageModel.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/BaseLanguageModel.ts
@@ -32,6 +32,20 @@ export function getTextContent(content: string | ContentBlock[]): string {
     .join('\n');
 }
 
+function promptMetrics(messages: ChatMessage[]): { promptChars: number; promptTokens: number; toolResultChars: number; toolResultShare: number } {
+  const promptChars = messages.reduce((sum, message) => sum + JSON.stringify(message.content).length, 0);
+  const toolResultChars = messages.reduce((sum, message) => {
+    const content = JSON.stringify(message.content);
+    return sum + ((message.role === 'tool' || content.includes('tool_result')) ? content.length : 0);
+  }, 0);
+  return {
+    promptChars,
+    promptTokens: Math.ceil(promptChars / 4),
+    toolResultChars,
+    toolResultShare: promptChars ? Number((toolResultChars / promptChars).toFixed(4)) : 0,
+  };
+}
+
 export interface ChatMessage {
   id?:           string;
   role:          'user' | 'assistant' | 'system' | 'tool';
@@ -306,6 +320,7 @@ export abstract class BaseLanguageModel {
   ): Promise<NormalizedResponse | null> {
     const startTime = performance.now();
     const convId = options.conversationId;
+    const metrics = promptMetrics(messages);
 
     try {
       // Use provided model or fallback to default
@@ -324,6 +339,7 @@ export abstract class BaseLanguageModel {
             format:      options.format,
             tools:       options.tools,
             messages,
+            ...metrics,
           });
         } catch { /* best-effort */ }
       }
@@ -428,6 +444,8 @@ export abstract class BaseLanguageModel {
     const startTime = performance.now();
     const effectiveModel = options.model ?? this.model;
     const convId = options.conversationId;
+    const metrics = promptMetrics(messages);
+    let ttftMs: number | undefined;
 
     // Log outgoing request (same as chat())
     if (convId) {
@@ -442,6 +460,7 @@ export abstract class BaseLanguageModel {
           format:      options.format,
           tools:       options.tools,
           messages,
+          ...metrics,
           streaming:   true,
         });
       } catch { /* best-effort */ }
@@ -458,7 +477,10 @@ export abstract class BaseLanguageModel {
         // Provider supports streaming — parse the SSE stream
         const normalized = await this.parseStreamResponse(
           streamResponse,
-          callbacks,
+          { ...callbacks, onToken: (token: string) => {
+            ttftMs ??= Math.round(performance.now() - startTime);
+            callbacks.onToken(token);
+          } },
           options.signal,
         );
 
@@ -480,6 +502,8 @@ export abstract class BaseLanguageModel {
               reasoning:        normalized.metadata.reasoning,
               toolCalls:        normalized.metadata.tool_calls,
               streaming:        true,
+              ttftMs,
+              ...metrics,
             });
           } catch { /* best-effort */ }
         }

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -19,6 +19,7 @@ import { sanitizeConversationContext } from '../utils/conversationContext';
 import { stripProtocolTags, stripProtocolTagsStreaming } from '../utils/stripProtocolTags';
 import { resolveSullaProjectsDir, resolveSullaSkillsDir, resolveSullaAgentsDir, resolveSullaCodebaseDir, findAgentDir, resolveSullaHomeDir, resolveSullaDocsDir } from '../utils/sullaPaths';
 import { DEFAULT_CORE_ROUTINE_AGENT_ID } from '../routines/core/defaultCoreAgent';
+import { prepareProviderMessages } from './contextBudget';
 
 import type { BaseThreadState, NodeResult } from './Graph';
 import type { StreamContext } from '../controllers/Extractor';
@@ -1048,67 +1049,20 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
       };
     }
 
-    // Pre-flight context check: trim messages to fit the active model's context window
-    const contextWindow = this.llm.getContextWindow();
-    const responseReserve = Math.floor(contextWindow * 0.20);
-    const inputBudgetTokens = contextWindow - responseReserve;
-    const estimateTokens = (text: string) => Math.ceil((text?.length ?? 0) / 4);
-
-    let totalTokens = messages.reduce((sum, m) => {
-      const content = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
-      return sum + estimateTokens(content);
-    }, 0);
-
-    if (totalTokens > inputBudgetTokens) {
-      console.warn(`[${ this.name }] Pre-flight trim: ~${ totalTokens } tokens exceeds ${ inputBudgetTokens } budget (ctx=${ contextWindow })`);
-      // Find protected indices: system messages + latest user message
-      const systemIndices = new Set<number>();
-      let latestUserIdx = -1;
-      for (let i = 0; i < messages.length; i++) {
-        if (messages[i].role === 'system') systemIndices.add(i);
-        if (messages[i].role === 'user') latestUserIdx = i;
-      }
-      // Build a set of indices that form tool_use/tool_result pairs so we
-      // never drop one half of a pair (which would corrupt the message array
-      // and cause "tool_call_id not found" API errors).
-      const toolPairIndices = new Set<number>();
-      for (let idx = 0; idx < messages.length; idx++) {
-        const msg = messages[idx];
-        const hasToolUse = msg.role === 'assistant' && Array.isArray(msg.content) &&
-          msg.content.some((b: any) => b?.type === 'tool_use');
-        if (hasToolUse) {
-          const next = messages[idx + 1];
-          const nextHasToolResult = next?.role === 'user' && Array.isArray(next.content) &&
-            next.content.some((b: any) => b?.type === 'tool_result');
-          if (nextHasToolResult) {
-            toolPairIndices.add(idx);
-            toolPairIndices.add(idx + 1);
-          }
-        }
-      }
-
-      // Drop from oldest non-protected until under budget
-      let i = 0;
-      while (totalTokens > inputBudgetTokens && i < messages.length) {
-        if (!systemIndices.has(i) && i !== latestUserIdx && !toolPairIndices.has(i)) {
-          const rawContent = messages[i].content;
-          totalTokens -= estimateTokens(typeof rawContent === 'string' ? rawContent : JSON.stringify(rawContent));
-          messages.splice(i, 1);
-          // Rebuild protected indices after splice
-          if (latestUserIdx > i) latestUserIdx--;
-          // Shift toolPairIndices down
-          const shifted = new Set<number>();
-          for (const idx of toolPairIndices) {
-            if (idx > i) shifted.add(idx - 1);
-            else if (idx < i) shifted.add(idx);
-          }
-          toolPairIndices.clear();
-          for (const idx of shifted) toolPairIndices.add(idx);
-        } else {
-          i++;
-        }
-      }
-      console.log(`[${ this.name }] Pre-flight trim complete: ${ messages.length } messages, ~${ totalTokens } tokens`);
+    // Curate the exact provider input after the system prompt/context is in
+    // place. This compacts stale tool payloads before pair-safe eviction.
+    const budget = prepareProviderMessages(messages, this.llm.getContextWindow());
+    messages.splice(0, messages.length, ...budget.messages);
+    (state.metadata as any).contextBudget = {
+      inputBudgetTokens: budget.inputBudgetTokens,
+      beforeTokens:      budget.beforeTokens,
+      afterTokens:       budget.afterTokens,
+      beforeChars:       budget.beforeChars,
+      afterChars:        budget.afterChars,
+      toolResultChars:   budget.toolResultChars,
+    };
+    if (budget.beforeTokens !== budget.afterTokens || budget.beforeChars !== budget.afterChars) {
+      console.log(`[${ this.name }] Provider context curated: ~${ budget.beforeTokens } → ~${ budget.afterTokens } tokens, ${ budget.beforeChars } → ${ budget.afterChars } chars`);
     }
 
     // Check for abort before making LLM calls
@@ -1391,6 +1345,13 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
             console.warn(
               `[${ this.name }:BaseNode] Falling back to secondary provider ` +
               `(from=${ primaryName }/${ primaryId || '(default)' }, to=${ secondaryName }/${ secondaryModel || '(default)' }, reason=${ recovery.kind })`,
+            );
+            void this.wsChatMessage(
+              state,
+              `Provider fallback: ${ primaryName }/${ primaryId || '(default)' } → ${ secondaryName }/${ secondaryModel || '(default)' } (${ recovery.kind })`,
+              'system',
+              'progress',
+              { event: 'provider_fallback', fromProvider: primaryName, fromModel: primaryId, toProvider: secondaryName, toModel: secondaryModel, reason: recovery.kind },
             );
             const chatMessages = messages.filter(msg =>
               ['system', 'user', 'assistant'].includes(msg.role),

--- a/pkg/rancher-desktop/agent/nodes/__tests__/contextBudget.test.ts
+++ b/pkg/rancher-desktop/agent/nodes/__tests__/contextBudget.test.ts
@@ -1,0 +1,34 @@
+import { estimateMessagesTokens, prepareProviderMessages } from '../contextBudget';
+
+describe('context budget', () => {
+  it('compacts large tool results without breaking tool pairs', () => {
+    const messages: any[] = [
+      { role: 'system', content: 'system' },
+      { role: 'user', content: 'run the tool' },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 't1', name: 'search', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 't1', content: 'x'.repeat(10_000) }] },
+      { role: 'user', content: 'continue' },
+    ];
+    const result = prepareProviderMessages(messages, 128_000);
+    expect(result.messages).toHaveLength(5);
+    expect(JSON.stringify(result.messages)).toContain('tool result compacted');
+    expect(result.afterChars).toBeLessThan(result.beforeChars);
+  });
+
+  it('bounds a 40+ tool-loop transcript while preserving complete pairs', () => {
+    const messages: any[] = [{ role: 'system', content: 's'.repeat(20_000) }];
+    for (let i = 0; i < 45; i++) {
+      messages.push({ role: 'assistant', content: [{ type: 'tool_use', id: `t${ i }`, name: 'tool', input: {} }] });
+      messages.push({ role: 'user', content: [{ type: 'tool_result', tool_use_id: `t${ i }`, content: 'result '.repeat(1_500) }] });
+    }
+    messages.push({ role: 'user', content: 'final request' });
+    const result = prepareProviderMessages(messages, 16_000);
+    expect(result.afterTokens).toBeLessThanOrEqual(result.inputBudgetTokens + estimateMessagesTokens(result.messages.slice(-1)));
+    for (let i = 0; i < result.messages.length; i++) {
+      const message = result.messages[i];
+      if (message.role === 'assistant' && Array.isArray(message.content) && message.content[0]?.type === 'tool_use') {
+        expect((result.messages[i + 1]?.content as any[])?.[0]?.type).toBe('tool_result');
+      }
+    }
+  });
+});

--- a/pkg/rancher-desktop/agent/nodes/contextBudget.ts
+++ b/pkg/rancher-desktop/agent/nodes/contextBudget.ts
@@ -1,0 +1,130 @@
+import type { ChatMessage, ContentBlock } from '../languagemodels/BaseLanguageModel';
+
+export const PROVIDER_RESPONSE_RESERVE = 0.2;
+export const TOOL_RESULT_COMPACT_LIMIT = 2_000;
+export const TOOL_RESULT_HEAD_CHARS = 700;
+export const TOOL_RESULT_TAIL_CHARS = 500;
+
+const CHARS_PER_TOKEN = 4;
+
+export function estimateMessageTokens(message: ChatMessage): number {
+  const content = typeof message.content === 'string' ? message.content : JSON.stringify(message.content);
+  return Math.ceil((content?.length ?? 0) / CHARS_PER_TOKEN);
+}
+
+export function estimateMessagesTokens(messages: ChatMessage[]): number {
+  return messages.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
+}
+
+function isToolUse(message: ChatMessage): boolean {
+  return message.role === 'assistant' && Array.isArray(message.content) &&
+    message.content.some((block: any) => block?.type === 'tool_use');
+}
+
+function isToolResult(message: ChatMessage): boolean {
+  return message.role === 'tool' || (message.role === 'user' && Array.isArray(message.content) &&
+    message.content.some((block: any) => block?.type === 'tool_result'));
+}
+
+function compactText(text: string): string {
+  if (text.length <= TOOL_RESULT_COMPACT_LIMIT) return text;
+  const omitted = text.length - TOOL_RESULT_HEAD_CHARS - TOOL_RESULT_TAIL_CHARS;
+  return `${ text.slice(0, TOOL_RESULT_HEAD_CHARS) }\n[tool result compacted: ${ omitted } chars omitted]\n${ text.slice(-TOOL_RESULT_TAIL_CHARS) }`;
+}
+
+function compactBlock(block: ContentBlock): ContentBlock {
+  if (block.type !== 'tool_result') return block;
+  if (typeof block.content === 'string') return { ...block, content: compactText(block.content) };
+  return {
+    ...block,
+    content: block.content.map(child => child.type === 'text' ? { ...child, text: compactText(child.text) } : child),
+  };
+}
+
+function compactToolResults(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map(message => {
+    if (!isToolResult(message)) return message;
+    if (typeof message.content === 'string') return { ...message, content: compactText(message.content) };
+    if (!Array.isArray(message.content)) return message;
+    return { ...message, content: message.content.map(compactBlock) };
+  });
+}
+
+function buildUnits(messages: ChatMessage[]): ChatMessage[][] {
+  const units: ChatMessage[][] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const current = messages[i];
+    const next = messages[i + 1];
+    if (isToolUse(current) && next && isToolResult(next)) {
+      units.push([current, next]);
+      i++;
+    } else if (isToolResult(current) && units.length > 0 && units[units.length - 1].length === 1 && isToolUse(units[units.length - 1][0])) {
+      units[units.length - 1].push(current);
+    } else {
+      units.push([current]);
+    }
+  }
+  return units;
+}
+
+/**
+ * Curates the exact array sent to a provider. The budget is applied after the
+ * caller's system prompt has been added, and tool use/result messages are
+ * treated as indivisible units so providers never see a broken transcript.
+ */
+export function prepareProviderMessages(messages: ChatMessage[], contextWindow: number): {
+  messages: ChatMessage[];
+  inputBudgetTokens: number;
+  beforeTokens: number;
+  afterTokens: number;
+  beforeChars: number;
+  afterChars: number;
+  toolResultChars: number;
+} {
+  const beforeTokens = estimateMessagesTokens(messages);
+  const beforeChars = messages.reduce((sum, message) => sum + JSON.stringify(message.content).length, 0);
+  const compacted = compactToolResults(messages);
+  const inputBudgetTokens = Math.max(1, Math.floor(contextWindow * (1 - PROVIDER_RESPONSE_RESERVE)));
+  const units = buildUnits(compacted);
+  const latestUserUnit = [...units].reverse().find(unit => unit.some(message => message.role === 'user'));
+  const protectedUnits = new Set(latestUserUnit ? [latestUserUnit] : []);
+  const kept: Array<{ index: number; unit: ChatMessage[] }> = [];
+  let used = 0;
+
+  // System prompt and the current user turn are mandatory. Recent transcript
+  // units are retained next; old units are evicted as whole tool pairs.
+  for (const unit of units) {
+    if (unit.some(message => message.role === 'system')) {
+      kept.push({ index: units.indexOf(unit), unit });
+      used += unit.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
+    }
+  }
+  for (let i = units.length - 1; i >= 0; i--) {
+    const unit = units[i];
+    if (unit.some(message => message.role === 'system') || protectedUnits.has(unit)) continue;
+    const unitTokens = unit.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
+    if (used + unitTokens <= inputBudgetTokens) {
+      kept.push({ index: i, unit });
+      used += unitTokens;
+    }
+  }
+  for (const unit of protectedUnits) {
+    if (!kept.some(entry => entry.unit === unit)) kept.push({ index: units.indexOf(unit), unit });
+  }
+
+  const result = kept.sort((a, b) => a.index - b.index).flatMap(entry => entry.unit);
+  const afterChars = result.reduce((sum, message) => sum + JSON.stringify(message.content).length, 0);
+  const toolResultChars = result.reduce((sum, message) => {
+    if (!isToolResult(message)) return sum;
+    return sum + JSON.stringify(message.content).length;
+  }, 0);
+  return {
+    messages: result,
+    inputBudgetTokens,
+    beforeTokens,
+    afterTokens: estimateMessagesTokens(result),
+    beforeChars,
+    afterChars,
+    toolResultChars,
+  };
+}


### PR DESCRIPTION
## What changed

- Apply one provider-aware input budget after the system prompt is assembled.
- Compact oversized tool results before pair-safe transcript eviction.
- Keep assistant tool_use and matching tool_result messages together.
- Record prompt chars/tokens and tool-result share in LLM request telemetry, plus streaming TTFT.
- Emit an explicit provider-fallback progress event to the chat UI.
- Add regression coverage for a 45-pair tool loop.

## Validation

- `node --experimental-vm-modules node_modules/.bin/jest pkg/rancher-desktop/agent/nodes/__tests__/contextBudget.test.ts --runInBand --forceExit` — 2/2 passed.
- esbuild parse of BaseLanguageModel, BaseNode, and contextBudget — passed.
- `git diff --check` — passed.
- Full `tsc --noEmit -p tsconfig.agent-check.json` — not completed in the VM timeout; no claim of full typecheck.

Closes Projects task 7ayx once reviewed and merged.