### PR TITLE
fix(projects): arm lane automation for recovery transitions

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/LifecycleCapabilityModel.ts
@@ -348,6 +348,10 @@ export class LifecycleCapabilityModel {
     `, [taskId, input.actor]);
     if (!updated.rows[0]) return { settled: false, alreadySettled: true };
 
+    const { recordTaskTransitionWithClient } = await import('./TaskTransitionEffects');
+    await recordTaskTransitionWithClient(client, taskId, current.status, updated.rows[0].status,
+      input.actor, 'review-reject');
+
     const receipt = buildReceipt({
       taskId,
       eventType:         'repair',

--- a/pkg/rancher-desktop/agent/database/models/TaskTransitionEffects.ts
+++ b/pkg/rancher-desktop/agent/database/models/TaskTransitionEffects.ts
@@ -1,0 +1,33 @@
+import type { PoolClient } from 'pg';
+
+/** Record the lane-entry generation and transition outbox event for direct task updates. */
+export async function recordTaskTransitionWithClient(
+  client: PoolClient,
+  taskId: string,
+  previousLaneKey: string,
+  nextLaneKey: string,
+  actor: string,
+  source: string,
+): Promise<void> {
+  const { WorkLaneWorkflowBindingModel } = await import('./WorkLaneWorkflowBindingModel');
+  const claimed = await WorkLaneWorkflowBindingModel.claimLaneEntryInTransaction(
+    client, taskId, nextLaneKey, actor,
+  );
+  const { createPostgresProjectsRepositories } = await import('../../projects/infrastructure/PostgresProjectsRepositories');
+  await createPostgresProjectsRepositories(client).events.append({
+    id:             `projects-event-${ taskId }-${ claimed.entry.generation }-transition`,
+    taskId,
+    generation:     claimed.entry.generation,
+    eventType:      'projects.task.transitioned',
+    idempotencyKey: `projects.task.transitioned:${ taskId }:${ claimed.entry.generation }`,
+    occurredAt:     new Date(),
+    payload: {
+      actor,
+      source,
+      fromLane:      previousLaneKey,
+      toLane:        nextLaneKey,
+      laneEntryId:   claimed.entry.id,
+      laneAutomated: claimed.entry.status === 'pending',
+    },
+  });
+}

--- a/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
@@ -357,6 +357,7 @@ export class WorkLaneWorkflowBindingModel {
         LEFT JOIN workflow_executions execution ON execution.execution_id = lane.execution_id
        WHERE lane.workflow_id IS NOT NULL AND (
          lane.status = 'pending'
+         OR (lane.status = 'failed' AND lane.outcome->>'disposition' IN ('dispatch_failed', 'delegation_failed'))
          OR (lane.status = 'running' AND (
            execution.execution_id IS NULL OR execution.status IN ('completed', 'failed')
            OR (execution.status IN ('running', 'suspended')
@@ -375,6 +376,18 @@ export class WorkLaneWorkflowBindingModel {
        WHERE id = $1 AND status = 'pending' AND execution_id IS NULL
        RETURNING *
     `, [id, executionId]);
