### PR TITLE
fix(dispatcher): distinguish generation-superseded abstention from malformed protected review output

### DIFF
--- a/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
+++ b/pkg/rancher-desktop/agent/services/TaskDispatcherService.ts
@@ -757,7 +757,18 @@ export class TaskDispatcherService {
         } else if (verificationOwner === 'core-routine') {
           const { value: parsed, reason: parseFailureReason } = this.parseProtectedReview(finalState.metadata?.lastCompletedWorkflow);
           if (!parsed) {
-            await WorkTaskDispatchModel.failVerification(dispatch.id, `malformed_protected_review_output:${ parseFailureReason }`);
+            // A missing disposition can mean the synthesis node correctly abstained on a generation superseded mid-flight, not a malformed output.
+            const liveTask = await WorkItemsModel.getTask(task.id);
+            if (liveTask?.status !== 'in_review') {
+              const currentArtifacts = await this.resolveReviewArtifacts(task, comments, dispatch.origin_evidence);
+              const currentGenerationHash = WorkTaskDispatchModel.reviewGenerationHash(currentArtifacts);
+              await WorkTaskDispatchModel.failVerification(
+                dispatch.id,
+                `artifact_generation_changed:${ generationHash }:${ currentGenerationHash }`,
+              );
+            } else {
+              await WorkTaskDispatchModel.failVerification(dispatch.id, `malformed_protected_review_output:${ parseFailureReason }`);
+            }
           } else {
             const currentArtifacts = await this.resolveReviewArtifacts(task, comments, dispatch.origin_evidence);
             const currentGenerationHash = WorkTaskDispatchModel.reviewGenerationHash(currentArtifacts);

--- a/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
+++ b/pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts
@@ -26,6 +26,7 @@ const touchMock: any = jest.fn(() => Promise.resolve());
 const hasActiveDispatchForTaskMock: any = jest.fn(() => Promise.resolve(false));
 const addCommentMock: any = jest.fn(() => Promise.resolve());
 const updateTaskMock: any = jest.fn(() => Promise.resolve());
+const getTaskMock: any = jest.fn(() => Promise.resolve({ id: 'task-core', status: 'in_review' }));
 const executeMock: any = jest.fn();
 const graphGetMock: any = jest.fn(() => Promise.resolve({
   graph: { execute: executeMock },
@@ -107,6 +108,7 @@ jest.unstable_mockModule('../../database/models/WorkItemsModel', () => ({
   WorkItemsModel: {
     addComment:   addCommentMock,
     updateTask:   updateTaskMock,
+    getTask:      getTaskMock,
     listComments: jest.fn(() => Promise.resolve([{ author: 'worker', body: 'Draft PR #123 at head.' }])),
   },
 }));
@@ -810,6 +812,123 @@ describe('TaskDispatcherService', () => {
         reviewerAgentIds:    ['sulla-desktop'],
         artifactHash:        hash,
       }), expect.any(Array),
+    );
+  });
+
+  it('settles a synthesis abstention as artifact_generation_changed when the task is no longer live in_review', async() => {
+    claimNextReviewMock
+      .mockResolvedValueOnce({
+        task: {
+          id:           'task-core',
+          title:        'Core review',
+          description:  'Verify all criteria.',
+          project_id:   'p',
+          epic_id:      'e',
+          priority:     'critical',
+          github_issue: null,
+        },
+        dispatch: {
+          id:              'verify-core',
+          task_id:         'task-core',
+          agent_id:        'sulla-desktop',
+          thread_id:       'core-thread',
+          kind:            'verification',
+          attempt:         1,
+          origin_agent_id: 'sulla-desktop',
+        },
+        stage_claim: { id: 'review-stage-core' },
+      })
+      .mockResolvedValue(null);
+    settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+      if (key === 'heartbeatEnabled' || key === 'taskVerifierEnabled' || key === 'taskReviewCoreRoutineEnabled') return Promise.resolve(true);
+      if (key === 'taskVerifierOwner') return Promise.resolve('core-routine');
+      return Promise.resolve(fallback);
+    });
+    resolvePullRequestHeadsMock.mockResolvedValue([]);
+    getTaskMock.mockResolvedValueOnce({ id: 'task-core', status: 'todo' });
+    executeMock.mockResolvedValue({
+      metadata: {
+        agent:                 { status: 'completed' },
+        finalSummary:          'Routine complete.',
+        lastCompletedWorkflow: {
+          workflowId:  'core-routine-review-project-artifact',
+          executionId: 'wfp-review-2',
+          outcome:     'completed',
+          nodeResults: [{ nodeId: 'node-review-synthesize', result: 'No disposition JSON is being issued: there is no live in_review generation to transition.' }],
+        },
+      },
+      messages: [],
+    });
+
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    await new Promise(resolve => setTimeout(resolve, 10));
+    service.destroy();
+
+    expect(getTaskMock).toHaveBeenCalledWith('task-core');
+    expect(failVerificationMock).toHaveBeenCalledWith(
+      'verify-core', expect.stringMatching(/^artifact_generation_changed:/),
+    );
+    expect(failVerificationMock).not.toHaveBeenCalledWith(
+      'verify-core', expect.stringMatching(/^malformed_protected_review_output:/),
+    );
+  });
+
+  it('settles a missing disposition as malformed_protected_review_output when the task is still live in_review', async() => {
+    claimNextReviewMock
+      .mockResolvedValueOnce({
+        task: {
+          id:           'task-core',
+          title:        'Core review',
+          description:  'Verify all criteria.',
+          project_id:   'p',
+          epic_id:      'e',
+          priority:     'critical',
+          github_issue: null,
+        },
+        dispatch: {
+          id:              'verify-core',
+          task_id:         'task-core',
+          agent_id:        'sulla-desktop',
+          thread_id:       'core-thread',
+          kind:            'verification',
+          attempt:         1,
+          origin_agent_id: 'sulla-desktop',
+        },
+        stage_claim: { id: 'review-stage-core' },
+      })
+      .mockResolvedValue(null);
+    settingsGetMock.mockImplementation((key: string, fallback: unknown) => {
+      if (key === 'heartbeatEnabled' || key === 'taskVerifierEnabled' || key === 'taskReviewCoreRoutineEnabled') return Promise.resolve(true);
+      if (key === 'taskVerifierOwner') return Promise.resolve('core-routine');
+      return Promise.resolve(fallback);
+    });
+    resolvePullRequestHeadsMock.mockResolvedValue([]);
+    getTaskMock.mockResolvedValueOnce({ id: 'task-core', status: 'in_review' });
+    executeMock.mockResolvedValue({
+      metadata: {
+        agent:                 { status: 'completed' },
+        finalSummary:          'Routine complete.',
+        lastCompletedWorkflow: {
+          workflowId:  'core-routine-review-project-artifact',
+          executionId: 'wfp-review-3',
+          outcome:     'completed',
+          nodeResults: [{ nodeId: 'node-review-synthesize', result: 'not json' }],
+        },
+      },
+      messages: [],
+    });
+
+    const { TaskDispatcherService } = await import('../TaskDispatcherService');
+    const service = new TaskDispatcherService();
+    await service.initialize();
+    await new Promise(resolve => setTimeout(resolve, 10));
+    service.destroy();
+
+    expect(getTaskMock).toHaveBeenCalledWith('task-core');
+    expect(failVerificationMock).toHaveBeenCalledWith(
+      'verify-core', 'malformed_protected_review_output:missing_or_invalid_disposition',
     );
   });
 


