### PR TITLE
fix: durably deliver async sub-agent completions

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0094_durable_agent_completion_delivery.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0094_durable_agent_completion_delivery.ts
@@ -1,0 +1,24 @@
+/**
+ * Migration 0094 — make async sub-agent completion delivery durable.
+ *
+ * The completion report and its graph wake target must survive the parent
+ * process exiting between the worker finishing and the in-process callback.
+ */
+export const up = `
+  ALTER TABLE agent_jobs
+    ADD COLUMN IF NOT EXISTS parent_channel TEXT,
+    ADD COLUMN IF NOT EXISTS parent_thread_id TEXT,
+    ADD COLUMN IF NOT EXISTS completion_delivered_at TIMESTAMPTZ;
+
+  CREATE INDEX IF NOT EXISTS idx_agent_jobs_pending_completion
+    ON agent_jobs (status, completion_delivered_at)
+    WHERE status = 'completed' AND completion_delivered_at IS NULL;
+`;
+
+export const down = `
+  DROP INDEX IF EXISTS idx_agent_jobs_pending_completion;
+  ALTER TABLE agent_jobs
+    DROP COLUMN IF EXISTS completion_delivered_at,
+    DROP COLUMN IF EXISTS parent_thread_id,
+    DROP COLUMN IF EXISTS parent_channel;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0094_durable_agent_completion_delivery.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0094_durable_agent_completion_delivery.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { down, up } from '../0094_durable_agent_completion_delivery';
+
+describe('0094_durable_agent_completion_delivery', () => {
+  it('adds a durable parent target and acknowledgement marker', () => {
+    expect(up).toContain('parent_channel TEXT');
+    expect(up).toContain('parent_thread_id TEXT');
+    expect(up).toContain('completion_delivered_at TIMESTAMPTZ');
+    expect(up).toContain("status = 'completed' AND completion_delivered_at IS NULL");
+    expect(down).toContain('DROP INDEX IF EXISTS idx_agent_jobs_pending_completion');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -80,6 +80,7 @@ import { up as up_0090, down as down_0090 } from './0090_create_work_task_outcom
 import { up as up_0091, down as down_0091 } from './0091_create_dispatcher_liveness';
 import { up as up_0092, down as down_0092 } from './0092_allow_core_lane_bindings';
 import { up as up_0093, down as down_0093 } from './0093_create_meterable_usage_ledger';
+import { up as up_0094, down as down_0094 } from './0094_durable_agent_completion_delivery';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -161,4 +162,5 @@ export const migrationsRegistry = [
   { name: '0091_create_dispatcher_liveness',                         up: up_0091, down: down_0091 },
   { name: '0092_allow_core_lane_bindings',                           up: up_0092, down: down_0092 },
   { name: '0093_create_meterable_usage_ledger',                       up: up_0093, down: down_0093 },
+  { name: '0094_durable_agent_completion_delivery',                   up: up_0094, down: down_0094 },
 ] as const;

--- a/pkg/rancher-desktop/agent/services/AgentCompletionRecoveryService.ts
+++ b/pkg/rancher-desktop/agent/services/AgentCompletionRecoveryService.ts
@@ -1,0 +1,56 @@
+import { getWebSocketClientService } from './WebSocketClientService';
+import { getPendingCompletions, markCompletionDelivered, type AgentJob } from '../tools/agents/jobRegistry';
+
+let recoveryPromise: Promise<void> | null = null;
+const inFlight = new Set<string>();
+
+function wakeContent(job: AgentJob): string {
+  const formatted = job.results.map(result =>
+    `### ${ result.label } [${ result.status.toUpperCase() }]\n${ result.output }`,
+  ).join('\n\n---\n\n');
+  return `[sub-agent job ${ job.jobId } complete — ${ job.results.length } result(s)]\n\n` +
+    'These are the durable results returned by the background sub-agent(s). ' +
+    'Continue your orchestration using them (do NOT call check_agent_jobs for this job):\n\n' +
+    formatted;
+}
+
+/**
+ * Re-deliver completed graph-owned sub-agent reports after process recovery.
+ * Delivery is idempotent at the job level and remains pending if the message
+ * bus is unavailable, so a later boot can retry it.
+ */
+export async function recoverPendingAgentCompletions(): Promise<void> {
+  if (recoveryPromise) return recoveryPromise;
+  recoveryPromise = (async() => {
+    const jobs = await getPendingCompletions();
+    for (const job of jobs) {
+      if (inFlight.has(job.jobId) || !job.parentChannel || !job.parentThreadId) continue;
+      inFlight.add(job.jobId);
+      try {
+        const ws = getWebSocketClientService();
+        await ws.send(job.parentChannel, {
+          type: 'user_message',
+          data: {
+            content: wakeContent(job),
+            threadId: job.parentThreadId,
+            metadata: {
+              source: 'sub_agent_completion',
+              origin: 'spawn_agent_recovery',
+              inputSource: 'system',
+              jobId: job.jobId,
+              recovered: true,
+            },
+          },
+        });
+        await markCompletionDelivered(job.jobId);
+      } catch (error) {
+        console.warn(`[AgentCompletionRecovery] delivery failed for ${ job.jobId }; will retry:`, error);
+      } finally {
+        inFlight.delete(job.jobId);
+      }
+    }
+  })().finally(() => {
+    recoveryPromise = null;
+  });
+  return recoveryPromise;
+}

