### PR TITLE
fix(github): surface full head SHA from github_get_pr (protected-review kTJ1)

### DIFF
--- a/pkg/rancher-desktop/agent/tools/github/github_get_pr.ts
+++ b/pkg/rancher-desktop/agent/tools/github/github_get_pr.ts
@@ -39,6 +39,7 @@ export class GitHubGetPRWorker extends BaseTool {
         `State: ${ pr.state }${ pr.draft ? ' (draft)' : '' }${ pr.merged ? ' (merged)' : '' }`,
         `Author: ${ pr.user?.login }`,
         `Head: ${ pr.head.ref } (${ pr.head.sha.slice(0, 8) }) → Base: ${ pr.base.ref }`,
+        `Head SHA (full): ${ pr.head.sha }`,
         `Commits: ${ pr.commits }  |  Changed files: ${ pr.changed_files }  |  +${ pr.additions }/-${ pr.deletions }`,
         `Comments: ${ pr.comments }  |  Review comments: ${ pr.review_comments }`,
         `Reviewers: ${ reviewers }`,


### PR DESCRIPTION
## Root cause

Protected-review synthesis (parseProtectedReview in TaskDispatcherService.ts) requires every artifact hash to be a full 40-64 hex char SHA:

    typeof artifact.hash !== 'string' || !/^[a-f0-9]{40,64}$/i.test(artifact.hash)
    => reason: 'invalid_artifacts_shape'

But github_get_pr.ts only ever exposed the 8-char abbreviated SHA (pr.head.sha.slice(0, 8)) in its tool response text -- the reviewer agent has no other adapter call that returns the full SHA for a PR head. This is a deterministic, 100%-reproduction-rate bug: every protected review of a code_pr artifact that resolves its head via this tool fails synthesis validation, no matter how correct the underlying review is.

### Live confirmed instance

Data Ripple task nGF9 (worker PR #2425, dataripple-org/ripple-receptionist-worker) hit this exactly today. The synthesis node's raw output (pulled from workflow_checkpoints.node_output) shows a fully correct, well-reasoned REPAIRABLE disposition with a properly-shaped artifacts array -- except hash: "de7f0291" (8 chars). The reviewer's own text explains why: "Neither of the two conflicting full-SHA claims in upstream evidence could be confirmed; only the short SHA de7f0291 is independently verifiable here." It was doing the conservative, correct thing (not inventing an unverified full SHA) -- the tool just never gave it access to one.

## Fix

One-line additive change: github_get_pr.ts now also emits `Head SHA (full): <pr.head.sha>` alongside the existing short-SHA display line. Reviewer agents can now independently confirm the full SHA instead of falling back to the 8-char prefix. No existing behavior removed; no test asserted the old exact output shape (checked graphToolSurface.test.ts, the only test referencing this tool -- it only checks tool-surface registration, not response text).

Validated via esbuild parse-check (clean) and a scoped tsc --noEmit pass on the file (zero errors attributable to this change; all pre-existing errors were unrelated path-alias/tsconfig issues from running tsc outside the project's -p context on other files). No test harness exists for this tool today (no Octokit-mocking pattern anywhere in the repo to follow) -- flagging that as a gap rather than inventing an unverified mocking scaffold under time pressure.

## Secondary finding (not fixed here, flagging for follow-up)

Same investigation also surfaced task gb2I's review failing with missing_or_invalid_disposition for a different reason: the review synthesis correctly detected its bound generation had already been superseded (the dispatcher rejected + reset the task to todo while the review was still in flight) and intentionally declined to emit any disposition JSON rather than adjudicate stale state. That's the right call by the model, but TaskDispatcherService.ts has no path for "generation superseded, no verdict needed" -- it falls into the same malformed_protected_review_output bucket as a genuine parse failure, mislabeling a correct abstention as an infra defect in the audit trail. Lower severity than the SHA bug (the WHERE status = 'in_review' guard in failVerification already prevents it from clobbering the task's real state, and it self-bounds at 3 attempts before going to terminal), so leaving it as a follow-up rather than bundling a state-machine change into this fix.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>