+    return rows[0] ?? null;
+  }
+
+  static async resetFailed(id: string): Promise<LaneEntryAutomationRecord | null> {
+    const rows = await postgresClient.query<LaneEntryAutomationRecord>(`
+      UPDATE work_lane_entry_automations
+         SET execution_id = NULL, status = 'pending', started_at = NULL,
+             completed_at = NULL, outcome = NULL
+       WHERE id = $1 AND status = 'failed'
+         AND outcome->>'disposition' IN ('dispatch_failed', 'delegation_failed')
+       RETURNING *
+    `, [id]);
     return rows[0] ?? null;
   }
 

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDependencyModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDependencyModel.ts
@@ -96,6 +96,7 @@ export interface ClaimabilityExplanation {
   reason: string;
   unresolved: UnresolvedDependency[];
   chain: DependencyChainEntry[];
+  exclusionReasons?: string[];
 }
 
 function normalizeRelation(value?: DependencyRelationType | string | null): DependencyRelationType {
@@ -344,6 +345,60 @@ export class WorkTaskDependencyModel {
   /** Human/agent-facing claimability explanation with the transitive chain. */
   static async explainClaimability(taskId: string, maxDepth = 25): Promise<ClaimabilityExplanation> {
     const unresolved = await this.listUnresolvedDependencies(taskId);
+    const task = await postgresClient.queryOne<{
+      id: string;
+      status: string;
+      archived: boolean;
+      assignee: string | null;
+      labels: string[] | null;
+      epic_status: string | null;
+      project_status: string | null;
+      epic_archived: boolean | null;
+      project_archived: boolean | null;
+      has_active_child: boolean;
+      has_running_dispatch: boolean;
+    }>(`
+      SELECT t.id, t.status, t.archived, t.assignee, t.labels,
+             e.status AS epic_status, p.status AS project_status,
+             e.archived AS epic_archived, p.archived AS project_archived,
+             EXISTS (
+               SELECT 1 FROM work_tasks child
+                WHERE child.parent_id = t.id AND child.archived = false
+                  AND child.status NOT IN ('done', 'cancelled', 'parked')
+             ) AS has_active_child,
+             EXISTS (
+               SELECT 1 FROM work_task_dispatches d
+                WHERE d.task_id = t.id AND d.status = 'running'
+             ) AS has_running_dispatch
+        FROM work_tasks t
+        LEFT JOIN work_epics e ON e.id = t.epic_id
+        LEFT JOIN work_projects p ON p.id = e.project_id
+       WHERE t.id = $1
+    `, [taskId]);
+    const exclusionReasons: string[] = [];
+    if (!task) exclusionReasons.push('task is missing');
+    else {
+      if (task.archived) exclusionReasons.push('task is archived');
+      if (!['todo', 'in_review'].includes(task.status)) {
+        exclusionReasons.push(`status '${ task.status }' is not a claimable execution or review lane`);
+      }
+      if (task.epic_status === null || task.epic_archived) exclusionReasons.push('epic is missing or archived');
+      else if (['done', 'cancelled', 'parked', 'blocked'].includes(task.epic_status)) {
+        exclusionReasons.push(`epic is '${ task.epic_status }'`);
+      }
+      if (task.project_status === null || task.project_archived) exclusionReasons.push('project is missing or archived');
+      else if (['done', 'cancelled', 'parked', 'blocked'].includes(task.project_status)) {
+        exclusionReasons.push(`project is '${ task.project_status }'`);
+      }
+      if (task.assignee && !['heartbeat', 'dispatcher', 'verifier'].includes(task.assignee.toLowerCase())) {
+        exclusionReasons.push(`assignee '${ task.assignee }' is outside autonomous ownership`);
+      }
+      if ((task.labels ?? []).some(label => ['gated', 'decision', 'human', 'manual', 'no-auto-dispatch'].includes(label.trim().toLowerCase()))) {
+        exclusionReasons.push('task has a non-autonomous label');
+      }
+      if (task.has_active_child) exclusionReasons.push('task has open non-terminal children');
+      if (task.has_running_dispatch) exclusionReasons.push('task already has a running dispatch');
+    }
     const chainRows = await postgresClient.query<any>(
       `WITH RECURSIVE chain AS (
          SELECT d.depends_on_task_id AS task_id, d.relation_type, 1 AS depth
@@ -369,10 +424,11 @@ export class WorkTaskDependencyModel {
       depth:        r.depth,
       resolved:     r.status === 'done',
     }));
-    const claimable = unresolved.length === 0;
+    const reasons = [...unresolved.map(u => u.reason), ...exclusionReasons];
+    const claimable = reasons.length === 0;
     const reason = claimable
-      ? `Task ${ taskId } is claimable: no unresolved dependencies.`
-      : `Task ${ taskId } is NOT claimable — ${ unresolved.map(u => u.reason).join('; ') }`;
-    return { taskId, claimable, reason, unresolved, chain };
+      ? `Task ${ taskId } is claimable: no dispatcher or review exclusions.`
+      : `Task ${ taskId } is NOT claimable — ${ reasons.join('; ') }`;
+    return { taskId, claimable, reason, unresolved, chain, exclusionReasons };
   }
 }

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskDispatchModel.ts
@@ -827,7 +827,7 @@ export class WorkTaskDispatchModel {
           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         `, [auditId, task.id, attemptNumber, outcome, reason, task.status, task.assignee, task.last_activity_at]);
 
-        await client.query(`
+        const moved = await client.query<WorkTaskRecord>(`
           WITH inserted AS (
             INSERT INTO work_task_comments (id, task_id, body, author)
             VALUES ($1, $2, $3, 'dispatcher')
@@ -847,6 +847,11 @@ export class WorkTaskDispatchModel {
           `Outcome: ${ nextStatus }/${ nextAssignee }. Undo: ${ undo }.`,
           nextStatus, nextAssignee,
         ]);
+        if (moved.rows[0]) {
+          const { recordTaskTransitionWithClient } = await import('./TaskTransitionEffects');
+          await recordTaskTransitionWithClient(client, task.id, task.status, moved.rows[0].status,
+            TASK_ASSIGNEES.dispatcher, 'orphan-recovery');
+        }
         results.push({ taskId: task.id, outcome, attemptNumber });
       }
       return results;
@@ -1277,6 +1282,11 @@ export class WorkTaskDispatchModel {
       if (!moved.rows[0]) {
         throw new Error(`Task ${ taskId } is no longer owned by dispatch ${ id }`);
       }
+      if (['planning', 'blocked'].includes(moved.rows[0].status)) {
+        const { recordTaskTransitionWithClient } = await import('./TaskTransitionEffects');
+        await recordTaskTransitionWithClient(client, taskId, 'in_progress', moved.rows[0].status,
+          'dispatcher', 'dispatch-outcome');
+      }
       // Finalization is the durable ownership handoff. Releasing the stage
       // claim in this same transaction is required for journal replay after a
       // process death: runClaim's finally block may never execute after
@@ -1602,14 +1612,19 @@ export class WorkTaskDispatchModel {
         artifacts:          [{ type: 'reviewed_artifact', canonicalRef: artifactSha, hash: artifactSha }],
         evidence:           { kind: 'dispatch', ref: id },
       }), 'verifier');
-      await client.query(`
+      const moved = await client.query<WorkTaskRecord>(`
         UPDATE work_tasks
            SET status = $2, assignee = $3, updated_at = now(),
                last_moved_at = now(), last_activity_at = now(),
                last_moved_by = 'verifier',
                completed_at = CASE WHEN $2 = 'done' THEN now() ELSE NULL END
          WHERE id = $1 AND status = 'in_review'
-      `, [taskId, transition.status, transition.assignee]);
+        `, [taskId, transition.status, transition.assignee]);
+        if (moved.rows[0] && ['planning', 'blocked'].includes(moved.rows[0].status)) {
+          const { recordTaskTransitionWithClient } = await import('./TaskTransitionEffects');
+          await recordTaskTransitionWithClient(client, taskId, 'in_review', moved.rows[0].status,
+            'dispatcher', 'dispatch-outcome');
+        }
       return finalVerdict;
     });
   }
