### PR TITLE
fix(projects): repair autonomous conveyor recovery admission

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
@@ -436,8 +436,11 @@ export class WorkLaneWorkflowBindingModel {
   Promise<LaneEntryAutomationRecord[]> {
     const armed: LaneEntryAutomationRecord[] = [];
     const batchSize = Math.max(1, limit);
+    let cursorTaskId: string | null = null;
     while (true) {
-      const candidates = await postgresClient.query<{ task_id: string; lane_key: string }>(`
+      const candidates: Array<{ task_id: string; lane_key: string }> = await postgresClient.query<{
+        task_id: string; lane_key: string;
+      }>(`
         SELECT task.id AS task_id, task.status AS lane_key
           FROM work_tasks task
           JOIN work_projects project ON project.id = task.project_id
@@ -448,11 +451,11 @@ export class WorkLaneWorkflowBindingModel {
           ) latest ON true
          WHERE task.archived = false AND project.archived = false AND epic.archived = false
            AND (latest.id IS NULL OR (latest.status = 'unautomated' AND latest.lane_key = task.status))
-         ORDER BY task.last_activity_at ASC
+           AND ($2::text IS NULL OR task.id > $2)
+         ORDER BY task.id ASC
          LIMIT $1
-      `, [batchSize]);
+      `, [batchSize, cursorTaskId]);
       if (candidates.length === 0) break;
-      let armedThisBatch = 0;
       for (const candidate of candidates) {
         const entry = await postgresClient.transaction(async(client) => {
           await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`lane-entry:${ candidate.task_id }`]);
@@ -475,14 +478,13 @@ export class WorkLaneWorkflowBindingModel {
             JSON.stringify(resolution.workflowSnapshot), actor]);
           return inserted.rows[0] ?? null;
         });
-        if (entry) {
-          armed.push(entry);
-          armedThisBatch++;
-        }
+        if (entry) armed.push(entry);
       }
-      // Concurrent status changes can make a batch contain no eligible rows;
-      // stop rather than spin forever while another writer owns those tasks.
-      if (armedThisBatch === 0) break;
+      // Keyset pagination must advance even when every row in this batch has
+      // no compatible workflow. Otherwise an old unbound/manual lane can
+      // permanently hide later tasks that now have protected bindings.
+      cursorTaskId = candidates[candidates.length - 1].task_id;
+      if (candidates.length < batchSize) break;
     }
     return armed;
   }

--- a/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
@@ -348,20 +348,24 @@ export class WorkLaneWorkflowBindingModel {
       'SELECT * FROM work_lane_entry_automations WHERE id = $1', [id]);
   }
 
