### PR TITLE
fix: auto-approve graph-bound Codex MCP tools

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/CodexMcpBridge.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/CodexMcpBridge.test.ts
@@ -14,6 +14,7 @@ describe('CodexService MCP bridge', () => {
     expect(overrides).toEqual([
       'mcp_servers.sulla-native.url="http://host.lima.internal:43123/mcp"',
       'mcp_servers.sulla-native.bearer_token_env_var="SULLA_MCP_SESSION_TOKEN"',
+      'mcp_servers.sulla-native.default_tools_approval_mode="approve"',
     ]);
     expect(CODEX_MCP_TOKEN_ENV).toBe('SULLA_MCP_SESSION_TOKEN');
   });

--- a/pkg/rancher-desktop/agent/languagemodels/codexMcpConfig.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/codexMcpConfig.ts
@@ -33,5 +33,10 @@ export function buildCodexMcpOverrides(session?: CodexMcpSessionConfig | null): 
   return [
     `mcp_servers.sulla-native.url=${ JSON.stringify(session.url) }`,
     `mcp_servers.sulla-native.bearer_token_env_var=${ JSON.stringify(CODEX_MCP_TOKEN_ENV) }`,
+    // The verifier intentionally runs with approval_policy=never.  Codex's
+    // read-only shell sandbox still gates MCP calls unless the graph-bound
+    // server is explicitly trusted, so approve this in-process, allowlisted
+    // surface at the server boundary rather than weakening the shell sandbox.
+    'mcp_servers.sulla-native.default_tools_approval_mode="approve"',
   ];
 }


### PR DESCRIPTION
## Problem

Protected verifier sessions run Codex with `--sandbox read-only`, but Codex separately approval-gates MCP calls. With headless `approval_policy=never`, every graph-projected `sulla_tool` read is auto-denied, so protected reviews fail closed before evidence reads.

## Fix

Set `mcp_servers.sulla-native.default_tools_approval_mode="approve"` on the ephemeral graph-bound MCP session. The server is already graph-allowlisted, read-only, and in-process; this trusts only that projected surface while preserving the read-only shell sandbox and avoiding persistent Codex config changes.

## Validation

- TypeScript transpilation: implementation + sandbox policy + bridge test clean
- Direct emitted override assertion: exact `default_tools_approval_mode="approve"` key
- Verifier sandbox assertion: `--sandbox read-only` unchanged
- `git diff --check`: clean
- Jest could not start because the shared macOS `node_modules` lacks a Linux-compatible `ts-jest` resolution in this Lima VM

Projects task: gOcU
Dispatch: dispatch-3674b775-6cbc-4530-bf52-ffe2cc290594