### PR TITLE
feat(projects): add full-screen issue review and approval gates

### DIFF
--- a/pkg/rancher-desktop/agent/database/migrations/0095_add_lane_human_approval.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/0095_add_lane_human_approval.ts
@@ -1,0 +1,16 @@
+/**
+ * Migration 0095 — let each Projects lane opt into a simple human gate.
+ *
+ * The decision is lane configuration, not PR-head state. Advancing a task
+ * leaves the recorded approval in its append-only comment history and later
+ * GitHub pushes do not revoke it.
+ */
+export const up = `
+  ALTER TABLE work_lane_definitions
+    ADD COLUMN IF NOT EXISTS requires_human_approval BOOLEAN NOT NULL DEFAULT false;
+`;
+
+export const down = `
+  ALTER TABLE work_lane_definitions
+    DROP COLUMN IF EXISTS requires_human_approval;
+`;

--- a/pkg/rancher-desktop/agent/database/migrations/__tests__/0095_add_lane_human_approval.test.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/__tests__/0095_add_lane_human_approval.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { down, up } from '../0095_add_lane_human_approval';
+
+describe('0095_add_lane_human_approval', () => {
+  it('adds an explicit fail-closed lane approval flag', () => {
+    expect(up).toContain('requires_human_approval BOOLEAN NOT NULL DEFAULT false');
+    expect(down).toContain('DROP COLUMN IF EXISTS requires_human_approval');
+  });
+});

--- a/pkg/rancher-desktop/agent/database/migrations/index.ts
+++ b/pkg/rancher-desktop/agent/database/migrations/index.ts
@@ -81,6 +81,7 @@ import { up as up_0091, down as down_0091 } from './0091_create_dispatcher_liven
 import { up as up_0092, down as down_0092 } from './0092_allow_core_lane_bindings';
 import { up as up_0093, down as down_0093 } from './0093_create_meterable_usage_ledger';
 import { up as up_0094, down as down_0094 } from './0094_durable_agent_completion_delivery';
