### PR TITLE
Fix chat Markdown link clicks

### DIFF
--- a/pkg/rancher-desktop/pages/chat/components/transcript/TurnStreaming.vue
+++ b/pkg/rancher-desktop/pages/chat/components/transcript/TurnStreaming.vue
@@ -14,18 +14,21 @@
         v-else
         v-html="rendered"
       />
-      <span class="chat-cursor" aria-hidden="true" />
+      <span
+        class="chat-cursor"
+        aria-hidden="true"
+      />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import DOMPurify from 'dompurify';
-import { marked } from 'marked';
+
+import IsolatedHtml from './IsolatedHtml.vue';
+import { renderMarkdown } from '../../messages/markdown';
 
 import type { StreamingMessage } from '../../models/Message';
-import IsolatedHtml from './IsolatedHtml.vue';
 
 const props = defineProps<{ msg: StreamingMessage }>();
 
@@ -34,8 +37,5 @@ const props = defineProps<{ msg: StreamingMessage }>();
 const HTML_DOC_RE = /<style\b|<script\b|<!doctype|<html\b|<body\b|<head\b/i;
 const isHtmlDocument = computed(() => HTML_DOC_RE.test(props.msg.text || ''));
 
-const rendered = computed(() => {
-  const html = (marked(props.msg.text || '') as string) || '';
-  return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
-});
+const rendered = computed(() => renderMarkdown(props.msg.text));
 </script>

--- a/pkg/rancher-desktop/pages/chat/components/transcript/TurnSulla.vue
+++ b/pkg/rancher-desktop/pages/chat/components/transcript/TurnSulla.vue
@@ -38,20 +38,23 @@
       @fork="onFork"
     />
 
-    <ChatContextMenu ref="ctxMenu" @new-chat="onNewChat" />
+    <ChatContextMenu
+      ref="ctxMenu"
+      @new-chat="onNewChat"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import DOMPurify from 'dompurify';
-import { marked } from 'marked';
 
-import type { SullaMessage } from '../../models/Message';
-import TurnActions from './TurnActions.vue';
 import IsolatedHtml from './IsolatedHtml.vue';
+import TurnActions from './TurnActions.vue';
 import ChatContextMenu from '../../ChatContextMenu.vue';
 import { useChatController } from '../../controller/useChatController';
+import { renderMarkdown } from '../../messages/markdown';
+
+import type { SullaMessage } from '../../models/Message';
 
 /**
  * Detect raw HTML-ish content. When the agent emits things like a bare
@@ -72,22 +75,16 @@ const ctxMenu = ref<InstanceType<typeof ChatContextMenu> | null>(null);
 
 const timeLabel = computed(() => {
   const d = new Date(props.msg.createdAt);
-  return `${d.getHours() % 12 || 12}:${String(d.getMinutes()).padStart(2, '0')}`;
+  return `${ d.getHours() % 12 || 12 }:${ String(d.getMinutes()).padStart(2, '0') }`;
 });
 
 const isHtmlDocument = computed(() => HTML_DOC_RE.test(props.msg.text || ''));
 
-const rendered = computed(() => {
-  const html = (marked(props.msg.text || '') as string) || '';
-  return DOMPurify.sanitize(html, {
-    USE_PROFILES: { html: true },
-    ADD_ATTR: ['target', 'rel'],
-  });
-});
+const rendered = computed(() => renderMarkdown(props.msg.text));
 
 function copy(): void {
-  void navigator.clipboard?.writeText(props.msg.text);
-  // eslint-disable-next-line no-console
+  navigator.clipboard?.writeText(props.msg.text).catch(() => undefined);
+
   console.log('[chat] copied sulla message', props.msg.id);
 }
 
@@ -105,7 +102,7 @@ function onQuote(): void {
 
 function onFork(): void {
   // Forking needs a registry hook that doesn't exist yet. Visual-only for now.
-  // eslint-disable-next-line no-console
+
   console.log('fork from', props.msg.id);
 }
 

--- a/pkg/rancher-desktop/pages/chat/messages/__tests__/markdown.test.ts
+++ b/pkg/rancher-desktop/pages/chat/messages/__tests__/markdown.test.ts
@@ -1,0 +1,35 @@
+import { renderMarkdown } from '../markdown';
+
+describe('renderMarkdown', () => {
+  it('routes ordinary Markdown links through the main-window tab handler', () => {
+    const html = renderMarkdown('[Sulla](https://sulladesktop.com/docs)');
+    const container = document.createElement('div');
+
+    container.innerHTML = html;
+    const anchor = container.querySelector('a');
+
+    expect(anchor?.getAttribute('href')).toBe('https://sulladesktop.com/docs');
+    expect(anchor?.getAttribute('target')).toBe('_blank');
+    expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('makes local file links clickable without changing their target', () => {
+    const html = renderMarkdown('[ChatPage](/workspace/sulla/ChatPage.vue:12)');
+    const container = document.createElement('div');
+
+    container.innerHTML = html;
+    const anchor = container.querySelector('a');
+
+    expect(anchor?.getAttribute('href')).toBe('/workspace/sulla/ChatPage.vue:12');
+    expect(anchor?.getAttribute('target')).toBe('_blank');
+  });
+
+  it('still strips unsafe link protocols', () => {
+    const html = renderMarkdown('[unsafe](javascript:alert(1))');
+    const container = document.createElement('div');
+
+    container.innerHTML = html;
+
+    expect(container.querySelector('a')?.hasAttribute('href')).toBe(false);
+  });
+});

--- a/pkg/rancher-desktop/pages/chat/messages/markdown.ts
+++ b/pkg/rancher-desktop/pages/chat/messages/markdown.ts
@@ -10,11 +10,24 @@ import { marked } from 'marked';
 export function renderMarkdown(markdown: string): string {
   const raw = typeof markdown === 'string' ? markdown : String(markdown || '');
   const html = (marked(raw) as string) || '';
-
-  return DOMPurify.sanitize(html, {
+  const sanitized = DOMPurify.sanitize(html, {
     USE_PROFILES:       { html: true },
     ADD_TAGS:           ['audio', 'source'],
-    ADD_ATTR:           ['controls', 'preload', 'src', 'type'],
+    ADD_ATTR:           ['controls', 'preload', 'src', 'type', 'target', 'rel'],
     ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel|file):|data:image\/(?:png|gif|jpe?g|webp);base64,|\/|\.|#)/i,
   });
+
+  // Sulla's main BrowserWindow routes target=_blank navigations into an
+  // in-app browser tab. Citation cards already opt into that path; Markdown
+  // links must do the same or Electron leaves them in the chat renderer,
+  // where navigation is intentionally suppressed.
+  const container = document.createElement('template');
+
+  container.innerHTML = sanitized;
+  container.content.querySelectorAll('a[href]').forEach((anchor) => {
+    anchor.setAttribute('target', '_blank');
+    anchor.setAttribute('rel', 'noopener noreferrer');
+  });
+
+  return container.innerHTML;
 }


### PR DESCRIPTION
## What changed
- route sanitized Markdown links through the same target=_blank path citation cards already use
- reuse the shared Markdown renderer for completed and streaming transcript messages
- preserve DOMPurify protocol filtering

## Verification
- focused Jest regression: 3/3 passed
- scoped ESLint: clean
- git diff --check: clean

Projects task: 1Zxl