### PR TITLE
fix(agent): structurally disallow provider-native sub-agent spawn tools (zj21)

### DIFF
--- a/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/ClaudeCodeService.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 
 import { BaseLanguageModel, type ChatMessage, type NormalizedResponse, type StreamCallbacks, FinishReason, usageTokenTotal } from './BaseLanguageModel';
 import { buildClaudeLaunchCommand } from './claudeLaunchCommand';
+import { BASE_DISALLOWED_TOOLS, SUBCONSCIOUS_NATIVE_TOOL_DENYLIST } from './claudeToolPolicy';
 import { buildEditPatch, buildWritePatch, type FilePatchInfo } from '../util/linePatch';
 import { getMCPServerHost, type RegisteredSession } from '@pkg/main/MCPServerHost';
 import { redisClient } from '../database/RedisClient';
@@ -45,33 +46,11 @@ const perf = Logging.perf;
  * (or ANTHROPIC_API_KEY) and stay out of its auth lifecycle.
  */
 
-/**
- * Base `--disallowedTools` set applied to EVERY claude spawn (primary and
- * subconscious): the built-in AskUserQuestion (routed through the sulla-native
- * MCP tool instead) and Claude Code's built-in task/todo list, which competes
- * with Sulla Projects. See buildSpawnArgs for the full rationale.
- */
-const BASE_DISALLOWED_TOOLS = 'AskUserQuestion TaskCreate TaskUpdate TaskList TaskGet TodoWrite TodoRead';
-
-/**
- * Additional native tools disabled for SUBCONSCIOUS (observer) spawns only.
- *
- * Subconscious agents (observation/identity writers + recalls, summarizer,
- * digester) are OBSERVERS — their entire job is to read the conversation and
- * record memory through their Sulla DB tools. They must never take real action
- * on the host. Their Sulla-registry toolset is already locked down to DB tools
- * via `allowedToolNames`, but that gate does NOT govern Claude Code's OWN
- * built-in tools. Spawned with --dangerously-skip-permissions, the CLI would
- * otherwise hand an observer full Read/Write/Edit/Bash/Grep/WebFetch access —
- * so a subconscious pass could (and did) start editing files instead of just
- * observing. Denylisting the native actor tools here makes acting structurally
- * impossible, matching the observer invariant (observers get DB tools only,
- * never filesystem/shell/source-control/browser/code-editing tools).
- *
- * Names include current + legacy aliases (e.g. KillShell/KillBash) so a rename
- * on either side is harmless — an unknown disallowed name is simply ignored.
- */
-const SUBCONSCIOUS_NATIVE_TOOL_DENYLIST = 'Read Write Edit MultiEdit NotebookEdit Bash BashOutput KillShell KillBash Glob Grep WebFetch WebSearch Task SlashCommand';
+// Native-tool policy (BASE_DISALLOWED_TOOLS + SUBCONSCIOUS_NATIVE_TOOL_DENYLIST)
+// lives in claudeToolPolicy.ts so tests can assert it without importing this
+// service's full dependency graph. Includes the zj21 sub-agent spawn lockdown:
+// Task/Agent are disallowed on every spawn — delegation goes through
+// `sulla agents/spawn_agent`, whose completions durably wake the parent graph.
 
 /** Idle timeout for a speculatively-booted process that is never claimed. */
 const PREWARM_IDLE_REAP_MS = 60_000;
