### PR TITLE
fix(projects): handle PostgreSQL Date values in schedule rendering

### DIFF
--- a/pkg/rancher-desktop/pages/ProjectsHome.vue
+++ b/pkg/rancher-desktop/pages/ProjectsHome.vue
@@ -1325,6 +1325,7 @@ import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 
 import type { SemanticStage, WorkConveyorMetricsModel } from '@pkg/agent/database/models/WorkConveyorMetricsModel';
 import type { BackpressureDecision, RoleCounts, WipLimits } from '@pkg/agent/services/ProjectAutomationWipLimits';
+import { formatDateOnly } from '@pkg/agent/utils/formatDateOnly';
 import LaneSettings from '@pkg/components/projects/LaneSettings.vue';
 import ProjectDependencyGraph from '@pkg/components/projects/ProjectDependencyGraph.vue';
 import {
@@ -1797,8 +1798,8 @@ async function onColumnDrop(colKey: string): Promise<void> {
 }
 
 // ══ date helpers ══
-function ymd(iso?: string | null): string {
-  return iso ? iso.slice(0, 10) : '';
+function ymd(value?: unknown): string {
+  return formatDateOnly(value);
 }
 function isoFromYmd(v: string): string | null {
   return v ? new Date(`${ v }T00:00:00`).toISOString() : null;

--- a/pkg/rancher-desktop/pages/__tests__/ProjectsHome.views.test.ts
+++ b/pkg/rancher-desktop/pages/__tests__/ProjectsHome.views.test.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 import { describe, expect, it } from '@jest/globals';
 import { compileScript, compileStyle, compileTemplate, parse } from '@vue/compiler-sfc';
 
+import { formatDateOnly } from '../../agent/utils/formatDateOnly';
+
 const source = fs.readFileSync('pkg/rancher-desktop/pages/ProjectsHome.vue', 'utf8');
 
 describe('Projects multi-view contract', () => {
@@ -21,6 +23,15 @@ describe('Projects multi-view contract', () => {
     expect(source).toContain('Unscheduled work');
     expect(source).toContain('const TABLE_RENDER_LIMIT = 500');
     expect(source).toContain('visibleTasks.slice(0, TABLE_RENDER_LIMIT)');
+  });
+
+  it('formats PostgreSQL Date values through the shared date boundary helper', () => {
+    expect(formatDateOnly(new Date('2026-09-01T18:00:00.000Z'))).toBe('2026-09-01');
+    expect(formatDateOnly('2026-09-01T18:00:00.000Z')).toBe('2026-09-01');
+    expect(formatDateOnly(null)).toBe('');
+    expect(source).toContain("import { formatDateOnly } from '@pkg/agent/utils/formatDateOnly'");
+    expect(source).toContain('return formatDateOnly(value);');
+    expect(source).not.toContain("return iso ? iso.slice(0, 10) : '';");
   });
 
   it('compiles the real light/dark SFC render and style paths without diagnostics', () => {


### PR DESCRIPTION
## Problem

Projects board data loads successfully, but the renderer enters a high-CPU `e.slice is not a function` loop when PostgreSQL `timestamptz` values cross Electron IPC as `Date` objects. ProjectsHome had reintroduced the unsafe string-only date formatting pattern previously fixed for identity observations in commit `ce77a1b4b4`.

## Fix

- Route Projects schedule dates through the existing `formatDateOnly(value: unknown)` boundary helper.
- Preserve ISO string and missing-date behavior.
- Add a Projects regression test with a real `Date` payload and assert the unsafe direct `.slice()` path is absent.

## Validation

- Focused Jest: 2 suites, 13/13 tests passed.
- Real Projects SFC script/template/style compilation passed.
- esbuild parse passed.
- `git diff --check` passed.
- Focused ESLint: 0 errors; 66 pre-existing template-style warnings.

Projects task: `NXoX`.

Merge and rebuild remain human-gated.