### PR TITLE
fix(workflow): continue active runs after sub-agent completion

### DIFF
--- a/pkg/rancher-desktop/agent/controllers/PlaybookController.ts
+++ b/pkg/rancher-desktop/agent/controllers/PlaybookController.ts
@@ -71,6 +71,7 @@ import {
 } from '../workflow/lockedCoreRoutineExecution';
 
 import type { WorkflowPlaybookState, PlaybookNodeOutput } from '../workflow/types';
+import { shouldWakeWorkflowConversation } from '../workflow/workflowContinuation';
 
 // ============================================================================
 // PLAYBOOK DEBUG LOGGER
@@ -2634,7 +2635,12 @@ export class PlaybookController<TState = any> {
     }
 
     const meta = (state as any).metadata;
-    if (meta?.waitingForUser || meta?.cycleComplete) {
+    // Workflow continuations must re-enter the playbook while an active
+    // workflow is still running. These flags can be inherited from the
+    // surrounding chat state (and are intentionally used for normal chat
+    // wake-ups), but treating them as idle here strands a completed child at
+    // the frontier and leaves the execution running forever.
+    if (shouldWakeWorkflowConversation(meta)) {
       const channel = meta?.wsChannel;
       const threadId = meta?.threadId;
       if (channel && threadId) {

--- a/pkg/rancher-desktop/agent/controllers/__tests__/PlaybookController.continuation.test.ts
+++ b/pkg/rancher-desktop/agent/controllers/__tests__/PlaybookController.continuation.test.ts
@@ -1,0 +1,20 @@
+import { shouldWakeWorkflowConversation } from '../../workflow/workflowContinuation';
+
+describe('workflow sub-agent continuation routing', () => {
+  it('re-enters a running workflow even when chat metadata is waiting', () => {
+    expect(shouldWakeWorkflowConversation({
+      waitingForUser: true,
+      activeWorkflow: { status: 'running' },
+    })).toBe(false);
+  });
+
+  it('wakes an idle chat when no workflow is running', () => {
+    expect(shouldWakeWorkflowConversation({ waitingForUser: true })).toBe(true);
+    expect(shouldWakeWorkflowConversation({ cycleComplete: true })).toBe(true);
+  });
+
+  it('does not wake when neither workflow nor chat needs continuation', () => {
+    expect(shouldWakeWorkflowConversation({ activeWorkflow: { status: 'completed' } })).toBe(false);
+    expect(shouldWakeWorkflowConversation(undefined)).toBe(false);
+  });
+});

--- a/pkg/rancher-desktop/agent/workflow/workflowContinuation.ts
+++ b/pkg/rancher-desktop/agent/workflow/workflowContinuation.ts
@@ -1,0 +1,9 @@
+/**
+ * Chat wake-ups are only valid once the workflow has stopped owning the
+ * graph. A running workflow must always be continued through the playbook
+ * walker, even when its surrounding chat state says it is waiting or idle.
+ */
+export function shouldWakeWorkflowConversation(metadata: Record<string, any> | undefined): boolean {
+  return metadata?.activeWorkflow?.status !== 'running' &&
+    Boolean(metadata?.waitingForUser || metadata?.cycleComplete);
+}


### PR DESCRIPTION
## Summary

Fixes workflow continuation after an async sub-agent completes while the surrounding chat metadata still has waitingForUser/cycleComplete set.

## Evidence

- Historical run wfp-1787295600034-y23xf6 stopped at Prune Stale Observations after a drained escalation and remained running/ZOMBIE.
- Restarted run wfp-1787295600034-y23xf6-restart-1788204738668 reached the prune child, but parent continuation did not advance; the child archived 17 observations before it completed. All 17 were restored and verified active.
- The fix routes continuation back through the playbook whenever activeWorkflow.status is running.

## Validation

- git diff --check passed.
- Focused Jest test was attempted but hung in the current shared dependency/runtime state; no passing test is claimed.
- Requires rebuild/restart before live runtime acceptance.

Production schedule should remain disarmed until the rebuilt runtime passes a supervised run without unapproved observation mutation and reaches prune/write/done with persisted checkpoints.