### PR TITLE
fix(mcp): add index signature to GraphToolCallResult for SDK assignability

### DIFF
--- a/pkg/rancher-desktop/main/graphToolSurface.ts
+++ b/pkg/rancher-desktop/main/graphToolSurface.ts
@@ -20,6 +20,8 @@
  */
 
 export interface GraphToolCallResult {
+  // Index signature required for assignability to the MCP SDK's CallToolResult.
+  [key: string]: unknown;
   content: { type: 'text'; text: string }[];
   isError?: boolean;
 }


### PR DESCRIPTION
Build break on main from #807: webpack ts-loader rejects the sulla_tool handler because the MCP SDK's CallToolResult type carries an index signature that GraphToolCallResult lacked (TS2345 at MCPServerHost.ts:510). Two-line fix adding the index signature. graphToolSurface.test.ts 9/9. Caught by the 8/31 test build; esbuild transpile-only validation missed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)