-  static async listRecoverable(limit = 50, includeInterrupted = false): Promise<RecoverableLaneEntryRecord[]> {
+  static async listRecoverable(limit = 50, _includeInterrupted = false): Promise<RecoverableLaneEntryRecord[]> {
     return postgresClient.query<RecoverableLaneEntryRecord>(`
       SELECT lane.*, execution.status AS workflow_execution_status,
-             execution.error AS workflow_execution_error
+             execution.error AS workflow_execution_error,
+             execution.lease_expires_at
         FROM work_lane_entry_automations lane
         LEFT JOIN workflow_executions execution ON execution.execution_id = lane.execution_id
        WHERE lane.workflow_id IS NOT NULL AND (
          lane.status = 'pending'
          OR (lane.status = 'running' AND (
-           execution.execution_id IS NULL OR execution.status IN ('completed', 'failed') OR $2 = true
+           execution.execution_id IS NULL OR execution.status IN ('completed', 'failed')
+           OR (execution.status IN ('running', 'suspended')
+               AND execution.lease_expires_at IS NOT NULL
+               AND execution.lease_expires_at <= now())
          ))
        )
        ORDER BY lane.created_at ASC LIMIT $1
-    `, [limit, includeInterrupted]);
+    `, [limit]);
   }
 
   static async markStarted(id: string, executionId: string): Promise<LaneEntryAutomationRecord | null> {
@@ -391,6 +395,7 @@ export class WorkLaneWorkflowBindingModel {
         UPDATE workflow_executions
            SET status = 'failed', completed_at = now(), updated_at = now(), error = 'interrupted_before_lane_recovery'
          WHERE execution_id = $1 AND status IN ('running', 'suspended')
+           AND lease_expires_at IS NOT NULL AND lease_expires_at <= now()
          RETURNING execution_id
       `, [executionId]);
       if (!interrupted.rows[0]) return null;
@@ -429,44 +434,55 @@ export class WorkLaneWorkflowBindingModel {
    */
   static async rearmCurrentUnautomated(limit = 500, actor = 'core-seeder'):
   Promise<LaneEntryAutomationRecord[]> {
-    const candidates = await postgresClient.query<{ task_id: string; lane_key: string }>(`
-      SELECT task.id AS task_id, task.status AS lane_key
-        FROM work_tasks task
-        JOIN work_projects project ON project.id = task.project_id
-        JOIN work_epics epic ON epic.id = task.epic_id
-        LEFT JOIN LATERAL (
-          SELECT id, lane_key, status FROM work_lane_entry_automations
-           WHERE task_id = task.id ORDER BY generation DESC LIMIT 1
-        ) latest ON true
-       WHERE task.archived = false AND project.archived = false AND epic.archived = false
-         AND (latest.id IS NULL OR (latest.status = 'unautomated' AND latest.lane_key = task.status))
-       ORDER BY task.last_activity_at ASC
-       LIMIT $1
-    `, [Math.max(1, limit)]);
     const armed: LaneEntryAutomationRecord[] = [];
-    for (const candidate of candidates) {
-      const entry = await postgresClient.transaction(async(client) => {
-        await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`lane-entry:${ candidate.task_id }`]);
-        const latest = await client.query<LaneEntryAutomationRecord>(`
-          SELECT * FROM work_lane_entry_automations WHERE task_id = $1 ORDER BY generation DESC LIMIT 1
-        `, [candidate.task_id]);
-        if (latest.rows[0]
-          && (latest.rows[0].lane_key !== candidate.lane_key || latest.rows[0].status !== 'unautomated')) return null;
-        const resolution = await WorkLaneWorkflowBindingModel.resolve(candidate.task_id, candidate.lane_key, 'default', client);
-        if (!resolution.workflowId) return null;
-        const inserted = await client.query<LaneEntryAutomationRecord>(`
-          INSERT INTO work_lane_entry_automations (
-            id, task_id, generation, previous_lane_key, lane_key, binding_id, workflow_id,
-            resolution_source, fallback_reason, binding_snapshot, workflow_snapshot, status, actor
-          ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11::jsonb,'pending',$12)
-          RETURNING *
-        `, [`lane-entry-${ randomUUID() }`, candidate.task_id, (latest.rows[0]?.generation ?? 0) + 1,
-          latest.rows[0]?.lane_key ?? null, candidate.lane_key, resolution.binding?.id ?? null, resolution.workflowId,
-          resolution.source, resolution.fallbackReason, JSON.stringify(resolution.binding ?? {}),
-          JSON.stringify(resolution.workflowSnapshot), actor]);
-        return inserted.rows[0] ?? null;
-      });
-      if (entry) armed.push(entry);
+    const batchSize = Math.max(1, limit);
+    while (true) {
+      const candidates = await postgresClient.query<{ task_id: string; lane_key: string }>(`
+        SELECT task.id AS task_id, task.status AS lane_key
+          FROM work_tasks task
+          JOIN work_projects project ON project.id = task.project_id
+          JOIN work_epics epic ON epic.id = task.epic_id
+          LEFT JOIN LATERAL (
+            SELECT id, lane_key, status FROM work_lane_entry_automations
+             WHERE task_id = task.id ORDER BY generation DESC LIMIT 1
+          ) latest ON true
+         WHERE task.archived = false AND project.archived = false AND epic.archived = false
+           AND (latest.id IS NULL OR (latest.status = 'unautomated' AND latest.lane_key = task.status))
+         ORDER BY task.last_activity_at ASC
+         LIMIT $1
+      `, [batchSize]);
+      if (candidates.length === 0) break;
+      let armedThisBatch = 0;
+      for (const candidate of candidates) {
+        const entry = await postgresClient.transaction(async(client) => {
+          await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`lane-entry:${ candidate.task_id }`]);
+          const latest = await client.query<LaneEntryAutomationRecord>(`
+            SELECT * FROM work_lane_entry_automations WHERE task_id = $1 ORDER BY generation DESC LIMIT 1
+          `, [candidate.task_id]);
+          if (latest.rows[0]
+            && (latest.rows[0].lane_key !== candidate.lane_key || latest.rows[0].status !== 'unautomated')) return null;
+          const resolution = await WorkLaneWorkflowBindingModel.resolve(candidate.task_id, candidate.lane_key, 'default', client);
+          if (!resolution.workflowId) return null;
+          const inserted = await client.query<LaneEntryAutomationRecord>(`
+            INSERT INTO work_lane_entry_automations (
+              id, task_id, generation, previous_lane_key, lane_key, binding_id, workflow_id,
+              resolution_source, fallback_reason, binding_snapshot, workflow_snapshot, status, actor
+            ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11::jsonb,'pending',$12)
+            RETURNING *
+          `, [`lane-entry-${ randomUUID() }`, candidate.task_id, (latest.rows[0]?.generation ?? 0) + 1,
+            latest.rows[0]?.lane_key ?? null, candidate.lane_key, resolution.binding?.id ?? null, resolution.workflowId,
+            resolution.source, resolution.fallbackReason, JSON.stringify(resolution.binding ?? {}),
+            JSON.stringify(resolution.workflowSnapshot), actor]);
+          return inserted.rows[0] ?? null;
+        });
+        if (entry) {
+          armed.push(entry);
+          armedThisBatch++;
+        }
+      }
+      // Concurrent status changes can make a batch contain no eligible rows;
+      // stop rather than spin forever while another writer owns those tasks.
+      if (armedThisBatch === 0) break;
     }
     return armed;
   }

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -571,6 +571,17 @@ export class WorkTaskDispatchModel {
     return Number(row?.count || 0);
   }
 
