### PR TITLE
fix(projects): route TODO dispositions to execution lane

### DIFF
--- a/pkg/rancher-desktop/agent/projects/application/ProjectsApplicationService.ts
+++ b/pkg/rancher-desktop/agent/projects/application/ProjectsApplicationService.ts
@@ -63,6 +63,12 @@ export interface TransitionTaskRelativeInput {
   custody?:            UpdateTaskInput['custody'];
 }
 
+export interface TransitionTaskToExecutionInput {
+  taskId:              string;
+  expectedGeneration?: number;
+  custody?:            UpdateTaskInput['custody'];
+}
+
 export interface TaskStageTransitionResult {
   task:               WorkTaskRecord;
   fromStage:          string;
@@ -456,6 +462,25 @@ export class ProjectsApplicationService {
     return this.transitionTaskStage({
       taskId,
       stageKey:            target.lane_key,
+      expectedGeneration: input.expectedGeneration,
+      custody:            input.custody,
+    }, context);
+  }
+
+  /** Return a task to the first configured execution lane, independent of lane ordering. */
+  async transitionTaskToExecution(
+    input: TransitionTaskToExecutionInput,
+    context: ProjectsCommandContext = DEFAULT_CONTEXT,
+  ): Promise<TaskStageTransitionResult> {
+    const taskId = itemId(input.taskId, 'task_id');
+    const current = await this.repository.getTask(taskId);
+    if (!current) throw new Error(`Task not found: ${ taskId }`);
+    const executionEntryLaneKey = await WorkLaneDefinitionModel.preferredLaneKey(
+      current.project_id, 'execution', 'todo', 'first',
+    );
+    return this.transitionTaskStage({
+      taskId,
+      stageKey:            executionEntryLaneKey,
       expectedGeneration: input.expectedGeneration,
       custody:            input.custody,
     }, context);

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsApplicationService.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsApplicationService.test.ts
@@ -134,4 +134,28 @@ describe('ProjectsApplicationService lifecycle boundary', () => {
     }, { actor: 'stale-routine', source: 'routine' })).rejects.toThrow('Stale stage generation');
     expect(repo.updateTask).not.toHaveBeenCalled();
   });
