### PR TITLE
Make provider failover silent in chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /dist/
 /e2e/reports/
 /go.work.sum
-/node_modules/
+/node_modules
 /resources/cert-manager*
 /resources/darwin/
 /resources/host/

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/jonathonbyrdziak/Sites/sulla/sulla-desktop/node_modules

--- a/pkg/rancher-desktop/agent/languagemodels/GrokService.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/GrokService.ts
@@ -102,6 +102,10 @@ export class GrokService extends OpenAICompatibleService {
     super(config);
   }
 
+  override getProviderName(): string {
+    return 'Grok';
+  }
+
   override getContextWindow(): number {
     return GROK_SUBSCRIPTION_CONTEXT_WINDOWS[this.model] ?? super.getContextWindow();
   }

--- a/pkg/rancher-desktop/agent/languagemodels/__tests__/providerRecovery.test.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/__tests__/providerRecovery.test.ts
@@ -13,6 +13,12 @@ describe('providerRecovery', () => {
       retryPrimary:    false,
       fallbackAllowed: true,
     });
+
+    expect(classifyLLMFailure(new Error("You've hit your session limit · resets 3:50pm"))).toMatchObject({
+      kind:            'quota',
+      retryPrimary:    false,
+      fallbackAllowed: true,
+    });
   });
 
   it('classifies process and stream failures as retryable before fallback', () => {

--- a/pkg/rancher-desktop/agent/languagemodels/providerRecovery.ts
+++ b/pkg/rancher-desktop/agent/languagemodels/providerRecovery.ts
@@ -52,7 +52,13 @@ export function classifyLLMFailure(error: unknown): LLMFailureRecovery {
     };
   }
 
-  if (/\b402\b/.test(lower) || lower.includes('balance exhausted') || lower.includes('usage balance') || lower.includes('weekly limit')) {
+  if (
+    /\b402\b/.test(lower) ||
+    lower.includes('balance exhausted') ||
+    lower.includes('usage balance') ||
+    lower.includes('weekly limit') ||
+    lower.includes('session limit')
+  ) {
     return {
       kind:            'quota',
       retryPrimary:    false,

--- a/pkg/rancher-desktop/agent/nodes/BaseNode.ts
+++ b/pkg/rancher-desktop/agent/nodes/BaseNode.ts
@@ -1354,13 +1354,9 @@ export abstract class BaseNode<T extends BaseThreadState = BaseThreadState> {
               `[${ this.name }:BaseNode] Falling back to secondary provider ` +
               `(from=${ primaryName }/${ primaryId || '(default)' }, to=${ secondaryName }/${ secondaryModel || '(default)' }, reason=${ recovery.kind })`,
             );
-            void this.wsChatMessage(
-              state,
-              `Provider fallback: ${ primaryName }/${ primaryId || '(default)' } → ${ secondaryName }/${ secondaryModel || '(default)' } (${ recovery.kind })`,
-              'system',
-              'progress',
-              { event: 'provider_fallback', fromProvider: primaryName, fromModel: primaryId, toProvider: secondaryName, toModel: secondaryModel, reason: recovery.kind },
-            );
+            // Successful provider failover is intentionally silent in chat.
+            // The warning above retains the diagnostic trail without surfacing
+            // an operational detail that does not require user action.
             const chatMessages = messages.filter(msg =>
               ['system', 'user', 'assistant'].includes(msg.role),
             );


### PR DESCRIPTION
## What changed

- stop posting a chat progress notice when the primary model silently fails over to the configured fallback
- keep the provider handoff in internal warning logs for diagnostics
- give Grok a stable provider label instead of relying on a production-minified class name
- classify Claude Code session-limit responses as quota failures for accurate internal diagnostics

## Validation

- `git diff --check` passed
- BaseNode, GrokService, and providerRecovery bundled successfully with esbuild
- direct classifier assertion passed for Claude session-limit errors
- verified no `Provider fallback:` or `provider_fallback` chat event remains under `pkg/rancher-desktop`
- focused Jest could not start in this Lima VM and timed out without output; CI remains the authoritative Jest run

Projects task: 0EIA