### PR TITLE
fix(projects): preserve lane-owned workflow executions on retry

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneWorkflowBindingModel.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { WorkTaskDependencyModel } from './WorkTaskDependencyModel';
+import { DISPATCHER_RECONCILED_LANE_MESSAGE } from './WorkflowExecutionModel';
 
 import { postgresClient } from '../PostgresClient';
 
@@ -354,10 +355,23 @@ export class WorkLaneWorkflowBindingModel {
              execution.error AS workflow_execution_error,
              execution.lease_expires_at
         FROM work_lane_entry_automations lane
+        JOIN work_tasks task ON task.id = lane.task_id
+          AND task.archived = false AND task.status = lane.lane_key
+        JOIN work_projects project ON project.id = task.project_id AND project.archived = false
+        JOIN work_epics epic ON epic.id = task.epic_id AND epic.archived = false
         LEFT JOIN workflow_executions execution ON execution.execution_id = lane.execution_id
-       WHERE lane.workflow_id IS NOT NULL AND (
+       WHERE lane.workflow_id IS NOT NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM work_lane_entry_automations newer
+            WHERE newer.task_id = lane.task_id AND newer.generation > lane.generation
+         )
+         AND (
          lane.status = 'pending'
-         OR (lane.status = 'failed' AND lane.outcome->>'disposition' IN ('dispatch_failed', 'delegation_failed'))
+         OR (lane.status = 'failed' AND (
+           lane.outcome->>'disposition' IN ('dispatch_failed', 'delegation_failed')
+           OR (lane.outcome->>'disposition' = 'runtime_failed'
+               AND lane.outcome->>'message' = '${ DISPATCHER_RECONCILED_LANE_MESSAGE }')
+         ))
          OR (lane.status = 'running' AND (
            execution.execution_id IS NULL OR execution.status IN ('completed', 'failed')
            OR (execution.status IN ('running', 'suspended')
@@ -381,12 +395,20 @@ export class WorkLaneWorkflowBindingModel {
 
   static async resetFailed(id: string): Promise<LaneEntryAutomationRecord | null> {
     const rows = await postgresClient.query<LaneEntryAutomationRecord>(`
-      UPDATE work_lane_entry_automations
+      UPDATE work_lane_entry_automations lane
          SET execution_id = NULL, status = 'pending', started_at = NULL,
              completed_at = NULL, outcome = NULL
-       WHERE id = $1 AND status = 'failed'
-         AND outcome->>'disposition' IN ('dispatch_failed', 'delegation_failed')
-       RETURNING *
+        FROM work_tasks task
+       WHERE lane.id = $1 AND lane.status = 'failed'
+         AND task.id = lane.task_id AND task.archived = false AND task.status = lane.lane_key
+         AND NOT EXISTS (
+           SELECT 1 FROM work_lane_entry_automations newer
+            WHERE newer.task_id = lane.task_id AND newer.generation > lane.generation
+         )
+         AND (lane.outcome->>'disposition' IN ('dispatch_failed', 'delegation_failed')
+              OR (lane.outcome->>'disposition' = 'runtime_failed'
+                  AND lane.outcome->>'message' = '${ DISPATCHER_RECONCILED_LANE_MESSAGE }'))
+       RETURNING lane.*
     `, [id]);
     return rows[0] ?? null;
   }

--- a/pkg/rancher-desktop/agent/database/models/WorkflowExecutionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkflowExecutionModel.ts
@@ -29,6 +29,13 @@ interface WorkflowExecutionAttributes {
   terminal_reason:  string | null;
 }
 
+/**
+ * Outcome message the dispatcher reconciler writes when it fails a running
+ * lane automation row. Lane boot retry keys on this exact marker to reclaim
+ * rows the reconciler killed, so the two sites must never drift apart.
+ */
+export const DISPATCHER_RECONCILED_LANE_MESSAGE = 'dispatcher workflow execution reconciled';
+
 export class WorkflowExecutionModel extends BaseModel<WorkflowExecutionAttributes> {
   protected readonly tableName = 'workflow_executions';
   protected readonly primaryKey = 'execution_id';
@@ -158,7 +165,13 @@ export class WorkflowExecutionModel extends BaseModel<WorkflowExecutionAttribute
     return rows.map(WorkflowExecutionModel.hydrate);
   }
 
-  /** The dispatcher is the sole recovery authority for scoped executions. */
+  /**
+   * The dispatcher is the recovery authority for dispatch-parented scoped
+   * executions only. Lane-entry automations launch scoped executions with no
+   * work_task_dispatches parent at all (their parent is the lane entry), so a
+   * scoped execution bound to a running lane automation must be left alone --
+   * LaneEntryAutomationService.drainRecoverable() owns that recovery path.
+   */
   static async reconcileDispatcherOwnedExecutions(): Promise<string[]> {
     return postgresClient.transaction(async(client) => {
       const rows = await client.query<{ execution_id: string }>(`
@@ -170,6 +183,11 @@ export class WorkflowExecutionModel extends BaseModel<WorkflowExecutionAttribute
           WHERE execution.scope_task_id IS NOT NULL
             AND execution.status IN ('running', 'suspended')
             AND (dispatch.id IS NULL OR dispatch.status <> 'running')
+            AND NOT EXISTS (
+              SELECT 1 FROM work_lane_entry_automations lane
+              WHERE lane.execution_id = execution.execution_id
+                AND lane.status = 'running'
+            )
           FOR UPDATE OF execution
         ), settled AS (
           UPDATE workflow_executions execution
@@ -192,7 +210,7 @@ export class WorkflowExecutionModel extends BaseModel<WorkflowExecutionAttribute
         WHERE workflow_execution_id = ANY($1::text[]) AND status = 'running'`, [executionIds]);
       await client.query(`UPDATE work_lane_entry_automations
         SET status = 'failed',
-            outcome = jsonb_build_object('disposition', 'runtime_failed', 'message', 'dispatcher workflow execution reconciled'),
+            outcome = jsonb_build_object('disposition', 'runtime_failed', 'message', '${ DISPATCHER_RECONCILED_LANE_MESSAGE }'),
             completed_at = COALESCE(completed_at, NOW())
         WHERE execution_id = ANY($1::text[]) AND status = 'running'`, [executionIds]);
       return executionIds;

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.postgres.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.postgres.test.ts
@@ -9,11 +9,14 @@ import { up as createWorkItems } from '../../migrations/0044_create_work_items_t
 import { up as addWorkTaskActor } from '../../migrations/0047_add_work_task_actor';
 import { up as addCoreWorkflowFields } from '../../migrations/0055_add_system_and_content_hash_to_workflows';
 import { up as addWorkTaskActivity } from '../../migrations/0061_add_work_task_activity';
+import { up as createWorkTaskDispatches } from '../../migrations/0062_create_work_task_dispatches';
+import { up as addVerificationDispatches } from '../../migrations/0064_add_verification_dispatches';
 import { up as createLaneDefinitions } from '../../migrations/0069_create_work_lane_definitions';
 import { up as createLaneWorkflowBindings } from '../../migrations/0070_create_lane_workflow_bindings';
 import { up as scopeLaneWorkflowExecutions } from '../../migrations/0071_scope_lane_workflow_executions';
 import { up as createPlanningRuns } from '../../migrations/0072_create_work_task_planning_runs';
 import { up as addProjectViewsAndScheduling } from '../../migrations/0075_add_project_views_and_scheduling';
+import { up as extendDispatchCustody } from '../../migrations/0076_extend_work_task_dispatch_custody';
 import { up as addWorkflowExecutionLeases } from '../../migrations/0081_add_workflow_execution_leases';
 import { up as createWorkTaskDependencies } from '../../migrations/0083_create_work_task_dependencies';
 import { up as createProjectsDomainEventOutbox } from '../../migrations/0086_create_projects_domain_event_outbox';
@@ -22,7 +25,7 @@ import {
   LANE_ENTRY_INPUT_ENVELOPE, LANE_OUTCOME_OUTPUT_ENVELOPE,
   WorkLaneWorkflowBindingModel,
 } from '../WorkLaneWorkflowBindingModel';
-import { WorkflowExecutionModel } from '../WorkflowExecutionModel';
+import { DISPATCHER_RECONCILED_LANE_MESSAGE, WorkflowExecutionModel } from '../WorkflowExecutionModel';
 
 const connectionString = process.env.SULLA_INTEGRATION_POSTGRES_URL;
 const describeWithPostgres = connectionString ? describe : describe.skip;
@@ -41,6 +44,9 @@ describeWithPostgres('WorkLaneWorkflowBindingModel migrated PostgreSQL integrati
     await pool.query(createWorkItems);
     await pool.query(addWorkTaskActor);
     await pool.query(addWorkTaskActivity);
+    await pool.query(createWorkTaskDispatches);
+    await pool.query(addVerificationDispatches);
+    await pool.query(extendDispatchCustody);
     await pool.query(createLaneDefinitions);
     await pool.query(createLaneWorkflowBindings);
     await pool.query(scopeLaneWorkflowExecutions);
@@ -349,5 +355,76 @@ describeWithPostgres('WorkLaneWorkflowBindingModel migrated PostgreSQL integrati
       status:       'failed',
       outcome:      { disposition: 'runtime_failed', message: 'runtime failure' },
     });
+  }, 30_000);
+
+  it('reconciles only dispatcher-parented orphans, spares live lane automations, and boot-retries reconciled rows', async() => {
+    await pool.query(`
+      INSERT INTO work_tasks (id, project_id, epic_id, title, status)
+      VALUES ('task-reconcile', 'project-1', 'epic-1', 'Reconcile task', 'backlog');
+    `);
+    jest.spyOn(LaneEntryAutomationService, 'dispatchEntry').mockImplementation(async(id) =>
+      (await WorkLaneWorkflowBindingModel.getLaneEntry(id))!);
+
+    await WorkItemsModel.updateTask('task-reconcile', { status: 'todo', actor: 'integration-test' });
+    const laneEntry = (await WorkLaneWorkflowBindingModel.listLaneEntries('task-reconcile'))[0];
+    const laneExecution = 'lane-exec-task-reconcile-1';
+    await WorkLaneWorkflowBindingModel.markStarted(laneEntry.id, laneExecution);
+    await WorkflowExecutionModel.markRunning({
+      executionId:     laneExecution,
+      workflowId:      'workflow-1',
+      workflowName:    'Workflow 1',
+      workflowSlug:    'workflow-1',
+      scopeTaskId:     'task-reconcile',
+      scopeGeneration: 1,
+    });
+    await WorkflowExecutionModel.markRunning({
+      executionId:     'dispatcher-orphan-exec',
+      workflowId:      'workflow-1',
+      workflowName:    'Workflow 1',
+      workflowSlug:    'workflow-1',
+      scopeTaskId:     'task-orphan',
+      scopeGeneration: 1,
+    });
+
+    const reconciled = await WorkflowExecutionModel.reconcileDispatcherOwnedExecutions();
+
+    expect(reconciled).toContain('dispatcher-orphan-exec');
+    expect(reconciled).not.toContain(laneExecution);
+    expect((await pool.query(
+      'SELECT status FROM workflow_executions WHERE execution_id = $1', [laneExecution],
+    )).rows[0]).toMatchObject({ status: 'running' });
+    expect(await WorkLaneWorkflowBindingModel.getLaneEntry(laneEntry.id))
+      .toMatchObject({ status: 'running', execution_id: laneExecution });
+
+    // Rows the pre-fix reconciler already killed must re-enter boot retry.
+    await pool.query(`
+      UPDATE work_lane_entry_automations
+         SET status = 'failed',
+             outcome = jsonb_build_object('disposition', 'runtime_failed', 'message', $1::text),
+             completed_at = now()
+       WHERE id = $2
+    `, [DISPATCHER_RECONCILED_LANE_MESSAGE, laneEntry.id]);
+    await pool.query(
+      'UPDATE workflow_executions SET status = $1, completed_at = now() WHERE execution_id = $2',
+      ['failed', laneExecution]);
+
+    const recoverable = await WorkLaneWorkflowBindingModel.listRecoverable();
+    expect(recoverable.map(row => row.id)).toContain(laneEntry.id);
+    await expect(WorkLaneWorkflowBindingModel.resetFailed(laneEntry.id))
+      .resolves.toMatchObject({ status: 'pending', execution_id: null, outcome: null });
+
+    // A later lane generation makes the old row historical. Boot recovery must
+    // never replay that stale generation, even if it carries a retryable marker.
+    await WorkItemsModel.updateTask('task-reconcile', { status: 'in_review', actor: 'integration-test' });
+    await pool.query(`
+      UPDATE work_lane_entry_automations
+         SET status = 'failed',
+             outcome = jsonb_build_object('disposition', 'runtime_failed', 'message', $1::text),
+             completed_at = now()
+       WHERE id = $2
+    `, [DISPATCHER_RECONCILED_LANE_MESSAGE, laneEntry.id]);
+    expect((await WorkLaneWorkflowBindingModel.listRecoverable()).map(row => row.id))
+      .not.toContain(laneEntry.id);
+    await expect(WorkLaneWorkflowBindingModel.resetFailed(laneEntry.id)).resolves.toBeNull();
   }, 30_000);
 });

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneWorkflowBindingModel.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
 import { postgresClient } from '../../PostgresClient';
 import { WorkTaskDependencyModel } from '../WorkTaskDependencyModel';
+import { DISPATCHER_RECONCILED_LANE_MESSAGE } from '../WorkflowExecutionModel';
 import {
   LANE_ENTRY_INPUT_ENVELOPE, LANE_OUTCOME_OUTPUT_ENVELOPE,
   WorkLaneWorkflowBindingModel,
@@ -114,6 +115,24 @@ describe('WorkLaneWorkflowBindingModel', () => {
     expect(result).toEqual({ created: false, entry: expect.objectContaining({ generation: 4 }) });
     expect(client.query.mock.calls[0][0]).toContain('pg_advisory_xact_lock');
     expect(client.query).toHaveBeenCalledTimes(3);
+  });
+
+  it('boot retry reclaims lane rows the dispatcher reconciler failed, not just dispatch/delegation failures', async() => {
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([]));
+
+    await WorkLaneWorkflowBindingModel.listRecoverable();
+    const listSql = (postgresClient.query as any).mock.calls[0][0];
+    expect(listSql).toContain("IN ('dispatch_failed', 'delegation_failed')");
+    expect(listSql).toContain(`lane.outcome->>'message' = '${ DISPATCHER_RECONCILED_LANE_MESSAGE }'`);
+    expect(listSql).toContain('task.status = lane.lane_key');
+    expect(listSql).toContain('newer.generation > lane.generation');
+
+    await WorkLaneWorkflowBindingModel.resetFailed('entry-1');
+    const resetSql = (postgresClient.query as any).mock.calls[1][0];
+    expect(resetSql).toContain(`outcome->>'message' = '${ DISPATCHER_RECONCILED_LANE_MESSAGE }'`);
+    expect(resetSql).toContain("status = 'pending'");
+    expect(resetSql).toContain('task.status = lane.lane_key');
+    expect(resetSql).toContain('newer.generation > lane.generation');
   });
 
   it('does not let an unresolved dependency block entry into blocked', async() => {


### PR DESCRIPTION
## Problem

Boot recovery re-armed lane automations, but the dispatcher reconciler treated every task-scoped workflow execution as dispatch-owned. Lane-owned planning and review executions have no work_task_dispatches parent, so the reconciler failed them with dispatcher_parent_terminal_or_missing even while their lane-entry parent was running.

The same retry scan could also replay a stale lane generation after the task had already moved on.

## Fix

- Treat a running work_lane_entry_automations row as the durable parent for its workflow execution.
- Keep the existing fail-closed dispatcher-parent guard for executions that have neither a live dispatch nor a running lane parent.
- Make pre-fix reconciler-killed lane rows retryable.
- Restrict recovery and reset to the task current lane and latest generation, excluding archived task, project, and epic state.

## Validation

- 15 of 15 focused Jest tests passed in WorkLaneWorkflowBindingModel.test.ts and LaneEntryAutomationService.test.ts.
- The 0r3A migrated PostgreSQL regression passed in an isolated PostgreSQL 18 instance:
  - true dispatcher orphan reconciled
  - running lane-owned execution preserved
  - current pre-fix killed row re-armed
  - stale generation rejected
- Changed production files bundled successfully with esbuild.
- git diff --check passed.

The full PostgreSQL file also has two unrelated pre-existing failures in dependency-held planning and interrupted-lease fixtures; the new 0r3A regression passes independently.

Projects task: 0r3A
Dispatch: dispatch-1a4bb9e4-594c-4fe3-b95d-e245ca58452d