--- a/pkg/rancher-desktop/agent/services/BackendGraphWebSocketService.ts
+++ b/pkg/rancher-desktop/agent/services/BackendGraphWebSocketService.ts
@@ -5,6 +5,7 @@ import { AbortService } from './AbortService';
 import { GraphRegistry, getAgentIdForTrigger, nextThreadId, nextMessageId } from './GraphRegistry';
 import { getSchedulerService } from './SchedulerService';
 import { getWebSocketClientService, type WebSocketMessage } from './WebSocketClientService';
+import { recoverPendingAgentCompletions } from './AgentCompletionRecoveryService';
 
 import { frontendGraphLogger as console } from '@pkg/agent/utils/agentLogger';
 
@@ -129,6 +130,12 @@ export class BackendGraphWebSocketService {
     // Subscribe to any custom agent channels from ~/sulla/agents/
     this.subscribeToAgentChannels().catch(err =>
       console.warn('[BackendGraphWS] Failed to subscribe to agent channels:', err));
+
+    // The database-backed completion outbox must replay only after the graph
+    // channels are subscribed; otherwise a recovered wake can be emitted into
+    // an empty in-process bus and incorrectly acknowledged as delivered.
+    recoverPendingAgentCompletions().catch(err =>
+      console.warn('[BackendGraphWS] Failed to recover agent completions:', err));
   }
 
   /**

--- a/pkg/rancher-desktop/agent/services/__tests__/AgentCompletionRecoveryService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/AgentCompletionRecoveryService.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const send = jest.fn<(channel: string, message: unknown) => Promise<boolean>>(async() => true);
+const markCompletionDelivered = jest.fn<(jobId: string) => Promise<void>>(async() => undefined);
+const getPendingCompletions = jest.fn(async() => [{
+  jobId: 'agent-job-recovered',
+  status: 'completed',
+  createdAt: 1,
+  finishedAt: 2,
+  taskCount: 1,
+  parentChannel: 'sulla-desktop',
+  parentThreadId: 'parent-thread',
+  results: [{ label: 'worker', status: 'completed', output: 'done', threadId: 'worker-thread' }],
+}]);
+
+jest.unstable_mockModule('../WebSocketClientService', () => ({
+  getWebSocketClientService: jest.fn(() => ({ send })),
+}));
+jest.unstable_mockModule('../../tools/agents/jobRegistry', () => ({
+  getPendingCompletions,
+  markCompletionDelivered,
+}));
+
+describe('AgentCompletionRecoveryService', () => {
+  beforeEach(() => {
+    send.mockClear();
+    markCompletionDelivered.mockClear();
+    getPendingCompletions.mockClear();
+  });
+
+  it('replays the durable report and acknowledges only after the wake send', async() => {
+    const { recoverPendingAgentCompletions } = await import('../AgentCompletionRecoveryService');
+
+    await recoverPendingAgentCompletions();
+
+    expect(send).toHaveBeenCalledWith('sulla-desktop', expect.objectContaining({
+      type: 'user_message',
+      data: expect.objectContaining({
+        threadId: 'parent-thread',
+        metadata: expect.objectContaining({
+          jobId: 'agent-job-recovered',
+          recovered: true,
+        }),
+        content: expect.stringContaining('done'),
+      }),
+    }));
+    expect(markCompletionDelivered).toHaveBeenCalledWith('agent-job-recovered');
+  });
+});

--- a/pkg/rancher-desktop/agent/tools/agents/check_agent_jobs.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/check_agent_jobs.ts
@@ -67,20 +67,21 @@ export class CheckAgentJobsWorker extends BaseTool {
         };
       }
 
-      // Completed — return results and clean up
+      // Completed — return results. Keep an undelivered completion in the
+      // durable outbox so boot recovery can still wake its parent graph.
       const allSuccess = job.results.every(r => r.status === 'completed');
 
       const formatted = job.results.map(r =>
         `### ${ r.label } [${ r.status.toUpperCase() }]\n${ r.output }`,
       ).join('\n\n---\n\n');
 
-      deleteJob(jobId);
+      if (job.completionDeliveredAt) deleteJob(jobId);
 
       return {
         successBoolean: allSuccess,
         responseString: job.results.length === 1
           ? job.results[0].output
-          : `${ job.results.length } sub-agent(s) completed.\n\n${ formatted }`,
+          : `${ job.results.length } sub-agent(s) completed.${ job.completionDeliveredAt ? '' : ' Completion remains queued for parent-graph recovery.' }\n\n${ formatted }`,
       };
     }
 

--- a/pkg/rancher-desktop/agent/tools/agents/jobRegistry.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/jobRegistry.ts
@@ -34,6 +34,9 @@ export interface AgentJob {
   taskCount:  number;
   results:    AgentJobResult[];
   error?:     string;
+  parentChannel?: string;
+  parentThreadId?: string;
+  completionDeliveredAt?: number | null;
 }
 
 const JOB_TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -68,6 +71,9 @@ function rowToJob(r: any): AgentJob {
     taskCount:  Number(r.task_count) || 0,
     results:    Array.isArray(r.results) ? r.results : [],
     error:      r.error ?? undefined,
+    parentChannel: r.parent_channel ?? undefined,
+    parentThreadId: r.parent_thread_id ?? undefined,
+    completionDeliveredAt: r.completion_delivered_at ? new Date(r.completion_delivered_at).getTime() : null,
   };
 }
 
@@ -92,7 +98,7 @@ function ensureBootSweep(): Promise<void> {
 
 // ── API ────────────────────────────────────────────────────────────────
 
-export async function createJob(taskCount: number): Promise<AgentJob> {
+export async function createJob(taskCount: number, parentChannel?: string, parentThreadId?: string): Promise<AgentJob> {
   await ensureBootSweep();
   jobCounter += 1;
   const jobId = `agent-job-${ Date.now() }-${ jobCounter }`;
@@ -103,16 +109,19 @@ export async function createJob(taskCount: number): Promise<AgentJob> {
     finishedAt: null,
     taskCount,
     results:    [],
+    parentChannel,
+    parentThreadId,
+    completionDeliveredAt: null,
   };
 
   jobs.set(jobId, job);
   abortControllers.set(jobId, new AbortController());
 
   await dbWrite(
-    `INSERT INTO agent_jobs (job_id, status, task_count, created_at)
-     VALUES ($1, 'running', $2, to_timestamp($3 / 1000.0))
+    `INSERT INTO agent_jobs (job_id, status, task_count, parent_channel, parent_thread_id, created_at)
+     VALUES ($1, 'running', $2, $4, $5, to_timestamp($3 / 1000.0))
      ON CONFLICT (job_id) DO NOTHING`,
-    [jobId, taskCount, job.createdAt],
+    [jobId, taskCount, job.createdAt, parentChannel ?? null, parentThreadId ?? null],
   );
 
   return job;
@@ -189,7 +198,7 @@ export async function getAllJobs(): Promise<AgentJob[]> {
   return Array.from(jobs.values());
 }
 
-export function completeJob(jobId: string, results: AgentJobResult[]): void {
+export async function completeJob(jobId: string, results: AgentJobResult[]): Promise<void> {
   const job = jobs.get(jobId);
   if (!job) return;
   abortControllers.delete(jobId);
@@ -198,7 +207,7 @@ export function completeJob(jobId: string, results: AgentJobResult[]): void {
   // 'stopped' verdict but record whatever partial results came back.
   if (job.status === 'stopped') {
     job.results = results;
-    void dbWrite(`UPDATE agent_jobs SET results = $2::jsonb WHERE job_id = $1`, [jobId, JSON.stringify(results)]);
+    await dbWrite(`UPDATE agent_jobs SET results = $2::jsonb WHERE job_id = $1`, [jobId, JSON.stringify(results)]);
 
     return;
   }
@@ -207,10 +216,37 @@ export function completeJob(jobId: string, results: AgentJobResult[]): void {
   job.finishedAt = Date.now();
   job.results = results;
 
-  void dbWrite(
-    `UPDATE agent_jobs SET status = 'completed', finished_at = now(), results = $2::jsonb WHERE job_id = $1`,
+  await dbWrite(
+    `UPDATE agent_jobs SET status = 'completed', finished_at = now(), results = $2::jsonb, completion_delivered_at = NULL WHERE job_id = $1`,
     [jobId, JSON.stringify(results)],
   );
+}
+
+/** Mark a persisted completion delivered only after the graph wake was sent. */
+export async function markCompletionDelivered(jobId: string): Promise<void> {
+  const job = jobs.get(jobId);
+  if (job) job.completionDeliveredAt = Date.now();
+  await dbWrite(
+    `UPDATE agent_jobs SET completion_delivered_at = now() WHERE job_id = $1 AND status = 'completed' AND completion_delivered_at IS NULL`,
+    [jobId],
+  );
+}
+
+/** Read completed reports whose graph wake was not durably acknowledged. */
+export async function getPendingCompletions(): Promise<AgentJob[]> {
+  await ensureBootSweep();
+  try {
+    const rows = await postgresClient.query(
+      `SELECT * FROM agent_jobs
+         WHERE status = 'completed' AND completion_delivered_at IS NULL
+           AND parent_channel IS NOT NULL AND parent_thread_id IS NOT NULL
+         ORDER BY finished_at ASC`,
+    ) as any[];
+    return (rows ?? []).map(rowToJob);
+  } catch (err) {
+    console.warn('[jobRegistry] pending completion read failed:', (err as Error).message);
+    return [];
+  }
 }
 
 export function failJob(jobId: string, error: string): void {

--- a/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
+++ b/pkg/rancher-desktop/agent/tools/agents/spawn_agent.ts
@@ -214,7 +214,7 @@ export class SpawnAgentWorker extends BaseTool {
 
     // ── Async mode: fire and forget ─────────────────────────────
     if (async_) {
-      const job = await createJob(tasks.length);
+      const job = await createJob(tasks.length, parentChannel, parentThreadId);
       // Wire this job's abort signal in BEFORE launching, so a stop_agent_job
       // call fans out to every sub-agent this job spawns.
       jobAbortSignal = getJobAbortSignal(job.jobId);
@@ -222,14 +222,16 @@ export class SpawnAgentWorker extends BaseTool {
       // Launch in background — do not await
       executeAll()
         .then(async(results) => {
-          completeJob(job.jobId, results);
+          await completeJob(job.jobId, results);
           console.log(`[spawn_agent] Async job ${ job.jobId } completed — ${ results.length } result(s)`);
           await emitProactiveCompletion(parentChannel, job.jobId, results);
           // Feed the results back INTO the orchestrator's loop, not just onto a
           // UI card. Without this the parent's turn already ended and nothing
           // re-invokes it — the results would strand and the orchestrator would
           // report that the sub-agents "died".
-          wakeParentGraph(parentChannel, parentThreadId, job.jobId, results);
+          const delivered = await wakeParentGraph(parentChannel, parentThreadId, job.jobId, results);
+          const { markCompletionDelivered } = await import('./jobRegistry');
+          if (delivered) await markCompletionDelivered(job.jobId);
         })
         .catch(async(err) => {
           failJob(job.jobId, (err as Error).message);
@@ -283,20 +285,20 @@ export class SpawnAgentWorker extends BaseTool {
 //
 // No-op when there is no parent thread to resume (falls back to card-only,
 // the legacy behaviour).
-function wakeParentGraph(
+async function wakeParentGraph(
   parentChannel: string,
   parentThreadId: string | undefined,
   jobId: string,
   results: AgentJobResult[],
   failureReason?: string,
-): void {
-  if (!parentThreadId) return;
+): Promise<boolean> {
+  if (!parentThreadId) return false;
 
   try {
     const ws = getWebSocketClientService();
     const content = buildWakeContent(jobId, results, failureReason);
 
-    ws.send(parentChannel, {
+    await ws.send(parentChannel, {
       type: 'user_message',
       data: {
         content,
@@ -312,8 +314,10 @@ function wakeParentGraph(
       },
     });
     console.log(`[spawn_agent] Woke parent graph — channel="${ parentChannel }" thread="${ parentThreadId.slice(-8) }" job=${ jobId }`);
+    return true;
   } catch (e) {
     console.warn('[spawn_agent] wakeParentGraph failed:', e);
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary
- persist parent channel/thread targets on async sub-agent jobs
- make completed reports durable until the parent graph wake is acknowledged
- replay unconsumed completions after boot, with focused recovery coverage

## Validation
- `node --experimental-vm-modules node_modules/jest/bin/jest.js pkg/rancher-desktop/agent/services/__tests__/AgentCompletionRecoveryService.test.ts pkg/rancher-desktop/agent/database/migrations/__tests__/0094_durable_agent_completion_delivery.test.ts --runInBand` — 2 suites, 2 tests passed
- prior focused agent/migration/compatibility run — 3 suites, 11 tests passed
- `git diff --check` — passed
- full `tsc` — VM exited 137 from memory pressure
- ESLint/esbuild — blocked by known host-native Darwin bindings mounted in the Linux VM

This is the reversible review edge for Projects task zj21. Merge, rebuild, restart, and live kill/restart acceptance remain human-gated.