### PR DESCRIPTION
Companion to #823 (short-SHA fix). Fixes a lower-severity mislabeling in TaskDispatcherService.runClaim: when a bound review generation is superseded mid-flight (dispatcher independently resets the task off in_review while the protected-review workflow is still running), the synthesis node correctly abstains and emits no disposition JSON. Previously this hit the same parseProtectedReview `missing_or_invalid_disposition` path as a genuinely malformed model output and was recorded as `malformed_protected_review_output:...`, mislabeling a correct abstention as an infra defect in the audit trail and burning a retry cycle.

Fix: in the `!parsed` branch, live-check the task via `WorkItemsModel.getTask(task.id)` before classifying the failure. If the task is no longer `in_review`, settle the dispatch via the existing `artifact_generation_changed` path (same pattern already used for parsed-but-stale generations a few lines below) instead of `malformed_protected_review_output`. If the task is still live `in_review`, the missing disposition is genuinely malformed and is recorded as before.

Not an infinite loop or state-machine risk: the `WHERE status = in_review` guard in `failVerification` already made this a no-op once the task moved off `in_review`, and it self-bounds at 3 identical-reason failures. This only fixes the audit-trail label and avoids the wasted review-concurrency slot/retry cycle.

Validation:
- `node --experimental-vm-modules node_modules/jest/bin/jest.js pkg/rancher-desktop/agent/services/__tests__/TaskDispatcherService.test.ts` — 31/31 passed, including 2 new tests: one proving a superseded-task abstention now settles as `artifact_generation_changed:...` (not malformed), and one proving a still-live-in_review missing disposition still settles as `malformed_protected_review_output:missing_or_invalid_disposition`.
- `eslint` on both changed files — no new errors/warnings introduced (pre-existing unrelated warnings in the file untouched).
- Repo-wide `tsc --noEmit` OOMs on this host (known constraint); scoped to the touched types by hand: `WorkItemsModel.getTask` returns `WorkTaskRecord | null` with `status: string`, matching the `liveTask?.status !== in_review` comparison used elsewhere in this file.

Projects task: 9p6P.