### PR TITLE
fix(models): route work-executing sub-agents to the primary model chain

### DIFF
--- a/pkg/rancher-desktop/agent/controllers/PlaybookController.ts
+++ b/pkg/rancher-desktop/agent/controllers/PlaybookController.ts
@@ -1756,6 +1756,9 @@ export class PlaybookController<TState = any> {
               const subPlaybook = createPlaybookState(subDefinition, step.payload);
               subState.metadata.activeWorkflow = subPlaybook;
               subState.metadata.isSubAgent = true;
+              // Workflow-node agents do real work — primary model chain, not
+              // the subconscious observer slot.
+              subState.metadata.modelSlot = 'primary';
 
               const parentChannel = (state as any).metadata?.wsChannel || 'workbench';
               subState.metadata.workflowNodeId = step.nodeId;
@@ -2418,6 +2421,9 @@ export class PlaybookController<TState = any> {
     subState.messages.push({ role: 'user', content: prompt });
 
     subState.metadata.isSubAgent = true;
+    // Workflow-node agents do real work — primary model chain, not the
+    // subconscious observer slot.
+    subState.metadata.modelSlot = 'primary';
     inheritSubAgentToolPolicy(_state, subState, config);
 
     const parentChannel = (_state as any).metadata?.wsChannel || 'workbench';

--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/modelSlotRouting.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/modelSlotRouting.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { resolveModelSlot } from '../modelSlotRouting';
+
+describe('resolveModelSlot', () => {
+  it('routes plain interactive graphs to the primary slot', () => {
+    expect(resolveModelSlot({})).toBe('primary');
+    expect(resolveModelSlot(null)).toBe('primary');
+    expect(resolveModelSlot(undefined)).toBe('primary');
+  });
+
+  it('routes work-executing sub-agents stamped primary to the primary slot', () => {
+    expect(resolveModelSlot({ isSubAgent: true, modelSlot: 'primary' })).toBe('primary');
+  });
+
+  it('routes explicitly stamped observers to the subconscious slot', () => {
+    expect(resolveModelSlot({ isSubAgent: true, modelSlot: 'subconscious' })).toBe('subconscious');
+  });
+
+  it('keeps the legacy heuristic for unmarked sub-agents', () => {
+    expect(resolveModelSlot({ isSubAgent: true })).toBe('subconscious');
+  });
+
+  it('ignores invalid modelSlot values and falls back to the heuristic', () => {
+    expect(resolveModelSlot({ isSubAgent: true, modelSlot: 'fast' })).toBe('subconscious');
+    expect(resolveModelSlot({ modelSlot: 'fast' })).toBe('primary');
+  });
+
+  it('explicit slot wins even without the isSubAgent flag', () => {
+    expect(resolveModelSlot({ modelSlot: 'subconscious' })).toBe('subconscious');
+  });
+});

--- a/pkg/rancher-desktop/agent/languagemodels/modelSlotRouting.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/modelSlotRouting.ts
@@ -1,0 +1,23 @@
+/**
+ * Which configured model slot a graph run should chat through.
+ *
+ * Work-executing agents (mechanical dispatcher workers, protected verifiers,
+ * workflow-node agents, spawned worker agents) must run on the PRIMARY model
+ * chain so autonomous work quality matches interactive chat on every install,
+ * regardless of local configuration (Jonathon directive 2026-09-01). The
+ * subconscious slot is reserved for observation/recall/summarizer agents.
+ *
+ * Resolution order:
+ *   1. `metadata.modelSlot` — explicit graph-stamped slot, always wins.
+ *   2. Legacy heuristic — `isSubAgent` alone implies subconscious. Kept so
+ *      unmarked observer graphs keep their fast tool-emitting chat peer.
+ */
+
+export type ModelSlot = 'primary' | 'subconscious';
+
+export function resolveModelSlot(metadata: Record<string, unknown> | null | undefined): ModelSlot {
+  const explicit = (metadata as any)?.modelSlot;
+  if (explicit === 'primary' || explicit === 'subconscious') return explicit;
+
+  return (metadata as any)?.isSubAgent ? 'subconscious' : 'primary';
+}

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -7,6 +7,7 @@ import { SullaSettingsModel } from '../database/models/SullaSettingsModel';
 import { SystemPromptSectionModel } from '../database/models/SystemPromptSectionModel';
 import { getAgentOverrideService, getPrimaryService, getSecondaryService, getSubconsciousService } from '../languagemodels';
 import { BaseLanguageModel, ChatMessage, NormalizedResponse, FinishReason, type StreamCallbacks } from '../languagemodels/BaseLanguageModel';
+import { resolveModelSlot } from '../languagemodels/modelSlotRouting';
 import { classifyLLMFailure, redactLLMFailureMessage, sameLLMRoute } from '../languagemodels/providerRecovery';
 import { SystemPromptBuilder, type PromptBuildContext, type DbPromptSection, type AgentConfig, type AnthropicSystemBlock } from '../prompts/SystemPromptBuilder';
 import { INTEGRATIONS_INSTRUCTIONS_BLOCK } from '../prompts/environment';
@@ -677,9 +678,8 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
     // Detect provider — use the same routing logic as the LLM call itself
     // so the system prompt's provider-conditional sections (e.g. Anthropic
     // cache blocks vs OpenAI response format) match the model we'll invoke.
-    const isSubAgentForPrompt = !!(state.metadata as any).isSubAgent;
     const overrideLLMForPrompt = await getAgentOverrideService((state.metadata as any).agent);
-    const llm = overrideLLMForPrompt ?? (isSubAgentForPrompt
+    const llm = overrideLLMForPrompt ?? (resolveModelSlot(state.metadata as any) === 'subconscious'
       ? await getSubconsciousService()
       : await getPrimaryService());
     const providerName = llm?.getProviderName?.() || 'anthropic';
@@ -1005,13 +1005,13 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
   ): Promise<NormalizedResponse | null> {
     // Agent-definition override first: an agent whose config.yaml declares
     // model/provider gets its own service instance regardless of role slot.
-    // Otherwise: subconscious agents (observation writer/recall,
-    // summarizer) need a fast tool-emitting chat peer, not the
-    // autonomous Claude-Code-style primary. Route them to the dedicated
-    // subconscious provider (falls back to secondary, then primary).
-    const isSubAgent = !!(state.metadata as any).isSubAgent;
+    // Otherwise route by graph-stamped model slot: work-executing sub-agents
+    // (dispatcher workers/verifiers, workflow nodes, spawned workers) stamp
+    // modelSlot='primary' so autonomous work runs on the primary chain on
+    // every install; only subconscious observers (observation writer/recall,
+    // summarizer) keep the fast subconscious chat peer.
     const agentOverrideLLM = await getAgentOverrideService((state.metadata as any).agent);
-    this.llm = agentOverrideLLM ?? (isSubAgent
+    this.llm = agentOverrideLLM ?? (resolveModelSlot(state.metadata as any) === 'subconscious'
       ? await getSubconsciousService()
       : await getPrimaryService());
 

--- a/pkg/rancher-desktop/agent/services/GraphRegistry.ts
+++ b/pkg/rancher-desktop/agent/services/GraphRegistry.ts
@@ -2062,6 +2062,9 @@ async function buildSubconsciousState(opts: {
       cycleComplete:        false,
       waitingForUser:       false,
       isSubAgent:           true,
+      // Observers are the one sub-agent class that belongs on the fast
+      // subconscious chat peer (see modelSlotRouting.ts).
+      modelSlot:            'subconscious',
       subAgentDepth:        0,
       llmModel,
       llmLocal,

--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -676,6 +676,9 @@ export class TaskDispatcherService {
         state.messages.push({ role: 'user', content: this.buildWorkerPrompt(task, dispatch.id, dispatch.agent_id) });
       }
       state.metadata.isSubAgent = true;
+      // Dispatched workers and verifiers do real work; they must chat through
+      // the primary model chain, not the subconscious observer slot.
+      state.metadata.modelSlot = 'primary';
       state.metadata.subAgentDepth = 1;
       state.metadata.workflowParentChannel = 'task-dispatcher';
       state.metadata.options ??= {};

--- a/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
@@ -120,8 +120,10 @@ export class SpawnAgentWorker extends BaseTool {
         // Inject the task prompt
         subState.messages.push({ role: 'user', content: task.prompt });
 
-        // Mark as sub-agent
+        // Mark as sub-agent. Spawned agents do real delegated work — primary
+        // model chain, not the subconscious observer slot.
         subState.metadata.isSubAgent = true;
+        subState.metadata.modelSlot = 'primary';
         subState.metadata.subAgentDepth = parentDepth + 1;
         subState.metadata.workflowParentChannel = parentChannel;
 


### PR DESCRIPTION
## Problem

Every work-executing sub-agent in the system was silently running on the **subconscious (fast-tier) model** instead of the primary model chain. `BaseNode` routed any state with `isSubAgent=true` to `getSubconsciousService()`, and that flag is stamped by:

- `TaskDispatcherService.runClaim` — mechanical workers **and** protected verifiers
- `PlaybookController` (both sub-workflow and workflow-node agent paths) — planning councils, review classifiers/reviewers
- `spawn_agent` — delegated worker agents

So on any install, autonomous code work, planning, and review ran on whatever the fast tier resolves to, while only interactive chat used the primary model. This violates the invariant: generic workers must point at the primary AI models so behavior is consistent across a production distribution regardless of local configuration (Jonathon, 2026-09-01).

## Fix

New `modelSlotRouting.resolveModelSlot(metadata)`:

1. Explicit graph-stamped `metadata.modelSlot` (`'primary' | 'subconscious'`) always wins.
2. Fallback keeps the legacy heuristic (`isSubAgent` → subconscious) so unmarked observer graphs are unaffected.

Stamped `modelSlot='primary'` at all four work-executing sites, and `modelSlot='subconscious'` explicitly in the GraphRegistry observer factory (observation writers/recall/summarizer are the one class that belongs on the fast peer). Agent-definition overrides still take precedence over both.

## Validation

- `modelSlotRouting.test.ts` 6/6 (precedence, fallback, invalid-value handling)
- Per-file esbuild transpile clean on all six touched files; `git diff --check` clean

## Acceptance after rebuild

A dispatched worker/verifier logs the primary provider/model in its provider trace instead of the subconscious tier; observers continue using the subconscious slot.