@@ -264,6 +243,11 @@ export class ClaudeCodeService extends BaseLanguageModel {
       // (Postgres) — there must be exactly one task system, not a second
       // in-memory to-do list. NOTE: TaskOutput / TaskStop are background-process
       // controls (not the to-do list) and stay enabled.
+      //
+      // Also disable native sub-agent spawning (Task, and its Agent rename).
+      // Provider-native sub-agents report completion to this process only, so
+      // their finished work dies with it; delegation must go through
+      // `sulla agents/spawn_agent`, which durably wakes the parent graph (zj21).
       //
       // Subconscious observers additionally lose the native actor tools
       // (Read/Write/Edit/Bash/…) — see SUBCONSCIOUS_NATIVE_TOOL_DENYLIST.

--- a/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/CodexService.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { BaseLanguageModel, type ChatMessage, type NormalizedResponse, type StreamCallbacks, FinishReason, usageTokenTotal } from './BaseLanguageModel';
 import { bindCodexMcpSession, buildCodexMcpOverrides, CODEX_MCP_TOKEN_ENV } from './codexMcpConfig';
 import { emitCodexToolEvent } from './codexToolEvents';
-import { codexSandboxArgs } from './codexSandboxPolicy';
+import { codexSandboxArgs, CODEX_NATIVE_SPAWN_FEATURE_PINS } from './codexSandboxPolicy';
 import { redisClient } from '../database/RedisClient';
 import { ensureCodexAuthFile, codexAuthPath, codexHomeDir } from '../util/codexAuthFile';
 import { graphBrowserControllerContext } from '../utils/graphBrowserController';
@@ -173,6 +173,12 @@ export class CodexService extends BaseLanguageModel {
     codexArgs.push('--json');
     codexArgs.push(...codexSandboxArgs(!!p.readOnly));
     codexArgs.push('--skip-git-repo-check');
+    // Structurally disallow codex's native sub-agent spawning — delegation
+    // goes through `sulla agents/spawn_agent` so completions durably wake the
+    // parent graph (zj21). See CODEX_NATIVE_SPAWN_FEATURE_PINS.
+    for (const pin of CODEX_NATIVE_SPAWN_FEATURE_PINS) {
+      codexArgs.push('-c', shq(pin));
+    }
     if (p.mcpSession) {
       for (const override of buildCodexMcpOverrides(p.mcpSession)) {
         codexArgs.push('-c', shq(override));

--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/nativeSpawnLockdown.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/nativeSpawnLockdown.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { BASE_DISALLOWED_TOOLS } from '../claudeToolPolicy';
+import { CODEX_NATIVE_SPAWN_FEATURE_PINS } from '../codexSandboxPolicy';
+
+/**
+ * zj21 — provider-native sub-agent spawning is structurally disallowed on
+ * every graph-provisioned CLI session. Natively spawned sub-agents report
+ * completion to the parent CLI process, not the Sulla graph, so their
+ * finished work is silently lost when the process exits. Delegation goes
+ * through `sulla agents/spawn_agent` instead (durable parent-graph wake).
+ */
+describe('native sub-agent spawn lockdown', () => {
+  it('disallows Claude Code native spawn tools (Task + Agent rename) on every spawn', () => {
+    const disallowed = BASE_DISALLOWED_TOOLS.split(' ');
+
+    expect(disallowed).toContain('Task');
+    expect(disallowed).toContain('Agent');
+  });
+
+  it('keeps the base non-spawn denylist intact (todo list + AskUserQuestion)', () => {
+    const disallowed = BASE_DISALLOWED_TOOLS.split(' ');
+
+    for (const tool of ['AskUserQuestion', 'TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet', 'TodoWrite', 'TodoRead']) {
+      expect(disallowed).toContain(tool);
+    }
+    // Background-process controls are NOT the to-do list and stay enabled.
+    expect(disallowed).not.toContain('TaskOutput');
+    expect(disallowed).not.toContain('TaskStop');
+  });
+
+  it('pins codex multi-agent features off so user config cannot re-enable them', () => {
+    expect(CODEX_NATIVE_SPAWN_FEATURE_PINS).toContain('features.multi_agent=false');
+    expect(CODEX_NATIVE_SPAWN_FEATURE_PINS).toContain('features.multi_agent_v2=false');
+    // Every pin must be an explicit `key=false` — a pin that enables anything
+    // does not belong in a lockdown list.
+    for (const pin of CODEX_NATIVE_SPAWN_FEATURE_PINS) {
+      expect(pin).toMatch(/^features\.[a-z0-9_]+=false$/);
+    }
+  });
+});

--- a/pkg/rancher-desktop/agent/languagemodels/claudeToolPolicy.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/claudeToolPolicy.ts
@@ -1,0 +1,39 @@
+/**
+ * Native-tool policy for every `claude` CLI spawn. Kept in its own module
+ * (like codexSandboxPolicy) so tests can assert the policy without importing
+ * the full ClaudeCodeService dependency graph.
+ */
+
+/**
+ * Base `--disallowedTools` set applied to EVERY claude spawn (primary and
+ * subconscious): the built-in AskUserQuestion (routed through the sulla-native
+ * MCP tool instead), Claude Code's built-in task/todo list, which competes
+ * with Sulla Projects, and the native sub-agent spawn tools (Task + its Agent
+ * rename). Sub-agent spawning must go through `sulla agents/spawn_agent`, whose
+ * completions durably wake the parent graph — a natively spawned sub-agent
+ * reports only to this (ephemeral) CLI process, so its finished work is
+ * silently lost whenever the process exits before the report lands (zj21).
+ * See ClaudeCodeService.buildSpawnArgs for the full rationale.
+ */
+export const BASE_DISALLOWED_TOOLS = 'AskUserQuestion TaskCreate TaskUpdate TaskList TaskGet TodoWrite TodoRead Task Agent';
+
+/**
+ * Additional native tools disabled for SUBCONSCIOUS (observer) spawns only.
+ *
+ * Subconscious agents (observation/identity writers + recalls, summarizer,
+ * digester) are OBSERVERS — their entire job is to read the conversation and
+ * record memory through their Sulla DB tools. They must never take real action
+ * on the host. Their Sulla-registry toolset is already locked down to DB tools
+ * via `allowedToolNames`, but that gate does NOT govern Claude Code's OWN
+ * built-in tools. Spawned with --dangerously-skip-permissions, the CLI would
+ * otherwise hand an observer full Read/Write/Edit/Bash/Grep/WebFetch access —
+ * so a subconscious pass could (and did) start editing files instead of just
+ * observing. Denylisting the native actor tools here makes acting structurally
+ * impossible, matching the observer invariant (observers get DB tools only,
+ * never filesystem/shell/source-control/browser/code-editing tools).
+ *
+ * Names include current + legacy aliases (e.g. KillShell/KillBash) so a rename
+ * on either side is harmless — an unknown disallowed name is simply ignored.
+ * (Task also appears in BASE_DISALLOWED_TOOLS now; the duplicate is harmless.)
+ */
+export const SUBCONSCIOUS_NATIVE_TOOL_DENYLIST = 'Read Write Edit MultiEdit NotebookEdit Bash BashOutput KillShell KillBash Glob Grep WebFetch WebSearch Task SlashCommand';

--- a/pkg/rancher-desktop/agent/languagemodels/codexSandboxPolicy.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/codexSandboxPolicy.ts
@@ -4,3 +4,22 @@ export function codexSandboxArgs(readOnly: boolean): string[] {
     ? ['--sandbox', 'read-only']
     : ['--dangerously-bypass-approvals-and-sandbox'];
 }
+
+/**
+ * Codex feature pins applied to EVERY graph-provisioned codex spawn:
+ * provider-native sub-agent spawning is structurally disallowed (zj21).
+ *
+ * codex-cli 0.151.0 ships the `multi_agent` feature stable AND enabled by
+ * default, so without an explicit pin every graph session carries a native
+ * spawn surface. Natively spawned sub-agents report completion to the
+ * (ephemeral) parent CLI process rather than the Sulla graph — finished work
+ * is silently lost when that process exits. Delegation must go through
+ * `sulla agents/spawn_agent`, whose results durably wake the parent graph.
+ *
+ * Pinned as `-c` overrides so a user-level ~/.codex/config.toml can never
+ * re-enable them for graph sessions; unknown keys are ignored by older CLIs.
+ */
+export const CODEX_NATIVE_SPAWN_FEATURE_PINS = [
+  'features.multi_agent=false',
+  'features.multi_agent_v2=false',
+];


### PR DESCRIPTION
## Summary
Completes the structural half of Projects task zj21 (directive points 1-2; PR #813 delivered point 3, durable completion delivery). Provider-native sub-agent spawning is now structurally impossible on graph-provisioned CLI sessions — delegation must go through `sulla agents/spawn_agent`, whose completions durably wake the parent graph.

- **Claude Code**: `Task` + `Agent` (its rename) added to `BASE_DISALLOWED_TOOLS`, applied to EVERY claude spawn. Policy consts extracted to `claudeToolPolicy.ts` (mirroring `codexSandboxPolicy.ts`) so tests assert them without the service import graph.
- **Codex**: `-c features.multi_agent=false` / `-c features.multi_agent_v2=false` pinned on every spawn. Verified live: codex-cli 0.151.0 ships `multi_agent` **stable and enabled by default**, and a user-level `~/.codex/config.toml` could otherwise enable it for graph sessions; `-c` overrides win over user config.

## Why
Natively spawned sub-agents report completion only to the ephemeral parent CLI process. Proven 2026-09-01: 4 of 5 finished background audits were silently lost when the parent process exited; 2 of 4 needed zero further tool calls on manual resume — the work was done, the report had nowhere to land.

## Validation
- Focused Jest (`nativeSpawnLockdown` + `CodexService.verifierSandbox`): 2 suites, **5/5 passed**
- `git diff --check` clean; TypeScript `transpileModule` syntax pass on all 4 changed source files
- Full `tsc` and ClaudeCodeService-chain ts-jest compile OOM in the VM (exit 134/137, known limitation, same as #811/#813); esbuild binary blocked by known VM native-binding issue

## Merge gate
Merge requires Jonathon's explicit go. After merge + rebuild/restart, acceptance: a graph-provisioned claude session shows no Task/Agent tool; `codex exec` args carry both feature pins.