+import { up as up_0095, down as down_0095 } from './0095_add_lane_human_approval';
 
 export const migrationsRegistry = [
   { name: '0001_create_migrations_and_seeders_table', up: up_0001, down: down_0001 },
@@ -163,4 +164,5 @@ export const migrationsRegistry = [
   { name: '0092_allow_core_lane_bindings',                           up: up_0092, down: down_0092 },
   { name: '0093_create_meterable_usage_ledger',                       up: up_0093, down: down_0093 },
   { name: '0094_durable_agent_completion_delivery',                   up: up_0094, down: down_0094 },
+  { name: '0095_add_lane_human_approval',                              up: up_0095, down: down_0095 },
 ] as const;

--- a/pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts
+++ b/pkg/rancher-desktop/agent/database/models/WorkLaneDefinitionModel.ts
@@ -37,6 +37,7 @@ export interface WorkLaneDefinitionRecord {
   enabled:         boolean;
   archived:        boolean;
   system_required: boolean;
+  requires_human_approval: boolean;
   created_by:      string | null;
   updated_by:      string | null;
   created_at:      string;
@@ -63,6 +64,7 @@ export interface CreateWorkLaneInput {
   semantic_role?:   WorkLaneSemanticRole;
   enabled?:         boolean;
   system_required?: boolean;
+  requires_human_approval?: boolean;
   actor?:           string;
 }
 
@@ -74,6 +76,7 @@ export interface UpdateWorkLaneInput {
   position?:      number;
   semantic_role?: WorkLaneSemanticRole;
   enabled?:       boolean;
+  requires_human_approval?: boolean;
   actor?:         string;
 }
 
@@ -192,15 +195,18 @@ export class WorkLaneDefinitionModel {
     const rows = await postgresClient.query<WorkLaneDefinitionRecord>(`
       INSERT INTO work_lane_definitions (
         id, lane_key, scope, project_id, base_lane_key, display_name, description,
-        color, icon, position, semantic_role, enabled, system_required, created_by
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+        color, icon, position, semantic_role, enabled, system_required,
+        requires_human_approval, created_by
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
       RETURNING *
     `, [
       generateId(), laneKey, scope, projectId, scope === 'project' ? baseLaneKey : null,
       input.display_name.trim() || titleFromKey(laneKey), input.description ?? '',
       input.color ?? null, input.icon ?? null, input.position ?? 0,
       input.semantic_role ?? inherited?.semantic_role ?? 'manual', input.enabled ?? true,
-      inherited?.system_required ?? input.system_required ?? false, input.actor ?? 'sulla',
+      inherited?.system_required ?? input.system_required ?? false,
+      input.requires_human_approval ?? inherited?.requires_human_approval ?? false,
+      input.actor ?? 'sulla',
     ]);
     return rows[0];
   }
@@ -232,6 +238,9 @@ export class WorkLaneDefinitionModel {
     if (changes.position !== undefined) assign('position', changes.position);
     if (changes.semantic_role !== undefined) assign('semantic_role', changes.semantic_role);
     if (changes.enabled !== undefined) assign('enabled', changes.enabled);
+    if (changes.requires_human_approval !== undefined) {
+      assign('requires_human_approval', changes.requires_human_approval);
+    }
     values.push(id);
     const rows = await postgresClient.query<WorkLaneDefinitionRecord>(
       `UPDATE work_lane_definitions SET ${ sets.join(', ') } WHERE id = $${ values.length } RETURNING *`, values,
@@ -465,10 +474,12 @@ export class WorkLaneDefinitionModel {
           result = await client.query(`
             INSERT INTO work_lane_definitions (
               id, lane_key, scope, project_id, base_lane_key, display_name, description,
-              color, icon, position, semantic_role, enabled, system_required, created_by
+              color, icon, position, semantic_role, enabled, system_required,
+              requires_human_approval, created_by
             )
             SELECT $1, lane_key, 'project', $2, lane_key, display_name, description,
-              color, icon, $3, semantic_role, enabled, system_required, $4
+              color, icon, $3, semantic_role, enabled, system_required,
+              requires_human_approval, $4
               FROM work_lane_definitions
              WHERE scope = 'global_default' AND project_id IS NULL AND lane_key = $5
                AND reset_at IS NULL
@@ -511,8 +522,9 @@ export class WorkLaneDefinitionModel {
       await postgresClient.query<WorkLaneDefinitionRecord>(`
         INSERT INTO work_lane_definitions (
           id, lane_key, scope, project_id, base_lane_key, display_name, description,
-          color, icon, position, semantic_role, enabled, system_required, created_by
-        ) VALUES ($1, $2, 'global_default', NULL, NULL, $3, '', NULL, NULL, $4, 'manual', true, false, $5)
+          color, icon, position, semantic_role, enabled, system_required,
+          requires_human_approval, created_by
+        ) VALUES ($1, $2, 'global_default', NULL, NULL, $3, '', NULL, NULL, $4, 'manual', true, false, false, $5)
         RETURNING *
       `, [
         generateId(), status,

--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneDefinitionModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneDefinitionModel.test.ts
@@ -19,6 +19,7 @@ function lane(overrides: Partial<WorkLaneDefinitionRecord> = {}): WorkLaneDefini
     enabled:         true,
     archived:        false,
     system_required: false,
+    requires_human_approval: false,
     created_by:      'test',
     updated_by:      null,
     created_at:      '2026-08-23T00:00:00Z',
@@ -70,6 +71,16 @@ describe('WorkLaneDefinitionModel', () => {
     const sql = (postgresClient.query as any).mock.calls[0][0] as string;
     expect(sql).toContain('display_name');
     expect(sql).not.toContain('lane_key =');
+  });
+
+  it('persists a configured human approval gate on a lane', async() => {
+    (postgresClient as any).queryOne = jest.fn(() => Promise.resolve(lane()));
+    (postgresClient as any).query = jest.fn(() => Promise.resolve([lane({ requires_human_approval: true })]));
+
+    await WorkLaneDefinitionModel.update('lane-1', { requires_human_approval: true });
+
+    expect((postgresClient.query as any).mock.calls[0][0]).toContain('requires_human_approval');
+    expect((postgresClient.query as any).mock.calls[0][1]).toContain(true);
   });
 
   it('rejects direct disabling before any lane update can hide populated tasks', async() => {

--- a/pkg/rancher-desktop/agent/services/ProjectsIssueDetailService.ts
+++ b/pkg/rancher-desktop/agent/services/ProjectsIssueDetailService.ts
@@ -1,0 +1,247 @@
+import { Octokit } from '@octokit/rest';
+
+import { extractPullRequestReferences } from './GitHubPullRequestHeadService';
+import { getIntegrationService } from './IntegrationService';
+import { evaluatePullRequestMergeReadiness } from './ProjectsIssueReview';
+import { ArtifactReceiptModel, type ArtifactReceiptRow } from '../database/models/ArtifactReceiptModel';
+import { WorkItemsModel, type WorkCommentRecord, type WorkTaskRecord } from '../database/models/WorkItemsModel';
+import { WorkLaneDefinitionModel } from '../database/models/WorkLaneDefinitionModel';
+import { WorkTaskWaitModel } from '../database/models/WorkTaskWaitModel';
+import { getProjectsApplicationService } from '../projects/application/ProjectsApplicationService';
+
+export interface ProjectsPullRequestBrief {
+  repository:     string;
+  number:         number;
+  url:            string;
+  title:          string;
+  state:          string;
+  draft:          boolean;
+  headSha:        string;
+  headRef:        string;
+  baseRef:        string;
+  mergeable:      boolean | null;
+  mergeableState: string;
+  checks:         { name: string; status: string; conclusion: string | null; url: string | null }[];
+  reviews:        { author: string; state: string; submittedAt: string | null; body: string }[];
+  mergeReady:     boolean;
+  error?:         string;
+}
+
+export interface ProjectsIssueReviewBrief {
+  pullRequests:    ProjectsPullRequestBrief[];
+  reviewEvidence:  string[];
+  documentation:   string[];
+  testResults:     string[];
+  riskNotes:       string[];
+  stagingEvidence: string[];
+  rollbackNotes:   string[];
+}
+
+export interface ProjectsHumanGateBrief {
+  active:        boolean;
+  waitIds:       string[];
+  currentStage:  string;
+  previousStage: string | null;
+  nextStage:     string | null;
+}
+
+export interface ProjectsIssueDetail {
+  task:      WorkTaskRecord;
+  comments:  WorkCommentRecord[];
+  review:    ProjectsIssueReviewBrief;
+  humanGate: ProjectsHumanGateBrief;
+}
+
+type OctokitClient = InstanceType<typeof Octokit>;
+
+function conciseEvidence(value: unknown): string[] {
+  const text = typeof value === 'string' ? value : JSON.stringify(value ?? '');
+  return text.split(/\r?\n/).map(line => line.trim()).filter(Boolean).slice(0, 40);
+}
+
+function matchingNotes(lines: string[], expression: RegExp): string[] {
+  return [...new Set(lines.filter(line => expression.test(line)).map(line => line.slice(0, 700)))].slice(0, 8);
+}
+
+async function githubClient(): Promise<OctokitClient> {
+  const token = await getIntegrationService().getIntegrationValue('github', 'token');
+  if (!token) throw new Error('GitHub is not connected in the vault.');
+  return new Octokit({ auth: token.value });
+}
+
+async function loadPullRequestBriefs(
+  task: WorkTaskRecord,
+  comments: WorkCommentRecord[],
+): Promise<ProjectsPullRequestBrief[]> {
+  const references = extractPullRequestReferences(task.github_issue, comments);
+  if (!references.length) return [];
+
+  let octokit: OctokitClient;
+  try {
+    octokit = await githubClient();
+  } catch (error: any) {
+    return references.map(reference => ({
+      repository:     `${ reference.owner }/${ reference.repo }`,
+      number:         reference.pullNumber,
+      url:            '',
+      title:          '',
+      state:          'unavailable',
+      draft:          false,
+      headSha:        '',
+      headRef:        '',
+      baseRef:        '',
+      mergeable:      null,
+      mergeableState: 'unknown',
+      checks:         [],
+      reviews:        [],
+      mergeReady:     false,
+      error:          error?.message ?? String(error),
+    }));
+  }
+
+  return Promise.all(references.map(async(reference): Promise<ProjectsPullRequestBrief> => {
+    try {
+      const { data: pull } = await octokit.pulls.get({
+        owner: reference.owner, repo: reference.repo, pull_number: reference.pullNumber,
+      });
+      const [checksResponse, reviewsResponse] = await Promise.all([
+        octokit.checks.listForRef({ owner: reference.owner, repo: reference.repo, ref: pull.head.sha, per_page: 100 }),
+        octokit.pulls.listReviews({ owner: reference.owner, repo: reference.repo, pull_number: reference.pullNumber, per_page: 100 }),
+      ]);
+      const checks = checksResponse.data.check_runs.map(run => ({
+        name: run.name, status: run.status, conclusion: run.conclusion ?? null, url: run.html_url ?? null,
+      }));
+      const reviews = reviewsResponse.data.map(review => ({
+        author:      review.user?.login ?? 'unknown',
+        state:       review.state,
+        submittedAt: review.submitted_at ?? null,
+        body:        review.body ?? '',
+      }));
+      const mergeReady = evaluatePullRequestMergeReadiness({
+        state: pull.state, draft: pull.draft === true, mergeable: pull.mergeable, checks, reviews,
+      });
+
+      return {
+        repository:     `${ reference.owner }/${ reference.repo }`,
+        number:         pull.number,
+        url:            pull.html_url,
+        title:          pull.title,
+        state:          pull.merged ? 'merged' : pull.state,
+        draft:          pull.draft === true,
+        headSha:        pull.head.sha,
+        headRef:        pull.head.ref,
+        baseRef:        pull.base.ref,
+        mergeable:      pull.mergeable,
+        mergeableState: pull.mergeable_state,
+        checks,
+        reviews,
+        mergeReady,
+      };
+    } catch (error: any) {
+      return {
+        repository:     `${ reference.owner }/${ reference.repo }`,
+        number:         reference.pullNumber,
+        url:            '',
+        title:          '',
+        state:          'unavailable',
+        draft:          false,
+        headSha:        '',
+        headRef:        '',
+        baseRef:        '',
+        mergeable:      null,
+        mergeableState: 'unknown',
+        checks:         [],
+        reviews:        [],
+        mergeReady:     false,
+        error:          error?.response?.data?.message ?? error?.message ?? String(error),
+      };
+    }
+  }));
+}
+
+function receiptEvidence(receipts: ArtifactReceiptRow[]): string[] {
+  return receipts.flatMap(receipt => [
+    receipt.validation_summary ?? '',
+    receipt.disposition ? `Disposition: ${ receipt.disposition }` : '',
+    ...conciseEvidence(receipt.artifacts),
+  ]).filter(Boolean);
+}
+
+export async function loadProjectsIssueDetail(taskId: string): Promise<ProjectsIssueDetail> {
+  const task = await WorkItemsModel.getTask(taskId);
+  if (!task || task.archived) throw new Error(`Issue ${ taskId } was not found.`);
+  const [comments, receipts, waits, lanes] = await Promise.all([
+    WorkItemsModel.listComments(task.id),
+    ArtifactReceiptModel.listByTask(task.id),
+    WorkTaskWaitModel.list({ taskId: task.id, status: 'active' }),
+    WorkLaneDefinitionModel.resolveEffective(task.project_id),
+  ]);
+  const evidenceLines = [
+    ...comments.flatMap(comment => conciseEvidence(comment.body)),
+    ...receiptEvidence(receipts),
+  ];
+  const humanWaits = waits.filter(wait => wait.wait_kind === 'human_gate');
+  const stageIndex = lanes.findIndex(lane => lane.lane_key === task.status && lane.enabled && !lane.archived);
+  const currentLane = stageIndex >= 0 ? lanes[stageIndex] : null;
+
+  return {
+    task,
+    comments,
+    review: {
+      pullRequests:    await loadPullRequestBriefs(task, comments),
+      reviewEvidence:  receiptEvidence(receipts).slice(0, 12),
+      documentation:   matchingNotes(evidenceLines, /\b(documentation|docs?|readme|runbook)\b/i),
+      testResults:     matchingNotes(evidenceLines, /\b(test(?:s|ed|ing)?|jest|vitest|playwright|passed|failed)\b/i),
+      riskNotes:       matchingNotes(evidenceLines, /\b(risk|regression|security|privacy|tenant|danger)\b/i),
+      stagingEvidence: matchingNotes(evidenceLines, /\b(staging|smoke test|acceptance|runtime verification)\b/i),
+      rollbackNotes:   matchingNotes(evidenceLines, /\b(rollback|revert|undo|recovery)\b/i),
+    },
+    humanGate: {
+      active:        currentLane?.requires_human_approval === true || humanWaits.length > 0,
+      waitIds:       humanWaits.map(wait => wait.id),
+      currentStage:  task.status,
+      previousStage: stageIndex > 0 ? lanes[stageIndex - 1].lane_key : null,
+      nextStage:     stageIndex >= 0 && stageIndex < lanes.length - 1 ? lanes[stageIndex + 1].lane_key : null,
+    },
+  };
+}
+
+export async function decideProjectsHumanGate(
+  taskId: string,
+  decision: 'approved' | 'rejected',
+  reason: string,
+  expectedStage: string,
+): Promise<ProjectsIssueDetail> {
+  const before = await loadProjectsIssueDetail(taskId);
+  if (!expectedStage || before.task.status !== expectedStage) {
+    throw new Error(`This issue moved from ${ expectedStage || 'an unknown stage' } to ${ before.task.status }. Refresh before deciding.`);
+  }
+  if (!before.humanGate.active) throw new Error('This issue is not at an active human approval gate.');
+  if (decision === 'approved' && !before.humanGate.nextStage) throw new Error('No next pipeline stage is configured.');
+  if (decision === 'rejected' && !before.humanGate.previousStage) throw new Error('No previous pipeline stage is configured.');
+  const normalizedReason = reason.trim();
+  if (decision === 'rejected' && !normalizedReason) throw new Error('A rejection reason is required.');
+
+  const decidedAt = new Date().toISOString();
+  const projects = getProjectsApplicationService();
+  await projects.transitionTaskRelative({
+    taskId,
+    direction: decision === 'approved' ? 'next' : 'previous',
+  }, { actor: 'human', source: 'ipc' });
+  await projects.addComment({
+    task_id: taskId,
+    author:  'human',
+    body:    [
+      `Human gate ${ decision }.`,
+      'Decision by: human',
+      `Recorded at: ${ decidedAt }`,
+      normalizedReason ? `Reason: ${ normalizedReason }` : '',
+      decision === 'approved'
+        ? 'This decision advanced the configured Projects pipeline only. No merge, deployment, payment, or external communication was performed.'
+        : 'This decision returned the issue to the previous configured pipeline stage for repair.',
+    ].filter(Boolean).join('\n'),
+  }, { actor: 'human', source: 'ipc' });
+  await Promise.all(before.humanGate.waitIds.map(waitId =>
+    WorkTaskWaitModel.cancel(waitId, `Human gate ${ decision } by human at ${ decidedAt }`)));
+  return loadProjectsIssueDetail(taskId);
+}

--- a/pkg/rancher-desktop/agent/services/ProjectsIssueReview.ts
+++ b/pkg/rancher-desktop/agent/services/ProjectsIssueReview.ts
@@ -1,0 +1,28 @@
+export interface MergeReadinessCheck {
+  status:     string;
+  conclusion: string | null;
+}
+
+export interface MergeReadinessReview {
+  state: string;
+}
+
+/**
+ * A conservative, deterministic summary only. The UI never treats this as
+ * authority to merge and a human gate remains independent of the PR head.
+ */
+export function evaluatePullRequestMergeReadiness(input: {
+  state:     string;
+  draft:     boolean;
+  mergeable: boolean | null;
+  checks:    MergeReadinessCheck[];
+  reviews:   MergeReadinessReview[];
+}): boolean {
+  const successful = new Set(['success', 'neutral', 'skipped']);
+  const checksReady = input.checks.length > 0 && input.checks.every(check =>
+    check.status === 'completed' && successful.has(check.conclusion ?? ''));
+  const reviewBlocked = input.reviews.some(review => review.state === 'CHANGES_REQUESTED');
+
+  return input.state === 'open' && !input.draft && input.mergeable === true &&
+    checksReady && !reviewBlocked;
+}

--- a/pkg/rancher-desktop/agent/services/__tests__/ProjectsIssueDetailService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/ProjectsIssueDetailService.test.ts
@@ -1,0 +1,34 @@
+import { evaluatePullRequestMergeReadiness } from '../ProjectsIssueReview';
+
+const successCheck = { name: 'build', status: 'completed', conclusion: 'success', url: null };
+
+describe('Projects issue review readiness', () => {
+  it('requires an open non-draft mergeable PR with completed successful checks', () => {
+    expect(evaluatePullRequestMergeReadiness({
+      state: 'open', draft: false, mergeable: true, checks: [successCheck], reviews: [],
+    })).toBe(true);
+    expect(evaluatePullRequestMergeReadiness({
+      state: 'open', draft: true, mergeable: true, checks: [successCheck], reviews: [],
+    })).toBe(false);
+    expect(evaluatePullRequestMergeReadiness({
+      state: 'open', draft: false, mergeable: true, checks: [], reviews: [],
+    })).toBe(false);
+  });
+
+  it('fails closed for pending checks and requested changes', () => {
+    expect(evaluatePullRequestMergeReadiness({
+      state:     'open',
+      draft:     false,
+      mergeable: true,
+      checks:    [{ ...successCheck, status: 'in_progress', conclusion: null }],
+      reviews:   [],
+    })).toBe(false);
+    expect(evaluatePullRequestMergeReadiness({
+      state:     'open',
+      draft:     false,
+      mergeable: true,
+      checks:    [successCheck],
+      reviews:   [{ state: 'CHANGES_REQUESTED' }],
+    })).toBe(false);
+  });
+});

--- a/pkg/rancher-desktop/components/projects/LaneSettings.vue
+++ b/pkg/rancher-desktop/components/projects/LaneSettings.vue
@@ -75,6 +75,7 @@
           <div class="ls-badges">
             <span>{{ provenanceLabel(lane) }}</span>
             <span>{{ lane.semantic_role }}</span>
+            <span v-if="lane.requires_human_approval">human approval</span>
             <span v-if="lane.system_required">protected required</span>
             <span v-if="lane.archived">archived</span>
             <span v-else>{{ lane.semantic_role === 'manual' ? 'manual' : 'automated-capable' }}</span>
@@ -200,6 +201,10 @@
             </select>
           </label>
         </div>
+        <label class="ls-check">
+          <input v-model="editor.requiresHumanApproval" type="checkbox">
+          Require a human approval before this lane can advance
+        </label>
         <div class="ls-footer">
           <button
             type="submit"
@@ -419,6 +424,7 @@ const editor = reactive({
   description:  '',
   color:        '#5096b3',
   semanticRole: 'manual' as WorkLaneSemanticRole,
+  requiresHumanApproval: false,
 });
 const archiveDialog = reactive({
   open: false, lane: null as EffectiveWorkLane | null, preview: null as ArchiveWorkLanePreview | null, destination: '',
@@ -461,10 +467,10 @@ function provenanceLabel(lane: EffectiveWorkLane): string {
 }
 
 function openCreate(): void {
-  Object.assign(editor, { open: true, create: true, lane: null, laneKey: '', displayName: '', description: '', color: '#5096b3', semanticRole: 'manual' });
+  Object.assign(editor, { open: true, create: true, lane: null, laneKey: '', displayName: '', description: '', color: '#5096b3', semanticRole: 'manual', requiresHumanApproval: false });
 }
 function openEdit(lane: EffectiveWorkLane): void {
-  Object.assign(editor, { open: true, create: false, lane, laneKey: lane.lane_key, displayName: lane.display_name, description: lane.description, color: lane.color || '#5096b3', semanticRole: lane.semantic_role });
+  Object.assign(editor, { open: true, create: false, lane, laneKey: lane.lane_key, displayName: lane.display_name, description: lane.description, color: lane.color || '#5096b3', semanticRole: lane.semantic_role, requiresHumanApproval: lane.requires_human_approval });
 }
 async function saveLane(): Promise<void> {
   await run(async() => {
@@ -477,6 +483,7 @@ async function saveLane(): Promise<void> {
         description:   editor.description,
         color:         editor.color,
         semantic_role: editor.semanticRole,
+        requires_human_approval: editor.requiresHumanApproval,
         position:      lanes.value.length,
       });
     } else if (editor.lane) {
@@ -492,9 +499,10 @@ async function saveLane(): Promise<void> {
           icon:          editor.lane.icon,
           position:      editor.lane.position,
           semantic_role: editor.semanticRole,
+          requires_human_approval: editor.requiresHumanApproval,
         });
       } else {
-        await updateLane(editor.lane.id, { display_name: editor.displayName, description: editor.description, color: editor.color, semantic_role: editor.semanticRole });
+        await updateLane(editor.lane.id, { display_name: editor.displayName, description: editor.description, color: editor.color, semantic_role: editor.semanticRole, requires_human_approval: editor.requiresHumanApproval });
       }
     }
     editor.open = false; message.value = 'Lane saved.'; await reload(); emit('refresh');
@@ -688,7 +696,9 @@ defineExpose({ openEdit, openAssignment });
 .ls-modal { width: 480px; max-width: calc(100vw - 40px); max-height: calc(100vh - 50px); overflow: auto; background: var(--psurface); border: 1px solid var(--pborder); border-radius: 14px; padding: 22px; box-shadow: 0 30px 80px rgba(0,0,0,.5); }
 .ls-modal.wide { width: 620px; }
 .ls-modal label { display: grid; gap: 5px; margin-top: 14px; color: var(--ptext2); font-size: 12px; }
-.ls-modal input:not([type=radio]), .ls-modal textarea, .ls-modal select { width: 100%; background: var(--psurface2); border: 1px solid var(--pborder); border-radius: 7px; color: var(--ptext); padding: 8px; }
+.ls-modal input:not([type=radio]):not([type=checkbox]), .ls-modal textarea, .ls-modal select { width: 100%; background: var(--psurface2); border: 1px solid var(--pborder); border-radius: 7px; color: var(--ptext); padding: 8px; }
+.ls-modal .ls-check { display: flex; align-items: flex-start; gap: 8px; }
+.ls-check input { margin-top: 2px; accent-color: var(--pacc); }
 .ls-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }.ls-modal fieldset { margin-top: 14px; border: 1px solid var(--pborder); border-radius: 8px; }.ls-modal fieldset label { display: flex; align-items: center; }
 .ls-provenance { margin-top: 15px; padding: 12px; background: var(--psurface2); border-radius: 8px; font-size: 12px; }.ls-provenance ol { padding-left: 20px; color: var(--ptext3); }.ls-provenance li.effective { color: var(--pacc); font-weight: 600; }
 .ls-footer { display: flex; gap: 8px; margin-top: 20px; }.ls-footer button { border: 1px solid var(--pborder); border-radius: 7px; }

--- a/pkg/rancher-desktop/components/projects/ProjectIssueDetail.vue
+++ b/pkg/rancher-desktop/components/projects/ProjectIssueDetail.vue
@@ -1,0 +1,418 @@
+<template>
+  <main
+    ref="detailRoot"
+    class="issue-detail"
+    tabindex="-1"
+    aria-labelledby="issue-detail-title"
+    @keydown.esc="$emit('close')"
+  >
+    <header class="issue-topbar">
+      <button
+        type="button"
+        class="back"
+        aria-label="Back to Projects"
+        @click="$emit('close')"
+      >
+        ← Projects
+      </button>
+      <span class="issue-id">ISSUE · {{ taskId }}</span>
+      <button
+        type="button"
+        class="refresh"
+        :disabled="loading"
+        @click="$emit('refresh')"
+      >
+        {{ loading ? 'Refreshing…' : '↻ Refresh' }}
+      </button>
+    </header>
+
+    <div
+      v-if="loading && !detail"
+      class="issue-state"
+      role="status"
+    >
+      Loading issue and live review state…
+    </div>
+    <div
+      v-else-if="error"
+      class="issue-state error"
+      role="alert"
+    >
+      <b>Couldn't load this issue.</b>
+      <p>{{ error }}</p>
+      <button
+        type="button"
+        @click="$emit('refresh')"
+      >
+        Try again
+      </button>
+    </div>
+
+    <div
+      v-else-if="detail"
+      class="issue-layout"
+    >
+      <article class="issue-main">
+        <div class="issue-heading">
+          <div class="eyebrow">
+            {{ projectTitle }} · {{ epicTitle }}
+          </div>
+          <h1 id="issue-detail-title">
+            {{ detail.task.title }}
+          </h1>
+          <div class="meta">
+            <span>{{ statusLabel(detail.task.status) }}</span>
+            <span>{{ detail.task.priority }}</span>
+            <span v-if="detail.task.assignee">{{ detail.task.assignee }}</span>
+            <span v-if="detail.task.github_issue">{{ detail.task.github_issue }}</span>
+          </div>
+        </div>
+
+        <section
+          class="panel description-panel"
+          aria-labelledby="primary-description-title"
+        >
+          <div class="section-title">
+            <div>
+              <span class="eyebrow">Primary record</span>
+              <h2 id="primary-description-title">
+                Description
+              </h2>
+            </div>
+            <span class="immutable">Immutable</span>
+          </div>
+          <div
+            class="rich-content"
+            v-html="rich(detail.task.description)"
+          />
+        </section>
+
+        <section
+          class="panel thread"
+          aria-labelledby="comment-thread-title"
+        >
+          <div class="section-title">
+            <div>
+              <span class="eyebrow">Append-only history</span>
+              <h2 id="comment-thread-title">
+                Comments · {{ detail.comments.length }}
+              </h2>
+            </div>
+          </div>
+          <ol
+            v-if="detail.comments.length"
+            class="comment-list"
+          >
+            <li
+              v-for="comment in detail.comments"
+              :key="comment.id"
+              class="comment"
+            >
+              <div class="comment-meta">
+                <b>{{ actorLabel(comment.author) }}</b>
+                <time :datetime="comment.created_at">{{ shortDate(comment.created_at) }}</time>
+              </div>
+              <div
+                class="rich-content compact"
+                v-html="rich(comment.body)"
+              />
+            </li>
+          </ol>
+          <p
+            v-else
+            class="empty"
+          >
+            No comments yet.
+          </p>
+          <form
+            class="comment-form"
+            @submit.prevent="submitComment"
+          >
+            <label for="issue-comment">Add to the thread</label>
+            <textarea
+              id="issue-comment"
+              v-model="commentDraft"
+              rows="4"
+              placeholder="Add context or evidence…"
+            />
+            <div class="form-actions">
+              <button
+                type="submit"
+                :disabled="busy || !commentDraft.trim()"
+              >
+                Append comment
+              </button>
+            </div>
+          </form>
+        </section>
+      </article>
+
+      <aside
+        class="review-column"
+        aria-label="Review brief"
+      >
+        <section class="panel review-brief">
+          <div class="section-title">
+            <div><span class="eyebrow">Canonical evidence</span><h2>Review brief</h2></div>
+          </div>
+          <p
+            v-if="!detail.review.pullRequests.length"
+            class="empty"
+          >
+            No pull request is linked to this issue.
+          </p>
+          <article
+            v-for="pull in detail.review.pullRequests"
+            :key="`${pull.repository}#${pull.number}`"
+            class="pull-card"
+          >
+            <div class="pull-head">
+              <div><b>{{ pull.repository }} #{{ pull.number }}</b><span>{{ pull.title || 'Pull request unavailable' }}</span></div>
+              <span
+                class="readiness"
+                :class="{ ready: pull.mergeReady }"
+              >{{ pull.mergeReady ? 'Ready' : 'Not ready' }}</span>
+            </div>
+            <p
+              v-if="pull.error"
+              class="inline-error"
+            >
+              {{ pull.error }}
+            </p>
+            <dl v-else>
+              <div><dt>GitHub</dt><dd>{{ pull.state }}{{ pull.draft ? ' · draft' : '' }}</dd></div>
+              <div><dt>Head</dt><dd><code>{{ pull.headSha }}</code></dd></div>
+              <div><dt>Branch</dt><dd>{{ pull.headRef }} → {{ pull.baseRef }}</dd></div>
+              <div><dt>Mergeable</dt><dd>{{ pull.mergeable === null ? 'unknown' : pull.mergeable ? pull.mergeableState : 'no' }}</dd></div>
+            </dl>
+            <div
+              v-if="pull.checks.length"
+              class="evidence-block"
+            >
+              <h3>Checks</h3>
+              <div
+                v-for="check in pull.checks"
+                :key="check.name"
+                class="evidence-row"
+              >
+                <span>{{ check.name }}</span><b>{{ check.conclusion || check.status }}</b>
+              </div>
+            </div>
+            <p
+              v-else-if="!pull.error"
+              class="empty small"
+            >
+              No hosted checks found.
+            </p>
+            <div
+              v-if="pull.reviews.length"
+              class="evidence-block"
+            >
+              <h3>Reviews</h3>
+              <div
+                v-for="review in pull.reviews"
+                :key="`${review.author}-${review.submittedAt}`"
+                class="evidence-row"
+              >
+                <span>{{ review.author }}</span><b>{{ review.state }}</b>
+              </div>
+            </div>
+            <a
+              v-if="pull.url"
+              :href="pull.url"
+              target="_blank"
+              rel="noopener noreferrer"
+            >Open on GitHub ↗</a>
+          </article>
+
+          <EvidenceNotes
+            title="Review evidence"
+            :items="detail.review.reviewEvidence"
+          />
+          <EvidenceNotes
+            title="Documentation"
+            :items="detail.review.documentation"
+            empty-label="No documentation notes recorded."
+          />
+          <EvidenceNotes
+            title="Test results"
+            :items="detail.review.testResults"
+            empty-label="No test results recorded."
+          />
+          <EvidenceNotes
+            title="Risk"
+            :items="detail.review.riskNotes"
+            empty-label="No explicit risk evidence recorded."
+          />
+          <EvidenceNotes
+            title="Staging"
+            :items="detail.review.stagingEvidence"
+            empty-label="No staging evidence recorded."
+          />
+          <EvidenceNotes
+            title="Rollback"
+            :items="detail.review.rollbackNotes"
+            empty-label="No rollback notes recorded."
+          />
+        </section>
+
+        <section
+          v-if="detail.humanGate.active"
+          class="panel gate"
+          aria-labelledby="human-gate-title"
+        >
+          <span class="eyebrow">Human-gated stage</span>
+          <h2 id="human-gate-title">
+            Jonathon's decision
+          </h2>
+          <p>
+            Approval advances from <b>{{ detail.humanGate.currentStage }}</b> to
+            <b>{{ detail.humanGate.nextStage || 'no configured next stage' }}</b>. It does not merge or deploy anything.
+          </p>
+          <label for="gate-reason">Decision note</label>
+          <textarea
+            id="gate-reason"
+            v-model="decisionReason"
+            rows="3"
+            placeholder="Required when rejecting…"
+          />
+          <div class="gate-actions">
+            <button
+              type="button"
+              class="approve"
+              :disabled="busy || !detail.humanGate.nextStage"
+              @click="decide('approved')"
+            >
+              Approve and advance
+            </button>
+            <button
+              type="button"
+              class="reject"
+              :disabled="busy || !detail.humanGate.previousStage || !decisionReason.trim()"
+              @click="decide('rejected')"
+            >
+              Reject for repair
+            </button>
+          </div>
+          <p class="gate-footnote">
+            The next pipeline stage must revalidate the GitHub head SHA and checks before any merge action.
+          </p>
+        </section>
+      </aside>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+
+import type { WorkCommentRecord } from '@pkg/agent/database/models/WorkItemsModel';
+import type { ProjectsIssueDetail } from '@pkg/agent/services/ProjectsIssueDetailService';
+import EvidenceNotes from '@pkg/components/projects/ProjectIssueEvidenceNotes.vue';
+import { renderProjectRichText } from '@pkg/utils/projectRichText';
+
+const props = defineProps<{
+  taskId:       string;
+  detail:       ProjectsIssueDetail | null;
+  projectTitle: string;
+  epicTitle:    string;
+  loading:      boolean;
+  busy:         boolean;
+  error:        string;
+  statusLabel:  (status: string) => string;
+}>();
+
+const emit = defineEmits<{
+  close:   [];
+  refresh: [];
+  comment: [body: string];
+  decide:  [decision: 'approved' | 'rejected', reason: string];
+}>();
+
+const detailRoot = ref<HTMLElement | null>(null);
+const commentDraft = ref('');
+const decisionReason = ref('');
+
+onMounted(() => detailRoot.value?.focus());
+
+function rich(value: string): string { return renderProjectRichText(value) }
+function shortDate(iso: string): string { return new Date(iso).toLocaleString() }
+function actorLabel(author: WorkCommentRecord['author']): string {
+  if (author === 'human') return 'You';
+  return author || 'Agent';
+}
+function submitComment(): void {
+  const body = commentDraft.value.trim();
+  if (!body || props.busy) return;
+  emit('comment', body);
+  commentDraft.value = '';
+}
+function decide(decision: 'approved' | 'rejected'): void {
+  if (props.busy) return;
+  emit('decide', decision, decisionReason.value.trim());
+}
+</script>
+
+<style scoped lang="scss">
+.issue-detail { position: absolute; inset: 0; z-index: 30; overflow: auto; background: var(--pbg); color: var(--ptext); outline: none; }
+.issue-topbar { position: sticky; top: 0; z-index: 2; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; min-height: 58px; padding: 0 28px; border-bottom: 1px solid var(--pborder); background: color-mix(in srgb, var(--pbg) 94%, transparent); backdrop-filter: blur(18px); }
+button { border: 1px solid var(--pacc-line); border-radius: 8px; padding: 8px 12px; background: var(--pacc-soft); color: var(--ptext); cursor: pointer; font: 600 12px var(--psans); }
+button:focus-visible, a:focus-visible, textarea:focus-visible { outline: 2px solid var(--pacc); outline-offset: 2px; }
+button:disabled { opacity: .45; cursor: default; }
+.back { justify-self: start; background: transparent; border-color: var(--pborder); }
+.refresh { justify-self: end; background: transparent; border-color: var(--pborder); }
+.issue-id, .eyebrow { color: var(--ptext3); font: 10px var(--pmono); letter-spacing: .12em; text-transform: uppercase; }
+.issue-layout { display: grid; grid-template-columns: minmax(0, 1fr) minmax(320px, 430px); gap: 28px; width: min(1500px, 100%); margin: 0 auto; padding: 38px; }
+.issue-main, .review-column { min-width: 0; }
+.review-column { display: flex; flex-direction: column; gap: 18px; }
+.issue-heading { margin: 0 0 28px; }
+h1 { max-width: 980px; margin: 9px 0 14px; font: 500 clamp(30px, 4vw, 54px)/1.08 var(--pserif); }
+h2 { margin: 4px 0 0; font: 500 22px var(--pserif); }
+h3 { margin: 0 0 8px; font: 600 11px var(--pmono); letter-spacing: .08em; text-transform: uppercase; color: var(--ptext3); }
+.meta { display: flex; flex-wrap: wrap; gap: 7px; }
+.meta span, .immutable, .readiness { border: 1px solid var(--pborder); border-radius: 999px; padding: 4px 9px; color: var(--ptext2); font: 10px var(--pmono); }
+.panel { border: 1px solid var(--pborder); border-radius: 14px; background: var(--psurface); padding: 24px; }
+.description-panel { margin-bottom: 20px; }
+.section-title, .pull-head, .evidence-row, .form-actions { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.immutable { color: var(--pacc); border-color: var(--pacc-line); }
+.rich-content { margin-top: 22px; color: var(--ptext2); font-size: 14px; line-height: 1.72; overflow-wrap: anywhere; }
+.rich-content.compact { margin-top: 8px; }
+.rich-content :deep(h1), .rich-content :deep(h2), .rich-content :deep(h3) { color: var(--ptext); font-family: var(--pserif); }
+.rich-content :deep(a) { color: var(--pacc); }
+.rich-content :deep(pre) { overflow: auto; padding: 12px; border: 1px solid var(--pborder); border-radius: 8px; background: var(--pbg); white-space: pre-wrap; }
+.rich-content :deep(code) { font-family: var(--pmono); }
+.rich-content :deep(table) { width: 100%; border-collapse: collapse; }
+.rich-content :deep(td), .rich-content :deep(th) { padding: 7px; border: 1px solid var(--pborder); text-align: left; }
+.comment-list { list-style: none; margin: 22px 0 0; padding: 0; }
+.comment { padding: 18px 0; border-top: 1px solid var(--pborder-soft); }
+.comment-meta { display: flex; justify-content: space-between; gap: 14px; color: var(--ptext3); font: 10px var(--pmono); }
+.comment-meta b { color: var(--pacc); }
+.comment-form { display: grid; gap: 8px; margin-top: 20px; padding-top: 20px; border-top: 1px solid var(--pborder); }
+label { color: var(--ptext3); font: 10px var(--pmono); letter-spacing: .08em; text-transform: uppercase; }
+textarea { width: 100%; resize: vertical; border: 1px solid var(--pborder); border-radius: 8px; padding: 11px; background: var(--psurface2); color: var(--ptext); font: 13px/1.5 var(--psans); }
+.pull-card { margin-top: 18px; padding-top: 18px; border-top: 1px solid var(--pborder); }
+.pull-head > div { display: grid; gap: 4px; min-width: 0; }
+.pull-head span { color: var(--ptext2); font-size: 12px; }
+.readiness.ready { color: var(--pgreen); border-color: var(--pgreen); }
+dl { display: grid; gap: 8px; margin: 16px 0; }
+dl div { display: grid; grid-template-columns: 76px minmax(0, 1fr); gap: 10px; }
+dt { color: var(--ptext3); font: 10px var(--pmono); text-transform: uppercase; }
+dd { min-width: 0; margin: 0; color: var(--ptext2); font-size: 12px; overflow-wrap: anywhere; }
+dd code { font-size: 10px; }
+.evidence-block { margin-top: 16px; }
+.evidence-row { padding: 6px 0; border-top: 1px solid var(--pborder-soft); color: var(--ptext2); font-size: 11px; }
+.evidence-row b { color: var(--ptext); font-family: var(--pmono); }
+a { display: inline-block; margin-top: 14px; color: var(--pacc); font-size: 12px; }
+.empty { color: var(--ptext3); font-size: 12px; }
+.empty.small { margin: 12px 0; }
+.inline-error, .issue-state.error { color: var(--pred); }
+.gate { border-color: var(--pacc-line); }
+.gate p { color: var(--ptext2); font-size: 12px; line-height: 1.55; }
+.gate textarea { margin-top: 6px; }
+.gate-actions { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 12px; }
+.gate-actions .approve { border-color: var(--pgreen); background: var(--pgreen); color: var(--pbg); }
+.gate-actions .reject { border-color: var(--pred); background: transparent; color: var(--pred); }
+.gate-footnote { padding-top: 12px; border-top: 1px solid var(--pborder); }
+.issue-state { display: grid; place-content: center; min-height: 60vh; gap: 8px; text-align: center; }
+@media (max-width: 960px) { .issue-layout { grid-template-columns: 1fr; padding: 24px; } }
+</style>

--- a/pkg/rancher-desktop/components/projects/ProjectIssueEvidenceNotes.vue
+++ b/pkg/rancher-desktop/components/projects/ProjectIssueEvidenceNotes.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="notes">
+    <h3>{{ title }}</h3>
+    <ul v-if="items.length">
+      <li
+        v-for="item in items"
+        :key="item"
+      >
+        {{ item }}
+      </li>
+    </ul>
+    <p v-else>
+      {{ emptyLabel }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+withDefaults(defineProps<{ title: string; items: string[]; emptyLabel?: string }>(), {
+  emptyLabel: 'No evidence recorded.',
+});
+</script>
+
+<style scoped>
+.notes { margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--pborder); }
+h3 { margin: 0 0 8px; color: var(--ptext3); font: 600 11px var(--pmono); letter-spacing: .08em; text-transform: uppercase; }
+ul { display: grid; gap: 7px; margin: 0; padding-left: 18px; color: var(--ptext2); font-size: 11px; line-height: 1.5; }
+p { margin: 0; color: var(--ptext3); font-size: 11px; }
+</style>

--- a/pkg/rancher-desktop/components/projects/__tests__/LaneSettings.contract.test.ts
+++ b/pkg/rancher-desktop/components/projects/__tests__/LaneSettings.contract.test.ts
@@ -22,4 +22,10 @@ describe('LaneSettings UI contract', () => {
     expect(source).toContain('removeLaneWorkflowBinding');
     expect(source).not.toContain('postgresClient');
   });
+
+  it('lets a lane require a human approval gate', () => {
+    expect(source).toContain('requiresHumanApproval');
+    expect(source).toContain('requires_human_approval');
+    expect(source).toContain('Require a human approval before this lane can advance');
+  });
 });

--- a/pkg/rancher-desktop/main/workItemsEvents.ts
+++ b/pkg/rancher-desktop/main/workItemsEvents.ts
@@ -123,6 +123,22 @@ export function initWorkItemsEvents(): void {
     return projects.listComments(taskId);
   });
 
+  ipcMainProxy.handle('work-items:issue-detail', async(_event: unknown, taskId: string) => {
+    if (!taskId) throw new Error('taskId is required.');
+    const { loadProjectsIssueDetail } = await import('@pkg/agent/services/ProjectsIssueDetailService');
+    return loadProjectsIssueDetail(taskId);
+  });
+
+  ipcMainProxy.handle('work-items:human-gate-decision', async(_event: unknown, input: {
+    taskId: string; decision: 'approved' | 'rejected'; reason?: string; expectedStage: string;
+  }) => {
+    if (!input?.taskId || !input.expectedStage || !['approved', 'rejected'].includes(input.decision)) {
+      throw new Error('A taskId, expected stage, and approved/rejected decision are required.');
+    }
+    const { decideProjectsHumanGate } = await import('@pkg/agent/services/ProjectsIssueDetailService');
+    return decideProjectsHumanGate(input.taskId, input.decision, input.reason ?? '', input.expectedStage);
+  });
+
   ipcMainProxy.handle('work-items:artifact-evidence', async(_event: unknown, commentId: string) => {
     if (!commentId) return null;
     const { ArtifactReceiptModel } = await import('@pkg/agent/database/models/ArtifactReceiptModel');

--- a/pkg/rancher-desktop/pages/ProjectsHome.vue
+++ b/pkg/rancher-desktop/pages/ProjectsHome.vue
@@ -1,18 +1,33 @@
 <!--
   ProjectsHome — the Projects project state (issue ledger).
 
-  Reads AND writes the Postgres work tables (work_projects → work_epics →
-  work_tasks → work_task_comments) through the useProjects composable /
+  Reads AND writes Projects records (projects → epics → tasks → comments)
+  through the useProjects composable /
   work-items:* IPC bridge. Full CRUD: create/edit/archive projects, epics and
   tasks, edit every value, and comment on issues.
 
   Layout: pick a project on the left, its epics and issues render on the right.
   Today = epics-as-sections list; Board = the four status columns; Projects =
-  the all-projects overview. Clicking an issue opens the detail drawer.
+  the all-projects overview. Clicking an issue opens its full-screen route.
 -->
 <template>
   <div class="projects-home">
-    <div class="ph-body">
+    <ProjectIssueDetail
+      v-if="issueRouteId && taskMode === 'edit'"
+      :task-id="issueRouteId"
+      :detail="issueDetail"
+      :project-title="issueProjectTitle"
+      :epic-title="issueEpicTitle"
+      :loading="issueDetailLoading"
+      :busy="saving"
+      :error="issueDetailError"
+      :status-label="statusLabel"
+      @close="closeTask"
+      @refresh="refreshIssueDetail"
+      @comment="postDetailComment"
+      @decide="decideHumanGate"
+    />
+    <div v-show="!issueRouteId || taskMode === 'create'" class="ph-body">
       <!-- project list -->
       <aside class="ph-side">
         <div class="ph-side-h">
@@ -873,12 +888,12 @@
 
     <!-- ══════════ TASK DETAIL DRAWER ══════════ -->
     <div
-      v-if="openTask"
+      v-if="openTask && taskMode === 'create'"
       class="ph-scrim"
       @click="closeTask"
     />
     <aside
-      v-if="openTask"
+      v-if="openTask && taskMode === 'create'"
       class="ph-drawer"
     >
       <div class="ph-dh">
@@ -1322,11 +1337,14 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 
 import type { SemanticStage, WorkConveyorMetricsModel } from '@pkg/agent/database/models/WorkConveyorMetricsModel';
 import type { BackpressureDecision, RoleCounts, WipLimits } from '@pkg/agent/services/ProjectAutomationWipLimits';
+import type { ProjectsIssueDetail } from '@pkg/agent/services/ProjectsIssueDetailService';
 import LaneSettings from '@pkg/components/projects/LaneSettings.vue';
 import ProjectDependencyGraph from '@pkg/components/projects/ProjectDependencyGraph.vue';
+import ProjectIssueDetail from '@pkg/components/projects/ProjectIssueDetail.vue';
 import {
   useProjects,
   type ProjectView, type EpicWithTasks, type TaskView, type WorkTaskRecord, type WorkCommentRecord, type WorkActivityRecord,
@@ -1345,6 +1363,8 @@ const {
   resolveView, saveView,
   listTaskDependencies, setTaskDependency, removeTaskDependency,
 } = useProjects();
+const route = useRoute();
+const router = useRouter();
 
 const PROJECT_VIEWS: { key: ProjectViewType; label: string; icon: string }[] = [
   { key: 'board', label: 'Board', icon: '▦' },
@@ -1404,6 +1424,7 @@ onMounted(async() => {
     console.error('[ProjectsHome] initial load failed:', err);
   });
   await restoreProjectView();
+  await openIssueFromRoute();
   automationStatus.value = await ipcRenderer.invoke('work-items:automation-status').catch(() => null);
   await loadConveyorHealth();
   refreshTimer = setInterval(() => {
@@ -1808,6 +1829,11 @@ function isoFromYmd(v: string): string | null {
 type TaskDraft = UpsertTaskInput & { id?: string };
 const openTask = ref<WorkTaskRecord | null>(null);
 const taskMode = ref<'edit' | 'create'>('edit');
+const issueDetail = ref<ProjectsIssueDetail | null>(null);
+const issueDetailLoading = ref(false);
+const issueDetailError = ref('');
+let issueRouteWasPushed = false;
+const issueRouteId = computed(() => typeof route.query.issue === 'string' ? route.query.issue : '');
 const taskDraft = reactive<TaskDraft>({ title: '' });
 const taskComments = ref<WorkCommentRecord[]>([]);
 const taskDependencies = ref<WorkTaskDependencyRecord[]>([]);
@@ -1849,16 +1875,57 @@ function fillTaskDraft(t: Partial<WorkTaskRecord> & { epic_id?: string | null })
   taskDraft.github_issue = t.github_issue ?? '';
 }
 
-async function openTaskDrawer(t: WorkTaskRecord): Promise<void> {
+async function openTaskDrawer(t: WorkTaskRecord, syncRoute = true): Promise<void> {
   taskMode.value = 'edit';
   openTask.value = t;
   fillTaskDraft(t);
-  [taskComments.value, taskDependencies.value] = await Promise.all([
-    loadComments(t.id),
-    listTaskDependencies(t.project_id),
-  ]);
+  if (selectedId.value !== t.project_id) select(t.project_id);
+  await Promise.all([refreshIssueDetail(t.id), listTaskDependencies(t.project_id).then(rows => { taskDependencies.value = rows })]);
+  taskComments.value = issueDetail.value?.comments ?? [];
   dependencyCandidate.value = '';
+  if (syncRoute && route.query.issue !== t.id) {
+    issueRouteWasPushed = true;
+    await router.push({ query: { ...route.query, issue: t.id } });
+  }
 }
+
+const issueProjectTitle = computed(() => projects.value.find(project => project.id === openTask.value?.project_id)?.title ?? 'Projects');
+const issueEpicTitle = computed(() => sel.value?.epics.find(epic => epic.id === openTask.value?.epic_id)?.title ?? 'Issue');
+
+async function refreshIssueDetail(taskId = issueRouteId.value || openTask.value?.id || ''): Promise<void> {
+  if (!taskId || taskMode.value !== 'edit') return;
+  issueDetailLoading.value = true;
+  issueDetailError.value = '';
+  try {
+    issueDetail.value = await ipcRenderer.invoke('work-items:issue-detail', taskId);
+    openTask.value = issueDetail.value.task;
+    if (selectedId.value !== issueDetail.value.task.project_id) select(issueDetail.value.task.project_id);
+    fillTaskDraft(issueDetail.value.task);
+    taskComments.value = issueDetail.value.comments;
+  } catch (error: any) {
+    issueDetailError.value = error?.message ?? String(error);
+  } finally {
+    issueDetailLoading.value = false;
+  }
+}
+
+async function openIssueFromRoute(): Promise<void> {
+  const taskId = issueRouteId.value;
+  if (!taskId || (openTask.value?.id === taskId && taskMode.value === 'edit')) return;
+  issueRouteWasPushed = false;
+  taskMode.value = 'edit';
+  openTask.value = null;
+  issueDetail.value = null;
+  await refreshIssueDetail(taskId);
+}
+
+watch(() => route.query.issue, (issue) => {
+  if (typeof issue === 'string' && issue) openIssueFromRoute().catch(() => undefined);
+  else if (taskMode.value === 'edit') {
+    openTask.value = null;
+    issueDetail.value = null;
+  }
+});
 
 const currentDependencies = computed(() => taskDependencies.value
   .filter(dependency => dependency.task_id === taskDraft.id));
@@ -1963,7 +2030,19 @@ function openNewTask(epicId: string): void {
 }
 
 function closeTask(): void {
+  if (taskMode.value === 'edit' && issueRouteId.value) {
+    if (issueRouteWasPushed) {
+      issueRouteWasPushed = false;
+      router.back();
+    } else {
+      const query = { ...route.query };
+      delete query.issue;
+      router.replace({ query }).catch(() => undefined);
+    }
+  }
   openTask.value = null;
+  issueDetail.value = null;
+  issueDetailError.value = '';
   newComment.value = '';
 }
 
@@ -2025,6 +2104,38 @@ async function postComment(): Promise<void> {
     taskComments.value = await loadComments(taskDraft.id);
     if (tab.value === 'activity') await refreshActivity();
     newComment.value = '';
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function postDetailComment(body: string): Promise<void> {
+  if (!taskDraft.id) return;
+  saving.value = true;
+  try {
+    await addComment(taskDraft.id, body, 'human');
+    await refreshIssueDetail();
+  } finally {
+    saving.value = false;
+  }
+}
+
+async function decideHumanGate(decision: 'approved' | 'rejected', reason: string): Promise<void> {
+  if (!taskDraft.id) return;
+  saving.value = true;
+  issueDetailError.value = '';
+  try {
+    issueDetail.value = await ipcRenderer.invoke('work-items:human-gate-decision', {
+      taskId:        taskDraft.id,
+      decision,
+      reason,
+      expectedStage: issueDetail.value?.humanGate.currentStage ?? '',
+    });
+    await load();
+    openTask.value = issueDetail.value.task;
+    fillTaskDraft(issueDetail.value.task);
+  } catch (error: any) {
+    issueDetailError.value = error?.message ?? String(error);
   } finally {
     saving.value = false;
   }

--- a/pkg/rancher-desktop/pages/__tests__/ProjectsIssueDetail.contract.test.ts
+++ b/pkg/rancher-desktop/pages/__tests__/ProjectsIssueDetail.contract.test.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+
+import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc';
+
+const detailSource = fs.readFileSync('pkg/rancher-desktop/components/projects/ProjectIssueDetail.vue', 'utf8');
+const homeSource = fs.readFileSync('pkg/rancher-desktop/pages/ProjectsHome.vue', 'utf8');
+const serviceSource = fs.readFileSync('pkg/rancher-desktop/agent/services/ProjectsIssueDetailService.ts', 'utf8');
+
+describe('full-screen Projects issue detail contract', () => {
+  it('compiles as a Vue SFC and owns the full Projects context', () => {
+    const { descriptor, errors } = parse(detailSource, { filename: 'ProjectIssueDetail.vue' });
+    expect(errors).toEqual([]);
+    expect(() => compileScript(descriptor, { id: 'project-issue-detail' })).not.toThrow();
+    const template = compileTemplate({
+      id: 'project-issue-detail', filename: 'ProjectIssueDetail.vue', source: descriptor.template?.content ?? '',
+    });
+    expect(template.errors).toEqual([]);
+    expect(detailSource).toContain('position: absolute; inset: 0');
+  });
+
+  it('separates immutable description from the append-only thread and sanitizes both render paths', () => {
+    expect(detailSource).toContain('Primary record');
+    expect(detailSource).toContain('Immutable');
+    expect(detailSource).toContain('Append-only history');
+    expect(detailSource).toContain('v-html="rich(detail.task.description)"');
+    expect(detailSource).toContain('v-html="rich(comment.body)"');
+    expect(detailSource).toContain('renderProjectRichText');
+  });
+
+  it('supports deep links, browser back, keyboard exit, loading, errors, and explicit gate decisions', () => {
+    expect(homeSource).toContain('route.query.issue');
+    expect(homeSource).toContain('router.back()');
+    expect(detailSource).toContain('@keydown.esc="$emit(\'close\')"');
+    expect(detailSource).toContain('Loading issue and live review state');
+    expect(detailSource).toContain('role="alert"');
+    expect(detailSource).toContain('Approve and advance');
+    expect(detailSource).toContain('Reject for repair');
+    expect(detailSource).toContain('background: var(--pgreen)');
+  });
+
+  it('loads live GitHub state and never invokes merge from the decision boundary', () => {
+    const decisionSource = serviceSource.slice(serviceSource.indexOf('export async function decideProjectsHumanGate'));
+
+    expect(serviceSource).toContain('octokit.pulls.get');
+    expect(serviceSource).toContain('octokit.checks.listForRef');
+    expect(serviceSource).toContain('octokit.pulls.listReviews');
+    expect(serviceSource).toContain('documentation:');
+    expect(serviceSource).toContain('testResults:');
+    expect(serviceSource).toContain('transitionTaskRelative');
+    expect(serviceSource).not.toMatch(/pulls\.merge|github_merge_pr|mergePullRequest/);
+    expect(serviceSource).toContain('requires_human_approval === true');
+    expect(serviceSource).toContain("'Decision by: human'");
+    expect(decisionSource).toContain('expectedStage');
+    expect(decisionSource).not.toContain('headSha');
+  });
+});

--- a/pkg/rancher-desktop/typings/electron-ipc.d.ts
+++ b/pkg/rancher-desktop/typings/electron-ipc.d.ts
@@ -436,6 +436,8 @@ export interface IpcMainInvokeEvents {
     laneCapability: import('@pkg/agent/database/models/WorkLaneDefinitionModel').WorkLaneRuntimeCapability;
   };
   'work-items:comments':        (taskId: string) => import('@pkg/agent/database/models/WorkItemsModel').WorkCommentRecord[];
+  'work-items:issue-detail':    (taskId: string) => import('@pkg/agent/services/ProjectsIssueDetailService').ProjectsIssueDetail;
+  'work-items:human-gate-decision': (input: { taskId: string; decision: 'approved' | 'rejected'; reason?: string; expectedStage: string }) => import('@pkg/agent/services/ProjectsIssueDetailService').ProjectsIssueDetail;
   'work-items:artifact-evidence': (commentId: string) => { receipt: import('@pkg/agent/database/models/ArtifactReceiptModel').ArtifactReceiptRow; evidence: unknown } | null;
   'work-items:activity':        (opts?: { projectId?: string; author?: string; limit?: number }) => import('@pkg/agent/database/models/WorkItemsModel').WorkActivityRecord[];
   'work-items:automation-status': () => {

--- a/pkg/rancher-desktop/utils/__tests__/projectRichText.test.ts
+++ b/pkg/rancher-desktop/utils/__tests__/projectRichText.test.ts
@@ -1,0 +1,20 @@
+/** @jest-environment jsdom */
+import { renderProjectRichText } from '../projectRichText';
+
+describe('Projects rich-text rendering', () => {
+  it('keeps the allowlisted document structure while removing executable content', () => {
+    const rendered = renderProjectRichText('<h2 onclick="steal()">Review</h2>\n' +
+      '<script>steal()</script>\n' +
+      '<a href="javascript:steal()" data-secret="nope">unsafe</a>\n' +
+      '<table><tr><th>Check</th><td>Passed</td></tr></table>');
+
+    expect(rendered).toContain('<h2>Review</h2>');
+    expect(rendered).toContain('<table>');
+    expect(rendered).not.toMatch(/script|onclick|javascript:|data-secret/i);
+  });
+
+  it('renders ordinary Markdown and preserves malformed source as readable content', () => {
+    expect(renderProjectRichText('**Passed**\n\n`sha`')).toContain('<strong>Passed</strong>');
+    expect(renderProjectRichText('plain <broken & text')).toContain('plain');
+  });
+});

--- a/pkg/rancher-desktop/utils/projectRichText.ts
+++ b/pkg/rancher-desktop/utils/projectRichText.ts
@@ -1,0 +1,39 @@
+import DOMPurify from 'dompurify';
+import { marked } from 'marked';
+
+const ALLOWED_TAGS = [
+  'a', 'blockquote', 'br', 'code', 'del', 'em', 'h1', 'h2', 'h3', 'h4',
+  'hr', 'li', 'ol', 'p', 'pre', 'strong', 'table', 'tbody', 'td', 'th',
+  'thead', 'tr', 'ul',
+];
+
+const ALLOWED_ATTR = ['href', 'title'];
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, character => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  })[character]!);
+}
+
+/**
+ * Render issue prose as Markdown (including trusted rich HTML), then reduce it
+ * to the small Projects allowlist. If either parser encounters malformed
+ * input, preserve a readable escaped plain-text rendering instead.
+ */
+export function renderProjectRichText(value: string | null | undefined): string {
+  const source = String(value ?? '');
+  if (!source.trim()) return '<p class="project-rich-empty">No content provided.</p>';
+
+  try {
+    const parsed = marked.parse(source, { async: false, breaks: true });
+    const sanitized = DOMPurify.sanitize(parsed, {
+      ALLOWED_TAGS,
+      ALLOWED_ATTR,
+      ALLOW_DATA_ATTR: false,
+      ALLOW_ARIA_ATTR: false,
+    });
+    return sanitized || `<pre>${ escapeHtml(source) }</pre>`;
+  } catch {
+    return `<pre>${ escapeHtml(source) }</pre>`;
+  }
+}


### PR DESCRIPTION
## What changed

- replaces the edit drawer with a deep-linkable full-screen issue detail view
- separates immutable primary description from append-only comments and sanitizes Markdown/rich HTML through a strict allowlist
- loads live PR identity, head, checks, reviews, evidence, docs, tests, risk, staging, rollback, and merge-readiness context
- adds configurable per-lane human approval gates with stale-stage protection; approvals record the human actor/time and advance only the Projects stage
- keeps approval independent from GitHub head SHA and performs no merge or deploy

## Validation

- focused Jest: 5 suites, 21 tests passed
- related Projects/Lane Jest: 7 contract tests passed; existing conveyor-health suite 3 tests passed; migration registry passed
- full TypeScript: `NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit --pretty false` passed
- `git diff --check` passed

## Review note

Fresh packaged-app visual/browser verification remains for independent review because this worker had no in-app browser-control runtime. No merge or deployment was performed.