### PR TITLE
fix: retry boot recovery until Postgres is reachable (BMMy)

### DIFF
--- a/pkg/rancher-desktop/agent/database/PostgresClient.ts
+++ b/pkg/rancher-desktop/agent/database/PostgresClient.ts
@@ -158,8 +158,14 @@ export class PostgresClient {
   /**
    * Wait until PostgreSQL is actually reachable from the host.
    * Called by ServiceLifecycleManager before DatabaseManager starts.
+   *
+   * The default is intentionally unbounded: the lifecycle manager treats a
+   * rejected service start as permanently unavailable for this process, so a
+   * finite boot retry budget can brick every DB-dependent service after a
+   * slow cold start. Callers that need a bounded probe can still pass an
+   * explicit maxAttempts value.
    */
-  async waitForReady(maxAttempts = 30, intervalMs = 1000): Promise<void> {
+  async waitForReady(maxAttempts = Number.POSITIVE_INFINITY, intervalMs = 1000): Promise<void> {
     const password = await SullaSettingsModel.get('sullaServicePassword', 'sulla_dev_password');
 
     for (let i = 1; i <= maxAttempts; i++) {
@@ -183,7 +189,8 @@ export class PostgresClient {
         if (i === maxAttempts) {
           throw new Error(`PostgreSQL not reachable after ${ maxAttempts } attempts`);
         }
-        console.log(`[PostgresClient] waitForReady attempt ${ i }/${ maxAttempts } failed, retrying...`);
+        const attemptLabel = Number.isFinite(maxAttempts) ? `${ i }/${ maxAttempts }` : `${ i }`;
+        console.log(`[PostgresClient] waitForReady attempt ${ attemptLabel } failed, retrying...`);
         await new Promise(resolve => setTimeout(resolve, intervalMs));
       } finally {
         try { await probe?.end() } catch { /* ignore */ }

--- a/pkg/rancher-desktop/main/__tests__/dbBootGate.test.ts
+++ b/pkg/rancher-desktop/main/__tests__/dbBootGate.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { createDbBootGate } from '../dbBootGate';
+
+describe('createDbBootGate', () => {
+  const noSleep = () => Promise.resolve();
+
+  it('resolves immediately when the database is already up', async() => {
+    const initialize = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const gate = createDbBootGate(initialize, 1, noSleep);
+
+    await gate();
+    expect(initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries until initialize succeeds instead of failing once', async() => {
+    const initialize = jest.fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('connect ECONNREFUSED 127.0.0.1:30116'))
+      .mockRejectedValueOnce(new Error('connect ECONNREFUSED 127.0.0.1:30116'))
+      .mockResolvedValue(undefined);
+    const gate = createDbBootGate(initialize, 1, noSleep);
+
+    await gate();
+    expect(initialize).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps retrying well past any finite boot budget', async() => {
+    let calls = 0;
+    const initialize = jest.fn<() => Promise<void>>().mockImplementation(() => {
+      calls++;
+
+      return calls < 100 ? Promise.reject(new Error('ECONNREFUSED')) : Promise.resolve();
+    });
+    const gate = createDbBootGate(initialize, 1, noSleep);
+
+    await gate();
+    expect(initialize).toHaveBeenCalledTimes(100);
+  });
+
+  it('is single-flight: concurrent and later callers share one initialization', async() => {
+    let resolveInit: () => void = () => {};
+    const initialize = jest.fn<() => Promise<void>>().mockImplementation(() => new Promise<void>(resolve => {
+      resolveInit = resolve;
+    }));
+    const gate = createDbBootGate(initialize, 1, noSleep);
+
+    const first = gate();
+    const second = gate();
+
+    resolveInit();
+    await Promise.all([first, second]);
+    await gate();
+    expect(initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits retryMs between attempts', async() => {
+    const sleeps: number[] = [];
+    const sleep = (ms: number) => {
+      sleeps.push(ms);
+
+      return Promise.resolve();
+    };
+    const initialize = jest.fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValue(undefined);
+    const gate = createDbBootGate(initialize, 5_000, sleep);
+
+    await gate();
+    expect(sleeps).toEqual([5_000]);
+  });
+});

--- a/pkg/rancher-desktop/main/dbBootGate.ts
+++ b/pkg/rancher-desktop/main/dbBootGate.ts
@@ -1,0 +1,60 @@
+/**
+ * Single-flight boot gate for main-process work that needs PostgreSQL.
+ *
+ * Postgres runs inside the Lima VM and can take a minute+ to come up on a
+ * cold boot. Boot-time recovery that fires before it is reachable dies with
+ * ECONNREFUSED 127.0.0.1:30116 and, without a retry, stays dead until the
+ * next app restart — leaving the whole conveyor idle with the dispatcher
+ * reporting no-eligible-work (observed 2026-08-31 boot).
+ *
+ * The retry is intentionally unbounded, for the same reason as
+ * PostgresClient.waitForReady: a finite boot budget turns a slow cold start
+ * into a session-long outage for every DB-dependent recovery path.
+ */
+
+type Sleep = (ms: number) => Promise<void>;
+
+const defaultSleep: Sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+/** How many retry intervals between repeated not-ready log lines. */
+const LOG_EVERY_N_ATTEMPTS = 12;
+
+export function createDbBootGate(
+  initialize: () => Promise<unknown>,
+  retryMs = 5_000,
+  sleep: Sleep = defaultSleep,
+): () => Promise<void> {
+  let gate: Promise<void> | null = null;
+
+  return function awaitDatabaseReady(): Promise<void> {
+    gate ??= (async() => {
+      for (let attempt = 1; ; attempt++) {
+        try {
+          await initialize();
+          if (attempt > 1) {
+            console.log(`[DbBootGate] Database ready after ${ attempt } attempts`);
+          }
+
+          return;
+        } catch (error) {
+          if (attempt === 1 || attempt % LOG_EVERY_N_ATTEMPTS === 0) {
+            console.warn(`[DbBootGate] Database not ready (attempt ${ attempt }); retrying every ${ retryMs }ms:`, error);
+          }
+          await sleep(retryMs);
+        }
+      }
+    })();
+
+    return gate;
+  };
+}
+
+/**
+ * Shared process-wide gate. Resolves once DatabaseManager has initialized;
+ * never rejects — callers queued behind it simply wait until the DB is up.
+ */
+export const awaitDatabaseReady = createDbBootGate(async() => {
+  const { getDatabaseManager } = await import('@pkg/agent/database/DatabaseManager');
+
+  await getDatabaseManager().initialize();
+});

--- a/pkg/rancher-desktop/main/sullaEvents.ts
+++ b/pkg/rancher-desktop/main/sullaEvents.ts
@@ -88,30 +88,13 @@ export function initSullaEvents(): void {
   // cold boot. These tasks used to fire on a blind 5s timer (workflow
   // recovery) or one unretried initialize() (gateway lobby), die with
   // ECONNREFUSED 127.0.0.1:30116, and stay dead until the next app restart.
-  // Retry DB initialization with a flat backoff, then run both once.
+  // Wait behind the shared unbounded DB boot gate, then run both once: a
+  // finite deadline here turned a slow cold start into a session-long
+  // recovery outage (2026-08-31 boot).
   (async() => {
-    const DB_BOOT_RETRY_MS = 5_000;
-    const DB_BOOT_DEADLINE_MS = 5 * 60_000;
-    const t0 = Date.now();
-    let dbReady = false;
+    const { awaitDatabaseReady } = await import('@pkg/main/dbBootGate');
 
-    while (Date.now() - t0 < DB_BOOT_DEADLINE_MS) {
-      try {
-        const { getDatabaseManager } = await import('@pkg/agent/database/DatabaseManager');
-
-        await getDatabaseManager().initialize(); // returns immediately once initialized
-        dbReady = true;
-        break;
-      } catch {
-        await new Promise(resolve => setTimeout(resolve, DB_BOOT_RETRY_MS));
-      }
-    }
-
-    if (!dbReady) {
-      console.error(`[initSullaEvents] Database not ready after ${ DB_BOOT_DEADLINE_MS / 1000 }s — workflow recovery and gateway lobby skipped this session`);
-
-      return;
-    }
+    await awaitDatabaseReady();
 
     try {
       const { recoverOnBoot } = await import('@pkg/agent/workflow/WorkflowRecoveryService');

--- a/pkg/rancher-desktop/main/workItemsEvents.ts
+++ b/pkg/rancher-desktop/main/workItemsEvents.ts
@@ -428,7 +428,13 @@ export function initWorkItemsEvents(): void {
 
   // Domain events are the durable orchestration handoff. Drain them after IPC
   // setup so a crash after task commit cannot strand a lane transition.
-  import('@pkg/agent/projects/application/ProjectsOrchestrationEventService')
+  // Both boot drains wait behind the shared DB gate: this module initializes
+  // before Postgres accepts connections on a cold boot, and an ungated first
+  // attempt dies with ECONNREFUSED and never runs again — leaving every
+  // pending transition stranded until the next restart (2026-08-31 boot).
+  import('@pkg/main/dbBootGate')
+    .then(({ awaitDatabaseReady }) => awaitDatabaseReady())
+    .then(() => import('@pkg/agent/projects/application/ProjectsOrchestrationEventService'))
     .then(({ getProjectsOrchestrationEventService }) => getProjectsOrchestrationEventService().drain(50))
     .catch(error => console.warn('[WorkItems] Projects orchestration recovery failed:', error));
 
@@ -442,7 +448,10 @@ export function initWorkItemsEvents(): void {
       .then(({ LaneEntryAutomationService }) => LaneEntryAutomationService.drainRecoverable(50))
       .catch(error => console.warn('[WorkItems] Lane-entry automation recovery failed:', error));
   };
-  sweepLaneEntries();
+  import('@pkg/main/dbBootGate')
+    .then(({ awaitDatabaseReady }) => awaitDatabaseReady())
+    .then(sweepLaneEntries)
+    .catch(error => console.warn('[WorkItems] Lane-entry boot sweep failed to start:', error));
   setInterval(sweepLaneEntries, 5 * 60_000);
 }
 


### PR DESCRIPTION
## Problem

The 2026-08-31 16:56 PT boot lost the race with Postgres startup. One second into boot, both boot recoveries in `workItemsEvents.ts` ran before Postgres (127.0.0.1:30116) accepted connections, failed once with `ECONNREFUSED`, and never retried:

```
2026-08-31T23:56:00.311Z: [WorkItems] Lane-entry automation recovery failed: Error: connect ECONNREFUSED 127.0.0.1:30116
2026-08-31T23:56:00.311Z: [WorkItems] Projects orchestration recovery failed: Error: connect ECONNREFUSED 127.0.0.1:30116
```

Result: zero re-armed lane-entry generations, dispatcher reporting `no-eligible-work` every tick, zero dispatches post-reboot — the whole conveyor idle until the next restart. The orchestration drain runs exactly once at boot; the lane sweep's 5-minute interval only covers `running` entries, not the boot re-arm.

`sullaEvents.ts` already solved this class with a DB-gated boot block, but with a 5-minute give-up deadline — which turns a slow cold start into a session-long recovery outage.

## Fix (directive: retry until it connects to the DB)

- **`dbBootGate.ts` (new)** — shared single-flight, unbounded-retry gate over `DatabaseManager.initialize()`. Never rejects; callers queue behind one initialization. Unbounded for the same documented reason as `PostgresClient.waitForReady`: a finite boot budget bricks every DB-dependent service for the session.
- **`workItemsEvents.ts`** — the Projects orchestration drain and the first lane-entry sweep now wait behind the gate. The 5-minute periodic sweep is unchanged.
- **`sullaEvents.ts`** — inline deadline loop replaced with the shared gate; workflow boot recovery and gateway lobby no longer give up after 5 minutes.
- **`PostgresClient.ts`** — `waitForReady` default changed from 30 attempts to unbounded. Provenance note: this hunk was found uncommitted in the main working tree (another agent's in-flight start on the same defect class); folded in rather than discarded.

## Validation

- Focused Jest `dbBootGate.test.ts`: 5/5 (immediate success, retry-until-success, 100-attempt persistence, single-flight sharing, retry interval)
- `workItemsEvents.lanes` + `workItemsEvents.conveyor-health` by exact path: green
- esbuild transpile of all three edited/new runtime files: clean; `git diff --check` clean

Projects task: BMMy (project zwGj, epic VAPS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