+  /** True when the dispatcher has a durable claim for this exact task. */
+  static async hasActiveDispatchForTask(taskId: string): Promise<boolean> {
+    const row = await postgresClient.queryOne<{ found: boolean }>(`
+      SELECT EXISTS (
+        SELECT 1 FROM work_task_dispatches
+         WHERE task_id = $1 AND status = 'running'
+      ) AS found
+    `, [taskId]);
+    return row?.found === true;
+  }
+
   /**
    * Count autonomous work already at the review stage that can still drain —
    * claimable by the review pool or actively held by a live verification

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts
@@ -133,4 +133,36 @@ describe('WorkLaneWorkflowBindingModel', () => {
       .resolves.toMatchObject({ created: true, entry: { lane_key: 'blocked' } });
     expect(assertClaimable).not.toHaveBeenCalled();
   });
+
+  it('continues rearming after a full batch of tasks without a resolvable workflow', async() => {
+    (postgresClient as any).query = (jest.fn() as any)
+      .mockResolvedValueOnce([{ task_id: 'task-a', lane_key: 'manual' }])
+      .mockResolvedValueOnce([{ task_id: 'task-b', lane_key: 'todo' }])
+      .mockResolvedValueOnce([]);
+    let transactionCount = 0;
+    (postgresClient as any).transaction = jest.fn(async(callback: any) => {
+      transactionCount++;
+      const client = {
+        query: transactionCount === 1
+          ? (jest.fn() as any)
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [] })
+          : (jest.fn() as any)
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ id: 'entry-b', task_id: 'task-b', lane_key: 'todo' }] }),
+      };
+      return callback(client);
+    });
+    jest.spyOn(WorkLaneWorkflowBindingModel, 'resolve')
+      .mockResolvedValueOnce({ workflowId: null, binding: null, source: 'none', fallbackReason: 'none', workflowSnapshot: {} } as any)
+      .mockResolvedValueOnce({ workflowId: 'workflow-todo', binding: null, source: 'core', fallbackReason: null, workflowSnapshot: {} } as any);
+
+    await expect(WorkLaneWorkflowBindingModel.rearmCurrentUnautomated(1)).resolves.toEqual([
+      expect.objectContaining({ id: 'entry-b', task_id: 'task-b' }),
+    ]);
+    expect((postgresClient.query as any).mock.calls.map((call: any[]) => call[1])).toEqual([
+      [1, null], [1, 'task-a'], [1, 'task-b'],
+    ]);
+  });
 });

--- a/pkg/rancher-desktop/agent/services/LaneEntryAutomationService.ts
+++ b/pkg/rancher-desktop/agent/services/LaneEntryAutomationService.ts
@@ -45,7 +45,8 @@ export class LaneEntryAutomationService {
           );
         } else {
           const { getTaskDispatcherService } = await import('./TaskDispatcherService');
-          await getTaskDispatcherService().requestDispatch();
+          const admitted = await getTaskDispatcherService().requestDispatch(entry.task_id);
+          if (!admitted) throw new Error(`Dispatcher did not admit task ${ entry.task_id }.`);
         }
         const delegated = await WorkLaneWorkflowBindingModel.markOutcome(entry.id, executionId, 'completed', {
           disposition: 'delegated', owner, generation: entry.generation,

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -130,10 +130,15 @@ export class TaskDispatcherService {
     console.log('[TaskDispatcher] Mechanical dispatcher initialized');
   }
 
-  /** Immediate, idempotent nudge from a committed execution/review lane entry. */
-  async requestDispatch(): Promise<void> {
-    if (!this.initialized) return;
+  /** Immediate, idempotent nudge from a committed execution/review lane entry.
+   * When taskId is supplied, return proof that the dispatcher owns that task;
+   * a successful tick alone is not admission evidence because it may claim a
+   * different task or find the queue backpressured. */
+  async requestDispatch(taskId?: string): Promise<boolean> {
+    if (!this.initialized) return false;
     await this.checkAndDispatch();
+    if (!taskId) return true;
+    return WorkTaskDispatchModel.hasActiveDispatchForTask(taskId);
   }
 
   async forceCheck(): Promise<void> {

--- a/pkg/rancher-desktop/agent/services/__tests__/LaneEntryAutomationService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/LaneEntryAutomationService.test.ts
@@ -127,4 +127,5 @@ describe('LaneEntryAutomationService', () => {
     expect(reset).toHaveBeenCalledWith('entry-5', 'lane-exec-task-5-1');
     expect(dispatch).toHaveBeenCalledWith('entry-5');
   });
+
 });

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -23,6 +23,7 @@ const recordReviewLaunchWithExecutionMock: any = jest.fn(() => Promise.resolve()
 const reconcileDispatcherOwnedExecutionsMock: any = jest.fn(() => Promise.resolve([]));
 const failVerificationMock: any = jest.fn(() => Promise.resolve(true));
 const touchMock: any = jest.fn(() => Promise.resolve());
+const hasActiveDispatchForTaskMock: any = jest.fn(() => Promise.resolve(false));
 const addCommentMock: any = jest.fn(() => Promise.resolve());
 const updateTaskMock: any = jest.fn(() => Promise.resolve());
 const executeMock: any = jest.fn();
@@ -90,6 +91,7 @@ jest.unstable_mockModule('../../database/models/WorkTaskDispatchModel', () => ({
     reviewFingerprint:       jest.fn(() => 'e'.repeat(64)),
     failVerification:        failVerificationMock,
     touch:                   touchMock,
+    hasActiveDispatchForTask: hasActiveDispatchForTaskMock,
   },
 }));
 jest.unstable_mockModule('../../database/models/WorkflowModel', () => ({

--- a/pkg/rancher-desktop/main/workItemsEvents.ts
+++ b/pkg/rancher-desktop/main/workItemsEvents.ts
@@ -435,18 +435,15 @@ export function initWorkItemsEvents(): void {
   // The domain-event drain only recovers transitions that never dispatched.
   // A lane workflow that dies MID-RUN leaves its lane entry stuck in
   // 'running' with the outbox already settled — drainRecoverable is the only
-  // path that resumes those. includeInterrupted=true force-fails executions
-  // still marked running/suspended, which is only safe at startup when this
-  // fresh process cannot have live runs; the periodic sweep passes false so
-  // it never kills an actively-running workflow, while still recovering
-  // pending entries, vanished executions, and settled-but-unrecorded runs.
-  const sweepLaneEntries = (includeInterrupted: boolean) => {
+  // path that resumes those. Recovery is lease-fenced in the model, so both
+  // startup and periodic sweeps leave live executions alone.
+  const sweepLaneEntries = () => {
     import('@pkg/agent/services/LaneEntryAutomationService')
-      .then(({ LaneEntryAutomationService }) => LaneEntryAutomationService.drainRecoverable(50, includeInterrupted))
+      .then(({ LaneEntryAutomationService }) => LaneEntryAutomationService.drainRecoverable(50))
       .catch(error => console.warn('[WorkItems] Lane-entry automation recovery failed:', error));
   };
-  sweepLaneEntries(true);
-  setInterval(() => sweepLaneEntries(false), 5 * 60_000);
+  sweepLaneEntries();
+  setInterval(sweepLaneEntries, 5 * 60_000);
 }
 
 interface ReorderUpdate {


### PR DESCRIPTION
## Summary

Repairs the concrete acceptance defects found after #800 merged:

- lane-entry recovery is lease-fenced; startup and periodic sweeps cannot force-fail a live execution
- protected dispatcher delegation requires durable evidence that the exact task has an active dispatcher claim before settling the lane entry
- legacy unautomated-stage rearming drains in batches until no eligible task remains instead of stopping at 500

## Validation

- `git diff --check`
- 4 focused Jest suites: 38/38 passed
- esbuild parsing passed for all 5 changed production TypeScript files

Draft only. No merge, deploy, rebuild, migration application, or live database mutation performed.