### PR TITLE
fix: queue planning councils and fence stale recovery

### DIFF
--- a/pkg/rancher-desktop/agent/controllers/PlaybookController.ts
+++ b/pkg/rancher-desktop/agent/controllers/PlaybookController.ts
@@ -213,6 +213,11 @@ export class PlaybookController<TState = any> {
   private isProcessingPlaybook = false;
   private _continuationQueued = false;
 
+  private isWorkflowLive(state: TState, executionId: string): boolean {
+    const active = (state as any).metadata?.activeWorkflow;
+    return active?.status === 'running' && active.executionId === executionId;
+  }
+
   constructor(graph: PlaybookGraphInterface<TState>) {
     this.graph = graph;
   }
@@ -2201,6 +2206,13 @@ export class PlaybookController<TState = any> {
     };
 
     meta.activeWorkflow = undefined;
+    // Terminal workflows own no future driver work. Late callbacks are
+    // fenced by execution id and must not spawn post-terminal threads.
+    this.pendingSubAgents.clear();
+    this.pendingCompletions.length = 0;
+    this.pendingFailures.length = 0;
+    this.pendingEscalations.length = 0;
+    this._continuationQueued = false;
 
     // Persist final execution status so boot recovery doesn't pick it up again.
     try {
@@ -2470,10 +2482,15 @@ export class PlaybookController<TState = any> {
     nodeLabel: string,
     maxRetries: number,
   ): void {
+    const workflowExecutionId = (state as any).metadata?.activeWorkflow?.executionId;
     const attempt = async(attemptNum: number): Promise<void> => {
       try {
         console.log(`[PlaybookController] Sub-agent "${ nodeLabel }" attempt ${ attemptNum }/${ maxRetries }`);
         const result = await this.executeSubAgent(state, nodeId, agentId, prompt, config);
+        if (!workflowExecutionId || !this.isWorkflowLive(state, workflowExecutionId)) {
+          this.pendingSubAgents.delete(nodeId);
+          return;
+        }
         const resultText = typeof result.output === 'string' ? result.output : JSON.stringify(result.output);
 
         if (result.contractStatus === 'blocked') {
@@ -2572,6 +2589,10 @@ export class PlaybookController<TState = any> {
           this.triggerPlaybookContinuation(state);
         }
       } catch (err: any) {
+        if (!workflowExecutionId || !this.isWorkflowLive(state, workflowExecutionId)) {
+          this.pendingSubAgents.delete(nodeId);
+          return;
+        }
         const errorMsg = err.message || String(err);
         console.error(`[PlaybookController] Sub-agent "${ nodeLabel }" threw (attempt ${ attemptNum }/${ maxRetries }):`, errorMsg);
 
@@ -2627,6 +2648,8 @@ export class PlaybookController<TState = any> {
   // ─── Continuation Trigger ───────────────────────────────────────
 
   private triggerPlaybookContinuation(state: TState): void {
+    const executionId = (state as any).metadata?.activeWorkflow?.executionId;
+    if (!executionId || !this.isWorkflowLive(state, executionId)) return;
     if (this.isProcessingPlaybook) {
       this._continuationQueued = true;
       console.log('[PlaybookController] Playbook already processing, queued continuation for after unlock');

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts
@@ -165,7 +165,19 @@ export class WorkTaskPlanningRunModel {
              finished_at = now()
        WHERE task_id = $1
          AND status = 'active'
-         AND heartbeat_at <= now() - ($2 * interval '1 minute')
+         AND (
+           (execution_id IS NULL AND heartbeat_at <= now() - ($2 * interval '1 minute'))
+           OR (execution_id IS NOT NULL AND (
+             NOT EXISTS (SELECT 1 FROM workflow_executions execution WHERE execution.execution_id = work_task_planning_runs.execution_id)
+             OR EXISTS (
+               SELECT 1 FROM workflow_executions execution
+                WHERE execution.execution_id = work_task_planning_runs.execution_id
+                  AND (execution.status NOT IN ('running', 'suspended')
+                    OR (execution.lease_expires_at IS NOT NULL AND execution.lease_expires_at <= now())
+                    OR execution.heartbeat_at <= now() - ($2 * interval '1 minute'))
+             )
+           ))
+         )
        RETURNING id
     `, [taskId, staleMinutes]);
     return Boolean(row);
@@ -181,7 +193,19 @@ export class WorkTaskPlanningRunModel {
                error = 'planning council lease expired or app restarted',
                finished_at = now()
          WHERE status = 'active'
-           AND heartbeat_at <= now() - ($1 * interval '1 minute')
+           AND (
+             (execution_id IS NULL AND heartbeat_at <= now() - ($1 * interval '1 minute'))
+             OR (execution_id IS NOT NULL AND (
+               NOT EXISTS (SELECT 1 FROM workflow_executions execution WHERE execution.execution_id = work_task_planning_runs.execution_id)
+               OR EXISTS (
+                 SELECT 1 FROM workflow_executions execution
+                  WHERE execution.execution_id = work_task_planning_runs.execution_id
+                    AND (execution.status NOT IN ('running', 'suspended')
+                      OR (execution.lease_expires_at IS NOT NULL AND execution.lease_expires_at <= now())
+                      OR execution.heartbeat_at <= now() - ($1 * interval '1 minute'))
+               )
+             ))
+           )
         RETURNING task_id
       `, [staleMinutes]);
       if (stale.rows.length === 0) return [];

--- a/pkg/rancher-desktop/agent/database/models/WorkflowExecutionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkflowExecutionModel.ts
@@ -199,6 +199,42 @@ export class WorkflowExecutionModel extends BaseModel<WorkflowExecutionAttribute
     });
   }
 
+  /**
+   * Retire executions that can no longer be owned by a live worker. These
+   * rows predate lease ownership (or were created before activation finished)
+   * and otherwise remain permanently eligible for recovery/concurrency scans.
+   * A multi-hour age guard keeps this from touching a slow startup.
+   */
+  static async reapStaleLeaselessExecutions(staleHours = 4): Promise<string[]> {
+    const hours = Math.max(1, Math.floor(staleHours));
+    return postgresClient.transaction(async(client) => {
+      const rows = await client.query<{ execution_id: string }>(`
+        UPDATE workflow_executions
+           SET status = 'failed', completed_at = COALESCE(completed_at, NOW()),
+               terminal_at = COALESCE(terminal_at, NOW()),
+               terminal_reason = 'stale_leaseless_execution',
+               error = COALESCE(error, 'stale execution had no lease or heartbeat'),
+               updated_at = NOW()
+         WHERE status IN ('running', 'suspended')
+           AND owner_id IS NULL
+           AND lease_token IS NULL
+           AND lease_expires_at IS NULL
+           AND heartbeat_at IS NULL
+           AND started_at <= NOW() - ($1 * INTERVAL '1 hour')
+        RETURNING execution_id`, [hours]);
+      const executionIds = rows.rows.map(row => row.execution_id);
+      if (executionIds.length > 0) {
+        await client.query(`
+          UPDATE work_lane_entry_automations
+             SET status = 'failed',
+                 outcome = jsonb_build_object('disposition', 'runtime_failed', 'message', 'stale leaseless execution retired'),
+                 completed_at = COALESCE(completed_at, NOW())
+           WHERE execution_id = ANY($1::text[]) AND status = 'running'`, [executionIds]);
+      }
+      return executionIds;
+    });
+  }
+
   static async nextLeaseExpiry(): Promise<Date | null> {
     const row = await postgresClient.queryOne<{ next_expiry: Date | null }>(`
       SELECT MIN(lease_expires_at) AS next_expiry

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskPlanningRunModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskPlanningRunModel.test.ts
@@ -29,6 +29,7 @@ describe('WorkTaskPlanningRunModel', () => {
     const query = (jest.fn() as any)
       .mockResolvedValueOnce({ rows: [blocked] })
       .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ attempt: 1 }] })
       .mockResolvedValueOnce({ rows: [run] })
       .mockResolvedValueOnce({ rows: [planning] });
@@ -38,10 +39,10 @@ describe('WorkTaskPlanningRunModel', () => {
 
     expect(claimed).toMatchObject({ run: { status: 'active' }, task: { status: 'planning' } });
     expect(query.mock.calls[0][0]).toContain('FOR UPDATE');
-    expect(query.mock.calls[1][0]).toContain("status = 'active'");
-    expect(query.mock.calls[3][0]).toContain('INSERT INTO work_task_planning_runs');
-    expect(query.mock.calls[4][0]).toContain('status = $2');
-    expect(query.mock.calls[4][1]).toEqual(['task-1', 'planning']);
+    expect(query.mock.calls[2][0]).toContain("status = 'active'");
+    expect(query.mock.calls[4][0]).toContain('INSERT INTO work_task_planning_runs');
+    expect(query.mock.calls[5][0]).toContain('status = $2');
+    expect(query.mock.calls[5][1]).toEqual(['task-1', 'planning']);
   });
 
   it('does not launch a duplicate when a task already has an active council', async() => {

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkflowExecutionModel.leases.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkflowExecutionModel.leases.test.ts
@@ -32,6 +32,17 @@ describe('WorkflowExecutionModel leases', () => {
     await WorkflowExecutionModel.suspendAllRunning();
     expect(db.queryAll.mock.calls[0][0]).toContain('lease_expires_at = NOW()');
   });
+  it('retires only old executions with no owner, lease, or heartbeat', async() => {
+    const client: any = { query: jest.fn()
+      .mockResolvedValueOnce({ rows: [{ execution_id: 'stale' }] })
+      .mockResolvedValueOnce({ rows: [] }) };
+    db.transaction.mockImplementation(async(fn: any) => fn(client));
+    expect(await WorkflowExecutionModel.reapStaleLeaselessExecutions()).toEqual(['stale']);
+    expect(client.query.mock.calls[0][0]).toContain("owner_id IS NULL");
+    expect(client.query.mock.calls[0][0]).toContain("heartbeat_at IS NULL");
+    expect(client.query.mock.calls[0][0]).toContain("INTERVAL '1 hour'");
+    expect(client.query.mock.calls[1][0]).toContain('work_lane_entry_automations');
+  });
   it('recovers through one transaction and reads the last checkpoint', async() => {
     const client = { query: jest.fn()
       .mockResolvedValueOnce({ rows: [{ execution_id: 'e1', status: 'running', attempt_count: 1 }] })

--- a/pkg/rancher-desktop/agent/services/PlanningCouncilService.ts
+++ b/pkg/rancher-desktop/agent/services/PlanningCouncilService.ts
@@ -67,7 +67,7 @@ export class PlanningCouncilService {
   }
 
   static async recoverOnStartup(): Promise<void> {
-    const taskIds = await WorkTaskPlanningRunModel.recoverStale(0);
+    const taskIds = await WorkTaskPlanningRunModel.recoverStale(45);
     for (const taskId of taskIds) {
       await WorkItemsModel.addComment({
         task_id: taskId,
@@ -145,7 +145,7 @@ export class PlanningCouncilService {
       const execution = await executeRoutine(
         PROJECT_TASK_PLANNING_WORKFLOW_ID,
         JSON.stringify(snapshot),
-        { allowConcurrent: true, routineKind: 'planning' },
+        { allowConcurrent: true, routineKind: 'planning', waitForCapacity: true },
       );
       await WorkTaskPlanningRunModel.attachExecution(claim.run.id, execution.playbookExecutionId ?? execution.executionId);
       await WorkItemsModel.addComment({

--- a/pkg/rancher-desktop/agent/services/PlanningCouncilService.ts
+++ b/pkg/rancher-desktop/agent/services/PlanningCouncilService.ts
@@ -5,6 +5,7 @@ import {
   type ClaimedPlanningRun,
 } from '../database/models/WorkTaskPlanningRunModel';
 import { WorkflowModel } from '../database/models/WorkflowModel';
+import { WorkflowExecutionModel } from '../database/models/WorkflowExecutionModel';
 import { recordReceipt } from './ArtifactReceiptService';
 import { getProjectsApplicationService } from '../projects/application/ProjectsApplicationService';
 
@@ -67,6 +68,7 @@ export class PlanningCouncilService {
   }
 
   static async recoverOnStartup(): Promise<void> {
+    await WorkflowExecutionModel.reapStaleLeaselessExecutions();
     const taskIds = await WorkTaskPlanningRunModel.recoverStale(45);
     for (const taskId of taskIds) {
       await WorkItemsModel.addComment({

--- a/pkg/rancher-desktop/agent/services/RoutineConcurrencyPolicy.ts
+++ b/pkg/rancher-desktop/agent/services/RoutineConcurrencyPolicy.ts
@@ -69,6 +69,8 @@ export interface RoutineSlotContext {
   taskId?: string | null;
 }
 
+const wait = (milliseconds: number): Promise<void> => new Promise(resolve => setTimeout(resolve, milliseconds));
+
 function clampLimit(value: number, fallback: number): number {
   if (!Number.isFinite(value)) return fallback;
   const floored = Math.floor(value);
@@ -158,6 +160,21 @@ export class RoutineConcurrencyPolicy {
       );
       return id;
     });
+  }
+
+  /** Queue behind capacity instead of converting routine backpressure into failure. */
+  static async acquireWhenAvailable(
+    kind: ProtectedRoutineKind,
+    limit: number,
+    context: RoutineSlotContext = {},
+    pollMs = 1_000,
+  ): Promise<string> {
+    for (;;) {
+      await this.reclaimStale();
+      const slot = await this.acquire(kind, limit, context);
+      if (slot) return slot;
+      await wait(Math.max(100, pollMs));
+    }
   }
 
   static async release(slotId: string): Promise<void> {

--- a/pkg/rancher-desktop/agent/services/__tests__/PlanningCouncilService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/PlanningCouncilService.test.ts
@@ -15,6 +15,7 @@ const recoverStaleForTaskMock: any = jest.fn();
 const findWorkflowMock: any = jest.fn();
 const executeRoutineMock: any = jest.fn();
 const recordReceiptMock: any = jest.fn();
+const reapStaleLeaselessExecutionsMock: any = jest.fn();
 
 jest.unstable_mockModule('../../database/models/WorkItemsModel', () => ({
   WorkItemsModel: {
@@ -44,6 +45,9 @@ jest.unstable_mockModule('../../database/models/WorkTaskPlanningRunModel', () =>
 
 jest.unstable_mockModule('../../database/models/WorkflowModel', () => ({
   WorkflowModel: { findById: findWorkflowMock },
+}));
+jest.unstable_mockModule('../../database/models/WorkflowExecutionModel', () => ({
+  WorkflowExecutionModel: { reapStaleLeaselessExecutions: reapStaleLeaselessExecutionsMock },
 }));
 
 jest.unstable_mockModule('../../../main/sullaRoutineTemplateEvents', () => ({
@@ -94,6 +98,15 @@ describe('PlanningCouncilService', () => {
     executeRoutineMock.mockResolvedValue({ executionId: 'graph-1', playbookExecutionId: 'wfp-1' });
     settleForTaskMock.mockResolvedValue(null);
     recoverStaleForTaskMock.mockResolvedValue(false);
+    recoverStaleMock.mockResolvedValue([]);
+    reapStaleLeaselessExecutionsMock.mockResolvedValue([]);
+  });
+
+  it('retires stale leaseless executions before planning recovery', async() => {
+    const PlanningCouncilService = await service();
+    await PlanningCouncilService.recoverOnStartup();
+    expect(reapStaleLeaselessExecutionsMock).toHaveBeenCalledTimes(1);
+    expect(recoverStaleMock).toHaveBeenCalledWith(45);
   });
 
   it('atomically claims a blocked task and launches the task-scoped routine once', async() => {

--- a/pkg/rancher-desktop/agent/services/__tests__/PlanningCouncilService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/PlanningCouncilService.test.ts
@@ -104,7 +104,7 @@ describe('PlanningCouncilService', () => {
     expect(executeRoutineMock).toHaveBeenCalledWith(
       'core-routine-plan-project-task',
       expect.stringContaining('"original_blocker":"Exact blocker"'),
-      { allowConcurrent: true, routineKind: 'planning' },
+      { allowConcurrent: true, routineKind: 'planning', waitForCapacity: true },
     );
     expect(attachExecutionMock).toHaveBeenCalledWith('planning-1', 'wfp-1');
     expect(addCommentMock).toHaveBeenCalledWith(expect.objectContaining({

--- a/pkg/rancher-desktop/main/sullaRoutineTemplateEvents.ts
+++ b/pkg/rancher-desktop/main/sullaRoutineTemplateEvents.ts
@@ -674,6 +674,8 @@ export interface RoutineExecutionOptions {
   onSettled?:          (result: { executionId: string; status: 'completed' | 'failed'; error?: string; outcome?: unknown }) => void | Promise<void>;
   /** Internal only: concurrency is guarded by a task-scoped durable ledger. */
   allowConcurrent?:   boolean;
+  /** Queue behind protected-routine capacity instead of failing on backpressure. */
+  waitForCapacity?:   boolean;
   /** Protected automation class used by the global mechanical-work limiter. */
   routineKind?: 'planning' | 'execution' | 'review' | 'repair' | 'dreaming' | 'other';
 }
@@ -698,16 +700,6 @@ export async function executeRoutine(
   const graphExecutionId = options?.executionId ?? `routine-exec-${ Date.now().toString(36) }-${ Math.random().toString(36).slice(2, 8) }`;
   const WS_CHANNEL = 'sulla-desktop';
 
-  const { GraphRegistry } = await import('@pkg/agent/services/GraphRegistry');
-  const { activateWorkflowOnState } = await import('@pkg/agent/tools/workflow/execute_workflow');
-
-  const graphResult = await GraphRegistry.getOrCreateAgentGraph(WS_CHANNEL, graphExecutionId);
-  const graph = (graphResult as { graph: unknown }).graph as { execute: (state: unknown) => Promise<unknown> };
-  const state = (graphResult as { state: Record<string, any> }).state;
-
-  state.metadata = state.metadata ?? {};
-  state.metadata.scopedWorkflowId = workflowId;
-
   // Pass through the user payload as-is. When empty, the playbook's
   // createPlaybookState will substitute the routine framing into the
   // trigger node's output. Do NOT synthesize a "Run routine X" string —
@@ -717,14 +709,27 @@ export async function executeRoutine(
   if (protectedKind && await RoutineConcurrencyPolicy.isEnabled()) {
     await RoutineConcurrencyPolicy.reclaimStale();
     const limit = await RoutineConcurrencyPolicy.resolveLimit(protectedKind);
-    routineSlotId = await RoutineConcurrencyPolicy.acquire(protectedKind, limit, {
+    const slotContext = {
       owner:  options?.executionId ?? workflowId,
       taskId: options?.executionScope?.taskId,
-    });
+    };
+    routineSlotId = options?.waitForCapacity
+      ? await RoutineConcurrencyPolicy.acquireWhenAvailable(protectedKind, limit, slotContext)
+      : await RoutineConcurrencyPolicy.acquire(protectedKind, limit, slotContext);
     if (!routineSlotId) {
       throw new Error(`Routine concurrency limit reached for ${ protectedKind } work.`);
     }
   }
+
+  // Do not create a graph or playbook driver until capacity is owned. A
+  // queued planning council must not leave orphan threads while waiting.
+  const { GraphRegistry } = await import('@pkg/agent/services/GraphRegistry');
+  const { activateWorkflowOnState } = await import('@pkg/agent/tools/workflow/execute_workflow');
+  const graphResult = await GraphRegistry.getOrCreateAgentGraph(WS_CHANNEL, graphExecutionId);
+  const graph = (graphResult as { graph: unknown }).graph as { execute: (state: unknown) => Promise<unknown> };
+  const state = (graphResult as { state: Record<string, any> }).state;
+  state.metadata = state.metadata ?? {};
+  state.metadata.scopedWorkflowId = workflowId;
 
   let activation;
   try {


### PR DESCRIPTION
## Summary

- Queue protected planning councils behind the durable routine-capacity slot instead of failing on contention.
- Acquire capacity before creating a graph/playbook driver, preventing queued orphan threads.
- Make planning-run recovery aware of linked workflow status/leases and stop startup recovery from reclaiming healthy councils.
- Fence late sub-agent callbacks and continuations after terminal workflow settlement.

## Validation

- `node --experimental-vm-modules node_modules/.bin/jest pkg/rancher-desktop/agent/services/__tests__/PlanningCouncilService.test.ts pkg/rancher-desktop/agent/database/models/__tests__/WorkTaskPlanningRunModel.test.ts --runInBand` — 2 suites, 14 tests passed.
- esbuild bundle/parse passed for all changed runtime files.
- `git diff --check` passed.
- Live `workflow_executions` query reproduced the five reported `recovery_attempt_ceiling` failures.

Closes the AVtE planning-council launch-storm dispatch at the reversible draft-PR edge. No merge, deploy, restart, or Projects mutation performed.