@@ -1773,7 +1788,7 @@ export class WorkTaskDispatchModel {
         }), 'verifier');
       }
 
-      await client.query(`
+      const moved = await client.query<WorkTaskRecord>(`
         UPDATE work_tasks
            SET status = $2, assignee = $3, updated_at = now(),
                last_moved_at = now(), last_activity_at = now(),
@@ -1781,6 +1796,11 @@ export class WorkTaskDispatchModel {
                completed_at = CASE WHEN $2 = 'done' THEN now() ELSE NULL END
          WHERE id = $1 AND status = 'in_review'
       `, [taskId, transition.status, transition.assignee]);
+      if (moved.rows[0] && ['planning', 'blocked'].includes(moved.rows[0].status)) {
+        const { recordTaskTransitionWithClient } = await import('./TaskTransitionEffects');
+        await recordTaskTransitionWithClient(client, taskId, 'in_review', moved.rows[0].status,
+          'verifier', 'protected-review-outcome');
+      }
       return finalDisposition;
     });
   }
@@ -1831,12 +1851,17 @@ export class WorkTaskDispatchModel {
           evidence:          { kind: 'dispatch', ref: id },
         }), 'verifier');
       }
-      await client.query(`
+      const moved = await client.query<WorkTaskRecord>(`
         UPDATE work_tasks
            SET status = $2, assignee = $3, updated_at = now(),
                last_moved_at = now(), last_activity_at = now(), last_moved_by = 'verifier'
          WHERE id = $1 AND status = 'in_review'
       `, [taskId, terminal ? 'planning' : 'in_review', terminal ? 'dispatcher' : 'heartbeat']);
+      if (moved.rows[0] && ['planning', 'blocked'].includes(moved.rows[0].status)) {
+        const { recordTaskTransitionWithClient } = await import('./TaskTransitionEffects');
+        await recordTaskTransitionWithClient(client, taskId, 'in_review', moved.rows[0].status,
+          'verifier', 'verification-failure');
+      }
       return true;
     });
   }

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskPlanningRunModel.ts
@@ -111,6 +111,11 @@ export class WorkTaskPlanningRunModel {
            RETURNING *
         `, [taskId, planningLaneKey]);
         claimedTask = moved.rows[0] ?? task;
+        if (moved.rows[0]) {
+          const { recordTaskTransitionWithClient } = await import('./TaskTransitionEffects');
+          await recordTaskTransitionWithClient(client, taskId, task.status, moved.rows[0].status,
+            'planning-council', 'planning-council-claim');
+        }
       }
 
       return { run: inserted.rows[0], task: claimedTask };

--- a/pkg/rancher-desktop/agent/database/models/WorkTaskWaitModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkTaskWaitModel.ts
@@ -199,13 +199,18 @@ export class WorkTaskWaitModel {
          RETURNING *
       `, [id, observation.fingerprint, nextStatus, observation.nextCheckAt, changed, terminal]);
       if (changed || terminal) {
-        await client.query(`
+        const moved = await client.query<{ status: string }>(`
           UPDATE work_tasks
              SET status = $2, assignee = $3, updated_at = now(),
                  last_moved_at = now(), last_activity_at = now(),
                  last_moved_by = 'external-wait-monitor'
            WHERE id = $1 AND status = 'blocked'
         `, [current.task_id, nextStatus === 'failed' ? 'planning' : 'in_review', nextStatus === 'failed' ? 'dispatcher' : 'heartbeat']);
+        if (moved.rows[0]) {
+          const { recordTaskTransitionWithClient } = await import('./TaskTransitionEffects');
+          await recordTaskTransitionWithClient(client, current.task_id, 'blocked', moved.rows[0].status,
+            'external-wait-monitor', 'external-wait');
+        }
       }
       return { changed: changed || terminal, wait: updated.rows[0] ?? null };
     });
@@ -226,12 +231,17 @@ export class WorkTaskWaitModel {
       `, [id, message.slice(0, 2000), nextCheckAt, terminalAfter]);
       const wait = result.rows[0] ?? null;
       if (wait?.status === 'failed') {
-        await client.query(`
+        const moved = await client.query<{ status: string }>(`
           UPDATE work_tasks SET status = 'planning', assignee = 'dispatcher',
             updated_at = now(), last_moved_at = now(), last_activity_at = now(),
             last_moved_by = 'external-wait-monitor'
           WHERE id = $1 AND status = 'blocked'
         `, [wait.task_id]);
+        if (moved.rows[0]) {
+          const { recordTaskTransitionWithClient } = await import('./TaskTransitionEffects');
+          await recordTaskTransitionWithClient(client, wait.task_id, 'blocked', moved.rows[0].status,
+            'external-wait-monitor', 'external-wait-failure');
+        }
       }
       return { terminal: wait?.status === 'failed', wait };
     });

--- a/pkg/rancher-desktop/agent/services/LaneEntryAutomationService.ts
+++ b/pkg/rancher-desktop/agent/services/LaneEntryAutomationService.ts
@@ -144,6 +144,10 @@ export class LaneEntryAutomationService {
           : await WorkLaneWorkflowBindingModel.resetMissingExecution(entry.id, entry.execution_id);
         if (!reset) continue;
       }
+      if (entry.status === 'failed') {
+        const reset = await WorkLaneWorkflowBindingModel.resetFailed(entry.id);
+        if (!reset) continue;
+      }
       results.push(await LaneEntryAutomationService.dispatchEntry(entry.id));
     }
     return results;


### PR DESCRIPTION
## What changed

- Record a lane-entry generation and transition outbox event for direct controller transitions, including review escalation, planning claims, wait recovery, and protected review outcomes.
- Re-arm retryable settled lane automation failures (`dispatch_failed` and `delegation_failed`) during boot recovery.
- Expand `explain_task_claimability` to report the same live exclusions enforced by execution/review claim SQL: status, archived project/epic, ownership, non-autonomous labels, active children, running dispatches, and dependencies.

## Validation

- `git diff --check` passes.
- Focused Jest: 25 tests passed across lane automation, review-reject lifecycle, wait lifecycle, and claimability tooling.
- Full agent typecheck remains blocked by the repository TypeScript heap exhaustion at both default and 4 GB Node heaps. ESLint is blocked by the VM missing the native `oxc-resolver` binding.
- Existing `WorkTaskDispatchModel.test.ts` has six current-main mock-sequencing failures; no new source compiler error was reported after the patch.

Runtime acceptance still requires rebuild/restart and a live transition into planning/blocked with a fresh lane entry and council launch.