### PR TITLE
fix: persist playbook sub-agent transcripts

### DIFF
--- a/pkg/rancher-desktop/agent/controllers/PlaybookController.ts
+++ b/pkg/rancher-desktop/agent/controllers/PlaybookController.ts
@@ -56,6 +56,7 @@ const ORCHESTRATOR_REENTRY_MAX_MS = parseInt(
 import { throwIfAborted } from '../services/AbortService';
 import { getConversationLogger } from '../services/ConversationLogger';
 import { getWebSocketClientService } from '../services/WebSocketClientService';
+import { ChatMessageModel } from '../database/models/ChatMessageModel';
 import {
   processNextStep,
   resolveDecision,
@@ -2420,7 +2421,20 @@ export class PlaybookController<TState = any> {
         `Sub-agent "${ agentId || nodeId }"`,
         () => graph.execute(subState),
       );
+
     } finally {
+      // Persist the graph turn even when the provider/worker throws after
+      // emitting messages. This closes the crash window between playbook
+      // nodes and leaves a truthful partial transcript for recovery readers.
+      const persistedState = finalState || subState;
+      await ChatMessageModel.saveThreadState(threadId, {
+        thread: {
+          id:       threadId,
+          title:    String((persistedState as any)?.metadata?.agent?.name || agentId || nodeId),
+          messages: Array.isArray((persistedState as any)?.messages) ? (persistedState as any).messages : [],
+        },
+      });
+
       // Deregister from the parent's active-sub-agents list. Must run on
       // every exit path — success, contract-violation, or thrown error —
       // so an abort that fans out to stale threadIds doesn't see zombies.

--- a/pkg/rancher-desktop/agent/tools/browser/__tests__/search_conversations.test.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/__tests__/search_conversations.test.ts
@@ -1,0 +1,93 @@
+/** @jest-environment node */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const mockGetByThread = jest.fn<any>();
+const mockGetById = jest.fn<any>();
+const mockLoadThreadState = jest.fn<any>();
+const mockLoadThreadsByThreadId = jest.fn<any>();
+const mockQuery = jest.fn<any>();
+
+jest.unstable_mockModule('@pkg/agent/database/models/ConversationHistoryModel', () => ({
+  ConversationHistoryModel: {
+    getByThread: mockGetByThread,
+    getById: mockGetById,
+  },
+}));
+jest.unstable_mockModule('@pkg/agent/database/models/ChatMessageModel', () => ({
+  ChatMessageModel: {
+    loadThreadState: mockLoadThreadState,
+    loadThreadsByThreadId: mockLoadThreadsByThreadId,
+  },
+}));
+jest.unstable_mockModule('@pkg/agent/database/PostgresClient', () => ({
+  postgresClient: { query: mockQuery },
+}));
+
+async function loadWorker() {
+  const { SearchConversationsWorker } = await import('../search_conversations');
+  const worker = new SearchConversationsWorker();
+  worker.schemaDef = { action: { type: 'string', optional: true }, id: { type: 'string', optional: true }, threadId: { type: 'string', optional: true } };
+  return worker;
+}
+
+describe('SearchConversationsWorker transcript recovery', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sulla-search-conversations-'));
+    mockGetByThread.mockReset();
+    mockGetById.mockReset();
+    mockLoadThreadState.mockReset().mockResolvedValue(null);
+    mockLoadThreadsByThreadId.mockReset().mockResolvedValue([]);
+    mockQuery.mockReset().mockResolvedValue([]);
+  });
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it('falls back to conversation_history.log_file and includes messages plus tool events', async() => {
+    const logFile = path.join(tmpDir, 'worker.jsonl');
+    fs.writeFileSync(logFile, [
+      JSON.stringify({ type: 'message', role: 'user', content: 'plan this' }),
+      JSON.stringify({ type: 'tool_call', toolName: 'file_search' }),
+      JSON.stringify({ type: 'message', role: 'assistant', content: 'I found the relevant files.' }),
+      JSON.stringify({ type: 'graph_completed', status: 'completed' }),
+    ].join('\n') + '\n');
+    mockGetByThread.mockResolvedValue({ title: 'Planner A', thread_id: 'worker-1', log_file: logFile, last_active_at: '2026-08-31T00:00:00.000Z' });
+
+    const result = await (await loadWorker()).invoke({ action: 'messages', threadId: 'worker-1' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('USER: plan this');
+    expect(result.result).toContain('[tool_call: file_search]');
+    expect(result.result).toContain('ASSISTANT: I found the relevant files.');
+    expect(result.result).not.toContain('INCOMPLETE TRANSCRIPT');
+  });
+
+  it('reports a missing JSONL file as incomplete instead of claiming no failure', async() => {
+    const missing = path.join(tmpDir, 'missing.jsonl');
+    mockGetByThread.mockResolvedValue({ title: 'Planner B', thread_id: 'worker-2', log_file: missing });
+
+    const result = await (await loadWorker()).invoke({ action: 'messages', threadId: 'worker-2' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('Incomplete transcript');
+    expect(result.result).toContain('log file is missing');
+  });
+
+  it('marks valid messages with malformed JSONL as incomplete', async() => {
+    const logFile = path.join(tmpDir, 'partial.jsonl');
+    fs.writeFileSync(logFile, '{"type":"message","role":"assistant","content":"partial"}\nnot-json\n');
+    mockGetByThread.mockResolvedValue({ title: 'Planner C', thread_id: 'worker-3', log_file: logFile });
+
+    const result = await (await loadWorker()).invoke({ action: 'messages', threadId: 'worker-3' });
+
+    expect(result.success).toBe(true);
+    expect(result.result).toContain('INCOMPLETE TRANSCRIPT');
+    expect(result.result).toContain('ASSISTANT: partial');
+    expect(result.result).toContain('1 malformed JSONL line');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/browser/search_conversations.ts
+++ b/pkg/rancher-desktop/agent/tools/browser/search_conversations.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import readline from 'node:readline';
+
 import { BaseTool, ToolResponse } from '../base';
 
 import { ChatMessageModel } from '@pkg/agent/database/models/ChatMessageModel';
@@ -52,6 +55,63 @@ function buildTranscript(messages: Array<{ role?: string; content?: any }>): str
     transcript = `… [earlier turns omitted]\n\n${ transcript.slice(-TRANSCRIPT_CHAR_BUDGET) }`;
   }
   return transcript;
+}
+
+type LogTranscript = {
+  messages: Array<{ role?: string; content?: any }>;
+  complete: boolean;
+  incompleteReason?: string;
+};
+
+/** Read a conversation_history.log_file without claiming a complete transcript
+ * when the file is absent, truncated, or contains malformed JSONL. */
+async function readLogTranscript(logFile: string): Promise<LogTranscript> {
+  if (!fs.existsSync(logFile)) {
+    return { messages: [], complete: false, incompleteReason: `log file is missing (${ logFile })` };
+  }
+
+  const messages: Array<{ role?: string; content?: any }> = [];
+  let malformedLines = 0;
+  let sawCompletion = false;
+  const fileStream = fs.createReadStream(logFile, { encoding: 'utf-8' });
+  const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let event: any;
+      try {
+        event = JSON.parse(trimmed);
+      } catch {
+        malformedLines++;
+        continue;
+      }
+
+      if (event.type === 'message' && event.role && event.content != null) {
+        messages.push({ role: event.role, content: event.content });
+      } else if (event.type === 'tool_call') {
+        messages.push({
+          role: 'assistant',
+          content: `[tool_call: ${ event.toolName || 'tool' }]`,
+        });
+      } else if (event.type === 'graph_completed') {
+        sawCompletion = event.status === 'completed';
+      }
+    }
+  } finally {
+    rl.close();
+  }
+
+  const incompleteReason = malformedLines > 0
+    ? `${ malformedLines } malformed JSONL line(s)`
+    : (!sawCompletion ? 'no completed graph event' : undefined);
+
+  return {
+    messages,
+    complete: !incompleteReason,
+    ...(incompleteReason ? { incompleteReason } : {}),
+  };
 }
 
 /**
@@ -208,15 +268,30 @@ export class SearchConversationsWorker extends BaseTool {
           }
         }
 
+        // 3) Last-resort durable source: conversation_history.log_file. Keep
+        // the incomplete marker explicit; a partial JSONL stream is evidence
+        // of partial work, never a fabricated completed transcript.
+        let logTranscript: LogTranscript | null = null;
+        if (messages.length === 0 && record?.log_file) {
+          logTranscript = await readLogTranscript(record.log_file);
+          messages = logTranscript.messages;
+        }
+
         if (messages.length === 0) {
+          const incomplete = logTranscript?.incompleteReason
+            ? ` Incomplete transcript: ${ logTranscript.incompleteReason }.`
+            : '';
           return {
             successBoolean: true,
-            responseString: `No stored transcript found for ${ input.threadId ? `threadId "${ input.threadId }"` : `id "${ input.id }"` }.${ record ? ` (Conversation "${ title }" exists but its messages are not retrievable.)` : '' }`,
+            responseString: `${ incomplete || `No stored transcript found for ${ input.threadId ? `threadId "${ input.threadId }"` : `id "${ input.id }"` }.` }${ record ? ` (Conversation "${ title }" exists but its messages are not retrievable.)` : '' }`,
           };
         }
 
         const transcript = buildTranscript(messages);
-        const header = `Conversation: ${ title }${ record?.last_active_at ? ` — last active ${ new Date(record.last_active_at).toLocaleString() }` : '' } (${ messages.length } messages stored)`;
+        const completeness = logTranscript && !logTranscript.complete
+          ? ` INCOMPLETE TRANSCRIPT: ${ logTranscript.incompleteReason }.`
+          : '';
+        const header = `Conversation: ${ title }${ record?.last_active_at ? ` — last active ${ new Date(record.last_active_at).toLocaleString() }` : '' } (${ messages.length } messages stored)${ completeness }`;
 
         return {
           successBoolean: true,


### PR DESCRIPTION
## What changed

- Persist each playbook sub-agent graph state in `chat_messages` from the `finally` path, including partial state when a worker throws.
- Add `conversation_history.log_file` as the final `search_conversations(action:"messages")` fallback.
- Parse message and tool-call JSONL events and mark missing, malformed, or not-yet-completed logs as incomplete instead of claiming completion.
- Add focused recovery tests for complete, missing, and malformed worker logs.

## Validation

- `git diff --check` passed.
- Focused Jest and ESLint could not complete in this checkout: Jest/ESLint stall during startup; the repository `yarn lint:typescript:nofix` wrapper is also incompatible with the installed ESLint because it passes the removed `--nofix` option.

Acceptance remains gated on the migrated/runtime council integration test covering three planners plus synthesis and durable checkpoint settlement.