### PR TITLE
test(projects): cover execution-lane disabled/archived skip and generation consistency

### DIFF
--- a/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneDefinitionModel.test.ts
+++ b/pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneDefinitionModel.test.ts
@@ -175,6 +175,66 @@ describe('WorkLaneDefinitionModel', () => {
     );
   });
 
+  it('resolves the first active execution lane, skipping disabled and archived candidates', async() => {
+    const active = [
+      lane({ id: 'l-backlog', lane_key: 'backlog', semantic_role: 'backlog', position: 0 }),
+      lane({ id: 'l-todo', lane_key: 'todo', semantic_role: 'execution', position: 1, enabled: false }),
+      lane({ id: 'l-legacy-exec', lane_key: 'legacy-exec', semantic_role: 'execution', position: 2, archived: true }),
+      lane({ id: 'l-ready-custom', lane_key: 'ready-custom', semantic_role: 'execution', position: 3 }),
+      lane({ id: 'l-planning', lane_key: 'planning', semantic_role: 'planning', position: 4 }),
+      lane({ id: 'l-review', lane_key: 'in_review', semantic_role: 'review', position: 5 }),
+      lane({ id: 'l-blocked', lane_key: 'blocked', semantic_role: 'blocked', position: 6 }),
+      lane({ id: 'l-done', lane_key: 'done', semantic_role: 'terminal', position: 7 }),
+    ];
+    (postgresClient as any).queryOne = jest.fn(() => Promise.resolve({ present: true }));
+    (postgresClient as any).query = jest.fn(() => Promise.resolve(active));
+
+    await expect(WorkLaneDefinitionModel.preferredLaneKey('p1', 'execution', 'todo', 'first'))
+      .resolves.toBe('ready-custom');
+  });
+
+  it('prefers the compatibility key on a position tie between active role lanes', async() => {
+    const active = [
+      lane({ id: 'l-backlog', lane_key: 'backlog', semantic_role: 'backlog', position: 0 }),
+      lane({ id: 'l-other-exec', lane_key: 'other-exec', semantic_role: 'execution', position: 1 }),
+      lane({ id: 'l-todo', lane_key: 'todo', semantic_role: 'execution', position: 1 }),
+      lane({ id: 'l-planning', lane_key: 'planning', semantic_role: 'planning', position: 2 }),
+      lane({ id: 'l-review', lane_key: 'in_review', semantic_role: 'review', position: 3 }),
+      lane({ id: 'l-blocked', lane_key: 'blocked', semantic_role: 'blocked', position: 4 }),
+      lane({ id: 'l-done', lane_key: 'done', semantic_role: 'terminal', position: 5 }),
+    ];
+    (postgresClient as any).queryOne = jest.fn(() => Promise.resolve({ present: true }));
+    (postgresClient as any).query = jest.fn(() => Promise.resolve(active));
+
+    await expect(WorkLaneDefinitionModel.preferredLaneKey('p1', 'execution', 'todo', 'first'))
+      .resolves.toBe('todo');
+  });
+
+  it('throws when a project has no active lane for the requested role', async() => {
+    const active = [
+      lane({ id: 'l-backlog', lane_key: 'backlog', semantic_role: 'backlog', position: 0 }),
+      lane({ id: 'l-todo', lane_key: 'todo', semantic_role: 'execution', position: 1 }),
+      lane({ id: 'l-planning', lane_key: 'planning', semantic_role: 'planning', position: 2 }),
+      lane({ id: 'l-review', lane_key: 'in_review', semantic_role: 'review', position: 3 }),
+      lane({ id: 'l-blocked', lane_key: 'blocked', semantic_role: 'blocked', position: 4 }),
+      lane({ id: 'l-done', lane_key: 'done', semantic_role: 'terminal', position: 5 }),
+    ];
+    (postgresClient as any).queryOne = jest.fn(() => Promise.resolve({ present: true }));
+    (postgresClient as any).query = jest.fn(() => Promise.resolve(active));
+
+    await expect(WorkLaneDefinitionModel.preferredLaneKey('p1', 'manual', 'parked', 'first'))
+      .rejects.toThrow('Project p1 has no active manual lane.');
+  });
+
+  it('falls back to the compatibility key when the lane runtime capability is not ready', async() => {
+    (postgresClient as any).queryOne = jest.fn(() => Promise.resolve({ present: false }));
+    (postgresClient as any).query = jest.fn();
+
+    await expect(WorkLaneDefinitionModel.preferredLaneKey('p1', 'execution', 'todo', 'first'))
+      .resolves.toBe('todo');
+    expect(postgresClient.query).not.toHaveBeenCalled();
+  });
+
   it('materializes a project override when reordering an inherited lane', async() => {
     const client = {
       query: (jest.fn() as any)

--- a/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsApplicationService.test.ts
+++ b/pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsApplicationService.test.ts
@@ -162,4 +162,34 @@ describe('ProjectsApplicationService lifecycle boundary', () => {
     );
     expect(repo.updateTask).toHaveBeenCalledWith('task-1', expect.objectContaining({ status: 'ready-custom' }));
   });
+
+  it('rejects a stale generation on the execution-lane transition without moving the task', async() => {
+    const repo = repository();
+    repo.getTask.mockResolvedValue({ ...current, status: 'blocked' });
+    jest.spyOn(WorkLaneDefinitionModel, 'preferredLaneKey').mockResolvedValue('ready-custom');
+    jest.spyOn(WorkLaneWorkflowBindingModel, 'listLaneEntries').mockResolvedValue([
+      { generation: 12, lane_key: 'blocked' },
+    ] as any);
+    const service = new ProjectsApplicationService(repo);
+
+    await expect(service.transitionTaskToExecution({
+      taskId: 'task-1', expectedGeneration: 11,
+    }, { actor: 'planning-council', source: 'routine' })).rejects.toThrow('Stale stage generation');
+    expect(repo.updateTask).not.toHaveBeenCalled();
+  });
+
+  it('rejects a lane-entry ledger inconsistent with the task status at the same generation', async() => {
+    const repo = repository();
+    repo.getTask.mockResolvedValue({ ...current, status: 'blocked' });
+    jest.spyOn(WorkLaneDefinitionModel, 'preferredLaneKey').mockResolvedValue('ready-custom');
+    jest.spyOn(WorkLaneWorkflowBindingModel, 'listLaneEntries').mockResolvedValue([
+      { generation: 12, lane_key: 'in_progress' },
+    ] as any);
+    const service = new ProjectsApplicationService(repo);
+
+    await expect(service.transitionTaskToExecution({
+      taskId: 'task-1', expectedGeneration: 12,
+    }, { actor: 'planning-council', source: 'routine' })).rejects.toThrow('Stale stage generation');
+    expect(repo.updateTask).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

The semantic-TODO handoff fix (transition_task_to_execution, preferredLaneKey resolving the first active execution-role lane) was already implemented and merged via #802. This PR closes the remaining regression-coverage gap requested for task nZw9: disabled/archived lane exclusion and stale/mismatched-generation behavior specifically on the execution-lane transition path.

- `WorkLaneDefinitionModel.preferredLaneKey`: skips disabled and archived candidates, tie-breaks on the compatibility key, throws when a project has no active lane for the requested role, and falls back to the compatibility key when lane runtime capability is not ready.
- `ProjectsApplicationService.transitionTaskToExecution`: rejects a stale generation, and rejects a lane-entry ledger inconsistent with the current task status at the same generation (status/lane-entry consistency).

No production logic changed — test-only.

## Validation

- `node --experimental-vm-modules node_modules/.bin/jest pkg/rancher-desktop/agent/database/models/__tests__/WorkLaneDefinitionModel.test.ts pkg/rancher-desktop/agent/projects/application/__tests__/ProjectsApplicationService.test.ts --runInBand`: 2 suites, 24/24 tests passed (6 new)
- `git diff --check` passed

Task: nZw9