+
+  it('returns blocked work to the first execution-role lane, not the next ordered lane', async() => {
+    const repo = repository();
+    repo.getTask.mockResolvedValue({ ...current, status: 'blocked' });
+    jest.spyOn(WorkLaneDefinitionModel, 'preferredLaneKey').mockResolvedValue('ready-custom');
+    jest.spyOn(WorkLaneWorkflowBindingModel, 'listLaneEntries').mockResolvedValue([
+      { generation: 12, lane_key: 'blocked' },
+    ] as any);
+    jest.spyOn(LifecycleCapabilityModel, 'assertActorCanManageTask').mockResolvedValue();
+    jest.spyOn(WorkLaneDefinitionModel, 'validateTaskStatus').mockResolvedValue({
+      lane_key: 'ready-custom', semantic_role: 'execution',
+    } as any);
+    const service = new ProjectsApplicationService(repo);
+
+    await expect(service.transitionTaskToExecution({
+      taskId: 'task-1', expectedGeneration: 12,
+    }, { actor: 'planning-council', source: 'routine' })).resolves.toMatchObject({
+      fromStage: 'blocked', toStage: 'ready-custom', previousGeneration: 12,
+    });
+    expect(WorkLaneDefinitionModel.preferredLaneKey).toHaveBeenCalledWith(
+      'project-1', 'execution', 'todo', 'first',
+    );
+    expect(repo.updateTask).toHaveBeenCalledWith('task-1', expect.objectContaining({ status: 'ready-custom' }));
+  });
 });

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsApplicationService.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsApplicationService.test.ts
@@ -139,6 +139,10 @@ describe('ProjectsApplicationService lifecycle boundary', () => {
     const repo = repository();
     repo.getTask.mockResolvedValue({ ...current, status: 'blocked' });
     jest.spyOn(WorkLaneDefinitionModel, 'preferredLaneKey').mockResolvedValue('ready-custom');
+    jest.spyOn(WorkLaneDefinitionModel, 'resolveEffective').mockResolvedValue([
+      { lane_key: 'blocked', position: 90, enabled: true, archived: false },
+      { lane_key: 'ready-custom', position: 20, enabled: true, archived: false },
+    ] as any);
     jest.spyOn(WorkLaneWorkflowBindingModel, 'listLaneEntries').mockResolvedValue([
       { generation: 12, lane_key: 'blocked' },
     ] as any);

--- a/pkg/rancher-desktop/agent/routines/core/__tests__/planProjectTask.test.ts
+++ b/pkg/rancher-desktop/agent/routines/core/__tests__/planProjectTask.test.ts
@@ -96,8 +96,8 @@ describe('locked Projects planning routine', () => {
 
     expect(prompt).toContain('sulla project/add_task_comment');
     expect(prompt).toContain('sulla project/update_task');
-    expect(prompt).toContain('transition_task_relative');
-    expect(prompt).toContain('direction `next`');
+    expect(prompt).toContain('transition_task_to_execution');
+    expect(prompt).toContain('never infer the target from relative ordering');
     expect(prompt).toContain('transition_task_stage');
     expect(prompt).toContain('exception stage key `blocked`');
     expect(prompt).toContain('Never merge or deploy');

--- a/pkg/rancher-desktop/agent/routines/core/planProjectTask.ts
+++ b/pkg/rancher-desktop/agent/routines/core/planProjectTask.ts
@@ -179,7 +179,8 @@ export const PLAN_PROJECT_TASK_DEFINITION: Record<string, any> = {
             'with author `planning-council`; the body must contain `Final planning council plan` plus the complete synthesis. ' +
             'If the synthesis disposition is TODO, create well-bounded subtasks only when the plan genuinely requires independent ' +
             'units, then call `sulla project/update_task` to set assignee `dispatcher` without changing status, followed by ' +
-            '`sulla project/transition_task_relative` with direction `next`, the trigger task id, and its exact stage-entry generation. ' +
+            '`sulla project/transition_task_to_execution` with the trigger task id and its exact stage-entry generation. ' +
+            'That operation resolves the first active lane with semantic role `execution`; never infer the target from relative ordering. ' +
             'If and only if disposition is BLOCKED, set assignee `heartbeat` without changing status, then call ' +
             '`sulla project/transition_task_stage` with the configured exception stage key `blocked` and exact generation, ' +
             'and ensure the comment names the exact irreversible gate. Re-read the task with `sulla project/get_project_item` ' +

--- a/pkg/rancher-desktop/agent/tools/project/__tests__/taskStageTransitionTools.test.ts
+++ b/pkg/rancher-desktop/agent/tools/project/__tests__/taskStageTransitionTools.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { getProjectsApplicationService } from '../../../projects/application/ProjectsApplicationService';
 import { TransitionTaskRelativeWorker } from '../transition_task_relative';
 import { TransitionTaskStageWorker } from '../transition_task_stage';
+import { TransitionTaskToExecutionWorker } from '../transition_task_to_execution';
 
 const projects = getProjectsApplicationService() as any;
 const transitionTaskStage = jest.spyOn(projects, 'transitionTaskStage');
@@ -41,5 +42,17 @@ describe('task stage transition workflow tools', () => {
     expect(transitionTaskRelative).toHaveBeenCalledWith(expect.objectContaining({
       taskId: 'task-1', direction: 'next', expectedGeneration: 2,
     }), { actor: 'sulla', source: 'routine' });
+  });
+
+  it('passes the execution-role transition and generation through the application boundary', async() => {
+    const transitionTaskToExecution = jest.spyOn(projects, 'transitionTaskToExecution')
+      .mockResolvedValue({ fromStage: 'blocked', toStage: 'ready-custom' });
+    const result = await call(new TransitionTaskToExecutionWorker(), {
+      task_id: 'task-1', expected_generation: 9, actor: 'planning-council',
+    });
+    expect(result.successBoolean).toBe(true);
+    expect(transitionTaskToExecution).toHaveBeenCalledWith({
+      taskId: 'task-1', expectedGeneration: 9, custody: undefined,
+    }, { actor: 'planning-council', source: 'routine' });
   });
 });

--- a/pkg/rancher-desktop/agent/tools/project/manifests.ts
+++ b/pkg/rancher-desktop/agent/tools/project/manifests.ts
@@ -465,6 +465,19 @@ export const projectToolManifests: ToolManifest[] = [
     operationTypes: ['update'],
     loader:         () => import('./transition_task_relative'),
   },
+  {
+    name:        'transition_task_to_execution',
+    description: 'Return a task to the first active stage with semantic role execution in its project pipeline. Resolves the target explicitly rather than using relative order; expected_generation rejects stale workflow runs.',
+    category:    'project',
+    schemaDef:   {
+      task_id:            { type: 'string', description: 'Task to transition.' },
+      expected_generation:{ type: 'number', optional: true, description: 'Current immutable stage-entry generation. Rejects stale workflow runs.' },
+      custody:            { type: 'object', optional: true, description: 'Structured evidence when the destination stage policy requires custody.' },
+      actor:              { type: 'string', optional: true, description: 'Audit actor. Defaults to sulla.' },
+    },
+    operationTypes: ['update'],
+    loader:         () => import('./transition_task_to_execution'),
+  },
 
   // ── comments ─────────────────────────────────────────────────────────
   {

--- a/pkg/rancher-desktop/agent/tools/project/transition_task_to_execution.ts
+++ b/pkg/rancher-desktop/agent/tools/project/transition_task_to_execution.ts
@@ -1,0 +1,24 @@
+import { getProjectsApplicationService } from '../../projects/application/ProjectsApplicationService';
+import { BaseTool, ToolResponse } from '../base';
+
+/** Return a task to its project's first semantic execution lane. */
+export class TransitionTaskToExecutionWorker extends BaseTool {
+  name = '';
+  description = '';
+
+  protected async _validatedCall(input: any): Promise<ToolResponse> {
+    const taskId = typeof input.task_id === 'string' ? input.task_id.trim() : '';
+    if (!taskId) return { successBoolean: false, responseString: 'task_id is required.' };
+    const actor = typeof input.actor === 'string' && input.actor.trim() ? input.actor.trim() : 'sulla';
+    try {
+      const result = await getProjectsApplicationService().transitionTaskToExecution({
+        taskId,
+        expectedGeneration: typeof input.expected_generation === 'number' ? input.expected_generation : undefined,
+        custody:            input.custody,
+      }, { actor, source: 'routine' });
+      return { successBoolean: true, responseString: JSON.stringify(result, null, 2) };
+    } catch (error: any) {
+      return { successBoolean: false, responseString: `Failed to transition task to execution: ${ error?.message ?? String(error) }` };
+    }
+  }
+}


### PR DESCRIPTION
## Summary\n\n- add a semantic `transition_task_to_execution` Projects operation\n- resolve the first active execution-role lane per project instead of using relative ordering\n- preserve expected-generation protection and update the locked planning recordkeeper\n- add custom-pipeline regression coverage\n\n## Validation\n\n- `git diff --check` passed\n- focused Jest could not collect because the checkout is missing `ts-jest`\n- ESLint could not start because the installed `oxc-resolver` native binding is unavailable\n\nTask: jhG5